### PR TITLE
soft mount d81 images via IEC

### DIFF
--- a/software/application/ultimate/ultimate.cc
+++ b/software/application/ultimate/ultimate.cc
@@ -9,6 +9,7 @@
 #include "c64.h"
 #include "c64_subsys.h"
 #include "c1541.h"
+#include "c1581.h"
 #include "screen.h"
 #include "keyboard.h"
 #include "userinterface.h"
@@ -46,6 +47,7 @@ bool connectedToU64 = false;
 
 C1541 *c1541_A;
 C1541 *c1541_B;
+C1581 *c1581_C;
 
 TreeBrowser *root_tree_browser;
 StreamMenu *root_menu;
@@ -169,7 +171,9 @@ extern "C" void ultimate_main(void *a)
     if(capabilities & CAPAB_DRIVE_1541_2) {
         c1541_B = new C1541(C1541_IO_LOC_DRIVE_2, 'B');
     }
-
+    
+    c1581_C = new C1581('C');
+    
     if(c1541_A) {
     	c1541_A->init();
     }

--- a/software/drive/c1581.cc
+++ b/software/drive/c1581.cc
@@ -1,0 +1,82 @@
+/*
+ * c1581.cc
+ *
+ * Written by 
+ *    Gideon Zweijtzer <info@1541ultimate.net>
+ *    Daniel Kahlin <daniel@kahlin.net>
+ *    Scott Hutter <scott.hutter@gmail.com>
+ *
+ *  This file is part of the 1541 Ultimate-II application.
+ *  Copyright (C) 200?-2011 Gideon Zweijtzer <info@1541ultimate.net>
+ *  Copyright (C) 2011 Daniel Kahlin <daniel@kahlin.net>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include "itu.h"
+#include "dump_hex.h"
+#include "c1581.h"
+#include "c64.h"
+#include "userinterface.h"
+#include "filemanager.h"
+#include "iec.h"
+
+C1581 ::C1581(char letter) : SubSystem(SUBSYSID_DRIVE_C)
+{
+}
+C1581 ::~C1581()
+{
+}
+
+extern IecInterface iec_if;
+
+int C1581 :: executeCommand(SubsysCommand *cmd)
+{
+	bool g64;
+	bool protect;
+	uint8_t flags = 0;
+	File *newFile = 0;
+	FRESULT res;
+	FileInfo info(32);
+
+	switch(cmd->functionID) {
+		case D81FILE_MOUNT:
+		{
+			command_t command;
+			char fullpath[200];
+			strcpy(fullpath, (char *)cmd->path.c_str());
+			strcat(fullpath, (char *)cmd->filename.c_str());
+			strcpy(command.names[0].name,  fullpath);
+			
+			command.cmd = "CD";
+			command.digits = -1;
+
+			IecCommandChannel *ieccmdchnl;
+			ieccmdchnl = iec_if.get_command_channel();
+			ieccmdchnl->exec_command(command);
+			break;
+		}
+		default:
+			printf("Unhandled menu item for C1581.\n");
+			return -1;
+	}
+	return 0;
+}

--- a/software/drive/c1581.h
+++ b/software/drive/c1581.h
@@ -1,0 +1,33 @@
+#ifndef C1581_H_
+#define C1581_H_
+
+#include <stdio.h>
+#include "integer.h"
+#include "filemanager.h"
+#include "file_system.h"
+#include "config.h"
+#include "subsys.h"
+#include "menu.h" // to add menu items
+#include "flash.h"
+#include "iomap.h"
+#include "browsable_root.h"
+#include "iec.h"
+#include "iec_channel.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+#include "semphr.h"
+
+#define D81FILE_MOUNT      0x2102
+
+class C1581 : public SubSystem, ConfigurableObject, ObjectWithMenu
+{
+    public:
+        C1581(char letter);
+        ~C1581();
+        int  executeCommand(SubsysCommand *cmd);
+};
+
+extern C1581 *c1581_C;
+
+#endif

--- a/software/filetypes/filetype_d81.cc
+++ b/software/filetypes/filetype_d81.cc
@@ -1,0 +1,78 @@
+/*
+ * filetype_d81.cc
+ *
+ * Written by 
+ *    Gideon Zweijtzer <info@1541ultimate.net>
+ *    Daniel Kahlin <daniel@kahlin.net>
+ *    Scott Hutter <scott.hutter@gmail.com>
+ *
+ *  This file is part of the 1541 Ultimate-II application.
+ *  Copyright (C) 200?-2011 Gideon Zweijtzer <info@1541ultimate.net>
+ *  Copyright (C) 2011 Daniel Kahlin <daniel@kahlin.net>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "filetype_d81.h"
+#include "directory.h"
+#include "filemanager.h"
+#include "menu.h"
+#include "c64.h"
+#include "c1581.h"
+#include "subsys.h"
+
+extern "C" {
+    #include "dump_hex.h"
+}
+
+// tester instance
+FactoryRegistrator<BrowsableDirEntry *, FileType *> tester_d81(FileType :: getFileTypeFactory(), FileTypeD81 :: test_type);
+
+/*********************************************************************/
+/* D64/D71/D81 File Browser Handling                                 */
+/*********************************************************************/
+
+
+FileTypeD81 :: FileTypeD81(BrowsableDirEntry *node)
+{
+	this->node = node; // link
+}
+
+FileTypeD81 :: ~FileTypeD81()
+{
+
+}
+
+
+int FileTypeD81 :: fetch_context_items(IndexedList<Action *> &list)
+{
+    int count = 0;
+    uint32_t capabilities = getFpgaCapabilities();
+    
+    //if(capabilities & CAPAB_DRIVE_1541_2) {
+        list.append(new Action("Mount Disk on Soft IEC", SUBSYSID_DRIVE_C, D81FILE_MOUNT));
+        count += 1;
+    //}
+    
+    return count;
+}
+
+FileType *FileTypeD81 :: test_type(BrowsableDirEntry *obj)
+{
+	FileInfo *inf = obj->getInfo();
+    if(strcmp(inf->extension, "D81")==0)
+        return new FileTypeD81(obj);
+    return NULL;
+}

--- a/software/filetypes/filetype_d81.h
+++ b/software/filetypes/filetype_d81.h
@@ -1,0 +1,19 @@
+#ifndef FILETYPE_D81_H
+#define FILETYPE_D81_H
+
+#include "filetypes.h"
+#include "browsable_root.h"
+
+class FileTypeD81 : public FileType
+{
+	BrowsableDirEntry *node;
+public:
+    FileTypeD81(BrowsableDirEntry *node);
+    virtual ~FileTypeD81();
+
+    int   fetch_context_items(IndexedList<Action *> &list);
+
+    static FileType *test_type(BrowsableDirEntry *obj);
+};
+
+#endif

--- a/software/infra/subsys.h
+++ b/software/infra/subsys.h
@@ -30,6 +30,7 @@ class UserInterface;
 #define SUBSYSID_IEC             6
 #define SUBSYSID_CMD_IF			 7
 #define SUBSYSID_U64			 8
+#define SUBSYSID_DRIVE_C		 9
 
 class SubSystem  // implements function "executeCommand"
 {

--- a/target/software/nios2_u64/Makefile
+++ b/target/software/nios2_u64/Makefile
@@ -63,6 +63,7 @@ SRCS_CC	 =  u2p_init.cc \
 			keyboard_c64.cc \
 			disk_image.cc \
 			c1541.cc \
+			c1581.cc \
 			bam_header.cc \
 			mystring.cc \
 			path.cc \
@@ -101,6 +102,7 @@ SRCS_CC	 =  u2p_init.cc \
 			filetype_crt.cc \
 			filetype_sid.cc \
 			filetype_bin.cc \
+			filetype_d81.cc \
             host_stream.cc \
             keyboard_vt100.cc \
             screen_vt100.cc \

--- a/target/software/ultimate/Makefile
+++ b/target/software/ultimate/Makefile
@@ -105,6 +105,7 @@ SRCS_CC	 =  stream.cc \
 			keyboard.cc \
 			disk_image.cc \
 			c1541.cc \
+			c1581.cc \
 			bam_header.cc \
 			mystring.cc \
 			path.cc \


### PR DESCRIPTION
This is a means to allow users to "mount" D81 files in the UI.  It calls the CD command of the IEC interface to change directly to the inner D81 file.  If accepted, Ill do the same for D71 files.

Only issue is that mounting in the menus usually results in exiting the menu immediately.  Ill look and see how to do that.  Also, since its just a soft 1581, the disk header is wrong (it shows up at the first file on disk) and the blocks free is wrong. These can also be fixed as I know how to read and allocate the BAM.