### PR TITLE
Fix C64_STEREO_ADDRSEL during detection and configuration

### DIFF
--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -1546,6 +1546,7 @@ void U64Config :: S_SetupDetectionAddresses()
     C64_EMUSID2_MASK = 0xFE;
     C64_SID1_EN = 1;
     C64_SID2_EN = 1;
+    C64_STEREO_ADDRSEL = 0;
     wait_ms(1);
 }
 
@@ -1561,6 +1562,7 @@ void U64Config :: S_RestoreDetectionAddresses()
     C64_EMUSID2_MASK = C64_EMUSID2_MASK_BAK;
     C64_SID1_EN = C64_SID1_EN_BAK;
     C64_SID2_EN = C64_SID2_EN_BAK;
+    C64_STEREO_ADDRSEL = C64_STEREO_ADDRSEL_BAK;
 }
 
 int U64Config :: S_SidDetector(int &sid1, int &sid2)


### PR DESCRIPTION
C64_STEREO_ADDRSEL has to be unset during configuration. If it happens to be A8, configuration of the FPGASID in the 2nd socket does not work properly.