### PR TITLE
Add options to preload a REU image on startup

### DIFF
--- a/software/application/ultimate/ultimate.cc
+++ b/software/application/ultimate/ultimate.cc
@@ -34,6 +34,7 @@
 #include "dump_hex.h"
 #include "usb_base.h"
 #include "home_directory.h"
+#include "reu_preloader.h"
 #include "u2p.h"
 #include "keyboard_usb.h"
 
@@ -50,6 +51,7 @@ C64 *c64;
 C64_Subsys *c64_subsys;
 UserInterface *primaryUserInterface = 0;
 HomeDirectory *home_directory;
+REUPreloader *reu_preloader;
 StreamTextLog textLog(65536);
 
 extern "C" void (*custom_outbyte)(int c);
@@ -153,6 +155,7 @@ extern "C" void ultimate_main(void *a)
     }
 
     home_directory = new HomeDirectory(primaryUserInterface, root_tree_browser);
+    reu_preloader = new REUPreloader();
     
     printf("All linked modules have been initialized and are now running.\n");
     static char buffer[8192];
@@ -210,6 +213,8 @@ extern "C" void ultimate_main(void *a)
 	    delete tape_recorder;
     if(home_directory)
         delete home_directory;
+    if(reu_preloader)
+      delete reu_preloader;
     
     printf("Graceful exit!!\n");
 //    return 0;

--- a/software/filetypes/filetype_reu.cc
+++ b/software/filetypes/filetype_reu.cc
@@ -16,8 +16,9 @@ cart_def mod_cart  = { ID_MODPLAYER, (void *)0, 0x4000, CART_TYPE_16K | CART_REU
 /*********************************************************************/
 /* REU File Browser Handling                                         */
 /*********************************************************************/
-#define REUFILE_LOAD      0x5201
-#define REUFILE_PLAYMOD   0x5202
+#define REUFILE_LOAD        0x5201
+#define REUFILE_PLAYMOD     0x5202
+#define REUFILE_SET_PRELOAD 0x5203
 
 #define REU_TYPE_REU 0
 #define REU_TYPE_MOD 1
@@ -38,6 +39,7 @@ int FileTypeREU :: fetch_context_items(IndexedList<Action *> &list)
     int count = 1;
 
     list.append(new Action("Load into REU", FileTypeREU :: execute_st, REUFILE_LOAD));
+    list.append(new Action("Preload on Startup", FileTypeREU :: execute_st, REUFILE_SET_PRELOAD));
     uint32_t capabilities = getFpgaCapabilities();
     if ((type == REU_TYPE_MOD) && (capabilities & CAPAB_SAMPLER)) {
         list.append(new Action("Play MOD", FileTypeREU :: execute_st, REUFILE_PLAYMOD));
@@ -74,6 +76,15 @@ int FileTypeREU :: execute_st(SubsysCommand *cmd)
     FileInfo info(32);
     fm->fstat(cmd->path.c_str(), cmd->filename.c_str(), info);
 
+    if (cmd->functionID == REUFILE_SET_PRELOAD) {
+        char path[1024];
+        sprintf(path, "%s%s", cmd->path.c_str(), cmd->filename.c_str());
+        c64->cfg->set_string(CFG_C64_REU_IMG, path);
+        c64->cfg->write();
+        cmd->user_interface->popup("Set as REU Preload Image", BUTTON_OK);
+        return 0;
+    }
+    
     if (cmd->functionID == REUFILE_PLAYMOD) {
     	AudioConfig :: clear_sampler_registers();
     }

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -110,6 +110,7 @@ cart_def cartridges[] = { { 0x00,               0x000000, 0x00000,  0x00 | CART_
  };
                           
 const char *reu_size[] = { "128 KB", "256 KB", "512 KB", "1 MB", "2 MB", "4 MB", "8 MB", "16 MB" };
+const char *reu_offset[] = { "0 KB", "128 KB", "256 KB", "512 KB", "1 MB", "2 MB", "4 MB", "8 MB", "16 MB" };
 const char *en_dis2[] = { "Disabled", "Enabled" };
 const char *buttons[] = { "Reset|Menu|Freezer", "Freezer|Menu|Reset" };
 const char *timing1[] = { "20ns", "40ns", "60ns", "80ns", "100ns", "120ns", "140ns", "160ns" };
@@ -122,6 +123,9 @@ struct t_cfg_definition c64_config[] = {
     { CFG_C64_ALT_KERN, CFG_TYPE_ENUM,   "Alternate Kernal",             "%s", en_dis2,    0,  1, 0 },
     { CFG_C64_REU_EN,   CFG_TYPE_ENUM,   "RAM Expansion Unit",           "%s", en_dis2,    0,  1, 0 },
     { CFG_C64_REU_SIZE, CFG_TYPE_ENUM,   "REU Size",                     "%s", reu_size,   0,  7, 4 },
+    { CFG_C64_REU_PRE,  CFG_TYPE_ENUM,   "REU Preload",                  "%s", en_dis2,    0,  1, 0 },
+    { CFG_C64_REU_IMG,  CFG_TYPE_STRING, "REU Preload Image",            "%s", NULL,       0, 31, (int)"/Usb0/preload.reu" },
+    { CFG_C64_REU_OFFS, CFG_TYPE_ENUM,   "REU Preload Offset",           "%s", reu_offset, 0,  8, 0 }, 
     { CFG_C64_MAP_SAMP, CFG_TYPE_ENUM,   "Map Ultimate Audio $DF20-DFFF","%s", en_dis2,    0,  1, 0 },
     { CFG_C64_DMA_ID,   CFG_TYPE_VALUE,  "DMA Load Mimics ID:",          "%d", NULL,       8, 31, 8 },
     { CFG_C64_SWAP_BTN, CFG_TYPE_ENUM,   "Button order",                 "%s", buttons,    0,  1, 1 },

--- a/software/io/c64/c64.h
+++ b/software/io/c64/c64.h
@@ -152,21 +152,24 @@
 #define CART_ETH 0x40
 #define CART_RAM 0x20
 
-#define CFG_C64_CART     0xC1
-#define CFG_C64_CUSTOM   0xC2
-#define CFG_C64_REU_EN   0xC3
-#define CFG_C64_REU_SIZE 0xC4
-#define CFG_C64_ETH_EN   0xC5
-#define CFG_C64_SWAP_BTN 0xC6
-#define CFG_C64_DMA_ID   0xC7
-#define CFG_C64_MAP_SAMP 0xC8
-#define CFG_C64_ALT_KERN 0xC9
-#define CFG_C64_KERNFILE 0xCA
-#define CFG_C64_TIMING   0xCB
-#define CFG_C64_PHI2_REC 0xCC
-#define CFG_C64_RATE	 0xCD
-#define CFG_CMD_ENABLE   0x71
-#define CFG_CMD_ALLOW_WRITE   0x72
+#define CFG_C64_CART        0xC1
+#define CFG_C64_CUSTOM      0xC2
+#define CFG_C64_REU_EN      0xC3
+#define CFG_C64_REU_SIZE    0xC4
+#define CFG_C64_ETH_EN      0xC5
+#define CFG_C64_SWAP_BTN    0xC6
+#define CFG_C64_DMA_ID      0xC7
+#define CFG_C64_MAP_SAMP    0xC8
+#define CFG_C64_ALT_KERN    0xC9
+#define CFG_C64_KERNFILE    0xCA
+#define CFG_C64_TIMING      0xCB
+#define CFG_C64_PHI2_REC    0xCC
+#define CFG_C64_RATE        0xCD
+#define CFG_CMD_ENABLE      0x71
+#define CFG_CMD_ALLOW_WRITE 0x72
+#define CFG_C64_REU_PRE     0x80
+#define CFG_C64_REU_IMG     0x81
+#define CFG_C64_REU_OFFS    0x82
 
 #define ID_MODPLAYER 0xAA
 
@@ -258,6 +261,8 @@ public:
         
     friend class FileTypeSID; // sid load does some tricks
     friend class C64_Subsys; // the wrapper with file access
+    friend class REUPreloader; // preloader needs to access config
+    friend class FileTypeREU; // REU file needs to access config 
 };
 
 extern C64 *c64;

--- a/software/io/c64/reu_preloader.cc
+++ b/software/io/c64/reu_preloader.cc
@@ -1,0 +1,101 @@
+#include "reu_preloader.h"
+
+REUPreloader::REUPreloader()
+{
+#ifndef NO_FILE_ACCESS
+    cfg = c64->cfg;
+
+    if(cfg->get_value(CFG_C64_REU_EN) && cfg->get_value(CFG_C64_REU_PRE)) {
+
+        fm = FileManager :: getFileManager();
+        path = fm->get_new_path("REUPreloader");
+        path->cd(cfg->get_string(CFG_C64_REU_IMG));
+
+        observerQueue = new ObserverQueue();
+        fm->registerObserver(observerQueue);
+
+        xTaskCreate( REUPreloader :: poll_reu_preload, "REU Preloader", configMINIMAL_STACK_SIZE, this, tskIDLE_PRIORITY + 1, NULL);
+    }
+#endif
+}
+
+REUPreloader::~REUPreloader()
+{
+    if (observerQueue) {
+        fm->deregisterObserver(observerQueue);
+        delete observerQueue;
+    }
+    if(path) {
+        fm->release_path(path);
+    }
+}
+
+void REUPreloader::poll_reu_preload(void *a)
+{
+    REUPreloader *l = (REUPreloader*)a;
+    l->poll();
+}
+
+void REUPreloader::poll(void)
+{
+    FileManagerEvent *event;
+
+    while(1) {
+        if ((event = (FileManagerEvent *)observerQueue->waitForEvent(0))) {
+
+            if(event->eventType == eNodeUpdated && event->pathName == "/") {
+
+                if(strcasecmp(path->getElement(0), event->newName.c_str()) == 0) {
+
+                    vTaskDelay(25);
+                    preload();
+
+                    vTaskDelete(NULL);
+                    delete(this);
+                    break;
+                }
+            }
+        }
+        vTaskDelay(25);
+    }
+}
+
+
+void REUPreloader :: preload(void)
+{
+#ifndef NO_FILE_ACCESS
+  uint32_t reu_sizes[] =
+    { 0x20000, 0x40000, 0x80000, 0x100000, 0x200000, 0x400000, 0x800000, 0x1000000 };
+
+  if(cfg->get_value(CFG_C64_REU_EN) && cfg->get_value(CFG_C64_REU_PRE)) {
+
+    FileManager *fm = FileManager :: getFileManager();
+    const char *path = cfg->get_string(CFG_C64_REU_IMG);
+
+    File *f = 0;
+    if(fm->fopen(path, FA_READ, &f) != FR_OK) {
+      printf("REU Preloader: Failed to open %s\n", path);
+      return;
+    }
+
+    uint32_t offset = 0;
+    if(cfg->get_value(CFG_C64_REU_OFFS)) {
+      offset = reu_sizes[cfg->get_value(CFG_C64_REU_OFFS)];
+    }
+
+    uint32_t transferred;
+    uint32_t address = REU_MEMORY_BASE + offset;
+    uint32_t size = reu_sizes[cfg->get_value(CFG_C64_REU_SIZE)];
+    
+    if(offset < size) {
+        f->read((uint8_t *)address, size - offset, &transferred);
+        printf("REU preloader: loaded %d bytes to %d from %s\n", transferred, address, path);
+    }
+    else {
+        printf("REU preloader: Preload Offset %d >= REU size %d, skipping\n", offset, size);
+    }
+
+    fm->fclose(f);
+  }
+#endif
+}

--- a/software/io/c64/reu_preloader.h
+++ b/software/io/c64/reu_preloader.h
@@ -1,0 +1,26 @@
+#ifndef REU_PRELOADER_H
+#define REU_PRELOADER_H
+
+#include "observer.h"
+#include "filemanager.h"
+#include "c64.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+class REUPreloader {
+    ObserverQueue *observerQueue;
+    FileManager *fm;
+    ConfigStore *cfg;
+    Path *path;
+    
+    static void poll_reu_preload(void *a);
+    void poll(void);
+    void preload();
+
+  public:
+    REUPreloader();
+    virtual ~REUPreloader();
+};
+
+#endif // REU_PRELOADER_H

--- a/target/software/mb_ultimate/Makefile
+++ b/target/software/mb_ultimate/Makefile
@@ -124,7 +124,8 @@ SRCS_CC	 =  small_printf.cc \
             socket_gui.cc \
 			socket_dma.cc \
             home_directory.cc \
-			$(PRJ).cc
+            reu_preloader.cc \
+            $(PRJ).cc
 
 #            sock_echo.c \
 #			sys_calls.cc \

--- a/target/software/nios2_ultimate/Makefile
+++ b/target/software/nios2_ultimate/Makefile
@@ -133,7 +133,8 @@ SRCS_CC	 =  u2p_init.cc \
 			socket_test.cc \
 			rmii_interface.cc \
             home_directory.cc \
-			$(PRJ).cc
+            reu_preloader.cc \
+            $(PRJ).cc
 
 VPATH +=	$(PATH_SW)/FreeRTOS/Source/portable/nios
 VPATH +=	$(PATH_SW)/portable/nios


### PR DESCRIPTION
Adds three new configuration options to "C64 and cartridge settings":

REU Preload (Enable/Disable)
REU Preload Image (path)
REU PRELOAD Offset (128k - 16M)

If preload is enabled, the specified image will be loaded as soon as
the corresponding filesystem is available, starting at the specified
offset. If the image size exceeds the available REU memory space, the
image is only loaded up to the end of REU memory. No action is taken
if the specified offset is greater or equal to the available REU size.

In addition, this commit adds a "Set as Preload Image" option to the
REU file type.