### PR TITLE
Clean up action string drop-downs for CFG_TYPE_STRFUNC

### DIFF
--- a/software/api/route_configs.cc
+++ b/software/api/route_configs.cc
@@ -48,7 +48,7 @@ void emit_store(ConfigStore *st, JSON_Object *pobj, ArgsURI &args)
                     (preset_func)(NULL, presets);
                     for(int j=0;j < presets.get_elements(); j++) {
                         char *preset = presets[j];
-                        list->add(*preset == '\e' ? "" : preset);  // Strings starting with escape are always stored as an emptry string
+                        list->add(preset);
                         delete [] preset;
                     }
                     ob->add("default", (const char *)i->definition->def);

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -1338,8 +1338,8 @@ void C64 :: list_crts(ConfigItem *it, IndexedList<char *>& strings)
 {
 #ifndef NO_FILE_ACCESS
     // Always return at least the empty string
-    char *empty = new char[12];
-    strcpy(empty, "\er- None -");
+    char *empty = new char[1];
+    *empty = 0;
     strings.append(empty);
 
     Path p;
@@ -1367,8 +1367,8 @@ void C64 :: list_kernals(ConfigItem *it, IndexedList<char *>& strings)
 {
 #if !U64
     // Always return at least the empty string
-    char *empty = new char[12];
-    strcpy(empty, "\er- None -");
+    char *empty = new char[1];
+    *empty = 0;
     strings.append(empty);
 #endif
 

--- a/software/network/network_config.cc
+++ b/software/network/network_config.cc
@@ -32,8 +32,8 @@ NetworkConfig :: ~NetworkConfig() {
 
 void NetworkConfig :: list_unique_id_choices(ConfigItem *it, IndexedList<char *>& strings)
 {
-    char *empty = new char[12];
-    strcpy(empty, "\er- None -");
+    char *empty = new char[1];
+    *empty = 0;
     strings.append(empty);
 
     char *def = new char[12];

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -2089,8 +2089,8 @@ bool U64Config :: IsMonitorHDMI()
 void U64Config :: list_palettes(ConfigItem *it, IndexedList<char *>& strings)
 {
     // Always return at least the empty string
-    char *empty = new char[16];
-    strcpy(empty, "\er- Default -");
+    char *empty = new char[1];
+    *empty = 0;
     strings.append(empty);
 
     Path p;

--- a/software/userinterface/config_menu.h
+++ b/software/userinterface/config_menu.h
@@ -50,11 +50,7 @@ class BrowsableConfigItem: public Browsable
         ConfigItem *item = (ConfigItem *)(cmd->functionID);
         printf("Update String: %s\n", cmd->actionName.c_str());
         const char *actionString = cmd->actionName.c_str();
-        if (actionString[0] == '\e') {
-            item->setString("");
-        } else {
-            item->setString(actionString);
-        }
+        item->setString(actionString);
         return SSRET_OK;
     }
 

--- a/software/userinterface/context_menu.cc
+++ b/software/userinterface/context_menu.cc
@@ -85,6 +85,9 @@ void ContextMenu :: init(Window *parwin, Keyboard *key)
         for(int i=0;i<actions.get_elements();i++) {
         	Action *it = actions[i];
             len = strlen(it->getName());
+            if (len == 0) {
+                len = 8;   // "" will be transformed to "- None -"
+            }
             if(len > max_len)
                 max_len = len;
         }
@@ -311,7 +314,8 @@ void ContextMenu :: draw()
 	        window->set_background(0);
 		}
 		if (t) {
-			window->output_line(t->getName());
+			const char *string = t->getName();
+			window->output_line(*string ? string : "- None -");  // Action name or "- None -"
 		} else {
 			window->output_line("");
 		}


### PR DESCRIPTION
This PR avoids handling "empty" configuration settings presented for CFG_TYPE_STRFUNC as magically escaped strings. Instead a natural empty string is passed around and the screen renderer puts "- None -" in its place. This simplifies code as well.

The only visible change in the UI is that the U64 "Palette Definition" setting will now have "- None -" in the drop-down rather than "- Default -".