### PR TITLE
Fix closing device 3 using HyperSpeed kernal 

### DIFF
--- a/roms/c64rom/kernal/uci.s
+++ b/roms/c64rom/kernal/uci.s
@@ -207,19 +207,19 @@ op2         pla ; throw away return address and exit
 ulticlose   cmp OUR_DEVICE
             beq myclose
 cl1         cmp #3
-            beq op2       ;is screen...done
+            beq closeexit ;is screen...done
             rts           ; return to caller with original flags due to cmp #3
 
 myclose     ldx CMD_IF_COMMAND
             cpx #UCI_IDENTIFIER
             bne cl1
 
-            pla         ; kill return address
-            pla         ; kill return address
             ldx #UCI_CMD_CLOSE
             jsr uci_setup_cmd
             jsr uci_execute
             jsr uci_ack
+closeexit   pla         ; kill return address
+            pla         ; kill return address			
             jmp jx150
 
 ; $FFE4   


### PR DESCRIPTION
Fix HyperSpeed Kernal closing of device 3 (screen).
FB user reported this basic code crashes at the close statement:
10 open 8,3
20 close 8

After fix, code snip works fine.  FB user seems happier now.