### PR TITLE
Show missing "UserPort Power Enable" option in config menu.

### DIFF
--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -2474,6 +2474,7 @@ void U64Config :: setup_config_menu(void)
     grp->append(cfg->find_item(CFG_IEC_BURST_EN));
     grp->append(cfg->find_item(CFG_PARCABLE_ENABLE)->set_item_altname("Parallel Cable to Drive A"));
     grp->append(cfg->find_item(CFG_IEC_BUS_MODE));
+    grp->append(cfg->find_item(CFG_USERPORT_EN));
     //grp->append(cfg->find_item(CFG_HDMI_TX_SWING));
 
     // grp = ConfigGroupCollection :: getGroup("Drive A Settings", SORT_ORDER_CFG_DRVA);


### PR DESCRIPTION
Was the "UserPort Power Enable" option removed intentionally? Still seems to be fully supported. Just wasn't visible anywhere.

Or, maybe I'm blind or missing something obvious... 

Commit adds the option to the "Machine Tweaks" group.