### PR TITLE
Geos Ramdisk Support

### DIFF
--- a/software/filetypes/filetype_d64.cc
+++ b/software/filetypes/filetype_d64.cc
@@ -44,9 +44,10 @@ FactoryRegistrator<BrowsableDirEntry *, FileType *> tester_d64(FileType :: getFi
 /*********************************************************************/
 
 
-FileTypeD64 :: FileTypeD64(BrowsableDirEntry *node)
+FileTypeD64 :: FileTypeD64(BrowsableDirEntry *node, int ftype)
 {
 	this->node = node; // link
+	this->ftype = ftype;
 }
 
 FileTypeD64 :: ~FileTypeD64()
@@ -60,21 +61,28 @@ int FileTypeD64 :: fetch_context_items(IndexedList<Action *> &list)
     int count = 0;
     uint32_t capabilities = getFpgaCapabilities();
     C64 *machine = C64 :: getMachine();
-    if(capabilities & CAPAB_DRIVE_1541_1) {
-        list.append(new Action("Mount Disk", SUBSYSID_DRIVE_A, D64FILE_MOUNT));
-    	if (machine->exists())
-    		list.append(new Action("Run Disk", SUBSYSID_DRIVE_A, D64FILE_RUN));
-        list.append(new Action("Mount Disk Read Only", SUBSYSID_DRIVE_A, D64FILE_MOUNT_RO));
-        list.append(new Action("Mount Disk Unlinked", SUBSYSID_DRIVE_A, D64FILE_MOUNT_UL));
-        count += 4;
+    if (ftype == 1541) {
+        if(capabilities & CAPAB_DRIVE_1541_1) {
+            list.append(new Action("Mount Disk", SUBSYSID_DRIVE_A, D64FILE_MOUNT));
+            if (machine->exists())
+                list.append(new Action("Run Disk", SUBSYSID_DRIVE_A, D64FILE_RUN));
+            list.append(new Action("Mount Disk Read Only", SUBSYSID_DRIVE_A, D64FILE_MOUNT_RO));
+            list.append(new Action("Mount Disk Unlinked", SUBSYSID_DRIVE_A, D64FILE_MOUNT_UL));
+            count += 4;
+        }
+    
+        if(capabilities & CAPAB_DRIVE_1541_2) {
+            list.append(new Action("Mount Disk on B", SUBSYSID_DRIVE_B, D64FILE_MOUNT));
+            list.append(new Action("Mount Disk R/O on B", SUBSYSID_DRIVE_B, D64FILE_MOUNT_RO));
+            list.append(new Action("Mount Disk Unl. on B", SUBSYSID_DRIVE_B, D64FILE_MOUNT_UL));
+            count += 3;
+        }
     }
     
-    if(capabilities & CAPAB_DRIVE_1541_2) {
-        list.append(new Action("Mount Disk on B", SUBSYSID_DRIVE_B, D64FILE_MOUNT));
-        list.append(new Action("Mount Disk R/O on B", SUBSYSID_DRIVE_B, D64FILE_MOUNT_RO));
-        list.append(new Action("Mount Disk Unl. on B", SUBSYSID_DRIVE_B, D64FILE_MOUNT_UL));
-        count += 3;
-    }
+    if (C64 :: isMP3RamDrive(0) == ftype) {list.append(new Action("Load into MP3 Drv A", FileTypeD64 :: loadMP3_st, (ftype << 2) | 0)); count++;}
+    if (C64 :: isMP3RamDrive(1) == ftype) {list.append(new Action("Load into MP3 Drv B", FileTypeD64 :: loadMP3_st, (ftype << 2) | 1)); count++;}
+    if (C64 :: isMP3RamDrive(2) == ftype) {list.append(new Action("Load into MP3 Drv C", FileTypeD64 :: loadMP3_st, (ftype << 2) | 2)); count++;}
+    if (C64 :: isMP3RamDrive(3) == ftype) {list.append(new Action("Load into MP3 Drv D", FileTypeD64 :: loadMP3_st, (ftype << 2) | 3)); count++;}
     
     return count;
 }
@@ -83,6 +91,83 @@ FileType *FileTypeD64 :: test_type(BrowsableDirEntry *obj)
 {
 	FileInfo *inf = obj->getInfo();
     if(strcmp(inf->extension, "D64")==0)
-        return new FileTypeD64(obj);
+        return new FileTypeD64(obj, 1541);
+    if(strcmp(inf->extension, "D71")==0)
+        return new FileTypeD64(obj, 1571);
+    if(strcmp(inf->extension, "D81")==0)
+        return new FileTypeD64(obj, 1581);
+    if(strcmp(inf->extension, "DNP")==0)
+        return new FileTypeD64(obj, DRVTYPE_MP3_DNP);
     return NULL;
+}
+
+int FileTypeD64 :: loadMP3_st(SubsysCommand *cmd)
+{
+    int total_bytes_read;
+    uint32_t bytes_read;
+
+    int drvNo = cmd->functionID & 3;
+    int ftype = cmd->functionID >> 2;
+    uint8_t* reu = (uint8_t *)(REU_MEMORY_BASE);
+    uint8_t ramBase = reu[0x7dc7 + drvNo] ;
+    
+    bool ok = C64 :: isMP3RamDrive(drvNo) == ftype;
+    if (ramBase > 0x40) ok=false;
+    if (!ok)
+    {
+       cmd->user_interface->popup("Invalid operation", BUTTON_OK);
+       return -2;
+    }
+    
+    uint8_t* dstAddr = reu+(((uint32_t) ramBase) << 16);
+    
+    int expSize = 1;
+    if (ftype == 1541) expSize = 174848;
+    if (ftype == 1571) expSize = 2*174848;
+    if (ftype == 1581) expSize = 819200;
+    if (ftype == DRVTYPE_MP3_DNP)
+    {
+        expSize = C64 :: getSizeOfMP3NativeRamdrive(drvNo);
+        
+        FileInfo info(32);
+        FileManager *fm = FileManager :: getFileManager();
+        fm->fstat(cmd->path.c_str(), cmd->filename.c_str(), info);
+        int actSize = info.size;
+        
+        if (expSize != actSize)
+        {
+           cmd->user_interface->popup("Size does not match", BUTTON_OK);
+           return -3;
+        }
+        if (expSize > 12*1024*1024)
+        {
+           cmd->user_interface->popup("DNP file too large", BUTTON_OK);
+           return -4;
+        }
+    }
+
+    FileManager *fm = FileManager :: getFileManager();
+    FileInfo info(32);
+    fm->fstat(cmd->path.c_str(), cmd->filename.c_str(), info);
+    
+    File *file = 0;
+	FRESULT fres = fm->fopen(cmd->path.c_str(), cmd->filename.c_str(), FA_READ, &file);
+	if(file) {
+		total_bytes_read = 0;
+		file->read(dstAddr, expSize, &bytes_read);
+		total_bytes_read += bytes_read;
+
+		printf("\nClosing file. ");
+		fm->fclose(file);
+		file = NULL;
+		printf("done.\n");
+                  static char buffer[48];
+			sprintf(buffer, "Bytes loaded: %d ($%8x)", total_bytes_read, total_bytes_read);
+			cmd->user_interface->popup(buffer, BUTTON_OK);
+	} else {
+		printf("Error opening file.\n");
+        cmd->user_interface->popup(FileSystem :: get_error_string(fres), BUTTON_OK);
+		return -2;
+	}
+
 }

--- a/software/filetypes/filetype_d64.h
+++ b/software/filetypes/filetype_d64.h
@@ -7,13 +7,17 @@
 class FileTypeD64 : public FileType
 {
 	BrowsableDirEntry *node;
+	int ftype;
+	
 public:
-    FileTypeD64(BrowsableDirEntry *node);
+    FileTypeD64(BrowsableDirEntry *node, int ftype);
     virtual ~FileTypeD64();
 
     int   fetch_context_items(IndexedList<Action *> &list);
 
     static FileType *test_type(BrowsableDirEntry *obj);
+
+    static int loadMP3_st(SubsysCommand *cmd);
 };
 
 #endif

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -1344,3 +1344,29 @@ bool C64 :: ConfigureU64SystemBus(void)
     return ext_cart;
 }
 #endif
+
+int C64 :: isMP3RamDrive(int drvNo)
+{
+    uint8_t* reu = (uint8_t *)(REU_MEMORY_BASE);
+    uint8_t RealDrvType = reu[0xbb0e + drvNo];
+    uint8_t ramBase = reu[0x7dc7 + drvNo] ;
+    
+    int drvType = 0;
+    if (RealDrvType == 0x81) drvType = 1541;
+    if (RealDrvType == 0x82) drvType = 1571;
+    if (RealDrvType == 0x83) drvType = 1581;
+    if (RealDrvType == 0x84) drvType = DRVTYPE_MP3_DNP;
+    if (RealDrvType == 0xA4) drvType = DRVTYPE_MP3_DNP;
+    if (ramBase > 0x40) drvType = 0;
+    return drvType;
+}
+
+int C64 :: getSizeOfMP3NativeRamdrive(int devNo)
+{
+    uint8_t* reu = (uint8_t *)(REU_MEMORY_BASE);
+    uint8_t DskDrvBaseL = reu[0xbafe + devNo];
+    uint8_t DskDrvBaseH = reu[0xbafe + 4 + devNo];
+    uint16_t dskDrvBase = (((uint16_t) DskDrvBaseH) << 8) | DskDrvBaseL;
+    uint8_t noTracks = reu[dskDrvBase + 0x84];
+    return ((uint32_t) noTracks) << 16;
+}

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -1349,8 +1349,14 @@ int C64 :: isMP3RamDrive(int drvNo)
 {
     uint8_t* reu = (uint8_t *)(REU_MEMORY_BASE);
     uint8_t RealDrvType = reu[0xbb0e + drvNo];
-    uint8_t ramBase = reu[0x7dc7 + drvNo] ;
+    if ((reu[0xbb0e] == 0x03) && (reu[0xbb0f] == 0xA9) && (reu[0xbb10] == 0x06) && (reu[0xbb11] == 0x8D))
+    {
+        RealDrvType = reu[0x798e + drvNo];
+        if (RealDrvType > 0x83)
+            RealDrvType = 0;
+    }
     
+    uint8_t ramBase = reu[0x7dc7 + drvNo] ;
     int drvType = 0;
     if (RealDrvType == 0x81) drvType = 1541;
     if (RealDrvType == 0x82) drvType = 1571;

--- a/software/io/c64/c64.h
+++ b/software/io/c64/c64.h
@@ -25,6 +25,10 @@
 #define MENU_C64_PAUSE      0x640B
 #define MENU_C64_RESUME     0x640C
 #define MENU_U64_SAVERAM    0x640D
+#define MENU_C64_SAVE_MP3_DRV_A 0x640E
+#define MENU_C64_SAVE_MP3_DRV_B 0x640F
+#define MENU_C64_SAVE_MP3_DRV_C 0x6410
+#define MENU_C64_SAVE_MP3_DRV_D 0x6411
 #define C64_DMA_LOAD		0x6464
 #define C64_DRIVE_LOAD	    0x6465
 #define C64_DMA_LOAD_RAW	0x6466
@@ -127,6 +131,8 @@
 #define CART_TYPE_COMAL80PAKMA 0x1A
 #define CART_TYPE_SUPERGAMES   0x1B
 #define CART_TYPE_NORDIC      0x1C
+
+#define DRVTYPE_MP3_DNP       31
 
 #define VIC_REG(x)   *((volatile uint8_t *)(C64_MEMORY_BASE + 0xD000 + x))
 #define CIA1_REG(x)  *((volatile uint8_t *)(C64_MEMORY_BASE + 0xDC00 + x))
@@ -334,6 +340,9 @@ public:
     void reset(void);
     void start(void);
         
+    static int isMP3RamDrive(int dev);
+    static int getSizeOfMP3NativeRamdrive(int dev);
+
     friend class FileTypeSID; // sid load does some tricks
     friend class C64_Subsys; // the wrapper with file access
     friend class REUPreloader; // preloader needs to access config


### PR DESCRIPTION
This patch enables the filebrowser to load an D41, D71, D81 and DNP file into the RAMDISK of Geos 1.3 to 2.0 and Geos Megapatch 3.3 R6 and most probably later. It also enables the filebrowser to save the content of the RAMDISK of the mentioned GEOS versions to an image file.

Note: Ramdisk type and image type must match. And in case of DNP the size must match, too.

Another Note: Geos 2.0 and below do not support DNP Ramdisks, so you cannnot load a DNP file to them.