### PR TITLE
Code cleanup and runstop key support is now made optional

### DIFF
--- a/software/6502/sidcrt/Makefile
+++ b/software/6502/sidcrt/Makefile
@@ -11,7 +11,7 @@ $(TARGETDIR)/player.bin: $(PLAYERDIR)/player.asm
 	$(TOOLS)/64tass/64tass --nostart -o $@ $(PLAYERDIR)/player.asm
 
 $(TARGETDIR)/advancedplayer.bin: $(ADVPLAYERDIR)/advancedplayer.asm $(ADVPLAYERDIR)/clock.asm $(ADVPLAYERDIR)/math.asm $(ADVPLAYERDIR)/timebar.asm $(ADVPLAYERDIR)/keyboard.asm
-	$(TOOLS)/64tass/64tass --nostart -o $@ $(ADVPLAYERDIR)/advancedplayer.asm
+	$(TOOLS)/64tass/64tass --nostart -D INCLUDE_RUNSTOP=0 -o $@ $(ADVPLAYERDIR)/advancedplayer.asm
 
 $(TARGETDIR)/sidcrt.bin: sidcrt.asm relocator.asm memalloc.asm detection.asm songlengths.asm $(TARGETDIR)/player.bin $(TARGETDIR)/advancedplayer.bin
 	$(TOOLS)/64tass/64tass -o $@ -b sidcrt.asm

--- a/software/6502/sidcrt/player/advanced/keyboard.asm
+++ b/software/6502/sidcrt/player/advanced/keyboard.asm
@@ -40,9 +40,10 @@ keyPressed      cmp currentKey,x
                 cpx #$07            ; check for runstop to exit player and for <- key to fastforward tune
                 bne +
 
+.if INCLUDE_RUNSTOP==1
                 cmp #$7f            ; check if runstop key is pressed
                 beq gotoUltimateMenu
-
+.fi
                 cmp #$fd
                 bne +
                 ldy #$01
@@ -96,6 +97,7 @@ plusKey         lda currentSong
                 sta currentSong
 +               jmp selectSubTune
 
+.if INCLUDE_RUNSTOP==1
 gotoUltimateMenu
                 lda $dffd ; Identification register
                 cmp #$c9
@@ -124,7 +126,7 @@ noUCI           inc $d020
                 rts
 busyUCI         inc $d021
                 rts
-
+.fi
                 .section data
 keyRow          .byte $fe, $fd, $fb, $f7, $ef, $df, $bf, $7f
 currentKey      .byte 0, 0, 0, 0, 0, 0, 0, 0

--- a/software/6502/sidcrt/relocator.asm
+++ b/software/6502/sidcrt/relocator.asm
@@ -33,13 +33,13 @@ relocateCode    lda START_HI
 
 -               ldy #$00
                 jsr readAddress
-                cmp #$60            ; RTS is the only exception in opcode size between opcodes from $00-$3f and $40-$7f.
+                cmp #$20            ; JSR is the only exception in opcode size between opcodes from $00-$1f, $20-$3f, $40-$5f and $60-$7f.
                 bne +
-                lda #$00            ; interpret RTS as BRK
+                lda #$4c            ; interpret JSR as JMP
 
-+               and #$ff - $40      ; map $c0-$ff to $80-$bf and $40-$7f to $00-$3f
++               and #$ff - $60      ; map $e0-$ff, $c0-$df, $a0-$bf to $80-$9f and map $60-$7f, $40-$5f, $20-$3f to $00-$1f
                 bpl +
-                eor #$c0            ; map $80-$bf to $40-$7f
+                eor #$80 + $20      ; map $80-$9f to $20-$3f
 +               tax
                 lda opcodeSizes,x
                 pha
@@ -85,14 +85,10 @@ relocByte       tya
                 jmp writeAddress
 
                 ; these opcode sizes are compacted
-                ; opcodes $40-$7f are mapped to $00-$3f, except for RTS ($60) which should be handled separately
-                ; opcodes $80-$bf and $c0-$ff are mapped to $40-$7f
+                ; opcodes $60-$7f, $40-$5f, $20-$3f are mapped to $00-$1f, except for JSR ($20) which should be handled separately
+                ; opcodes $e0-$ff, $c0-$df, $a0-$bf, $80-$9f are mapped to $20-$3f
 opcodeSizes     .byte $01, $02, $01, $02, $02, $02, $02, $02, $01, $02, $01, $02, $03, $03, $03, $03
                 .byte $02, $02, $01, $02, $02, $02, $02, $02, $01, $03, $01, $03, $03, $03, $03, $03
-                .byte $03, $02, $01, $02, $02, $02, $02, $02, $01, $02, $01, $02, $03, $03, $03, $03
-                .byte $02, $02, $01, $02, $02, $02, $02, $02, $01, $03, $01, $03, $03, $03, $03, $03
 
-                .byte $02, $02, $02, $02, $02, $02, $02, $02, $01, $02, $01, $02, $03, $03, $03, $03
-                .byte $02, $02, $01, $02, $02, $02, $02, $02, $01, $03, $01, $03, $03, $03, $03, $03
                 .byte $02, $02, $02, $02, $02, $02, $02, $02, $01, $02, $01, $02, $03, $03, $03, $03
                 .byte $02, $02, $01, $02, $02, $02, $02, $02, $01, $03, $01, $03, $03, $03, $03, $03

--- a/software/6502/sidcrt/sidcrt.asm
+++ b/software/6502/sidcrt/sidcrt.asm
@@ -25,10 +25,9 @@
 ;
 ;-----------------------------------------------------------------------
 
-; TODO
-; - implement reading SSL files for songlength support
-
 ; CONSTANTS
+INCLUDE_RUNSTOP = 1
+
 SID_MODE = $aa
 DMA_MODE = $ab
 
@@ -1095,13 +1094,13 @@ prepareSidHeader
                 jsr readHeader
                 tax
                 tay
-                jsr readHeader     ; get load address low at offset $7c
+                jsr readHeader      ; get load address low at offset $7c
                 ldy #$08            ; set load address low
                 sta (SID_HEADER_LO),y
                 inx
                 txa
                 tay
-                jsr readHeader     ; get load address high at offset $7d
+                jsr readHeader      ; get load address high at offset $7d
                 ldy #$09            ; set load address high
                 sta (SID_HEADER_LO),y
 +
@@ -1733,16 +1732,14 @@ stopPrintData
 
 printNibble     tax
                 inx
-countOne
                 sed
                 ldy #$00
                 lda #$00
 convertToDec    clc
                 adc #$01
-                bcc noIncHundred
+                bcc +
                 iny
-noIncHundred
-                dex
++               dex
                 bne convertToDec
 stopDecConversion
                 cld
@@ -1760,7 +1757,6 @@ stopDecConversion
                 inc $fe
                 pla
 skipFirstNibble2
-
                 pha
                 lsr
                 lsr

--- a/software/6502/sidcrt/songlengths.asm
+++ b/software/6502/sidcrt/songlengths.asm
@@ -63,8 +63,7 @@ valid           lda #$00
 notValid        lda #$01
                 rts
 
-defaultTime
-                ldy #$00            ; set default song lengths to 5 minutes when no SSL or invalid song length is found
+defaultTime     ldy #$00            ; set default song lengths to 5 minutes when no SSL or invalid song length is found
 -               lda #$05            ; 5 minutes
                 jsr writeAddress
                 iny


### PR DESCRIPTION
Some code cleanup and saved some more bytes in the relocator asm file.
The runstop key support is now made optional for the advanced player. This is needed when it is used by ACID64 where UCI is turned off by default. The runstop key is enabled by default for the sidcrt.