### PR TITLE
Add support for logging to a remote syslog server

### DIFF
--- a/python/syslogd.py
+++ b/python/syslogd.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+#
+# Simple syslog server showing incoming messages on stdout.
+#
+
+import socket
+import sys
+import datetime
+
+# The default syslog port 514 requires root access, so we have 64514 as a fallback
+try_ports = [514, 64514]
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+bound = False
+for port in try_ports:
+    try:
+        sock.bind(('0.0.0.0', port))
+        print('Listening for incoming syslog packets on UDP port ' +  str(port))
+        bound = True
+        break
+    except PermissionError as e:
+        print('NOTE: Not allowed to bind to UDP port ' + str(port) + ' (root access needed)\n')
+    except Exception as e:
+        pass
+
+if not bound:
+    print('Unable to bind to port, aborting.')
+    sys.exit(1)
+
+print()
+while True:
+    data, address = sock.recvfrom(65536, 0)
+    ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
+    ip = address[0]
+    msg = data.decode('iso-8859-1').rstrip()
+    print(ts + ' [' + ip + '] ' + msg)

--- a/software/application/ultimate/ultimate.cc
+++ b/software/application/ultimate/ultimate.cc
@@ -77,6 +77,8 @@ void initialize_usb_hub();
 
 extern "C" void ultimate_main(void *a)
 {
+    custom_outbyte = outbyte_log;
+
     char time_buffer[32];
 
     uint32_t capabilities = getFpgaCapabilities();
@@ -195,7 +197,6 @@ extern "C" void ultimate_main(void *a)
     }
 #endif
 */
-    custom_outbyte = outbyte_log;
 
     while(c64) {
         int doIt = 0;

--- a/software/application/ultimate/ultimate.cc
+++ b/software/application/ultimate/ultimate.cc
@@ -6,6 +6,7 @@
 #include "task.h"
 
 #include "itu.h"
+#include "syslog.h"
 #include "c64.h"
 #include "c64_subsys.h"
 #include "c1541.h"
@@ -58,6 +59,7 @@ C64_Subsys *c64_subsys;
 HomeDirectory *home_directory;
 REUPreloader *reu_preloader;
 StreamTextLog textLog(96*1024);
+Syslog syslog;
 
 extern "C" void (*custom_outbyte)(int c);
 
@@ -70,6 +72,12 @@ void outbyte_log(int c)
 	textLog.charout(c);
 }
 
+void outbyte_log_syslog(int c)
+{
+	textLog.charout(c);  // Internal log
+	syslog.charout(c);  // Remote syslog server
+}
+
 extern "C" {
     void codec_init();
 }
@@ -77,7 +85,10 @@ void initialize_usb_hub();
 
 extern "C" void ultimate_main(void *a)
 {
-    custom_outbyte = outbyte_log;
+    // Normal boot log size is about 5k right now, so 16k should be enough to
+    // give time to flush the buffer.
+    const int syslog_bufsize = 16*1024;
+    custom_outbyte = syslog.init(syslog_bufsize) ? outbyte_log_syslog : outbyte_log;
 
     char time_buffer[32];
 

--- a/software/io/network/network_interface.cc
+++ b/software/io/network/network_interface.cc
@@ -69,7 +69,13 @@ err_t NetworkInterface :: lwip_output_callback(struct netif *netif, struct pbuf 
     	return ERR_ARG;
     }
     while(pbuf) {
-    	printf("Concat %p->%p (%d)\n", pbuf->payload, temp, pbuf->len);
+        // Disabling the below debug message by default. It causes an infinite
+        // stream of messages when remote syslogging is enabled. This printf()
+        // will cause a syslog packet to be sent, and since THAT packet will
+        // trigger this callback, another syslog message will be sent, again
+        // causing.... ad infinitum.
+
+    	// printf("Concat %p->%p (%d)\n", pbuf->payload, temp, pbuf->len);
     	memcpy(temp, pbuf->payload, pbuf->len);
     	temp += pbuf->len;
     	if (pbuf->len == pbuf->tot_len)

--- a/software/network/network_config.cc
+++ b/software/network/network_config.cc
@@ -16,6 +16,7 @@ struct t_cfg_definition network_config[] = {
     { CFG_NETWORK_TELNET_SERVICE,   CFG_TYPE_ENUM,      "Telnet Remote Menu Service",       "%s", en_dis,     0,  1, 1 },
     { CFG_NETWORK_FTP_SERVICE,      CFG_TYPE_ENUM,      "FTP File Service",                 "%s", en_dis,     0,  1, 1 },
     { CFG_NETWORK_HTTP_SERVICE,     CFG_TYPE_ENUM,      "Web Remote Control Service",       "%s", en_dis,     0,  1, 1 },
+    { CFG_NETWORK_REMOTE_SYSLOG_SERVER, CFG_TYPE_STRING,"Log to Syslog Server",             "%s", NULL,       8, 31, (int)"" },
     { CFG_TYPE_END,                CFG_TYPE_END,        "",                                 "",   NULL,       0,  0, 0 }
 };
 

--- a/software/network/network_config.h
+++ b/software/network/network_config.h
@@ -10,6 +10,7 @@
 #define CFG_NETWORK_TELNET_SERVICE         0x23
 #define CFG_NETWORK_FTP_SERVICE            0x24
 #define CFG_NETWORK_HTTP_SERVICE           0x25
+#define CFG_NETWORK_REMOTE_SYSLOG_SERVER   0x26
 
 
 class NetworkConfig : ConfigurableObject {

--- a/software/network/syslog.cc
+++ b/software/network/syslog.cc
@@ -1,0 +1,166 @@
+#include <sys/socket.h>
+
+#include "syslog.h"
+#include "network_interface.h"
+#include "network_config.h"
+
+
+bool Syslog::init(size_t buffer_size)
+{
+    const char *server = networkConfig.cfg->get_string(CFG_NETWORK_REMOTE_SYSLOG_SERVER);
+    if (!server || *server == 0) {
+        return false;  // Logging to syslog is disabled
+    }
+
+    // Determine ip and port
+    const char *sep = strchr(server, ':');
+    if (!sep) {
+        port = 514;  // Default syslog port
+        if (!ipaddr_aton(server, &ip)) {
+            ip.addr = INADDR_ANY;
+        }
+    }
+    else {
+        int len = sep - server;
+        if (len >= 7 && len <= 15) {
+            char addr[16];
+            memcpy(addr, server, len);
+            addr[len] = 0;
+            if (ipaddr_aton(addr, &ip)) {
+                port = atoi(sep + 1);
+                if (!port || port < 0 || port > 0xffff) {
+                    ip.addr = INADDR_ANY;
+                }
+            }
+            else {
+                ip.addr = INADDR_ANY;
+            }
+        }
+    }
+
+    // If a valid ip is configured we enable the syslog
+    if (ip.addr != INADDR_ANY) {
+        bufsize = buffer_size;
+        buf = new char[bufsize];
+        bufpos = 0;
+        xTaskCreate(syslogTask, "Syslog Task", configMINIMAL_STACK_SIZE, this, tskIDLE_PRIORITY + 1, &task);
+        printf("Sending logs to syslog server '%s'\n", server);
+        return true;
+    }
+
+    // Invalid config
+    printf("Invalid syslog server specified (expected <ip>[:<port>]): '%s'\n", server);
+    return false;
+}
+
+void Syslog::charout(int c)
+{
+    if (overflow) {
+        return;
+    }
+    if (bufpos < bufsize) {
+        buf[bufpos] = (char)c;
+        ENTER_SAFE_SECTION;
+        if (c == '\n') {
+            newlinepos = bufpos;
+        }
+        ++bufpos;
+        LEAVE_SAFE_SECTION;
+    }
+    else {
+        overflow = true;
+    }
+}
+
+void Syslog::syslogTask(void *arg)
+{
+    Syslog *obj = (Syslog *)arg;
+    obj->forwardLogging();
+    // Never reached
+    for (;;) {
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+    vTaskSuspend(NULL);
+}
+
+void Syslog::forwardLogging()
+{
+    // Wait until we have link on at least one of our interfaces
+    while (true) {
+        vTaskDelay(100 / portTICK_PERIOD_MS);
+        if (NetworkInterface::DoWeHaveLink()) {
+            break;
+        }
+    }
+    vTaskDelay(1000 / portTICK_PERIOD_MS);  // Wait one extra second to allow things to settle
+
+    // Open socket for sending packets to the remote syslog server
+    struct sockaddr_in sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = ip.addr;
+    sa.sin_port = htons(port);
+    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0 || connect(sockfd, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+    {
+        if (sockfd >= 0) {
+            closesocket(sockfd);
+            puts("Failed to open socket for sending syslog packets, terminating syslog task\n");
+        }
+        else {
+            puts("Failed to prepare connection to syslog server, terminating syslog task\n");
+        }
+        vTaskDelete(NULL);
+        // Never reached
+    }
+
+    // Forward lines to syslog as they come in
+    int linestartpos = 0;  // Where the next line to be sent starts
+    while (true) {
+        // If there is at least one newline found we loop forever until a "break" is reached
+        while (newlinepos >= 0) {
+            ENTER_SAFE_SECTION;
+            int safe_newlinepos = newlinepos;
+            LEAVE_SAFE_SECTION;
+            char *line = &buf[linestartpos];
+            char *newline = (char *)memchr(line, '\n', safe_newlinepos - linestartpos + 1);
+            if (newline) {
+                int linelen = newline - line;  // Excluding newline char
+                if (linelen) {
+                    if (send(sockfd, line, linelen, 0) < 0) {
+                        // Error sending, but not really much we can do except register the fact.
+                        // Can't risk logging as that could cause an infinite loop.
+                        ++failed_sends;
+                    }
+                    vTaskDelay(5 / portTICK_PERIOD_MS);  // Throttle to 200 messages per second
+                }
+                linestartpos += linelen + 1;
+
+                // See if we are all caught up and can rewind the buffer
+                if (linestartpos >= bufpos) {  // Preliminary quick peek
+                    ENTER_SAFE_SECTION;
+                    if (linestartpos >= bufpos) {
+                        // We are caught up
+                        rewind();
+                        linestartpos = 0;
+                    }
+                    LEAVE_SAFE_SECTION;
+                    break;  // No more data, done
+                }
+            }
+            else {
+                break;  // No more newlines found in the remaining buffer, done
+            }
+        }
+
+        // Check for overflow
+        if (overflow) {
+            ENTER_SAFE_SECTION;
+            rewind();
+            linestartpos = 0;
+            LEAVE_SAFE_SECTION;
+        }
+        vTaskDelay(100 / portTICK_PERIOD_MS);  // Wait for more data
+    }
+    // Never reached
+}

--- a/software/network/syslog.h
+++ b/software/network/syslog.h
@@ -1,0 +1,40 @@
+#ifndef SYSLOG_H
+#define SYSLOG_H
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include <sys/socket.h>
+#include "lwip/inet.h"
+
+
+class Syslog
+{
+  private:
+    ip_addr_t ip;
+    int port;
+
+    char *buf;
+    int bufsize;
+    int failed_sends;
+    TaskHandle_t task;
+
+    // Sensitive variables needing exclusive access
+    int bufpos;         // Where next character will be written by charout()
+    int newlinepos;     // Last position where a newline was written (or -1)
+    bool overflow;      // True when log data is coming faster than we can handle
+
+    static void syslogTask(void *arg);
+    void forwardLogging();
+
+  public:
+    Syslog() : buf(0), bufsize(0), failed_sends(0) { rewind(); }
+    ~Syslog() { if (buf) delete buf; }
+    void rewind() { bufpos = 0; newlinepos = -1; overflow = false; }
+    bool init(size_t buffer_size);
+    void charout(int c);
+};
+
+extern Syslog syslog;
+
+#endif  /* SYSLOG_H */

--- a/target/u2/microblaze/mb_ultimate/Makefile
+++ b/target/u2/microblaze/mb_ultimate/Makefile
@@ -120,6 +120,7 @@ SRCS_CC	 =  small_printf.cc \
             socket_stream.cc \
             socket_gui.cc \
 			socket_dma.cc \
+			syslog.cc \
             home_directory.cc \
             reu_preloader.cc \
             configio.cc \

--- a/target/u2/riscv/ultimate/Makefile
+++ b/target/u2/riscv/ultimate/Makefile
@@ -133,6 +133,7 @@ SRCS_CC	 =	small_printf.cc \
 			socket_stream.cc \
 			socket_gui.cc \
 			socket_dma.cc \
+			syslog.cc \
 			home_directory.cc \
 			reu_preloader.cc \
 			configio.cc \

--- a/target/u2plus/nios/ultimate/Makefile
+++ b/target/u2plus/nios/ultimate/Makefile
@@ -135,6 +135,7 @@ SRCS_CC	 =  u2p_init.cc \
 			socket_stream.cc \
 			socket_gui.cc \
 			socket_dma.cc \
+			syslog.cc \
 			rmii_interface.cc \
 			home_directory.cc \
 			reu_preloader.cc \

--- a/target/u2plus_L/riscv/ultimate/Makefile
+++ b/target/u2plus_L/riscv/ultimate/Makefile
@@ -138,6 +138,7 @@ SRCS_CC	 =  u2p_init.cc \
 			socket_stream.cc \
 			socket_gui.cc \
 			socket_dma.cc \
+			syslog.cc \
 			rmii_interface.cc \
 			home_directory.cc \
 			reu_preloader.cc \

--- a/target/u64/nios2/ultimate/Makefile
+++ b/target/u64/nios2/ultimate/Makefile
@@ -142,6 +142,7 @@ SRCS_CC	 =  u2p_init.cc \
 			socket_stream.cc \
 			socket_gui.cc \
 			socket_dma.cc \
+			syslog.cc \
 			home_directory.cc \
 			reu_preloader.cc \
 			color_timings.cc \

--- a/target/u64/riscv/ultimate/Makefile
+++ b/target/u64/riscv/ultimate/Makefile
@@ -146,6 +146,7 @@ SRCS_CC	 =  u2p_init.cc \
 			socket_stream.cc \
 			socket_gui.cc \
 			socket_dma.cc \
+			syslog.cc \
 			rmii_interface.cc \
 			home_directory.cc \
 			reu_preloader.cc \

--- a/target/u64ii/riscv/ultimate/Makefile
+++ b/target/u64ii/riscv/ultimate/Makefile
@@ -160,6 +160,7 @@ SRCS_CC	 =  u64ii_init.cc \
 			modem.cc \
 			socket_gui.cc \
 			socket_dma.cc \
+			syslog.cc \
 			listener_socket.cc \
 			system_info.cc \
 			ult_syscalls.cc \


### PR DESCRIPTION
This feature is useful for developers to receive console logs over the network instead of having to connect to the physical serial debug port on the Ultimate board.

Logs are buffered fairly early in the boot, and when the network is available the logs will be sent to the configured syslog server. The server is specified as `ip:port` where the port is optional and defaults to the syslog port (514). If no syslog server is defined (default) then no logging will be done.

Changes to the syslog serve ip or port always require a restart of the Ultimate product.

A tiny but fully usable syslog server is included as `python/syslogd.py`.