### PR TITLE
Fix #464 printer configured device number ignored

### DIFF
--- a/software/io/printer/iec_printer.cc
+++ b/software/io/printer/iec_printer.cc
@@ -139,7 +139,8 @@ void IecPrinter::effectuate_settings(void)
     uint8_t page_top, page_height;
 
     /* Printer ID on IEC from nvram */
-    int bus_id = cfg->get_value(CFG_PRINTER_ID);
+    printer_iec_addr = cfg->get_value(CFG_PRINTER_ID);
+    iec_if->configure();
 
     /* Load and apply virtual printer configuration from nvram */
     set_filename(cfg->get_string(CFG_PRINTER_FILENAME));
@@ -357,7 +358,7 @@ IecPrinter::IecPrinter() : SubSystem(SUBSYSID_PRINTER)
     /* Initial values */
     output_filename = NULL;
     f = NULL;
-    last_printer_addr = 4;
+    printer_iec_addr = 4;
     mps = MpsPrinter::getMpsPrinter();
     buffer_pointer = 0;
     output_type = PRINTER_UNSET_OUTPUT;

--- a/software/io/printer/iec_printer.h
+++ b/software/io/printer/iec_printer.h
@@ -100,7 +100,7 @@ class IecPrinter : public IecSlave, SubSystem, ObjectWithMenu, ConfigurableObjec
         const char *output_filename;
 
         /* Printer IEC address */
-        int last_printer_addr;
+        int printer_iec_addr;
 
         /* Printer enabled or not */
         uint8_t printer_enable;
@@ -160,7 +160,7 @@ class IecPrinter : public IecSlave, SubSystem, ObjectWithMenu, ConfigurableObjec
         t_channel_retval push_data(uint8_t b);
         t_channel_retval push_ctrl(uint16_t b);
         bool is_enabled(void) { return printer_enable; }
-        uint8_t get_address(void) { return (uint8_t) last_printer_addr; }
+        uint8_t get_address(void) { return (uint8_t) printer_iec_addr; }
         uint8_t get_type(void) { return 0x50; }
         const char *iec_identify(void) { return "Printer Emulation"; }
         void info(JSON_Object *);


### PR DESCRIPTION
This will call the configure method of IEC interface when printer device ID is changed