### PR TITLE
Make sure isEliteBoard() returns true for U64E2

### DIFF
--- a/software/system/product.cc
+++ b/software/system/product.cc
@@ -57,7 +57,7 @@ const char *getBoardRevision(void)
 bool isEliteBoard(void)
 {
     uint8_t rev = (U2PIO_BOARDREV >> 3);
-    if (rev == 0x13) {
+    if (rev == 0x13 || (rev >= 0x15 && rev <= 0x17)) {
         return true;
     }
     if (rev == 0x14) { // may be either!


### PR DESCRIPTION
As discussed in #471.