### PR TITLE
Add missing session skip on failed accept() for ftp server

### DIFF
--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -184,6 +184,7 @@ int FTPDaemon::listen_task()
         int actual_socket = accept(sockfd, (struct sockaddr * ) &cli_addr, &clilen);
         if (actual_socket < 0) {
             puts("FTPD: ERROR on accept");
+            continue;  // Remote probably closed, just wait for another connection
             // return -3;
         }
 


### PR DESCRIPTION
When the FTP socket listener accept() returns a negative number (aborted connection, no new socket created or other error) the current code just continues to do setsockopt() on the negative number then launches a new  FTPDaemonThread() which will likely just fail.

This patch ignores the failed accept() and goes back to waiting for new connections in accept().

There is a  "return -3" commented out, probably because this would terminate the entire FTP server just because one connection attempt was aborted.