### PR TITLE
Make u64ii branch build for U2+L again

### DIFF
--- a/software/portable/riscv/riscv_main.c
+++ b/software/portable/riscv/riscv_main.c
@@ -18,6 +18,8 @@
 #include "profiler.h"
 #include "usb_nano.h"
 
+void print_tasks(void);
+
 typedef uint8_t (*irq_function_t)(void *context);
 
 typedef struct{

--- a/software/wifi/raw_c3/main/rpc_calls.h
+++ b/software/wifi/raw_c3/main/rpc_calls.h
@@ -159,6 +159,7 @@ typedef struct {
 #define CMD_WIFI_DISABLE      0x0E
 #define CMD_MACHINE_OFF       0x0F
 #define CMD_GET_TIME          0x10
+#define CMD_CLEAR_APS         0x11
 
 /*
 #define CMD_SOCKET          0x11


### PR DESCRIPTION
NOTE: This PR is not toward "master" - it is toward "u64ii". I understand that branch is undergoing heavy development to get stuff ready for U64II, so please feel free to decline this PR if it is premature to do PRs there.

Either way, I managed to build and run the Ultimate app after applying the below fixes. I just did bare minimum and didn't add the event_pkt_connected struct which I noticed was added to the u64ctrl/main/rpc_calls.h file (I guess it is not needed for U2+ yet).
 

