### PR TITLE
Fix printf() replacing %x with an empty string

### DIFF
--- a/software/system/small_printf.cc
+++ b/software/system/small_printf.cc
@@ -176,8 +176,10 @@ _my_vprintf(void (*putc)(char c, void **param), void **param, const char *fmt, v
             case 'x': // any hex length
             case 'X': // any hex length
                 addr = va_arg(ap, int); // up to dword
-                _hex(addr, buf, width);
                 length = width;
+                if(!length || length > 8)
+                    length = 8;
+                _hex(addr, buf, length);
                 cp = buf;
                 break;
             case 'b': // byte


### PR DESCRIPTION
The default width for %x was zero causing an empty string to be inserted when no explicit width was supplied. Changed the default width to 8 (covers all data in the supplied 32 bit "int" argument). Also added protection against too large widths being specified.