### PR TITLE
Fix bug preventing config strings to be exactly their max length

### DIFF
--- a/software/components/config.cc
+++ b/software/components/config.cc
@@ -701,9 +701,9 @@ void ConfigItem :: setString(const char *s)
 {
     if(this->string) {
         strncpy(this->string, s, this->definition->max);
-        if (s[definition->max - 1]) { // has to be terminated
-            string[this->definition->max - 1] = 0;
-            string[this->definition->max - 2] = '*';
+        this->string[this->definition->max] = 0;  // Safe since the "string" buffer is max+1 (see ConfigItem constructor)
+        if (strlen(s) > this->definition->max) {
+            this->string[this->definition->max - 1] = '*';  // Indicate string was truncated
         }
         if ((definition->type == CFG_TYPE_STRING) || (definition->type == CFG_TYPE_STRFUNC)) {
             setChanged();


### PR DESCRIPTION
The code incorrectly started truncating configuration strings one byte before they needed to be truncated, thus only allowing max-1 long strings to be set.

Reproduction:

1. Press F2 to get to the Configuration menu.
2. Enter WiFi settings
3. Go to SSID (which has a limit of 22 chars at the moment) and hit Enter
4. Type "abcdefghijklmnopqrstu" (21 chars)
5. Hit Enter to save
6. Notice SSID is as entered
7. Hit Enter to edit SSID again
8. Add the 22nd character "v" and hit Enter
9. Notice how the SSID suddenly was truncated to "abcdefghijklmnopqrst*" (still just 21 chars).

Applying this commit fixes the problem allowing "abcdefghijklmnopqrstuv" (22 chars) to be configured.