### PR TITLE
Squeeze file and directory names if they are too long

### DIFF
--- a/software/userinterface/browsable.h
+++ b/software/userinterface/browsable.h
@@ -68,6 +68,7 @@ public:
 	virtual Browsable *getParent() { return 0; }
 	virtual const char *getName() { return "Browsable"; }
 	virtual void getDisplayString(char *buffer, int width) { strncpy(buffer, getName(), width-1); }
+	virtual void getDisplayString(char *buffer, int width, int squeeze_option) { getDisplayString(buffer, width); }
 };
 
 

--- a/software/userinterface/tree_browser_state.cc
+++ b/software/userinterface/tree_browser_state.cc
@@ -153,7 +153,8 @@ void TreeBrowserState :: draw_item(Browsable *t, int line, bool selected)
 		} else { // non selectable item
 			browser->window->set_color(12); // TODO
 		}
-		t->getDisplayString(buffer, browser->window->get_size_x());
+		int squeeze_type = browser->user_interface->filename_overflow_squeeze;
+		t->getDisplayString(buffer, browser->window->get_size_x(), squeeze_type);
 		browser->window->output_line(buffer);
         browser->window->set_background(0);
     } else {
@@ -172,7 +173,8 @@ void TreeBrowserState :: update_selected(void)
     browser->window->move_cursor(0, selected_line);
     browser->window->set_color(browser->user_interface->color_sel); // highlighted
     browser->window->set_background(browser->user_interface->color_sel_bg);
-    under_cursor->getDisplayString(buffer, browser->window->get_size_x());
+    int squeeze_type = browser->user_interface->filename_overflow_squeeze;
+    under_cursor->getDisplayString(buffer, browser->window->get_size_x(), squeeze_type);
     browser->window->output_line(buffer);
 }
     

--- a/software/userinterface/userinterface.cc
+++ b/software/userinterface/userinterface.cc
@@ -19,6 +19,7 @@
 static const char *colors[] = { "Black", "White", "Red", "Cyan", "Purple", "Green", "Blue", "Yellow",
                          "Orange", "Brown", "Pink", "Dark Grey", "Mid Grey", "Light Green", "Light Blue", "Light Grey" };
                           
+static const char *filename_overflow_squeeze[] = { "None", "Beginning", "Middle", "End" };
 static const char *itype[]      = { "Freeze", "Overlay on HDMI" };
 static const char *cfg_save[]   = { "No", "Ask", "Yes" };
 
@@ -38,6 +39,7 @@ struct t_cfg_definition user_if_config[] = {
     { CFG_USERIF_START_HOME, CFG_TYPE_ENUM,   "Enter Home on Startup", "%s", en_dis, 0,  1, 0 },
     { CFG_USERIF_CFG_SAVE,   CFG_TYPE_ENUM,   "Auto Save Config",      "%s", cfg_save, 0, 2, 1 },
     { CFG_USERIF_ULTICOPY_NAME, CFG_TYPE_ENUM, "Ulticopy Uses disk name", "%s", en_dis, 0, 1, 1 },
+    { CFG_USERIF_FILENAME_OVERFLOW_SQUEEZE, CFG_TYPE_ENUM, "Filename overflow squeeze", "%s", filename_overflow_squeeze, 0, 3, 0 },
     { CFG_TYPE_END,           CFG_TYPE_END,    "", "", NULL, 0, 0, 0 }         
 };
 
@@ -52,6 +54,7 @@ UserInterface :: UserInterface(const char *title) : title(title)
     doBreak = false;
     available = false;
     color_sel_bg = 0;
+    filename_overflow_squeeze = 0;
     register_store(0x47454E2E, "User Interface Settings", user_if_config);
     effectuate_settings();
 }
@@ -79,6 +82,7 @@ void UserInterface :: effectuate_settings(void)
     color_sel_bg = cfg->get_value(CFG_USERIF_SELECTED_BG);
 #endif
     config_save  = cfg->get_value(CFG_USERIF_CFG_SAVE);
+    filename_overflow_squeeze = cfg->get_value(CFG_USERIF_FILENAME_OVERFLOW_SQUEEZE);
 
     if(host && host->is_accessible())
         host->set_colors(color_bg, color_border);

--- a/software/userinterface/userinterface.h
+++ b/software/userinterface/userinterface.h
@@ -26,6 +26,7 @@
 #define CFG_USERIF_SELECTED_BG 0x09
 #define CFG_USERIF_CFG_SAVE    0x0A
 #define CFG_USERIF_ULTICOPY_NAME 0x0B
+#define CFG_USERIF_FILENAME_OVERFLOW_SQUEEZE 0x0C
 
 class UserInterface : public ConfigurableObject, public HostClient
 {
@@ -46,7 +47,7 @@ private:
     bool buttonDownFor(uint32_t ms);
     UIStatusBox *status_box;
 public:
-    int color_border, color_bg, color_fg, color_sel, color_sel_bg, config_save;
+    int color_border, color_bg, color_fg, color_sel, color_sel_bg, config_save, filename_overflow_squeeze;
 
     GenericHost *host;
     Keyboard *keyboard;


### PR DESCRIPTION
Adds an UI option to "User Interface Settings" -> "Filename overflow squeeze"
that allows user to select the squeeze point (None/Beginning/Middle/End)

Kind of fixes "Long file name, can name be scrolled?":
https://github.com/GideonZ/1541ultimate/issues/212