### PR TITLE
Gather product related functions in one place

### DIFF
--- a/software/application/programmer/u64_programmer.cc
+++ b/software/application/programmer/u64_programmer.cc
@@ -29,6 +29,7 @@
 #include "u64_tester.h"
 #include "i2c_drv_sockettest.h"
 #include "stream_textlog.h"
+#include "product.h"
 
 typedef struct {
 	const char *fileName;
@@ -116,31 +117,6 @@ void esp32_put_byte(uint8_t c)
     while(ioRead8(ESP_UART_FLAGS) & UART_TxFifoFull)
         ;
     ioWrite8(ESP_UART_DATA, c);
-}
-
-const char *getBoardRevision(void)
-{
-    uint8_t rev = (U2PIO_BOARDREV >> 3);
-
-    switch (rev) {
-    case 0x10:
-        return "U64 Prototype";
-    case 0x11:
-        return "U64 V1.1 (Null Series)";
-    case 0x12:
-        return "U64 V1.2 (Mass Prod)";
-    case 0x13:
-        return "U64 V1.3 (Elite)";
-    case 0x14:
-        return "U64 V1.4 (Std/Elite)";
-    case 0x15:
-        return "U64E V2.0 (Early Proto)";
-    case 0x16:
-        return "U64E V2.1 (Null Series)";
-    case 0x17:
-        return "U64E V2.2 (Mass Prod)";
-    }
-    return "Unknown";
 }
 
 int load_file(BinaryImage_t *flashFile)
@@ -668,22 +644,6 @@ void write_log(void)
 
 extern "C" {
     void codec_init(void);
-
-    bool isEliteBoard(void)
-    {
-        uint8_t rev = (U2PIO_BOARDREV >> 3);
-        if (rev == 0x13) {
-            return true;
-        }
-        if (rev == 0x14) { // may be either!
-            uint8_t joyswap = C64_PLD_JOYCTRL;
-            if (joyswap & 0x80) {
-                return true;
-            }
-            return false;
-        }
-        return false;
-    }
 
     void main_task(void *context)
 	{

--- a/software/application/u64ii_tester/u64ii_programmer.cc
+++ b/software/application/u64ii_tester/u64ii_programmer.cc
@@ -22,6 +22,7 @@
 #include "usb_base.h"
 #include "screen_logger.h"
 #include "flash.h"
+#include "product.h"
 
 // These defines are from the test concept that runs tests via jtag.
 #define PROG_BUFFER      ((uint8_t *)(0x1000000))
@@ -31,31 +32,6 @@
 #define DUT_TO_TESTER    (*(volatile uint32_t *)(0x0094))
 #define TESTER_TO_DUT	 (*(volatile uint32_t *)(0x0098))
 #define TEST_STATUS		 (*(volatile int *)(0x009C))
-
-static const char *getBoardRevision(void)
-{
-	uint8_t rev = (U2PIO_BOARDREV >> 3);
-
-	switch (rev) {
-	case 0x10:
-		return "U64 Prototype";
-	case 0x11:
-		return "U64 V1.1 (Null Series)";
-	case 0x12:
-		return "U64 V1.2 (Mass Prod)";
-	case 0x13:
-	    return "U64 V1.3 (Elite)";
-    case 0x14:
-        return "U64 V1.4 (Std/Elite)";
-    case 0x15:
-        return "U64E V2.0 (Early Proto)";
-    case 0x16:
-        return "U64E V2.1 (Null Series)";
-    case 0x17:
-        return "U64E V2.2 (Mass Prod)";
-	}
-	return "Unknown";
-}
 
 Screen *screen;
 Screen *screen2;

--- a/software/application/ultimate/ultimate.cc
+++ b/software/application/ultimate/ultimate.cc
@@ -40,15 +40,10 @@
 #include "u64.h"
 #include "keyboard_usb.h"
 #include "i2c_drv.h"
+#include "product.h"
 
 // these should move to main_loop.h
 extern "C" void main_loop(void *a);
-
-bool isEliteBoard(void) __attribute__((weak));
-bool isEliteBoard(void)
-{
-    return false;
-}
 
 bool connectedToU64 = false;
 
@@ -75,27 +70,6 @@ void outbyte_log(int c)
 	textLog.charout(c);
 }
 
-const char *getVersionString(char *title)
-{
-    uint32_t capabilities = getFpgaCapabilities();
-    if(capabilities & CAPAB_ULTIMATE64) {
-        if (isEliteBoard()) {
-            sprintf(title, "** Ultimate 64 Elite V1.%b - %s **", C64_CORE_VERSION, APPL_VERSION);
-        } else {
-            sprintf(title, "*** Ultimate 64 V1.%b - %s ***", C64_CORE_VERSION, APPL_VERSION);
-        }
-    } else if(capabilities & CAPAB_ULTIMATE2PLUS) {
-        if (capabilities & CAPAB_FPGA_TYPE) {
-    	    sprintf(title, "*** Ultimate-II Plus-L %s (1%b) ***", APPL_VERSION, getFpgaVersion());
-        } else {
-    	    sprintf(title, "*** Ultimate-II Plus %s (1%b) ***", APPL_VERSION, getFpgaVersion());
-        }
-    } else {
-    	sprintf(title, "*** 1541 Ultimate-II %s (1%b) ***", APPL_VERSION, getFpgaVersion());
-    }
-    return title;
-}
-
 extern "C" {
     void codec_init();
 }
@@ -107,7 +81,8 @@ extern "C" void ultimate_main(void *a)
 
     uint32_t capabilities = getFpgaCapabilities();
 
-	printf("*** Ultimate-II V3.x ***\n");
+    char product_version[41];
+    printf("*** %s ***\n", getProductVersionString(product_version, sizeof(product_version)));
     printf("*** FPGA Capabilities: %8x ***\n\n", capabilities);
 
     printf("%s ", rtc.get_long_date(time_buffer, 32));
@@ -128,7 +103,7 @@ extern "C" void ultimate_main(void *a)
     usb2.initHardware();
 
     char title[48];
-    getVersionString(title);
+    getProductTitleString(title, sizeof(title));
 
     if(capabilities & CAPAB_ULTIMATE64) {
         system_usb_keyboard.setMatrix((volatile uint8_t *)MATRIX_KEYB);

--- a/software/application/update_u2p/update_u64.cc
+++ b/software/application/update_u2p/update_u64.cc
@@ -8,6 +8,7 @@
 #include "update_common.h"
 #include "checksums.h"
 #include "wifi_cmd.h"
+#include "product.h"
 
 extern uint32_t _u64_rbf_start;
 extern uint32_t _u64_rbf_end;
@@ -31,24 +32,6 @@ extern uint8_t _snds1581_bin_start;
 extern const char _index_html_start[];
 extern const char _index_html_end[1];
 
-const char *getBoardRevision(void)
-{
-	uint8_t rev = (U2PIO_BOARDREV >> 3);
-
-	switch (rev) {
-	case 0x10:
-		return "U64 Prototype";
-	case 0x11:
-		return "U64 V1.1 (Null Series)";
-	case 0x12:
-		return "U64 V1.2 (Mass Prod)";
-	case 0x13:
-	    return "U64 V1.3 (Elite)";
-    case 0x14:
-        return "U64 V1.4 (Std/Elite)";
-	}
-	return "Unknown";
-}
 
 static void status_callback(void *user)
 {

--- a/software/application/update_u2p/update_u64ii.cc
+++ b/software/application/update_u2p/update_u64ii.cc
@@ -9,6 +9,7 @@
 #include "checksums.h"
 #include "i2c_drv.h"
 #include "wifi_cmd.h"
+#include "product.h"
 
 extern uint32_t _u64_rbf_start;
 extern uint32_t _u64_rbf_end;
@@ -32,30 +33,6 @@ extern uint8_t _snds1581_bin_start;
 extern const char _index_html_start[];
 extern const char _index_html_end[1];
 
-const char *getBoardRevision(void)
-{
-	uint8_t rev = (U2PIO_BOARDREV >> 3);
-
-	switch (rev) {
-	case 0x10:
-		return "U64 Prototype";
-	case 0x11:
-		return "U64 V1.1 (Null Series)";
-	case 0x12:
-		return "U64 V1.2 (Mass Prod)";
-	case 0x13:
-	    return "U64 V1.3 (Elite)";
-    case 0x14:
-        return "U64 V1.4 (Std/Elite)";
-    case 0x15:
-        return "U64E V2.0 (Early Proto)";
-    case 0x16:
-        return "U64E V2.1 (Null Series)";
-    case 0x17:
-        return "U64E V2.2 (Mass Prod)";
-	}
-	return "Unknown";
-}
 
 static void status_callback(void *user)
 {

--- a/software/filetypes/filetype_u2p.cc
+++ b/software/filetypes/filetype_u2p.cc
@@ -28,6 +28,7 @@
 #include "userinterface.h"
 #include "c64.h"
 #include "browsable_root.h"
+#include "product.h"
 
 extern "C" {
 	#include "dump_hex.h"
@@ -72,17 +73,8 @@ FileType *FileTypeUpdate :: test_type(BrowsableDirEntry *br)
 {
 	FileInfo *inf = br->getInfo();
 	uint32_t cap = getFpgaCapabilities();
-#if U64 == 2
-    const char *ext = "UE2";
-#elif U64 == 1
-    const char *ext = "U64";
-#elif U2P == 2
-    const char *ext = "U2L";
-#else
-    const char *ext = "U2P";
-#endif
 
-	if(strcmp(inf->extension, ext)==0)
+    if(strcmp(inf->extension, getProductUpdateFileExtension())==0)
         return new FileTypeUpdate(br);
     return NULL;
 }

--- a/software/filetypes/filetype_u2u.cc
+++ b/software/filetypes/filetype_u2u.cc
@@ -29,6 +29,7 @@
 #include "c64.h"
 #include "browsable_root.h"
 #include "acia.h"
+#include "product.h"
 
 extern "C" {
 	#include "dump_hex.h"
@@ -65,13 +66,8 @@ int FileTypeUpdate :: fetch_context_items(IndexedList<Action *> &list)
 FileType *FileTypeUpdate :: test_type(BrowsableDirEntry *br)
 {
 	FileInfo *inf = br->getInfo();
-#ifdef RISCV
-	if(strcmp(inf->extension, "U2R")==0)
+    if(strcmp(inf->extension, getProductUpdateFileExtension())==0)
         return new FileTypeUpdate(br);
-#else
-	if(strcmp(inf->extension, "U2U")==0)
-        return new FileTypeUpdate(br);
-#endif
     return NULL;
 }
 

--- a/software/network/socket_gui.cc
+++ b/software/network/socket_gui.cc
@@ -20,6 +20,7 @@
 #include "versions.h"
 #include "home_directory.h"
 #include "init_function.h"
+#include "product.h"
 
 SocketGui *socket_gui = NULL;
 InitFunction init_socket_gui([](void *_obj, void *_param) { socket_gui = new SocketGui(); }, NULL, NULL, 100); // global that causes us to exist
@@ -42,17 +43,12 @@ SocketGui :: SocketGui()
 
 void socket_gui_task(void *a)
 {
-    char title[64];
-#if U64
-    sprintf(title, "\eA*** Ultimate-64 %s (1%b) *** Remote ***\eO", APPL_VERSION, getFpgaVersion());
-#else
-    if(getFpgaCapabilities() & CAPAB_ULTIMATE2PLUS) {
-    	sprintf(title, "\eA*** Ultimate-II Plus %s (1%b) *** Remote ***\eO", APPL_VERSION, getFpgaVersion());
-    } else {
-    	sprintf(title, "\eA**** 1541 Ultimate %s (%b) - Remote ****\eO", APPL_VERSION, getFpgaVersion());
-    }
-#endif
 	SocketStream *str = (SocketStream *)a;
+
+	char product[41];
+	char title[81];
+	getProductVersionString(product, sizeof(product));
+	sprintf(title, "\eA*** %s *** Remote ***\eO", product);
 
 	HostStream *host = new HostStream(str);
 //	Screen *scr = host->getScreen();

--- a/software/system/product.cc
+++ b/software/system/product.cc
@@ -1,0 +1,161 @@
+#include <string.h>
+
+#include "flash.h"
+#include "versions.h"
+#include "product.h"
+#include "small_printf.h"
+#include "u64.h"
+
+// Longest supported product_name string is 16. Update below functions and callers if this increases!
+
+static char *product_name[] = {
+    "Ultimate",  // Default if unknown product
+    "Ultimate II",
+    "Ultimate II+",
+    "Ultimate II+L",
+    "Ultimate 64",
+    "Ultimate 64E",
+    "Ultimate 64E2",
+};
+
+#if U64
+const char *getBoardRevision(void)
+{
+    uint8_t rev = (U2PIO_BOARDREV >> 3);
+
+    switch (rev) {
+    case 0x10:
+        return "U64 Prototype";
+    case 0x11:
+        return "U64 V1.1 (Null Series)";
+    case 0x12:
+        return "U64 V1.2 (Mass Prod)";
+    case 0x13:
+        return "U64 V1.3 (Elite)";
+    case 0x14:
+        return "U64 V1.4 (Std/Elite)";
+    case 0x15:
+        return "U64E V2.0 (Early Proto)";
+    case 0x16:
+        return "U64E V2.1 (Null Series)";
+    case 0x17:
+        return "U64E V2.2 (Mass Prod)";
+    }
+    return "Unknown";
+}
+
+bool isEliteBoard(void)
+{
+    uint8_t rev = (U2PIO_BOARDREV >> 3);
+    if (rev == 0x13) {
+        return true;
+    }
+    if (rev == 0x14) { // may be either!
+        uint8_t joyswap = C64_PLD_JOYCTRL;
+        if (joyswap & 0x80) {
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+#endif
+
+uint8_t getProductId() {
+    return
+#if U64 == 1
+    isEliteBoard() ? PRODUCT_ULTIMATE_64_ELITE : PRODUCT_ULTIMATE_64
+#elif U64 == 2
+    PRODUCT_ULTIMATE_64_ELITE_II
+#elif U2P == 1
+    PRODUCT_ULTIMATE_II_PLUS
+#elif U2P == 2
+    PRODUCT_ULTIMATE_II_PLUS_L
+#else
+    PRODUCT_ULTIMATE_II
+#endif
+    ;
+}
+
+const char *getProductString() {
+    uint8_t product = getProductId();
+    if (product >= sizeof(product_name) / sizeof(char *))
+        product = 0;
+    return  product_name[product];
+}
+
+char *getProductVersionString(char *buf, int sz) {
+    uint8_t fpga_version;
+    const char *format;
+
+    // Required size is max of all fields:
+    //
+    //   7 fixed non-%-format-chars, 16 product, 2 fpga_version, 5 APPL_VERSION, 1 NULL-byte
+    if (sz < 7 + 16 + 2 + 5 + 1) {
+        return NULL;
+    }
+
+    // FIXME: Should order of APPL vs fpga version be unified across products?
+    switch(getProductId()) {
+        case PRODUCT_ULTIMATE_II:
+        case PRODUCT_ULTIMATE_II_PLUS:
+        case PRODUCT_ULTIMATE_II_PLUS_L:
+            format = "%s %s (1%b)";
+            fpga_version = getFpgaVersion();
+            sprintf(buf, format, getProductString(), APPL_VERSION, fpga_version);
+            break;
+        case PRODUCT_ULTIMATE_64:
+        case PRODUCT_ULTIMATE_64_ELITE:
+        case PRODUCT_ULTIMATE_64_ELITE_II:
+            format = "%s (V1.%b) %s";
+            fpga_version = C64_CORE_VERSION;
+            sprintf(buf, format, getProductString(), fpga_version, APPL_VERSION);
+            break;
+        default:
+            strcpy(buf, "Unknown product");
+    }
+    return buf;
+}
+
+char *getProductTitleString(char *buf, int sz)
+{
+    char product_version[41];
+
+    if (sz < 17)
+        return NULL;
+    if (sz < sizeof(product_version) || !getProductVersionString(product_version, sizeof(product_version))) {
+       strcpy(buf, "*** Ultimate ***");
+       return buf;
+    }
+
+    // Add as many stars around the title as space will allow
+    int space = 40 - strlen(product_version);
+    char *format = "%s";
+    if (space >= 8) format = "*** %s ***";
+    else if (space >= 6) format = "** %s **";
+    else if (space >= 4) format = "* %s *";
+    sprintf(buf, format, product_version);
+    return buf;
+}
+
+char *getProductUpdateFileExtension() {
+    return
+#if U64 == 1
+    "U64"
+#elif U64 == 2
+    "UE2"
+#elif U2P == 1
+    "U2P"
+#elif U2P == 2
+    "U2L"
+#else
+
+#ifdef RISCV
+    "U2R"
+#else
+    "U2U"
+#endif
+
+#endif
+    ;
+}

--- a/software/system/product.h
+++ b/software/system/product.h
@@ -1,0 +1,23 @@
+#ifndef PRODUCT_H
+#define PRODUCT_H
+
+#define PRODUCT_UNKNOWN                0x00
+#define PRODUCT_ULTIMATE_II            0x01
+#define PRODUCT_ULTIMATE_II_PLUS       0x02
+#define PRODUCT_ULTIMATE_II_PLUS_L     0x03
+#define PRODUCT_ULTIMATE_64            0x04
+#define PRODUCT_ULTIMATE_64_ELITE      0x05
+#define PRODUCT_ULTIMATE_64_ELITE_II   0x06
+
+#if U64
+const char *getBoardRevision(void);
+bool isEliteBoard(void);
+#endif
+
+uint8_t getProductId();
+const char *getProductString();
+char *getProductVersionString(char *buf, int sz);
+char *getProductTitleString(char *buf, int sz);
+char *getProductUpdateFileExtension();
+
+#endif  // PRODUCT_H

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -14,6 +14,7 @@ extern "C" {
 }
 #include <string.h>
 #include "flash.h"
+#include "product.h"
 #include "userinterface.h"
 #include "u64_config.h"
 #include "audio_select.h"
@@ -1866,22 +1867,6 @@ int swap_joystick()
 
     // swap performed, now exit menu
     return MENU_HIDE;
-}
-
-bool isEliteBoard(void)
-{
-    uint8_t rev = (U2PIO_BOARDREV >> 3);
-    if ((rev == 0x13)||(rev == 0x15)||(rev == 0x16)) {
-        return true;
-    }
-    if (rev == 0x14) { // may be either!
-        uint8_t joyswap = C64_PLD_JOYCTRL;
-        if (joyswap & 0x80) {
-            return true;
-        }
-        return false;
-    }
-    return false;
 }
 
 void U64Config :: auto_mirror(uint8_t *base, uint8_t *mask, uint8_t *split, int count)

--- a/software/u64/u64_config.h
+++ b/software/u64/u64_config.h
@@ -146,8 +146,6 @@ public:
     void access_socket_post(int socket);
 };
 
-bool isEliteBoard(void);
-
 extern uint8_t C64_EMUSID1_BASE_BAK;
 extern uint8_t C64_EMUSID2_BASE_BAK;
 extern uint8_t C64_SID1_BASE_BAK;

--- a/target/u2/microblaze/mb_ultimate/Makefile
+++ b/target/u2/microblaze/mb_ultimate/Makefile
@@ -35,6 +35,7 @@ SRCS_CC	 =  small_printf.cc \
 			at45_flash.cc \
 			w25q_flash.cc \
 			s25fl_flash.cc \
+			product.cc \
 			config.cc \
 			subsys.cc \
 			filemanager.cc \

--- a/target/u2/riscv/ultimate/Makefile
+++ b/target/u2/riscv/ultimate/Makefile
@@ -46,6 +46,7 @@ SRCS_CC	 =	small_printf.cc \
 			at45_flash.cc \
 			w25q_flash.cc \
 			s25fl_flash.cc \
+			product.cc \
 			config.cc \
 			subsys.cc \
 			filemanager.cc \

--- a/target/u2plus/nios/recovery/Makefile
+++ b/target/u2plus/nios/recovery/Makefile
@@ -39,6 +39,7 @@ SRCS_CC	 =  u2p_init.cc \
 			init_function.cc \
 			flash.cc \
 			w25q_flash.cc \
+			product.cc \
 			config.cc \
 			subsys.cc \
 			filemanager.cc \

--- a/target/u2plus/nios/ultimate/Makefile
+++ b/target/u2plus/nios/ultimate/Makefile
@@ -50,6 +50,7 @@ SRCS_CC	 =  u2p_init.cc \
 			w25q_flash.cc \
 			s25fl_flash.cc \
 			prog_flash.cc \
+			product.cc \
 			config.cc \
 			subsys.cc \
 			filemanager.cc \

--- a/target/u2plus_L/riscv/ultimate/Makefile
+++ b/target/u2plus_L/riscv/ultimate/Makefile
@@ -52,6 +52,7 @@ SRCS_CC	 =  u2p_init.cc \
 			w25q_flash.cc \
 			s25fl_flash.cc \
 			prog_flash.cc \
+			product.cc \
 			config.cc \
 			subsys.cc \
 			filemanager.cc \

--- a/target/u64/nios2/loader/Makefile
+++ b/target/u64/nios2/loader/Makefile
@@ -66,6 +66,7 @@ SRCS_CC	 =  small_printf.cc \
 			memory.cc \
 			screen.cc \
 			rtc_i2c.cc \
+			product.cc \
 			config.cc \
 			prog_flash.cc \
 			flash.cc \

--- a/target/u64/nios2/ultimate/Makefile
+++ b/target/u64/nios2/ultimate/Makefile
@@ -53,6 +53,7 @@ SRCS_CC	 =  u2p_init.cc \
 			s25fl_flash.cc \
 			s25fl_l_flash.cc \
 			prog_flash.cc \
+			product.cc \
 			config.cc \
 			subsys.cc \
 			filemanager.cc \

--- a/target/u64/nios2/updater/Makefile
+++ b/target/u64/nios2/updater/Makefile
@@ -65,6 +65,7 @@ SRCS_CC	 =  memory.cc \
 			stream.cc \
 			host_stream.cc \
 			prog_flash.cc \
+			product.cc \
 			stream_uart.cc \
 			path.cc \
 			blockdev.cc \

--- a/target/u64/riscv/ultimate/Makefile
+++ b/target/u64/riscv/ultimate/Makefile
@@ -48,6 +48,7 @@ SRCS_CC	 =  u2p_init.cc \
 			s25fl_flash.cc \
 			s25fl_l_flash.cc \
 			prog_flash.cc \
+			product.cc \
 			config.cc \
 			filemanager.cc \
 			file_device.cc \

--- a/target/u64ii/riscv/ultimate/Makefile
+++ b/target/u64ii/riscv/ultimate/Makefile
@@ -56,6 +56,7 @@ SRCS_CC	 =  u64ii_init.cc \
 			s25fl_flash.cc \
 			s25fl_l_flash.cc \
 			prog_flash.cc \
+			product.cc \
 			config.cc \
 			subsys.cc \
 			filemanager.cc \


### PR DESCRIPTION
The code to identify which hardware (i.e which product) is being used is duplicated in several places.

This merge request moves all of that half-messy code into a single "product"  unit, removing code duplication and keeping the calling code cleaner. A couple of future merge requests rely on this refactoring.

Note: This MR is toward the u64ii branch since the changes also cover the new U64E2 support.