### PR TITLE
Add unique_id to UDP discovery packet and /v1/info API endpoint

### DIFF
--- a/software/api/routes.cc
+++ b/software/api/routes.cc
@@ -131,7 +131,8 @@ API_CALL(GET, info, none, NULL, ARRAY( { }))
 #ifdef U64
         ->add("core_version", core_version)
 #endif
-        ->add("hostname", hostname);
+        ->add("hostname", hostname)
+        ->add("unique_id", getProductUniqueId());
 
     resp->json_response(HTTP_OK);
 }

--- a/software/network/socket_dma.cc
+++ b/software/network/socket_dma.cc
@@ -557,6 +557,7 @@ void SocketDMA::identThread(void *_a)
 #endif
                     ->add("hostname", hostname)
                     ->add("menu_header", menu_header)
+                    ->add("unique_id", getProductUniqueId())
                     ->add("your_string", client_message+4);
 
                 // Current Assembly64 ignores responses with booleans so we only send this if passwords

--- a/software/system/product.cc
+++ b/software/system/product.cc
@@ -195,3 +195,26 @@ char *getProductUpdateFileExtension() {
 #endif
     ;
 }
+
+char *getProductUniqueId()
+{
+    static char unique_id[17];
+    static bool initialized = false;
+
+    if (!initialized) {
+        // Generate a 24 bit unique number combining the same inputs as
+        // for the mac address, but in a slightly different way.
+        uint8_t serial[8];
+        memset(serial, 0, 8);
+        Flash *flash = get_flash();
+        flash->read_serial(serial);
+        serial[0] = serial[1] ^ serial[2];
+        serial[1] = serial[3] ^ serial[5];
+        serial[2] = serial[6] ^ serial[7];
+        for (int i=0; i < 3; ++i) {
+            sprintf(&unique_id[i*2], "%02x", serial[i]);
+        }
+        initialized = true;
+    }
+    return unique_id;
+}

--- a/software/system/product.h
+++ b/software/system/product.h
@@ -20,5 +20,6 @@ char *getProductVersionString(char *buf, int sz);
 char *getProductTitleString(char *buf, int sz);
 char *getProductDefaultHostname(char *buf, int sz);
 char *getProductUpdateFileExtension();
+char *getProductUniqueId();
 
 #endif  // PRODUCT_H


### PR DESCRIPTION
This is an ID which uniquely identifies the current Ultimate device. This allows Assembly64 (and other software) to recognize individual Ultimate units over time even if they change firmware version, hostname, ip or switch from LAN to WiFi (MAC address changes).

The latest beta of Assembly64 makes good use of this id to manage it's list of devices.