### PR TITLE
Displaying the correct error message for invalid special character codes.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -438,7 +438,8 @@ $(document).ready(async function () {
                     return [value, s.substring(token.length)];
                 }
             }
-            basic_error = "Error -> ..." + s + " \nInvalid code.";
+            basic_error = "Error -> ..." + s + " \nInvalid special character code occurred from this point.";
+            return [null, null];
         }
         return [asciiToPetscii(s.charCodeAt(0)), s.substring(1)];
     }


### PR DESCRIPTION
Goal of the changes:
To provide a more detailed and context-aware error message instead of the current generic output:
`Error in line 10. Program contains errors and was not sent. Error -> ...125 Unable to convert to PETSCII value.`

Tokenizer Logic Summary
- `10 print "{rvs on}hello"` (Success)
        The tag `{rvs on}` is matched in the SPECIAL table and converted to its PETSCII byte.
        Result: Processing continues successfully.
        
- `10 print "{rvs ox}hello"` (Error: Typo)
        The code `{rvs ox}` is not recognized. The parser captures the entire string from the error point.
        Result: `Error in line 10. Program contains errors and was not sent. Error -> ...{rvs ox}hello" Invalid special character code  occurred from this point.`
        
- `10 rem {rvs oooon}hello"` (Error: Invalid Name)
        The parser fails to find `{rvs oooon}` in the special tokens list,  even inside a `REM` statement, and halts execution.
        Result: `Error in line 10. Program contains errors and was not sent. Error -> ...{rvs oooon}hello" Invalid special character code occurred from this point.`
        
- `10 print "{rvs onhello"` (Error: Missing Brace )
        The missing `}` prevents a match. The context highlights the unclosed brace until the end of the line.
        Result: `Error in line 10. Program contains errors and was not sent. Error -> ...{rvs onhello" Invalid special character code occurred from this point.`
        

--        
Purpose of `return [null, null];`

Immediate Halt: It acts as a "kill switch," stopping the `scan` function instantly to prevent any further processing of the line.
Message Integrity: By exiting early, it prevents the code from reaching the final `asciiToPetscii` call. This ensures your specific error message is preserved and not overwritten by a generic "Unable to convert" error.