### PR TITLE
Support 81 track d81 images

### DIFF
--- a/software/drive/c1541.cc
+++ b/software/drive/c1541.cc
@@ -494,7 +494,7 @@ void C1541 :: insert_disk(bool protect, GcrImage *image)
 void C1541 :: map_gcr_image_to_mfm(void)
 {
     MfmDisk *mfm = mfm_controller->get_disk();
-    mfm->init(fmt_Clear);
+    mfm->init(fmt_Clear, 80);
     clear_mfm_dirty_bits();
 
     for(int z=0; z < 2; z++) {
@@ -555,7 +555,14 @@ void C1541 :: mount_d64(bool protect, File *file, int mode)
 	    return;
 	}
 	if (mode == 1581) {
-	    mfm_controller->format_d81();
+      FileInfo ffi(INFO_SIZE);
+      int tracks = 80;
+      FRESULT res = fm->fstat(file->get_path(), ffi);
+      if (res == FR_OK) {
+         tracks = ffi.size / 10240;
+      }
+
+	    mfm_controller->format_d81(tracks);
 	    mfm_controller->set_file(mount_file);
 	    mfm_controller->set_track_update_callback(NULL, NULL);
 	    registers[C1541_SOUNDS] = 1; // play insert sound

--- a/software/drive/disk_image.cc
+++ b/software/drive/disk_image.cc
@@ -1300,6 +1300,35 @@ SubsysResultCode_e ImageCreator :: S_createD71(SubsysCommand *cmd)
     return (fres == FR_OK) ? SSRET_OK : SSRET_DISK_ERROR;
 }
 
+SubsysResultCode_e ImageCreator :: S_createD81_81(SubsysCommand *cmd)
+{
+    FileManager *fm = FileManager :: getFileManager();
+    File *f = 0;
+    uint32_t written;
+    char name_buffer[32];
+    name_buffer[0] = 0;
+    FRESULT fres = create_user_file(cmd->user_interface, "Give name for new disk..", ".d81", cmd->path.c_str(), &f, name_buffer);
+    if (fres == FR_OK) {
+        fres = write_zeros(f, 81*10240, written);
+    }
+    if (fres == FR_OK) {
+        fres = f->seek(0);
+    }
+    if (fres == FR_OK) {
+        BlockDevice_File blk(f, 256);
+        Partition prt(&blk, 0, 0, 0);
+        FileSystemD81 fs(&prt, true);
+        fs.format(name_buffer);
+    }
+    if (fres != FR_OK) {
+        cmd->user_interface->popup(FileSystem :: get_error_string(fres), BUTTON_OK);
+    }
+    if (f) {
+        fm->fclose(f);
+    }
+    return (fres == FR_OK) ? SSRET_OK : SSRET_DISK_ERROR;
+}
+
 SubsysResultCode_e ImageCreator :: S_createD81(SubsysCommand *cmd)
 {
     FileManager *fm = FileManager :: getFileManager();

--- a/software/drive/disk_image.h
+++ b/software/drive/disk_image.h
@@ -145,17 +145,18 @@ extern BinImage static_bin_image; // for general use
 class ImageCreator : public ObjectWithMenu
 {
     TaskCategory *taskCategory;
-    Action *d64, *g64, *d71, *g71, *d81, *dnp;
+    Action *d64, *g64, *d71, *g71, *d81, *d81_81, *dnp;
 public:
 	ImageCreator() {
 	    taskCategory = TasksCollection :: getCategory("Create", SORT_ORDER_CREATE);
-	    d64 = g64 = d71 = g71 = d81 = dnp = NULL;
+	    d64 = g64 = d71 = g71 = d81 = d81_81 = dnp = NULL;
 	}
 	~ImageCreator() { }
 
 	static SubsysResultCode_e S_createD64(SubsysCommand *cmd);
     static SubsysResultCode_e S_createD71(SubsysCommand *cmd);
     static SubsysResultCode_e S_createD81(SubsysCommand *cmd);
+    static SubsysResultCode_e S_createD81_81(SubsysCommand *cmd);
     static SubsysResultCode_e S_createDNP(SubsysCommand *cmd);
 
 	// object with menu
@@ -166,12 +167,14 @@ public:
         d71 = new Action("D71 Image", ImageCreator :: S_createD71, 0, 0); // may also be created using createD64 with mode 2
         g71 = new Action("G71 Image", ImageCreator :: S_createD64, 0, 3);
         d81 = new Action("D81 Image", ImageCreator :: S_createD81, 0, 0);
+        d81_81 = new Action("D81 (81 Tr.)", ImageCreator :: S_createD81_81, 0, 0);
         dnp = new Action("DNP Image", ImageCreator :: S_createDNP, 0, 0);
         taskCategory->append(d64);
         taskCategory->append(g64);
         taskCategory->append(d71);
         taskCategory->append(g71);
         taskCategory->append(d81);
+        taskCategory->append(d81_81);
         taskCategory->append(dnp);
     }
 
@@ -182,6 +185,7 @@ public:
         d71->setDisabled(!writablePath);
         g71->setDisabled(!writablePath);
         d81->setDisabled(!writablePath);
+        d81_81->setDisabled(!writablePath);
         dnp->setDisabled(!writablePath);
 	}
 };

--- a/software/drive/mfmdisk.cc
+++ b/software/drive/mfmdisk.cc
@@ -90,7 +90,7 @@ int MfmDisk :: AddDataSpace(int physTrack, int physSide, const uint32_t pos, con
     return 0;
 }
 
-uint32_t MfmDisk :: init(MfmFormat_t type)
+uint32_t MfmDisk :: init(MfmFormat_t type, int tracks)
 {
     uint32_t size = 0;
     uint32_t offset = 0;
@@ -101,7 +101,7 @@ uint32_t MfmDisk :: init(MfmFormat_t type)
 
     switch(type) {
     case fmt_D81:
-        for (int t=0;t<80;t++) {
+        for (int t=0;t<tracks;t++) {
             side0[t].actualDataSize = 5120;
             side0[t].reservedSpace = 5120;
             side0[t].numSectors = 10;

--- a/software/drive/mfmdisk.h
+++ b/software/drive/mfmdisk.h
@@ -52,7 +52,7 @@ public:
     int AddDataSpace(int physTrack, int physSide, const uint32_t pos, const uint32_t size);
 
     // Predefined Formats. Returns the required data size
-    uint32_t init(MfmFormat_t type);
+    uint32_t init(MfmFormat_t type, int tracks);
 
     // Get track reference for external manipulation
     MfmTrack *GetTrack(int track, int side);

--- a/software/drive/wd177x.cc
+++ b/software/drive/wd177x.cc
@@ -517,9 +517,9 @@ int WD177x :: decode_write_track(uint8_t *inbuf, uint8_t *outbuf, MfmTrack& newT
 	return 0; // OK
 }
 
-void WD177x :: format_d81(void)
+void WD177x :: format_d81(int tracks)
 {
-    disk.init(fmt_D81);
+    disk.init(fmt_D81, tracks);
 }
 
 void WD177x :: set_file(File *f)

--- a/software/drive/wd177x.h
+++ b/software/drive/wd177x.h
@@ -96,7 +96,7 @@ public:
 
     void init(void);
     uint8_t IrqHandler(void);
-    void format_d81(void);
+    void format_d81(int);
     void set_file(File *);
     MfmDisk *get_disk(void);
     void set_track_update_callback(void *obj, track_update_callback_t func);


### PR DESCRIPTION
Well, Geos Wheels 4.1, 4.2 and 4.4 (both C64 & C128) has copy protection on track 81 for master disks and therefore need this extended format.