### PR TITLE
Patch to set default device#8 on init

### DIFF
--- a/roms/c64rom/basic/code26.s
+++ b/roms/c64rom/basic/code26.s
@@ -162,7 +162,7 @@ plsv
 ;
 ;default device #
 ;
-	ldx #1          ;device #1
+	ldx $ba         ;current device
 	ldy #0          ;command 0
 	jsr $ffba
 ;
@@ -208,7 +208,7 @@ paoc	lda #0
 	jsr getbyt      ;get la
 	stx andmsk
 	txa
-	ldx #1          ;default device
+	ldx $ba         ;current device
 	ldy #0          ;default command
 	jsr $ffba       ;store it
 	jsr paoc20      ;skip junk

--- a/roms/c64rom/kernal/editor.3.s
+++ b/roms/c64rom/kernal/editor.3.s
@@ -136,7 +136,7 @@ tvic
 	.byt $9b,55,0,0,0,$08,0,$14,$0f,0,0,0,0,0,0 ;data (17-31)
 	.byt 14,6,1,2,3,4,0,1,2,3,4,5,6,7 ;32-46
 ;
-runtb	.byt "LOAD",$d,"RUN",$d
+runtb	.byt "L",$6F,$22,$2a,$22,$d,"R",$75,$d  ;load and run first file
 ;
 linz0	= vicscn
 linz1	= linz0+llen

--- a/roms/c64rom/kernal/init.s
+++ b/roms/c64rom/kernal/init.s
@@ -20,7 +20,7 @@ start	ldx #$ff
 	jmp ($8000)     ; go init as $a000 rom wants
 start1	stx vicreg+22   ;set up refresh (.x=<5)
 	jsr ioinit      ;go initilize i/o devices
-	jsr ramtas      ;go ram test and set
+	jsr devpatch    ;go ram test and set  (call ramtas and set default device after, through patch)
 	jsr ulti_restor ;go set up os vectors
 ;
 	jsr pcint       ;go initilize screen newxxx

--- a/roms/c64rom/kernal/patches.s
+++ b/roms/c64rom/kernal/patches.s
@@ -1,7 +1,15 @@
 	.segment "KPATCH"
 
 	; unused patch area
-	.res 28, $aa
+	.res 20, $aa
+
+; devpatch - default device patch for ultimate 64
+;
+devpatch
+    jsr ramtas
+    ldx #8
+    stx fa
+    rts  
 
 ; prtyp - rs232 parity patch...added 901227-03
 ;


### PR DESCRIPTION
Also changed Shift-RUN/STOP behaviour to be disk-friendly, and does not reset device# on load/save.   Used kernal patch area so to not shift bytes.