### PR TITLE
Reenable Custom Final V1/V2 ROM and Custom CRT

### DIFF
--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -84,7 +84,9 @@ const char *cart_mode[] = { "None",
                       "Custom Snappy ROM",
                       "Custom KCS ROM",
                       "Custom Final V1/V2 ROM",
+#ifndef U64
                       "Custom C128 External ROM",
+#endif
                       "Custom CRT"
                    };
 
@@ -119,7 +121,9 @@ cart_def cartridges[] = { { 0x00,               0x000000, 0x00000,  0x00 | CART_
                           { FLASH_ID_CUSTOM_ROM,0x000000, 0x10000,  0x05 | CART_REU },
                           { FLASH_ID_CUSTOM_ROM,0x000000, 0x04000,  0x10 },
                           { FLASH_ID_CUSTOM_ROM,0x000000, 0x04000,  0x11 },
+#ifndef U64
                           { FLASH_ID_CUSTOM_ROM,0x000000, 0x08000,  0x18 | CART_REU | CART_ETH },
+#endif
                           { FLASH_ID_CUSTOM_ROM,0x000000, 0x00000,  0x00 }
  };
                           
@@ -141,7 +145,7 @@ static const char *fc3mode[] = { "Unchanged", "Desktop", "BASIC" };
 
 struct t_cfg_definition c64_config[] = {
 #if U64
-    { CFG_C64_CART,     CFG_TYPE_ENUM,   "Cartridge",                    "%s", cart_mode,  0, 17, 4 },
+    { CFG_C64_CART,     CFG_TYPE_ENUM,   "Cartridge",                    "%s", cart_mode,  0, 19, 4 },
 #else
     { CFG_C64_CART,     CFG_TYPE_ENUM,   "Cartridge",                    "%s", cart_mode,  0, 21, 4 },
 #endif


### PR DESCRIPTION
This fixes unavailable custom module types on Ultimate 64