### PR TITLE
Add startup state configuration (C64 / Ultimate Menu)

### DIFF
--- a/software/application/ultimate/ultimate.cc
+++ b/software/application/ultimate/ultimate.cc
@@ -120,7 +120,6 @@ extern "C" void ultimate_main(void *a)
 		c64 = C64 :: getMachine();
 		c64_subsys = new C64_Subsys(c64);
 		c64->init();
-		c64->start();
 	} else {
 		c64 = NULL;
 	}
@@ -221,6 +220,16 @@ extern "C" void ultimate_main(void *a)
 #endif
 */
     custom_outbyte = outbyte_log;
+
+    if (c64) {
+        ConfigStore *cs = ConfigManager::getConfigManager()->find_store("User Interface Settings");
+        if (cs && cs->get_value(CFG_USERIF_STARTUP_STATE) == 1) {  // 1 == Start into Ultimate
+            c64->setButtonPushed();
+        }
+        else {
+            c64->start();
+        }
+    }
 
     while(c64) {
         int doIt = 0;

--- a/software/userinterface/userinterface.cc
+++ b/software/userinterface/userinterface.cc
@@ -22,6 +22,7 @@ static const char *colors[] = { "Black", "White", "Red", "Cyan", "Purple", "Gree
 static const char *filename_overflow_squeeze[] = { "None", "Beginning", "Middle", "End" };
 static const char *itype[]      = { "Freeze", "Overlay on HDMI" };
 static const char *cfg_save[]   = { "No", "Ask", "Yes" };
+static const char *startup_state[]   = { "C64", "Ultimate Menu" };
 
 struct t_cfg_definition user_if_config[] = {
 #if U64
@@ -35,6 +36,7 @@ struct t_cfg_definition user_if_config[] = {
     { CFG_USERIF_SELECTED_BG,CFG_TYPE_ENUM,   "Selected Backgr (Overlay)",  "%s", colors,  0, 15, 6 },
 #endif
 //    { CFG_USERIF_WORDWRAP,   CFG_TYPE_ENUM,   "Wordwrap text viewer", "%s", en_dis,  0,  1, 1 },
+    { CFG_USERIF_STARTUP_STATE, CFG_TYPE_ENUM, "Startup State",         "%s", startup_state, 0, 1, 0 },
     { CFG_USERIF_HOME_DIR,   CFG_TYPE_STRING, "Home Directory",        "%s", NULL, 0, 31, (int)"" },
     { CFG_USERIF_START_HOME, CFG_TYPE_ENUM,   "Enter Home on Startup", "%s", en_dis, 0,  1, 0 },
     { CFG_USERIF_CFG_SAVE,   CFG_TYPE_ENUM,   "Auto Save Config",      "%s", cfg_save, 0, 2, 1 },

--- a/software/userinterface/userinterface.h
+++ b/software/userinterface/userinterface.h
@@ -36,6 +36,7 @@
 #define CFG_USERIF_CFG_SAVE    0x0A
 #define CFG_USERIF_ULTICOPY_NAME 0x0B
 #define CFG_USERIF_FILENAME_OVERFLOW_SQUEEZE 0x0C
+#define CFG_USERIF_STARTUP_STATE 0x0D
 
 class UserInterface : public ConfigurableObject, public HostClient
 {


### PR DESCRIPTION
Let users decide if they wish the machine to boot into the C64 or the Ultimate Menu. Convenient for users who always start their sessions by selecting disks or cartridges in the Ultimate Menu.