### PR TITLE
Fix IEC and Printer objects initialization sequence

### DIFF
--- a/software/io/iec/iec.cc
+++ b/software/io/iec/iec.cc
@@ -576,10 +576,12 @@ SubsysResultCode_e IecInterface :: executeCommand(SubsysCommand *cmd)
 	switch(cmd->functionID) {
 		case MENU_IEC_ON:
 			iec_enable = 1;
+			cfg->set_value(CFG_IEC_ENABLE, iec_enable);
                         iec_drive_enable(iec_enable);
 			break;
 		case MENU_IEC_OFF:
 			iec_enable = 0;
+			cfg->set_value(CFG_IEC_ENABLE, iec_enable);
 			iec_drive_enable(iec_enable);
 			break;
 		case MENU_IEC_RESET:

--- a/software/io/iec/iec.cc
+++ b/software/io/iec/iec.cc
@@ -299,9 +299,7 @@ IecInterface :: IecInterface() : SubSystem(SUBSYSID_IEC)
         channels[i] = new IecChannel(this, i);
     }
     channels[15] = new IecCommandChannel(this, 15);
-    
-    iec_printer->init_done();
-
+ 
     ulticopyBusy = xSemaphoreCreateBinary();
     ulticopyMutex = xSemaphoreCreateMutex();
     queueGuiToIec = xQueueCreate(2, sizeof(char *));

--- a/software/io/printer/iec_printer.cc
+++ b/software/io/printer/iec_printer.cc
@@ -99,20 +99,33 @@ static struct t_cfg_definition iec_printer_config[] = {
     { 0xFF,                   CFG_TYPE_END,    "",                  "",   NULL,   0,  0, 0 }
 };
 
-/* This is where the virtual printer is created */
-IecPrinter *iec_printer;
+/* =======  Subsystem creation and registration */
 
-// this global will cause us to run!
+/* This is the pointer to the virtual printer */
+IecPrinter *iec_printer = NULL;
+
+/* This will create the IecPrinter object */
 static void init_printer(void *_a, void *_b)
 {
     iec_printer = new IecPrinter();
-    if (iec_printer->get_current_printer_address() == 0) {
+
+    if (iec_printer->get_current_printer_address() == 0)
+    {
         delete iec_printer;
         iec_printer = NULL;
     }
 }
-InitFunction iec_printer_init(init_printer, NULL, NULL);
 
+/*-
+ *
+ *  This global will cause us to run!
+ *
+ *  Order=10 to be sure the IEC is already created when the Printer object
+ *  is initialized, the printer will need to register with the IEC, so the
+ *  IEC must exist
+ *
+-*/
+InitFunction iec_printer_init(init_printer, NULL, NULL, 10);
 
 /************************************************************************
 *                  IecPrinter::effectuate_settings()            Public  *

--- a/software/io/printer/iec_printer.cc
+++ b/software/io/printer/iec_printer.cc
@@ -276,11 +276,13 @@ SubsysResultCode_e IecPrinter::executeCommand(SubsysCommand *cmd)
         case MENU_PRINTER_ON:
             reset();
             printer_enable = 1;
+            cfg->set_value(CFG_PRINTER_ENABLE, printer_enable);
             iec_if->iec_printer_enable(printer_enable);
             break;
 
         case MENU_PRINTER_OFF:
             printer_enable = 0;
+            cfg->set_value(CFG_PRINTER_ENABLE, printer_enable);
             iec_if->iec_printer_enable(printer_enable);
             break;
 

--- a/software/io/printer/iec_printer.cc
+++ b/software/io/printer/iec_printer.cc
@@ -360,8 +360,7 @@ IecPrinter::IecPrinter() : SubSystem(SUBSYSID_PRINTER)
     last_printer_addr = 4;
     mps = MpsPrinter::getMpsPrinter();
     buffer_pointer = 0;
-    output_type = PRINTER_PNG_OUTPUT;
-    init = true;
+    output_type = PRINTER_UNSET_OUTPUT;
     cmd_ui = 0;
     is_color = false;
 
@@ -602,30 +601,6 @@ int IecPrinter::flush(void)
         open_file();
 
     close_file();
-
-    return IEC_OK;
-}
-
-/************************************************************************
-*                           IecPrinter::init_done()             Pubic   *
-*                           ~~~~~~~~~~~~~~~~~~~~~~~                     *
-* Function : Tell IecPrinter that system init is done                   *
-*            printer is disabled while system init                      *
-*-----------------------------------------------------------------------*
-* Inputs:                                                               *
-*                                                                       *
-*    none                                                               *
-*                                                                       *
-*-----------------------------------------------------------------------*
-* Outputs:                                                              *
-*                                                                       *
-*    IEC_OK always                                                      *
-*                                                                       *
-************************************************************************/
-
-int IecPrinter::init_done(void)
-{
-    init = false;
 
     return IEC_OK;
 }
@@ -1013,7 +988,8 @@ int IecPrinter::set_output_type(int t)
             break;
     }
 
-    if (!init && new_output_type != output_type)
+    // Don't close file on first selection (from nvram or default)
+    if ((output_type != PRINTER_UNSET_OUTPUT) && (new_output_type != output_type))
         close_file();
 
     output_type = new_output_type;

--- a/software/io/printer/iec_printer.h
+++ b/software/io/printer/iec_printer.h
@@ -56,7 +56,8 @@
 /*********************************  Types  ******************************/
 
 enum t_printer_output_type {
-    PRINTER_PNG_OUTPUT=0,
+    PRINTER_UNSET_OUTPUT=0,
+    PRINTER_PNG_OUTPUT,
     PRINTER_RAW_OUTPUT,
     PRINTER_ASCII_OUTPUT
 };
@@ -118,9 +119,6 @@ class IecPrinter : public SubSystem, ObjectWithMenu, ConfigurableObject
         /* Printer is color (only used for progress bar) */
         bool is_color;
 
-        /* Flag set to true while in Ultimate init sequence */
-        bool init;
-
         /* User interface descriptor */
         UserInterface *cmd_ui;
 
@@ -157,7 +155,6 @@ class IecPrinter : public SubSystem, ObjectWithMenu, ConfigurableObject
         int push_data(uint8_t b);
         int push_command(uint8_t b);
         int flush(void);
-        int init_done(void);
         int reset(void);
 
         /* =======  Interface menu */


### PR DESCRIPTION
Printer must register to IEC so IEC has to exist before Printer. And therefore, don't call Printer methods from IEC constructor. On previous firmware versions (up to 3.10j) IEC and Printer objects were statically declared at compilation time. Now they are dynamically created at system startup.