### PR TITLE
Allow loading & configurationg ROM of floppies

### DIFF
--- a/software/drive/c1541.h
+++ b/software/drive/c1541.h
@@ -164,6 +164,8 @@ public:
     // Called from user interface thread?  Is this allowed at all? -> no no, the interface thread should
     // issue a subsys command.
     void swap_disk(void);
+
+    friend class FileTypeBin; // bin file needs to access config
 };
 
 extern C1541 *c1541_A;

--- a/software/drive/c1581.cc
+++ b/software/drive/c1581.cc
@@ -635,6 +635,9 @@ int C1581 :: executeCommand(SubsysCommand *cmd)
 	case MENU_1541_REMOVE:
 		remove_disk();
 		break;
+  case FLOPPY_LOAD_DOS:
+  	memcpy((void *)&memory_map[0x8000], (void*) cmd->buffer, 0x8000);
+    break;
     	
 	default:
 		printf("Unhandled menu item for C1581.\n");

--- a/software/drive/c1581.h
+++ b/software/drive/c1581.h
@@ -134,6 +134,9 @@ public:
     bool get_drive_power();
 
     uint8_t IrqHandler(void);
+
+
+    friend class FileTypeBin; // bin file needs to access config
 };
 
 extern C1581 *c1581_C;

--- a/software/filetypes/filetype_bin.h
+++ b/software/filetypes/filetype_bin.h
@@ -8,9 +8,10 @@ class FileTypeBin : public FileType
 {
 	BrowsableDirEntry *node;
     static int execute_st(SubsysCommand *cmd);
+    static int setcfg_st(SubsysCommand *cmd);
     int execute(SubsysCommand *cmd);
     int load_kernal(SubsysCommand *cmd);
-    int load_dos(SubsysCommand *cmd);
+    int load_dos(SubsysCommand *cmd, int dev);
 public:
     FileTypeBin(BrowsableDirEntry *node);
     virtual ~FileTypeBin();


### PR DESCRIPTION
This is usefull at least until redesign is finished. It allows setting of Floppy ROMs from directory "/flash" via file browser.
Can be extended to other roms whenever tehy are switched to the new method.