### PR TITLE
Add numeric response codes to modem

### DIFF
--- a/software/io/acia/modem.cc
+++ b/software/io/acia/modem.cc
@@ -500,7 +500,7 @@ int Modem :: ExecuteCommand(ModemCommand_t *cmd)
     char responseBuffer[16];
     int registerValue, temp;
 
-    response = (verbose==TRUE ? responseText[0] : responseCode[0]);
+    response = (verbose==TRUE ? responseText[RESP_OK] : responseCode[RESP_OK]);
 
     printf("MODEM COMMAND: '%s'\n", cmd->command);
 

--- a/software/io/acia/modem.cc
+++ b/software/io/acia/modem.cc
@@ -569,6 +569,10 @@ int Modem :: ExecuteCommand(ModemCommand_t *cmd)
             	response = (verbose==TRUE ? responseText[RESP_OK] : responseCode[RESP_OK]);
             }
             break;
+        case 'E':
+        case 'M':
+        	response = (verbose==TRUE ? responseText[RESP_OK] : responseCode[RESP_OK]);
+        	break;
         case 'S': // register select
             registerSelect = 0;
             sscanf(cmd->command + i + 1, "%d", &registerSelect);

--- a/software/io/acia/modem.cc
+++ b/software/io/acia/modem.cc
@@ -571,7 +571,18 @@ int Modem :: ExecuteCommand(ModemCommand_t *cmd)
             break;
         case 'E':
         case 'M':
-        	response = (verbose==TRUE ? responseText[RESP_OK] : responseCode[RESP_OK]);
+            sscanf(cmd->command + i + 1, "%d", &temp);
+            while(i < cmd->length && (isdigit(cmd->command[i+1])))
+                i++;
+
+            if(temp>1)
+            {
+            	response = (verbose==TRUE ? responseText[RESP_ERROR] : responseCode[RESP_ERROR]);
+            }
+            else
+            {
+            	response = (verbose==TRUE ? responseText[RESP_OK] : responseCode[RESP_OK]);
+            }
         	break;
         case 'S': // register select
             registerSelect = 0;

--- a/software/io/acia/modem.cc
+++ b/software/io/acia/modem.cc
@@ -20,10 +20,32 @@
 #define CFG_MODEM_OFFLINEFILE 0x0B
 #define CFG_MODEM_LISTEN_RING 0x0C
 
+#define RESP_OK				0
+#define RESP_CONNECT		1
+#define RESP_RING			2
+#define RESP_NO_CARRIER		3
+#define RESP_ERROR			4
+#define RESP_CONNECT_1200	5
+#define RESP_NO_DIALTONE	6
+#define RESP_BUSY			7
+#define RESP_NO_ANSWER		8
+#define RESP_CONNECT_2400	9
+#define RESP_CONNECT_4800	10
+#define RESP_CONNECT_9600	11
+#define RESP_CONNECT_14400	12
+#define RESP_CONNECT_19200	13
+#define RESP_CONNECT_38400	14
+
 static const char *interfaces[] = { "ACIA / SwiftLink" };
 static const char *acia_mode[] = { "Off", "DE00/IRQ", "DE00/NMI", "DF00/IRQ", "DF00/NMI", "DF80/IRQ", "DF80/NMI" };
 static const char *dcd_dsr[] = { "Active (Low)", "Active when connected", "Inactive when connected", "Inactive (High)", "Act. when connecting", "Inact. when connecting" };
 static const int acia_base[] = { 0, 0xDE00, 0xDE01, 0xDF00, 0xDF01, 0xDF80, 0xDF81 };
+static char *responseCode[] = {"\r0\r","\r1\r","\r2\r","\r3\r","\r4\r","\r5\r","\r6\r","\r7\r","\r8\r",
+								"\r10\r","\r11\r","\r12\r","\r13\r","\r14\r","\r28\r"};
+static char *responseText[] = {"\rOK\r","\rCONNECT\r","\rRING\r","\rNO CARRIER\r","\rERROR\r","\rCONNECT 1200\r",
+								"\rNO DIALTONE\r","\rBUSY\r","\rNO ANSWER\r","\rCONNECT 2400\r","\rCONNECT 4800\r",
+								"\rCONNECT 9600\r","\rCONNECT 14400\r","\rCONNECT 19200\r","\rCONNECT 38400\r"};
+
 
 /*
 static const AciaMessage_t setDSR = { ACIA_MSG_DSR, 1, 0 };
@@ -73,6 +95,7 @@ Modem :: Modem()
     baudRate = 0;
     dropOnDTR = true;
     lastHandshake = 0;
+    verbose = true;
     ResetRegisters();
 }
 
@@ -204,12 +227,21 @@ void Modem :: IncomingConnection(int socket)
         ModemCommand_t modemCommand;
         registerValues[MODEM_REG_RINGCOUNTER] = 0;
         for(int rings=0; rings < 10; rings++) {
-            acia.SendToRx((uint8_t *)"RING\r", 5);
-            int len = sprintf(buffer, "RING\n");
-            registerValues[MODEM_REG_RINGCOUNTER] ++;
-            if (send(socket, buffer, len, 0) <= 0) {
-                break;
-            }
+
+        	responseString = (verbose==TRUE ? responseText[RESP_RING] : responseCode[RESP_RING]);
+        	responseLen = strlen(responseString);
+        	acia.SendToRx((uint8_t *)responseString, responseLen);
+
+            registerValues[MODEM_REG_RINGCOUNTER]++;
+
+            // this is removed because we dont want to send a response to the user
+            // while they are dialing.  if they dial a number and they see "RING  RING"
+            // it could be confused with an incoming RING. dialing out doesnt display anything
+            // until either gives up or connected
+            //
+            //if (send(socket, responseString, responseLen, 0) <= 0) {
+            //    break;
+            //}
             if (registerValues[MODEM_REG_AUTOANSWER]) {
                 if (registerValues[MODEM_REG_RINGCOUNTER] >= registerValues[MODEM_REG_AUTOANSWER]) {
                     keepConnection = true;
@@ -229,17 +261,39 @@ void Modem :: IncomingConnection(int socket)
         }
 
         if (keepConnection) {
-            int len = sprintf(buffer, "CONNECT %d\r", baudRate);
-            acia.SendToRx((uint8_t*)buffer, len);
-            buffer[len-1] = 0x0a; // Use Newline instead of carriage return for the socket
-            send(socket, buffer, len, 0);
+
+        	uint8_t tmp = RESP_CONNECT;
+
+        	switch(baudRate)
+        	{
+        		case 1200: { tmp=RESP_CONNECT_1200; break; }
+        		case 2400: { tmp=RESP_CONNECT_2400; break; }
+        		case 4800: { tmp=RESP_CONNECT_4800; break; }
+        		case 9600: { tmp=RESP_CONNECT_9600; break; }
+        		case 14400: { tmp=RESP_CONNECT_14400; break; }
+        		case 19200: { tmp=RESP_CONNECT_19200; break; }
+        		case 38400: { tmp=RESP_CONNECT_38400; break; }
+        	}
+
+        	responseString = responseText[tmp];
+        	responseLen = strlen(responseString);
+
+            acia.SendToRx((uint8_t*)responseString, responseLen);
+
+            // I dont believe this should be delivered locally
+            // per usage of other modems
+            //buffer[len-1] = 0x0a; // Use Newline instead of carriage return for the socket
+            //send(socket, buffer, len, 0);
 
             RunRelay(socket);
-            len = sprintf(buffer, "NO CARRIER\r");
-            acia.SendToRx((uint8_t*)buffer, len);
+
+            responseString = (verbose==TRUE ? responseText[RESP_NO_CARRIER] : responseCode[RESP_NO_CARRIER]);
+            responseLen=strlen(responseString);
+            acia.SendToRx((uint8_t*)responseString, responseLen);
         } else {
-            int len = sprintf(buffer, "NO ANSWER\n");
-            send(socket, buffer, len, 0);
+        	responseString = (verbose==TRUE ? responseText[RESP_NO_ANSWER] : responseCode[RESP_NO_ANSWER]);
+        	responseLen=strlen(responseString);
+            send(socket, responseString, responseLen, 0);
         }
     } else {
         // Silent relay
@@ -332,7 +386,9 @@ void Modem :: Caller()
     while(1) {
         xQueueReceive(connectQueue, &cmd, portMAX_DELAY);
         if (xSemaphoreTake(connectionLock, 50) != pdTRUE) {
-            acia.SendToRx((uint8_t *)"MODEM BUSY\r", 11);
+        	responseString = (verbose==TRUE ? responseText[RESP_BUSY] : responseCode[RESP_BUSY]);
+        	responseLen=strlen(responseString);
+            acia.SendToRx((uint8_t *)responseString, responseLen );
             continue;
         }
 
@@ -347,14 +403,18 @@ void Modem :: Caller()
         int result = gethostbyname_r(cmd.command, &my_host, buffer, 128, &ret_host, &error);
 
         if (!ret_host) {
-            acia.SendToRx((uint8_t *)"RESOLVE ERROR\r", 14);
+        	responseString = (verbose==TRUE ? responseText[RESP_NO_ANSWER] : responseCode[RESP_NO_ANSWER]);
+        	responseLen=strlen(responseString);
+            acia.SendToRx((uint8_t *)responseString, responseLen);
             xSemaphoreGive(connectionLock);
             continue;
         }
 
         int sock_fd = socket(AF_INET, SOCK_STREAM, 0);
         if (sock_fd < 0) {
-            acia.SendToRx((uint8_t *)"NO SOCKET\r", 10);
+        	responseString = (verbose==TRUE ? responseText[RESP_ERROR] : responseCode[RESP_ERROR]);
+        	responseLen=strlen(responseString);
+        	acia.SendToRx((uint8_t *)responseString, responseLen);
             xSemaphoreGive(connectionLock);
             continue;
         }
@@ -369,7 +429,9 @@ void Modem :: Caller()
         serv_addr.sin_port = htons(portno);
 
         if (connect(sock_fd, (struct sockaddr *)&serv_addr,sizeof(serv_addr)) < 0) {
-            acia.SendToRx((uint8_t *)"NO CARRIER\r", 14);
+        	responseString = (verbose==TRUE ? responseText[RESP_NO_CARRIER] : responseCode[RESP_NO_CARRIER]);
+        	responseLen=strlen(responseString);
+        	acia.SendToRx((uint8_t *)responseString, responseLen);
             xSemaphoreGive(connectionLock);
             continue;
         }
@@ -377,11 +439,15 @@ void Modem :: Caller()
         //dump_hex(buffer, 128);
         // run the relay
 
-        acia.SendToRx((uint8_t *)"CONNECTED\r", 10);
+        responseString = (verbose==TRUE ? responseText[RESP_CONNECT] : responseCode[RESP_CONNECT]);
+		responseLen=strlen(responseString);
+		acia.SendToRx((uint8_t *)responseString, responseLen);
         keepConnection = true;
         RunRelay(sock_fd);
         lwip_close(sock_fd);
-        acia.SendToRx((uint8_t *)"NO CARRIER\r", 14);
+        responseString = (verbose==TRUE ? responseText[RESP_NO_CARRIER] : responseCode[RESP_NO_CARRIER]);
+        responseLen=strlen(responseString);
+        acia.SendToRx((uint8_t *)responseString, responseLen);
         keepConnection = false;
         xSemaphoreGive(connectionLock);
     }
@@ -430,9 +496,11 @@ int Modem :: ExecuteCommand(ModemCommand_t *cmd)
 {
     int connectionStateChange = 0;
     char *c;
-    const char *response = "OK\r";
+    const char *response;
     char responseBuffer[16];
     int registerValue, temp;
+
+    response = (verbose==TRUE ? responseText[0] : responseCode[0]);
 
     printf("MODEM COMMAND: '%s'\n", cmd->command);
 
@@ -479,13 +547,27 @@ int Modem :: ExecuteCommand(ModemCommand_t *cmd)
                 commandMode = false;
                 response = "";
             } else {
-                response = "NO CARRIER\r";
+            	response = (verbose==TRUE ? responseText[RESP_NO_CARRIER] : responseCode[RESP_NO_CARRIER]);
             }
             break;
         case 'V': // Verbose mode
             sscanf(cmd->command + i + 1, "%d", &temp);
             while(i < cmd->length && (isdigit(cmd->command[i+1])))
                 i++;
+
+            if(temp>1)
+            {
+            	response = (verbose==TRUE ? responseText[RESP_ERROR] : responseCode[RESP_ERROR]);
+            }
+            else
+            {
+            	if(temp == 1)
+            		verbose=TRUE;
+            	else
+            		verbose=FALSE;
+
+            	response = (verbose==TRUE ? responseText[RESP_OK] : responseCode[RESP_OK]);
+            }
             break;
         case 'S': // register select
             registerSelect = 0;
@@ -505,7 +587,7 @@ int Modem :: ExecuteCommand(ModemCommand_t *cmd)
             WriteRegister(registerValue);
             break;
         default:
-            response = "?\r";
+        	response = (verbose==TRUE ? responseText[RESP_ERROR] : responseCode[RESP_ERROR]);
             i = cmd->length; // break outer loop
             break;
         }

--- a/software/io/acia/modem.h
+++ b/software/io/acia/modem.h
@@ -46,7 +46,6 @@ class Modem : public ConfigurableObject
     uint8_t ctsMode, dsrMode, dcdMode;
     uint8_t lastHandshake;
     char *responseString;
-    ModemCommand_t prevCommand;
     uint8_t responseLen;
     bool verbose;
     bool keepConnection;

--- a/software/io/acia/modem.h
+++ b/software/io/acia/modem.h
@@ -45,6 +45,10 @@ class Modem : public ConfigurableObject
     ListenerSocket *listenerSocket;
     uint8_t ctsMode, dsrMode, dcdMode;
     uint8_t lastHandshake;
+    char *responseString;
+    ModemCommand_t prevCommand;
+    uint8_t responseLen;
+    bool verbose;
     bool keepConnection;
     bool commandMode;
     bool busyMode;


### PR DESCRIPTION
This code should provide numeric response codes via atv0

also, fixed a potential issue of showing RING from calling side.  RING should only be sent to listener