### PR TITLE
2nd and 3rd SID addresses are only read when SID header version < 3

### DIFF
--- a/software/6502/sidcrt/sidcrt.asm
+++ b/software/6502/sidcrt/sidcrt.asm
@@ -1294,6 +1294,11 @@ setupScreen     jsr copyChars
 
                 jsr writeScreenData
 
+                ldy #$04            ; read version of header
+                jsr readHeader
+                cmp #$03
+                bcc noMoreSids      ; don't read 2nd SID address when SID header version is less than 3
+
                 ldy #$7a            ; is second SID address defined?
                 jsr readHeader
                 beq noMoreSids
@@ -1479,6 +1484,11 @@ printSidInfo
                 sta TEMP
                 ldx #$01            ; first SID
                 jsr printSingleSidInfo
+
+                ldy #$04            ; read version of header
+                jsr readHeader
+                cmp #$03
+                bcc noMoreSids2     ; don't read 2nd SID address when SID header version is less than 3
 
                 ldy #$7a            ; is second SID address defined?
                 jsr readHeader


### PR DESCRIPTION
This is needed for modified SIDs for Sidplayer64 which injects the song lengths on the location of the 2nd and 3rd SID address in the SID header. Those modified SID files will now not be displayed anymore as 2SID or 3SID files.