### PR TITLE
Fix display glitch in C64 and cartridge settings menu

### DIFF
--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -145,8 +145,15 @@ C64::C64()
     flash = get_flash();
 
     if (getFpgaCapabilities() & CAPAB_ULTIMATE2PLUS) {
-        c64_config[7].items = timing2; // hack!
-        c64_config[7].def = 5; // hack!
+        t_cfg_definition *timing;
+
+        for(int i=0; (timing = &c64_config[i])->id != CFG_TYPE_END; i++) {
+            if(timing->id == CFG_C64_TIMING) {
+                timing->items = timing2; // hack!
+                timing->def = 5; // hack!
+                break;
+            }
+        }
     }
     register_store(0x43363420, "C64 and cartridge settings", c64_config);
 


### PR DESCRIPTION
When adding the new REU preload options, a piece of code was overlooked that
adjusts the PHI timing values at runtime for either u2plus or the u64.

This caused the option for the ultimate audio to use 16ns and 32ns as values
rather than enable/disable, and the phi timing options to use the wrong
values as well.

This commits corrects this and similar bugs in the future by looking up
CFG_C64_TIMING by id instead of index.