### PR TITLE
Fixed various (minor) socket issues.

### DIFF
--- a/software/io/acia/listener_socket.cc
+++ b/software/io/acia/listener_socket.cc
@@ -7,13 +7,13 @@ ListenerSocket :: ListenerSocket(const char *socketName, SpawnFunction_t spawn, 
     spawnFunction = spawn;
     this->spawnName = spawnName;
     port = 0;
-    listenfd = 0;
+    listenfd = -1;
     listenerTask = 0;
 }
 
 ListenerSocket :: ~ListenerSocket()
 {
-    if (listenfd) {
+    if (listenfd >= 0) {
         closesocket(listenfd);
         vTaskDelay(10);
     }
@@ -55,7 +55,7 @@ int ListenerSocket :: Start(int port)
         listenerTask = 0;
     }
 
-    if (listenfd) {
+    if (listenfd >= 0) {
         closesocket(listenfd);
     }
 

--- a/software/io/acia/modem.cc
+++ b/software/io/acia/modem.cc
@@ -858,7 +858,7 @@ void Modem :: RelayFileToSocket(const char *filename, int socket, const char *al
 
 void Modem :: effectuate_settings()
 {
-    int newPort;
+    int newPort = 0;
     sscanf(cfg->get_string(CFG_MODEM_LISTEN_PORT), "%d", &newPort);
 
     int base = acia_base[cfg->get_value(CFG_MODEM_ACIA)];
@@ -885,7 +885,8 @@ void Modem :: effectuate_settings()
         acia.init(base & 0xFFFE, base & 1, aciaQueue, aciaQueue, aciaTxBuffer);
     }
 
-    listenerSocket->Start(newPort);
+    if (newPort > 0)
+        listenerSocket->Start(newPort);
 }
 
 void Modem :: reinit_acia(uint16_t base)

--- a/software/network/assembly.cc
+++ b/software/network/assembly.cc
@@ -98,7 +98,7 @@ int Assembly :: connect_to_server(void)
     struct sockaddr_in serv_addr;
     char buffer[1024];
 
-    this->socket_fd = 0;
+    this->socket_fd = -1;
     InitReqMessage(&this->response);
     this->response.usedAsResponseFromServer = 1;
 
@@ -141,10 +141,10 @@ int Assembly :: connect_to_server(void)
 
 void Assembly :: close_connection(void)
 {
-    if(socket_fd) {
+    if(socket_fd >= 0) {
         close(socket_fd);
     }
-    socket_fd = 0;
+    socket_fd = -1;
 }
 
 JSON *Assembly :: get_presets(void)
@@ -161,7 +161,7 @@ JSON *Assembly :: get_presets(void)
     if (presets) {
         return presets;
     }
-    if (connect_to_server() > 0) {
+    if (connect_to_server() >= 0) {
         send(this->socket_fd, request, strlen(request), MSG_DONTWAIT);
         get_response(collect_in_buffer);
         close_connection();
@@ -188,7 +188,7 @@ JSON *Assembly :: send_query(const char *query)
         "Connection: close\r\n"
         "\r\n";
 
-    if (connect_to_server() > 0) {
+    if (connect_to_server() >= 0) {
         send(this->socket_fd, request.c_str(), request.length(), MSG_DONTWAIT);
         get_response(collect_in_buffer);
         close_connection();
@@ -240,7 +240,7 @@ JSON *Assembly :: request_entries(const char *id, int cat)
         "Connection: close\r\n"
         "\r\n";
 
-    if (connect_to_server() > 0) {
+    if (connect_to_server() >= 0) {
         send(this->socket_fd, request.c_str(), request.length(), MSG_DONTWAIT);
         get_response(collect_in_buffer);
         close_connection();
@@ -289,7 +289,7 @@ void Assembly :: request_binary(const char *path, const char *filename)
         "Connection: close\r\n"
         "\r\n";
 
-    if (connect_to_server() > 0) { // resets userContext to NULL
+    if (connect_to_server() >= 0) { // resets userContext to NULL
         send(this->socket_fd, request.c_str(), request.length(), MSG_DONTWAIT);
         get_response(write_to_temp);
         close_connection();

--- a/software/network/assembly.h
+++ b/software/network/assembly.h
@@ -31,6 +31,7 @@ public:
     Assembly() {
         body = NULL;
         presets = NULL;
+        socket_fd = -1;
     }
     ~Assembly() {
         if (presets)

--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -873,10 +873,12 @@ int FTPDataConnection::setup_connection()
 
 void FTPDataConnection::close_connection()
 {
-    if (actual_socket)
+    if (actual_socket >= 0)
         closesocket(actual_socket);
-    if ((sockfd) && (actual_socket != sockfd))
+    if ((sockfd >= 0) && (actual_socket != sockfd))
         closesocket(sockfd);
+    actual_socket = -1;
+    sockfd = -1;
 }
 
 int FTPDataConnection::connect_to(ip_addr_t ip, uint16_t port) // active mode

--- a/software/network/sock_echo.c
+++ b/software/network/sock_echo.c
@@ -52,7 +52,7 @@ static void echo_run()
 		int nbytes;
 
 		clientfd = lwip_accept(lSocket, (struct sockaddr*)&client_addr, (socklen_t *)&addrlen);
-		if (clientfd > 0) {
+		if (clientfd >= 0) {
 			puts("Accepted Echo Connection");
 
 /*

--- a/software/network/socket_stream.cc
+++ b/software/network/socket_stream.cc
@@ -103,8 +103,9 @@ int SocketStream :: transmit(const char *buffer, int out_length)
 
 void SocketStream :: close()
 {
-	if(actual_socket > 0) {
+	if(actual_socket >= 0) {
 		shutdown(actual_socket, 2);
 		lwip_close(actual_socket);
+		actual_socket = -1;
 	}
 }


### PR DESCRIPTION
- I checked firmware sources using sockets, and found some more places where 0 was not properly handled as a valid socket descriptor. Nothing "dramatic" (as with the MicroHttpServer), but easy to fix. 

- Also, an undefined value was used for the port number in modem.cc, when an empty or non-numeric string was entered for CFG_MODEM_LISTEN_PORT, so when sscanf failed.

- Entering an empty string, 0, or any non-numeric value for CFG_MODEM_LISTEN_PORT now no longer starts the modem's listener thread (as port 0 is invalid anyway).