### PR TITLE
Fix USB keyboard shift handling

### DIFF
--- a/software/io/usb/keyboard_usb.cc
+++ b/software/io/usb/keyboard_usb.cc
@@ -148,7 +148,7 @@ void Keyboard_USB :: usb2matrix(uint8_t *kd)
 	// 1 = left shift   | 5 = right shift
 	// 2 = left alt     | 6 = right alt (altGr)
 	// 3 = left windows | 7 = right windows
-	uint8_t modi = kd[0];
+	const uint8_t modi = kd[0];
     // const uint8_t modifier_locations[] = { 0x72, 0x17, 0x00, 0x75, 0x72, 0x64, 0x00, 0x75 };
 	// without shift
 	const uint8_t modifier_locations[] = { 0x72, 0x00, 0x00, 0x75, 0x72, 0x00, 0x00, 0x75 };
@@ -162,8 +162,8 @@ void Keyboard_USB :: usb2matrix(uint8_t *kd)
 	}
 
 	// Handle the modifiers
-	for(int i=0;i<8;i++, modi >>= 1) {
-		if (modi & 1) {
+	for(int i=0;i<8;i++) {
+		if (modi & (1 << i)) {
 			uint8_t bit = modifier_locations[i];
 			if (bit) {
 				// printf("M%i ", i);


### PR DESCRIPTION
The for statement on line 165 was clearing all bits of the
modi variable causing the if statements testing for the
shift state, to become NOPs. Fix this by making modi const
to prevent this from happening again and checking the modifier
bits using a mask.

Fixes issue #168.

Signed-off-by: Peter De Schrijver <p2@psychaos.be>