### PR TITLE
Prevent /Temp filling up with temporary files

### DIFF
--- a/software/filemanager/filemanager.cc
+++ b/software/filemanager/filemanager.cc
@@ -567,6 +567,33 @@ FRESULT FileManager::delete_recursive(Path *path, const char *name)
     return ret;
 }
 
+FRESULT FileManager::house_keeping_delete(const char *dirpath, const char*matchPattern, int min_files, int max_files, uint32_t max_size)
+{
+    Path dir;
+    dir.cd(dirpath);
+    IndexedList<FileInfo *> files(32, NULL);
+    FRESULT res = get_directory(&dir, files, matchPattern);
+    if (res == FR_OK) {
+        files.sort(compare_timestamp);
+        uint32_t total_size = 0;
+        for (int i = 0; i < files.get_elements(); ++i) {
+            total_size += files[i]->size;
+            if (i >= min_files && (total_size >= max_size || i >= max_files)) {
+                printf("House keeping: Deleting %s from %s\n", files[i]->lfname, dirpath);
+                delete_file(&dir, files[i]->lfname);
+            }
+        }
+    }
+    return FR_OK;
+}
+
+int FileManager::compare_timestamp(IndexedList<FileInfo *> *list, int a, int b)
+{
+    uint32_t a_timestamp = ((*list)[a]->date << 16) | (*list)[a]->time;
+    uint32_t b_timestamp = ((*list)[b]->date << 16) | (*list)[b]->time;
+    return (int)(b_timestamp - a_timestamp);  // Newest first (descending)
+}
+
 
 FRESULT FileManager::rename(Path *path, const char *old_name, const char *new_name)
 {

--- a/software/filemanager/filemanager.h
+++ b/software/filemanager/filemanager.h
@@ -119,6 +119,8 @@ class FileManager
 	FRESULT rename_impl(PathInfo &from, PathInfo &to);
 	FRESULT delete_file_impl(PathInfo &pathInfo);
 
+    static int compare_timestamp(IndexedList<FileInfo *> *list, int a, int b);
+
 //	friend class FileDirEntry;
 
     void lock() {
@@ -211,6 +213,7 @@ public:
     FRESULT delete_file(Path *path, const char *name);
     FRESULT delete_file(const char *pathname);
     FRESULT delete_recursive(Path *path, const char *name);
+    FRESULT house_keeping_delete(const char *dirpath, const char*matchPattern, int min_files = 2, int max_files = 16, uint32_t max_size = 1024*1024);
 
     FRESULT create_dir(Path *path, const char *name);
     FRESULT create_dir(const char *pathname);

--- a/software/filesystem/filesystem_a64.cc
+++ b/software/filesystem/filesystem_a64.cc
@@ -16,9 +16,10 @@
 #include "init_function.h"
 
 /*************************************************************/
-/* T64 File System implementation                            */
+/* A64 File System implementation                            */
 /*************************************************************/
 uint32_t FileOnA64::node_count = 0;
+
 
 FileSystemA64 :: FileSystemA64() : FileSystem(0)
 {
@@ -42,13 +43,14 @@ FRESULT FileSystemA64 :: file_open(const char *filename, uint8_t flags, File **f
 
     // Let's see if cached copy exists
     FileInfo inf(128);
-    mstring fixed_temp_path("/Temp/");
+    mstring fixed_temp_path("/Temp/_a64");  // No trailing underscore since 'fixed' already starts with one
     fixed_temp_path += fixed;
     delete[] fixed;
     FRESULT fres = fm->fstat(fixed_temp_path.c_str(), inf);
 
     // File was not found on the temp disk, let's download it
     if (fres == FR_NO_FILE) {
+        fm->house_keeping_delete("/Temp/", "_a64_*");
         mstring work1, work2;
         const char *remain = temp.getTail(2, work2); // starts with slash, so we do +1
         assembly.request_binary(temp.getSub(0, 2, work1), remain+1);


### PR DESCRIPTION
Limits number of temporary files from the HTTP API as well as from the Assembly64 integration. House keeping retains at least 2 files, but may go up to 16 files or 1MB of total size, whichever is reached first. Older files are deleted before newer. The limits are counted separately for API files and Assemby64 files.

Temporary filenames were changed to have a slightly nicer (?) names and start numbering at 1 instead of 0 since this is (arguably) more intuitive to the user.

Also fixes a tiny typo in a comment.

This solves #435.