### PR TITLE
Tiny fix for missing network to host byte order conversions

### DIFF
--- a/software/io/wifi/wifi.cc
+++ b/software/io/wifi/wifi.cc
@@ -160,6 +160,7 @@ void WiFi :: RunModeThread()
     int result;
     state = eWifi_NotDetected;
     uint8_t conn;
+    uint32_t ip;
 
     RefreshRoot();
     static char boot_message[256];
@@ -314,8 +315,9 @@ void WiFi :: RunModeThread()
 
             case EVENT_GOTIP:
                 ev = (event_pkt_got_ip *)buf->data;
-                printf("-> ESP32 received IP from DHCP: %d.%d.%d.%d (changed: %d)\n", (ev->ip >> 24),
-                    (ev->ip >> 16) & 0xFF, (ev->ip >> 8) & 0xFF, ev->ip & 0xFF, ev->changed);
+                ip = ntohl(ev->ip);
+                printf("-> ESP32 received IP from DHCP: %d.%d.%d.%d (changed: %d)\n", (ip >> 24),
+                    (ip >> 16) & 0xFF, (ip >> 8) & 0xFF, ip & 0xFF, ev->changed);
                 cmd_buffer_free(packets, buf);
                 break;
 

--- a/software/network/sock_echo.c
+++ b/software/network/sock_echo.c
@@ -30,7 +30,7 @@ static void echo_run()
 	sLocalAddr.sin_family = AF_INET;
 	sLocalAddr.sin_len = sizeof(sLocalAddr);
 	sLocalAddr.sin_addr.s_addr = 0L; //htonl(IP_ADDR_ANY);
-	sLocalAddr.sin_port = 23;
+	sLocalAddr.sin_port = htons(23);
 
 	if (lwip_bind(lSocket, (struct sockaddr *)&sLocalAddr, sizeof(sLocalAddr)) < 0) {
 		lwip_close(lSocket);


### PR DESCRIPTION
First fix is to ESP32 debug logging.

Second fix is to sock_echo.c which is not used at the moment.