### PR TITLE
Fixed ACIA/IRQ support: ACIA always used NMI

### DIFF
--- a/software/io/acia/acia.cc
+++ b/software/io/acia/acia.cc
@@ -37,7 +37,7 @@ int Acia :: init(uint16_t base, bool useNMI, QueueHandle_t controlQueue, QueueHa
     if ((base < 0xDE00) || (base > 0xDFFC)) {
         return -1;
     }
-    printf("Enabling ACIA at address %04x\n", base);
+    printf("Enabling ACIA at address %04x, nmi=%u\n", base, useNMI);
 
     base -= 0xDE00;
     base >>= 2;

--- a/software/io/acia/modem.cc
+++ b/software/io/acia/modem.cc
@@ -886,7 +886,7 @@ void Modem :: reinit_acia(uint16_t base)
             acia.deinit();
             current_iobase = 0;
         } else {
-            acia.init(basecfg & 0xFFFE, base & 1, aciaQueue, aciaQueue, aciaTxBuffer);
+            acia.init(basecfg & 0xFFFE, basecfg & 1, aciaQueue, aciaQueue, aciaTxBuffer);
             current_iobase = basecfg & 0xFFFE;
         }
     } else {


### PR DESCRIPTION
- Modem never considered the NMI vs IRQ configuration option. The module is initialized by a call "Modem::reinit_acia(0xffff)", and in the code path "base == 0xffff" it used "base & 1" to determine the NMI selection - which is always true.
- Added "useNMI" to log output.