### PR TITLE
GeoRAM is indeed compatible with UCI

### DIFF
--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -940,7 +940,7 @@ void C64::set_cartridge(cart_def *cart)
         } else if (cfg->get_value(CFG_C64_REU_EN) == 2) { // GeoRAM
             current_cart_def.type = CART_TYPE_GEORAM;
             current_cart_def.name = "GeoRAM Cartridge";
-            current_cart_def.prohibit = CART_PROHIBIT_IO;
+            current_cart_def.prohibit = CART_PROHIBIT_ALL_BUT_REU;
         }
 #endif
     } else {


### PR DESCRIPTION
In Forum 64, it was found that GeoRAM together with UCI cannot be enabled. But they can work together.

Note that since REU and GeoRAM are set up by the same setting with different values, we know in advance that both are not enabled.