### PR TITLE
add missing include in promgen.c to make gcc14 happy

### DIFF
--- a/tools/promgen.c
+++ b/tools/promgen.c
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 
 #ifndef uchar


### PR DESCRIPTION
tools/promgen.c no longer compiles with gcc14 because implicit declaration of memcmp which is now an error. This pull request adds the required include statement to this file.