### PR TITLE
Support for 16k ROM

### DIFF
--- a/fpga/cart_slot/vhdl_source/all_carts_v4.vhd
+++ b/fpga/cart_slot/vhdl_source/all_carts_v4.vhd
@@ -41,6 +41,7 @@ port (
     serve_io1       : out std_logic; -- IO1n
     serve_io2       : out std_logic; -- IO2n
     allow_write     : out std_logic;
+    kernal_bank     : out  std_logic_vector(1 downto 0);
 
     mem_addr        : out unsigned(25 downto 0);   
 
@@ -915,9 +916,13 @@ begin
         if kernal_area='1' then
             if kernal_16k='0' then
                mem_addr_i <= g_kernal_base(27 downto 14) & slot_addr(12 downto 0) & '0';
+               kernal_bank <= "00";
            else
-               mem_addr_i <= g_rom_base(27 downto 15) & (not sense) & slot_addr(12 downto 0) & '0';
+               mem_addr_i <= g_rom_base(27 downto 15) & slot_addr(12 downto 0) & '0' & '0';
+               kernal_bank <= '0' & (not sense);
            end if;
+        else
+            kernal_bank <= "00";
         end if;
 
     end process;

--- a/fpga/cart_slot/vhdl_source/slot_server_v4.vhd
+++ b/fpga/cart_slot/vhdl_source/slot_server_v4.vhd
@@ -153,6 +153,7 @@ architecture structural of slot_server_v4 is
     signal serve_io1       : std_logic := '0'; -- IO1n
     signal serve_io2       : std_logic := '0'; -- IO2n
     signal allow_write     : std_logic := '0';
+    signal kernal_bank     : std_logic_vector(1 downto 0);
 
     -- kernal replacement logic
     signal kernal_area     : std_logic := '0';
@@ -401,6 +402,7 @@ begin
         serve_io1       => serve_io1, -- IO1n
         serve_io2       => serve_io2, -- IO2n
         allow_write     => allow_write,
+        kernal_bank     => kernal_bank,
 
         -- kernal emulation
         kernal_enable   => control.kernal_enable,
@@ -531,6 +533,7 @@ begin
         serve_io1       => serve_io1, -- IO1n
         serve_io2       => serve_io2, -- IO2n
         allow_write     => allow_write,
+        kernal_bank     => kernal_bank,
         kernal_area     => kernal_area,
         kernal_enable   => control.kernal_enable,
         kernal_16k      => control.kernal_16k,

--- a/fpga/cart_slot/vhdl_source/slot_slave.vhd
+++ b/fpga/cart_slot/vhdl_source/slot_slave.vhd
@@ -53,6 +53,7 @@ port (
     serve_io1       : in  std_logic := '0'; -- IO1n
     serve_io2       : in  std_logic := '0'; -- IO2n
     allow_write     : in  std_logic := '0';
+    kernal_bank     : in  std_logic_vector(1 downto 0) := "00";
     kernal_enable   : in  std_logic := '0';
     kernal_probe    : out std_logic := '0';
     kernal_area     : out std_logic := '0';
@@ -97,6 +98,8 @@ architecture gideon of slot_slave is
     signal kernal_area_i    : std_logic;
     signal mem_data_0       : std_logic_vector(7 downto 0) := X"00";
     signal mem_data_1       : std_logic_vector(7 downto 0) := X"00";
+    signal mem_data_2       : std_logic_vector(7 downto 0) := X"00";
+    signal mem_data_3       : std_logic_vector(7 downto 0) := X"00";
     signal data_mux         : std_logic;
     
     attribute register_duplication : string;
@@ -250,9 +253,13 @@ begin
                     if g_big_endian then
                         mem_data_0 <= mem_rdata(31 downto 24);
                         mem_data_1 <= mem_rdata(23 downto 16);
+                        mem_data_2 <= mem_rdata(15 downto 8);
+                        mem_data_3 <= mem_rdata(7 downto 0);
                     else
                         mem_data_0 <= mem_rdata(7 downto 0);
                         mem_data_1 <= mem_rdata(15 downto 8);
+                        mem_data_2 <= mem_rdata(23 downto 16);
+                        mem_data_3 <= mem_rdata(31 downto 24);
                     end if;
                     dav      <= '1';
                 end if;
@@ -338,7 +345,11 @@ begin
         
     BUFFER_ENn <= '0';
 
-    DATA_out <= mem_data_0 when data_mux='0' else mem_data_1;
+    -- DATA_out <= mem_data_0 when data_mux='0' else mem_data_1;
+    DATA_out <= mem_data_0 when data_mux='0' else
+                mem_data_1 when kernal_bank = "00" else
+                mem_data_2 when kernal_bank = "01" else
+                mem_data_3;
                                 
     slot_req.data        <= mem_wdata_i;
     slot_req.bus_address <= unsigned(address_c(15 downto 0));

--- a/software/filetypes/filetype_crt.cc
+++ b/software/filetypes/filetype_crt.cc
@@ -763,8 +763,13 @@ void FileTypeCRT::configure_cart(void)
         if (total_read > 8192) {
             C64_KERNAL_ENABLE = 3;
             uint8_t *src = (uint8_t *) (((uint32_t)C64_CARTRIDGE_RAM_BASE) << 16);
-            for (int i = 16383; i >= 0; i--)
-                *(src + 2 * i + 1) = *(src + i);
+            for (int i = 16383; i > 0; i--)
+                *(src + 4 * i) = *(src + i);
+            for (int i = 8191; i >= 0; i--)
+            {
+                *(src + 4 * i + 1) = *(src + 4*i);
+                *(src + 4 * i + 2) = *(src + 32768 + 4*i);
+            }
         } else {
             uint8_t *src = (uint8_t *) (((uint32_t)C64_CARTRIDGE_RAM_BASE) << 16);
             int fastreset = C64 :: getMachine()->get_cfg_value(CFG_C64_FASTRESET);


### PR DESCRIPTION
This patch removes the restiction that 16k kernal switch RAM, which is wrong.

It also prepairs for 24k kernals.