### PR TITLE
Fix bug in ftp server sockaddr_in initialization

### DIFF
--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -885,7 +885,7 @@ int FTPDataConnection::connect_to(ip_addr_t ip, uint16_t port) // active mode
         return -ENOTCONN;
 
     struct sockaddr_in serv_addr;
-    memset(&serv_addr, '0', sizeof(serv_addr));
+    memset(&serv_addr, 0, sizeof(serv_addr));
 
     serv_addr.sin_family = AF_INET;
     serv_addr.sin_port = htons(port);


### PR DESCRIPTION
The structure was accidentally initialized with bytes of 0x30 instead of 0x00.