### PR TITLE
U2p and u2 fix

### DIFF
--- a/software/io/rtc/rtc.cc
+++ b/software/io/rtc/rtc.cc
@@ -369,7 +369,7 @@ void RtcConfigStore::at_close_config(void)
 {
     printf("** Cfg RTC Write **\n");
 
-    if (!dirty)
+    if (!need_effectuate())
         return;
 
     int y, M, D, wd, h, m, s, corr;
@@ -428,7 +428,7 @@ void RtcConfigStore::at_close_config(void)
     rtc.set_time(y, M, D, wd, h, m, s);
     rtc.set_time_in_chip(corr, y, M, D, wd, h, m, s);
 
-    dirty = false;
+    set_effectuated();
 }
 
 extern "C" uint32_t get_fattime(void) /* 31-25: Year(0-127 org.1980), 24-21: Month(1-12), 20-16: Day(1-31) */

--- a/target/software/nios2_ultimate/Makefile
+++ b/target/software/nios2_ultimate/Makefile
@@ -97,6 +97,7 @@ SRCS_CC	 =  u2p_init.cc \
 			filetype_crt.cc \
 			filetype_sid.cc \
 			filetype_bin.cc \
+			filetype_cfg.cc \
 			host_stream.cc \
 			keyboard_vt100.cc \
 			screen_vt100.cc \
@@ -137,6 +138,7 @@ SRCS_CC	 =  u2p_init.cc \
 			rmii_interface.cc \
 			home_directory.cc \
 			reu_preloader.cc \
+      configio.cc \
 			$(PRJ).cc
 
 VPATH +=	$(PATH_SW)/FreeRTOS/Source/portable/nios


### PR DESCRIPTION
Makes firmware ready for testing on U2+.
On U2, it is also ready for testing.

You may want to add
```
--- a/target/software/mb_ultimate/Makefile
+++ b/target/software/mb_ultimate/Makefile
@@ -91,6 +91,7 @@ SRCS_CC        =  small_printf.cc \
                        filetype_crt.cc \
                        filetype_sid.cc \
                        filetype_bin.cc \
+          filetype_cfg.cc \
             host_stream.cc \
             keyboard_vt100.cc \
             screen_vt100.cc \
@@ -128,6 +129,7 @@ SRCS_CC      =  small_printf.cc \
                        socket_dma.cc \
             home_directory.cc \
             reu_preloader.cc \
+            configio.cc \
             $(PRJ).cc

 #            sock_echo.c \
```

on the U2, but then the Application is too large for current flash configuration.