### PR TITLE
Use tokenized length and fix line number parsing

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1479,7 +1479,7 @@ function disassembler(startInt, byteArray) {
             <p><b>Special characters:</b></p>
             <div id="tableContainer"></div>
 
-            <textarea id="basiceditor" class="c64-textarea" cols="80">
+            <textarea id="basiceditor" wrap="off" class="c64-textarea" cols="80">
 10 print "hello world"
 20 goto 10
             </textarea>


### PR DESCRIPTION
Description of changes:
- Removed UI restriction: Deleted the hardcoded 160-character limit in the keypress event. This allows users to type long descriptive tokens (like {3 spaces} or {clear}) without the editor blocking input prematurely.
- Added Binary Size Validation: Implemented a real memory-limit check in parseBASIC(). Now, each line is validated after tokenization to ensure the total binary size (including address and line number headers) does not exceed the C64 limit of 256 bytes.
- Improved Line Number Parsing: Switched from split(' ') to a regex-based approach (match(/^\d+/)) to extract line numbers. This correctly handles BASIC shorthand where no space is used between the line number and the command (e.g., 10print).
- Code Cleanup: Optimized memory address calculation by caching the tokenized line length and updated comments for better clarity.
<img width="924" height="510" alt="obraz" src="https://github.com/user-attachments/assets/5f109774-9291-4400-aab2-8e5f3fe24231" />