### PR TITLE
This might fix HomeDir on startup

### DIFF
--- a/software/userinterface/home_directory.cc
+++ b/software/userinterface/home_directory.cc
@@ -16,7 +16,7 @@ HomeDirectory::HomeDirectory(UserInterface *ui, TreeBrowser *browser)
     observerQueue = new ObserverQueue("HomeDir");
     fm->registerObserver(observerQueue);
 
-//    xTaskCreate( HomeDirectory :: poll_home_directory, "Home Directory", configMINIMAL_STACK_SIZE, this, tskIDLE_PRIORITY + 1, NULL);
+    xTaskCreate( HomeDirectory :: poll_home_directory, "Home Directory", configMINIMAL_STACK_SIZE, this, tskIDLE_PRIORITY + 1, NULL);
 #endif
 }
 


### PR DESCRIPTION
The function "Enter Home Directory" does not work anymore . I set it to "enabled" and selected a directory with C= + CLR HOME, but it does not jump there after power on, it stays in the root directory.

commit a04784e65c94a9418a4d16797c34a72b6f63a1b3
Date:   Sat Aug 20 00:57:41 2022 +0200

    [WIP] Trying to get DDR2 memory stable on Lattice ECP5, using dynamic phase shift and locking PLL for sys clock.

has disabled its Task, probably by accident not restored later.