### PR TITLE
Fix incorrect keyboard shortcut actions in popups

### DIFF
--- a/software/userinterface/ui_elements.cc
+++ b/software/userinterface/ui_elements.cc
@@ -88,21 +88,24 @@ int UIPopup :: poll(int dummy)
     if (c == -2) // error
     	return -1;
 
-    for(int i=0;i<btns_active;i++) {
+    int i;
+    int selected_button = -1;
+    if ((c == KEY_RETURN) || (c == KEY_SPACE)) {
+        selected_button = active_button;
+    }
+    for (i=0; i < btns_active; i++) {
         if(c == button_key[i]) {
-            return (1 << i);
+            selected_button = i;
+	}
+    }
+    if (selected_button >= 0) {
+        for(i=0; i < button_count; i++) {
+            if (button_key[selected_button] == button_keys[i]) {
+                return (1 << i);
+            }
         }
     }
-    if((c == KEY_RETURN)||(c == KEY_SPACE)) {
-		for(int i=0,j=0;i < button_count;i++) {
-			if(buttons & (1 << i)) {
-				if(active_button == j)
-					return (1 << i);
-				j++;
-			}
-		}
-        return 0;
-    }
+
     if(c == KEY_RIGHT) {
         active_button ++;
         if(active_button >= btns_active)


### PR DESCRIPTION
**NOTE:** This PR covers the half of what still remains after #440 was closed.

When using keyboard shortcuts in popups an incorrect value is often returned from poll(), causing the wrong action to be taken.

The problem is that an "active button index" is returned rather than the expected "absolute button index".

Refactored code to return the correct value in all situations.

Bug reproduction:

1. Navigate to a random file you want to delete

2. Hit Enter

3. Select "Delete"

4. When you get the "Are you sure?" question popup, press the "Y" key on the keyboard - and you will see the file NOT being deleted

5. Try again, but press the "N" key, and the file WILL (incorrectly) be deleted
