### PR TITLE
Provide alternate mappings for pound/up-arrow.

### DIFF
--- a/software/io/c64/transform.cc
+++ b/software/io/c64/transform.cc
@@ -38,13 +38,13 @@ const uint8_t keymap_usb[] = {
     'u', 'v', 'w', 'x', 'y', 'z', '1', '2',
     '3', '4', '5', '6', '7', '8', '9', '0',
     KEY_RETURN, KEY_ESCAPE, KEY_BACK, KEY_TAB, ' ', '-', '=', '[',
-    ']', '\\', 0x00, ';', '\'', '`', ',', '.',
+    ']', '\\', '\\', ';', '\'', '`', ',', '.',
     '/', KEY_CAPS, KEY_F1, KEY_F2, KEY_F3, KEY_F4, KEY_F5, KEY_F6,
     KEY_F7, KEY_F8, KEY_F9, KEY_F10, KEY_F11, KEY_F12, KEY_PRSCR, KEY_SCRLOCK,
     KEY_BREAK, KEY_INSERT, KEY_HOME, KEY_PAGEUP, KEY_DELETE, KEY_END, KEY_PAGEDOWN, KEY_RIGHT,
     KEY_LEFT, KEY_DOWN, KEY_UP, KEY_NUMLOCK, '/', '*', '-', '+',
     KEY_RETURN, '1', '2', '3', '4', '5', '6', '7',
-    '8', '9', '0', '.', 0x00 };
+    '8', '9', '0', '.', '|'};
 
 const uint8_t keymap_usb_shifted[] = {
     0x00, KEY_ERR, KEY_ERR, KEY_ERR, 'A', 'B', 'C', 'D',
@@ -53,13 +53,13 @@ const uint8_t keymap_usb_shifted[] = {
     'U', 'V', 'W', 'X', 'Y', 'Z', '!', '@',
     '#', '$', '%', '^', '&', '*', '(', ')',
     0x8D, KEY_ESCAPE, KEY_INSERT, KEY_TAB, KEY_SHIFT_SP, '-', '+', '{',
-    '}', '|', 0x00, ':', '\"', '~', '<', '>',
+    '}', '|', '|', ':', '\"', '~', '<', '>',
     '?', KEY_CAPS, KEY_F1, KEY_F2, KEY_F3, KEY_F4, KEY_F5, KEY_F6,
     KEY_F7, KEY_F8, KEY_F9, KEY_F10, KEY_F11, KEY_F12, KEY_PRSCR, KEY_SCRLOCK,
     KEY_BREAK, KEY_INSERT, KEY_HOME, KEY_PAGEUP, KEY_DELETE, KEY_END, KEY_PAGEDOWN, KEY_RIGHT,
     KEY_LEFT, KEY_DOWN, KEY_UP, KEY_NUMLOCK, '/', '*', '-', '+',
     0x8D, '1', '2', '3', '4', '5', '6', '7',
-    '8', '9', '0', '.', 0x00 };
+    '8', '9', '0', '.', '^'};
 
 // BSS, thus zero
 uint8_t mapped[64];


### PR DESCRIPTION
International keyboards don't have the key that's mapped to those, so this change maps the key one row below that was previously unmapped and another unmapped key between Shift and Z.