### PR TITLE
Fix writing Dxx Images

### DIFF
--- a/software/drive/disk_image.cc
+++ b/software/drive/disk_image.cc
@@ -1092,15 +1092,11 @@ int BinImage :: save(File *file, UserInterface *user_interface)
 
 	if(errors && error_size >= secs) {
 	    uint8_t orred = 0;
-	    int esize = error_size;
-	    if (secs < esize) {
-	        esize = secs;
-	    }
-	    for(int i=0;i<esize;i++) {
+	    for(int i=0;i<secs;i++) {
 	       orred |= errors[i];
 	    }
 	    if (orred) { // contains valid error data
-            res = file->write(errors, esize, &transferred);
+            res = file->write(errors, secs, &transferred);
             if(res != FR_OK) {
                 printf("WRITE ERROR: %d. Transferred = %d\n", res, transferred);
                 return -4;


### PR DESCRIPTION
To reproduce the problem to be solved:

(1) Load a D64 image (or probably other image) into the Floppy Drive A
(2) F5, Drive A, Save Binary, Enter Filename
(3) Observe that the size is not the expected size, in case d64 it should be 683 × 256 ≈ 171k, but the filemanager shows 172k and its size is exactly 686 × 256.

This patch fixes that.