### PR TITLE
Fixes web BASIC editor tokenizer bug with "DATA" statements

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -431,17 +431,21 @@ $(document).ready(async function () {
         let bytes = [];
         let inQuotes = false;
         let inRemark = false;
+        let inData   = false;
 
         while (remainingString) {
-            let [byte, newString] = scan(remainingString, !(inQuotes || inRemark));
+            let [byte, newString] = scan(remainingString, !(inQuotes || inRemark || inData));
             bytes.push(byte);
             remainingString = newString;
 
             if (byte === '"'.charCodeAt(0)) {
                 inQuotes = !inQuotes;
             }
-            if (byte === 143) {
+            else if (byte === 143) {
                 inRemark = true;
+            }
+            else if (byte === 131) {
+                inData = true;
             }
         }
 


### PR DESCRIPTION
The BASIC editor in the web interface incorrectly tokenized the parameters of a DATA statement.

Parameters of DATA are not tokenized by Commodore BASIC, so an expression like 1 + 2 has to be treated as a string "1+2", and the "+" character must be preserved. Likewise for any other keywords/characters with tokens.

Fixes bug #552.


Test program:
```
10 READ A$:PRINT A$
20 IF A$ <> "0" GOTO 10
30 END
100 DATA 1+2,3-2,*,+,-,0
```

Here's what the expected Commodore BASIC result when entered manually (DATA parameters not tokenized):
<img width="372" height="258" alt="BasicTokenizer1" src="https://github.com/user-attachments/assets/efe414a8-5f44-4613-bc36-ea73c82aac05" />

Here's what it incorrectly looked like when the same BASIC text was uploaded via the web interface (DATA parameters incorrectly tokenized):
<img width="487" height="339" alt="BasicTokenizer2" src="https://github.com/user-attachments/assets/fef0c6ca-441e-44d6-a355-acce8a410cf9" />

