### PR TITLE
Fix D71 loading into MP3 ramdisk

### DIFF
--- a/software/filetypes/filetype_d64.cc
+++ b/software/filetypes/filetype_d64.cc
@@ -154,7 +154,14 @@ int FileTypeD64 :: loadMP3_st(SubsysCommand *cmd)
 	FRESULT fres = fm->fopen(cmd->path.c_str(), cmd->filename.c_str(), FA_READ, &file);
 	if(file) {
 		total_bytes_read = 0;
-		file->read(dstAddr, expSize, &bytes_read);
+    if (ftype == 1571)
+    {
+		   file->read(dstAddr, expSize/2, &bytes_read);
+		   total_bytes_read += bytes_read;
+		   file->read(dstAddr+700*256, expSize/2, &bytes_read);
+    }
+    else
+		   file->read(dstAddr, expSize, &bytes_read);
 		total_bytes_read += bytes_read;
 
 		printf("\nClosing file. ");

--- a/software/io/c64/c64_subsys.cc
+++ b/software/io/c64/c64_subsys.cc
@@ -495,7 +495,15 @@ int C64_Subsys :: executeCommand(SubsysCommand *cmd)
                     printf("Opened file successfully.\n");
                     uint32_t bytes_written;
 
-                    f->write(srcAddr, expSize, &bytes_written);
+                    if (ftype == 1571)
+                    {
+                       f->write(srcAddr, expSize/2, &bytes_written);
+                       uint32_t tmp;
+                       f->write(srcAddr+700*256, expSize/2, &tmp);
+                       bytes_written += tmp;
+                    }
+                    else
+                       f->write(srcAddr, expSize, &bytes_written);
 
                     printf("written: %d...", bytes_written);
                     sprintf(buffer, "bytes saved: %d ($%8x)", bytes_written, bytes_written);


### PR DESCRIPTION
Due to an incorrect default setting in GEOS V2, which was adopted from MP3 for compatibility reasons, D71 disk images cannot be read directly.

This patch makes it work.

Now I have sucessfully loaded source code from all supported image types, so they all work.