### PR TITLE
Fix drv info

### DIFF
--- a/software/drive/c1541.cc
+++ b/software/drive/c1541.cc
@@ -367,6 +367,13 @@ int  C1541 :: get_current_iec_address(void)
 	return iec_address;
 }
 
+int  C1541 :: get_effective_iec_address(void)
+{
+	if(registers[C1541_POWER]) // if powered, read actual address from its ram
+		return int(memory_map[0x78] & 0x1F);
+	return iec_address;
+}
+
 bool C1541 :: check_if_save_needed(SubsysCommand *cmd)
 {
     if ((disk_state == e_gcr_disk) && (!gcr_image_up_to_date)) {

--- a/software/drive/c1541.h
+++ b/software/drive/c1541.h
@@ -182,6 +182,7 @@ public:
 
     // called from IEC (UltiCopy)
     int  get_current_iec_address(void);    
+    int  get_effective_iec_address(void);    
     void drive_power(bool on);
     bool get_drive_power();
     t_drive_type get_drive_type() { return current_drive_type; }

--- a/software/drive/c1581.cc
+++ b/software/drive/c1581.cc
@@ -232,6 +232,13 @@ int  C1581 :: get_current_iec_address(void)
 	return iec_address;
 }
 
+int  C1541 :: get_effective_iec_address(void)
+{
+	if(registers[C1541_POWER]) // if powered, read actual address from its ram
+		return int(memory_map[0x78] & 0x1F);
+	return iec_address;
+}
+
 void C1581 :: remove_disk(void)
 {
     registers[C1541_INSERTED] = 0;

--- a/software/drive/c1581.h
+++ b/software/drive/c1581.h
@@ -131,6 +131,7 @@ public:
 
     // Misc
     int  get_current_iec_address(void);
+    int  get_effective_iec_address(void);    
     bool get_drive_power();
 
     uint8_t IrqHandler(void);

--- a/software/filemanager/dos.cc
+++ b/software/filemanager/dos.cc
@@ -70,10 +70,10 @@ C1541* Dos::getDriveByID(uint8_t id) {
     C1541* drive = NULL;
 
     if (id) {
-        if (c1541_A != NULL && c1541_A->get_current_iec_address() == id) {
+        if (c1541_A != NULL && c1541_A->get_drive_power() && c1541_A->get_effective_iec_address() == id) {
             drive = c1541_A;
-        } else if (c1541_B != NULL
-                && c1541_B->get_current_iec_address() == id) {
+        } else if (c1541_B != NULL && c1541_B->get_drive_power() 
+                && c1541_B->get_effective_iec_address() == id) {
             drive = c1541_B;
         }
     } else {

--- a/software/io/command_interface/control_target.cc
+++ b/software/io/command_interface/control_target.cc
@@ -215,14 +215,14 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
             if (c1541_A) {
                 data_message.message[0]++;
                 data_message.message[offs++] = (uint8_t)c1541_A->get_drive_type();
-                data_message.message[offs++] = (uint8_t)c1541_A->get_current_iec_address();
+                data_message.message[offs++] = (uint8_t)c1541_A->get_effective_iec_address();
                 data_message.message[offs++] = c1541_A->get_drive_power() ? 1 : 0;
                 data_message.length += 3;
             }
             if (c1541_B) {
                 data_message.message[0]++;
                 data_message.message[offs++] = (uint8_t)c1541_B->get_drive_type();
-                data_message.message[offs++] = (uint8_t)c1541_B->get_current_iec_address();
+                data_message.message[offs++] = (uint8_t)c1541_B->get_effective_iec_address();
                 data_message.message[offs++] = c1541_B->get_drive_power() ? 1 : 0;
                 data_message.length += 3;
             }

--- a/software/io/command_interface/control_target.cc
+++ b/software/io/command_interface/control_target.cc
@@ -206,6 +206,9 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
             break;
         }
         case CTRL_CMD_GET_DRVINFO: {
+            int effectiveOD = 1;
+            if (command->length > 2)
+               effectiveOD = command->message[2];
             data_message.length = 1;
             data_message.message[0] = 0;
             data_message.last_part = true;
@@ -215,14 +218,20 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
             if (c1541_A) {
                 data_message.message[0]++;
                 data_message.message[offs++] = (uint8_t)c1541_A->get_drive_type();
-                data_message.message[offs++] = (uint8_t)c1541_A->get_effective_iec_address();
+                if (effectiveOD)
+                    data_message.message[offs++] = (uint8_t)c1541_A->get_effective_iec_address();
+                else
+                    data_message.message[offs++] = (uint8_t)c1541_A->get_current_iec_address();
                 data_message.message[offs++] = c1541_A->get_drive_power() ? 1 : 0;
                 data_message.length += 3;
             }
             if (c1541_B) {
                 data_message.message[0]++;
                 data_message.message[offs++] = (uint8_t)c1541_B->get_drive_type();
-                data_message.message[offs++] = (uint8_t)c1541_B->get_effective_iec_address();
+                if (effectiveOD)
+                    data_message.message[offs++] = (uint8_t)c1541_B->get_effective_iec_address();
+                else
+                    data_message.message[offs++] = (uint8_t)c1541_B->get_current_iec_address();
                 data_message.message[offs++] = c1541_B->get_drive_power() ? 1 : 0;
                 data_message.length += 3;
             }


### PR DESCRIPTION
CMD_GET_DRVINFO returned the hardware ID of the device (that is the one the DIP switches of the 1541 II are configured) instead of the software ID.

This patch improved the UCI call that by default the software ID is returned, but the calling programm can specify that the hardware ID is wanted.