### PR TITLE
Make sure users terminal is restored when exiting a Telnet session

### DIFF
--- a/software/io/stream/host_stream.cc
+++ b/software/io/stream/host_stream.cc
@@ -24,3 +24,9 @@ Keyboard *HostStream :: getKeyboard(void)
 	}
 	return keyboard;
 }
+
+void HostStream :: release_ownership(void) {
+	if (screen) {
+		((Screen_VT100 *)screen)->restore_terminal();
+	}
+}

--- a/software/io/stream/host_stream.h
+++ b/software/io/stream/host_stream.h
@@ -36,6 +36,8 @@ public:
     
     Screen   *getScreen(void);
     Keyboard *getKeyboard(void);
+
+    void release_ownership(void);
 };
 
 #endif /* IO_STREAM_HOST_STREAM_H_ */

--- a/software/io/stream/screen_vt100.cc
+++ b/software/io/stream/screen_vt100.cc
@@ -138,3 +138,9 @@ void Screen_VT100::sync(void)
 {
 	stream->sync();
 }
+
+void Screen_VT100::restore_terminal(void) {
+    stream->write("\ec\e[2J", 6);  // RIS (Reset Initial State) + ED2 (Clear entire screen)
+    move_cursor(0, 0);
+    sync();
+}

--- a/software/io/stream/screen_vt100.h
+++ b/software/io/stream/screen_vt100.h
@@ -39,6 +39,9 @@ public:
 
     // Synchronization
     void sync(void);
+
+    // VT100 specific
+    void restore_terminal(void);
 };
 
 #endif /* IO_STREAM_SCREEN_VT100_H_ */

--- a/software/userinterface/userinterface.cc
+++ b/software/userinterface/userinterface.cc
@@ -124,6 +124,7 @@ void UserInterface :: run_remote(void)
         }
         vTaskDelay(3);
     }
+    host->release_ownership();
 }
 
 void UserInterface :: run(void)


### PR DESCRIPTION
Avoids weird colors and attributes being active when the user returns to their terminal after a Telnet session ends.