### PR TITLE
Rework socket DMA for disks and cartridge files

### DIFF
--- a/software/network/socket_dma.h
+++ b/software/network/socket_dma.h
@@ -12,14 +12,14 @@
 #include "filemanager.h"
 #include "subsys.h"
 
-#define SOCKET_BUFFER_SIZE 200000
+#define SOCKET_BUFFER_SIZE 16384
 
 class SocketDMA {
 	static void dmaThread(void *a);
 	static void performCommand(int socket, void *load_buffer, int length, uint16_t cmd, uint32_t len, struct in_addr *client_ip);
 	static int  readSocket(int socket, void *buffer, int max_remain);
 	static int  writeSocket(int socket, void *buffer, int length);
-
+	static int readSocketToFile(int socket, const char *filename, void *buffer, uint32_t len);
 	uint8_t *load_buffer;
 public:
 	SocketDMA();


### PR DESCRIPTION
Rather than downloading the whole image into a 200KB buffer and then
writing the buffer to a ramdisk file, use a 16KB buffer and append
the data to the ramdisk file as it is received. This allows for images
larger than 200KB (eg easyflash CRT images or D81 images). With some more
work this can also be used for flashing the update and the esp32 images
using socket DMA.

Signed-off-by: Peter De Schrijver <p2@psychaos.be>