### PR TITLE
Add support for direct mouse wheel mapping (Micromys protocol)

### DIFF
--- a/software/io/usb/hid_decoder.h
+++ b/software/io/usb/hid_decoder.h
@@ -343,6 +343,7 @@ class HidMouseInterpreter
     };
 
     enum {
+        NATIVE_WHEEL_THRESHOLD = 8,
         SENSITIVITY_SCALE_STEP = 32,
         ADAPTIVE_ACCELERATION_TARGET_EMA = 32,
         ADAPTIVE_ACCELERATION_MAX_EMA = 96,
@@ -447,25 +448,9 @@ class HidMouseInterpreter
         return mouse_mode == MOUSE_MODE_MOUSE_WHEEL;
     }
 
-    static int computeNativeWheelGain(int sensitivity)
-    {
-        // Mouse + Wheel mode emits discrete Micromys pulses, so map the
-        // promoted detent directly to the configured sensitivity. This keeps
-        // sensitivity 1 unchanged and lets higher settings expand a single
-        // notch into multiple native wheel pulses.
-        return clampWheelSetting(sensitivity);
-    }
-
-    static int computeNativeWheelThreshold(int sensitivity)
-    {
-        (void)sensitivity;
-        return 8;
-    }
-
     static int accumulateNativeWheelSteps(int wheel_delta, int sensitivity, int& accumulator)
     {
-        int threshold = computeNativeWheelThreshold(sensitivity);
-        int scaled_delta = wheel_delta * computeNativeWheelGain(sensitivity);
+        int scaled_delta = wheel_delta * clampWheelSetting(sensitivity);
         int steps = 0;
 
         if (((wheel_delta > 0) && (accumulator < 0)) ||
@@ -474,12 +459,12 @@ class HidMouseInterpreter
         }
 
         accumulator += scaled_delta;
-        while (accumulator >= threshold) {
-            accumulator -= threshold;
+        while (accumulator >= NATIVE_WHEEL_THRESHOLD) {
+            accumulator -= NATIVE_WHEEL_THRESHOLD;
             steps++;
         }
-        while (accumulator <= -threshold) {
-            accumulator += threshold;
+        while (accumulator <= -NATIVE_WHEEL_THRESHOLD) {
+            accumulator += NATIVE_WHEEL_THRESHOLD;
             steps--;
         }
         return steps;

--- a/software/io/usb/hid_decoder.h
+++ b/software/io/usb/hid_decoder.h
@@ -450,7 +450,7 @@ class HidMouseInterpreter
 
     static int accumulateNativeWheelSteps(int wheel_delta, int sensitivity, int& accumulator)
     {
-        int scaled_delta = wheel_delta * clampWheelSetting(sensitivity);
+        (void)sensitivity;
         int steps = 0;
 
         if (((wheel_delta > 0) && (accumulator < 0)) ||
@@ -458,7 +458,7 @@ class HidMouseInterpreter
             accumulator = 0;
         }
 
-        accumulator += scaled_delta;
+        accumulator += wheel_delta;
         while (accumulator >= NATIVE_WHEEL_THRESHOLD) {
             accumulator -= NATIVE_WHEEL_THRESHOLD;
             steps++;
@@ -625,10 +625,31 @@ class HidMouseInterpreter
         return (raw_delta * scale_factor) / 256;
     }
 
+    static bool isCompactSharedWheelReport(const t_item_location& button3,
+                                           const t_item_location& wheel_v,
+                                           const t_item_location& wheel_h)
+    {
+        return (button3.report == 0) && (button3.offset == 2) && (button3.length == 1) &&
+               (wheel_v.report == 0) && (wheel_v.offset == 32) && (wheel_v.length == 8) &&
+               (wheel_h.report == 0) && (wheel_h.offset == 40) && (wheel_h.length == 8);
+    }
+
+    static bool shouldSuppressMiddleClickWheelNoise(bool compact_shared_wheel_report,
+                                                    bool middle_pressed,
+                                                    bool previous_middle_pressed)
+    {
+        return compact_shared_wheel_report && middle_pressed && !previous_middle_pressed;
+    }
+
+    static int normalizeHorizontalWheel(int wheel_h, bool invert)
+    {
+        return invert ? -wheel_h : wheel_h;
+    }
+
     static int normalizeHorizontalWheel(int wheel_h)
     {
         // AC Pan reports are opposite the existing right/left menu convention.
-        return -wheel_h;
+        return normalizeHorizontalWheel(wheel_h, true);
     }
 
     static int normalizeVerticalWheel(int wheel_v)

--- a/software/io/usb/hid_decoder.h
+++ b/software/io/usb/hid_decoder.h
@@ -332,7 +332,14 @@ class HidMouseInterpreter
     enum {
         MOUSE_MODE_CURSOR = 0,
         MOUSE_MODE_MOUSE = 1,
-        MOUSE_MODE_CURSOR_MOUSE = 2
+        MOUSE_MODE_MOUSE_CURSOR = 2,
+        MOUSE_MODE_MOUSE_WHEEL = 3
+    };
+
+    enum {
+        WHEEL_PULSE_PHASE_IDLE = 0,
+        WHEEL_PULSE_PHASE_LOW = 1,
+        WHEEL_PULSE_PHASE_HIGH = 2
     };
 
     enum {
@@ -427,12 +434,89 @@ class HidMouseInterpreter
 
     static bool mouseModeRoutesWheelToCursor(int mouse_mode)
     {
-        return mouse_mode != MOUSE_MODE_MOUSE;
+        return (mouse_mode == MOUSE_MODE_CURSOR) || (mouse_mode == MOUSE_MODE_MOUSE_CURSOR);
     }
 
     static bool mouseModeRoutesWheelToPointer(int mouse_mode)
     {
         return mouse_mode == MOUSE_MODE_MOUSE;
+    }
+
+    static bool mouseModeRoutesWheelToNative(int mouse_mode)
+    {
+        return mouse_mode == MOUSE_MODE_MOUSE_WHEEL;
+    }
+
+    static int computeNativeWheelThreshold(int sensitivity)
+    {
+        return 17 - clampWheelSetting(sensitivity);
+    }
+
+    static int accumulateWheelSteps(int wheel_delta, int sensitivity, int& accumulator)
+    {
+        int threshold = computeNativeWheelThreshold(sensitivity);
+        int steps = 0;
+
+        accumulator += wheel_delta;
+        while (accumulator >= threshold) {
+            accumulator -= threshold;
+            steps++;
+        }
+        while (accumulator <= -threshold) {
+            accumulator += threshold;
+            steps--;
+        }
+        return steps;
+    }
+
+    static bool advanceWheelPulse(int& pending_steps, int& phase, uint8_t& pulse_mask,
+                                  uint32_t& next_tick, uint32_t now, uint32_t phase_ticks)
+    {
+        if (phase_ticks == 0) {
+            phase_ticks = 1;
+        }
+
+        while (1) {
+            if (phase == WHEEL_PULSE_PHASE_IDLE) {
+                if (pending_steps > 0) {
+                    pulse_mask = 0x04;
+                    pending_steps--;
+                    phase = WHEEL_PULSE_PHASE_LOW;
+                    next_tick = now + phase_ticks;
+                    return true;
+                }
+                if (pending_steps < 0) {
+                    pulse_mask = 0x08;
+                    pending_steps++;
+                    phase = WHEEL_PULSE_PHASE_LOW;
+                    next_tick = now + phase_ticks;
+                    return true;
+                }
+                pulse_mask = 0;
+                return false;
+            }
+
+            if ((int32_t)(now - next_tick) < 0) {
+                return true;
+            }
+
+            if (phase == WHEEL_PULSE_PHASE_LOW) {
+                phase = WHEEL_PULSE_PHASE_HIGH;
+                next_tick += phase_ticks;
+                continue;
+            }
+
+            phase = WHEEL_PULSE_PHASE_IDLE;
+        }
+    }
+
+    static uint8_t applyWheelPulseMask(uint8_t mouse_joy, int phase, uint8_t pulse_mask)
+    {
+        mouse_joy |= 0x0C;
+        if ((phase == WHEEL_PULSE_PHASE_LOW) && pulse_mask) {
+            mouse_joy &= (uint8_t)~pulse_mask;
+        }
+        return mouse_joy;
     }
 
     static int scaleWheelDelta(int wheel_delta, int scroll_factor,

--- a/software/io/usb/hid_decoder.h
+++ b/software/io/usb/hid_decoder.h
@@ -448,9 +448,14 @@ class HidMouseInterpreter
         return mouse_mode == MOUSE_MODE_MOUSE_WHEEL;
     }
 
+    static int computeNativeWheelGain(int sensitivity)
+    {
+        return clampWheelSetting(sensitivity);
+    }
+
     static int accumulateNativeWheelSteps(int wheel_delta, int sensitivity, int& accumulator)
     {
-        (void)sensitivity;
+        int scaled_delta = wheel_delta * computeNativeWheelGain(sensitivity);
         int steps = 0;
 
         if (((wheel_delta > 0) && (accumulator < 0)) ||
@@ -458,7 +463,7 @@ class HidMouseInterpreter
             accumulator = 0;
         }
 
-        accumulator += wheel_delta;
+        accumulator += scaled_delta;
         while (accumulator >= NATIVE_WHEEL_THRESHOLD) {
             accumulator -= NATIVE_WHEEL_THRESHOLD;
             steps++;

--- a/software/io/usb/hid_decoder.h
+++ b/software/io/usb/hid_decoder.h
@@ -447,17 +447,33 @@ class HidMouseInterpreter
         return mouse_mode == MOUSE_MODE_MOUSE_WHEEL;
     }
 
-    static int computeNativeWheelThreshold(int sensitivity)
+    static int computeNativeWheelGain(int sensitivity)
     {
-        return 17 - clampWheelSetting(sensitivity);
+        // Mouse + Wheel mode emits discrete Micromys pulses, so map the
+        // promoted detent directly to the configured sensitivity. This keeps
+        // sensitivity 1 unchanged and lets higher settings expand a single
+        // notch into multiple native wheel pulses.
+        return clampWheelSetting(sensitivity);
     }
 
-    static int accumulateWheelSteps(int wheel_delta, int sensitivity, int& accumulator)
+    static int computeNativeWheelThreshold(int sensitivity)
+    {
+        (void)sensitivity;
+        return 8;
+    }
+
+    static int accumulateNativeWheelSteps(int wheel_delta, int sensitivity, int& accumulator)
     {
         int threshold = computeNativeWheelThreshold(sensitivity);
+        int scaled_delta = wheel_delta * computeNativeWheelGain(sensitivity);
         int steps = 0;
 
-        accumulator += wheel_delta;
+        if (((wheel_delta > 0) && (accumulator < 0)) ||
+            ((wheel_delta < 0) && (accumulator > 0))) {
+            accumulator = 0;
+        }
+
+        accumulator += scaled_delta;
         while (accumulator >= threshold) {
             accumulator -= threshold;
             steps++;
@@ -469,8 +485,32 @@ class HidMouseInterpreter
         return steps;
     }
 
-    static bool advanceWheelPulse(int& pending_steps, int& phase, uint8_t& pulse_mask,
-                                  uint32_t& next_tick, uint32_t now, uint32_t phase_ticks)
+    static void mergeNativeWheelBurst(int steps, uint8_t max_burst,
+                                      int& burst_direction, uint8_t& burst_count)
+    {
+        int direction;
+        int updated_count;
+
+        if ((steps == 0) || (max_burst == 0)) {
+            return;
+        }
+
+        direction = (steps > 0) ? 1 : -1;
+        if (burst_direction != direction) {
+            burst_direction = direction;
+            burst_count = 0;
+        }
+
+        updated_count = burst_count + absoluteValue(steps);
+        if (updated_count > max_burst) {
+            updated_count = max_burst;
+        }
+        burst_count = (uint8_t)updated_count;
+    }
+
+    static bool advanceNativeWheelBurst(int& burst_direction, uint8_t& burst_count,
+                                        int& phase, uint8_t& pulse_mask,
+                                        uint32_t& next_tick, uint32_t now, uint32_t phase_ticks)
     {
         if (phase_ticks == 0) {
             phase_ticks = 1;
@@ -478,20 +518,14 @@ class HidMouseInterpreter
 
         while (1) {
             if (phase == WHEEL_PULSE_PHASE_IDLE) {
-                if (pending_steps > 0) {
-                    pulse_mask = 0x04;
-                    pending_steps--;
+                if ((burst_count > 0) && (burst_direction != 0)) {
+                    pulse_mask = (burst_direction > 0) ? 0x04 : 0x08;
+                    burst_count--;
                     phase = WHEEL_PULSE_PHASE_LOW;
                     next_tick = now + phase_ticks;
                     return true;
                 }
-                if (pending_steps < 0) {
-                    pulse_mask = 0x08;
-                    pending_steps++;
-                    phase = WHEEL_PULSE_PHASE_LOW;
-                    next_tick = now + phase_ticks;
-                    return true;
-                }
+                burst_direction = 0;
                 pulse_mask = 0;
                 return false;
             }

--- a/software/io/usb/tests/usb_hid_mouse_test.cpp
+++ b/software/io/usb/tests/usb_hid_mouse_test.cpp
@@ -40,6 +40,18 @@ const uint8_t kMouseHorizontalWheelDescriptor[] = {
 	0x08, 0x95, 0x01, 0x81, 0x06, 0xC0, 0xC0,
 };
 
+const uint8_t kCompactSharedWheelDescriptor[] = {
+	0x05, 0x01, 0x09, 0x02, 0xA1, 0x01, 0x09, 0x01,
+	0xA1, 0x00, 0x05, 0x09, 0x19, 0x01, 0x29, 0x03,
+	0x15, 0x00, 0x25, 0x01, 0x95, 0x03, 0x75, 0x01,
+	0x81, 0x02, 0x95, 0x01, 0x75, 0x05, 0x81, 0x01,
+	0x05, 0x01, 0x09, 0x30, 0x09, 0x31, 0x15, 0x81,
+	0x25, 0x7F, 0x75, 0x08, 0x95, 0x02, 0x81, 0x06,
+	0x95, 0x01, 0x81, 0x01, 0x09, 0x38, 0x95, 0x01,
+	0x81, 0x06, 0x05, 0x0C, 0x0A, 0x38, 0x02, 0x95,
+	0x01, 0x81, 0x06, 0xC0, 0xC0,
+};
+
 const uint8_t kKeyboardDescriptor[] = {
 	0x05, 0x01, 0x09, 0x06, 0xA1, 0x01, 0x05, 0x07,
 	0x19, 0xE0, 0x29, 0xE7, 0x15, 0x00, 0x25, 0x01,
@@ -182,6 +194,7 @@ TEST(HidMouseDescriptorTest, ParseHorizontalWheelAcPan)
 	ASSERT_TRUE(items.locateMouseFields(fields));
 	EXPECT_TRUE(fields.has_wheel_v);
 	EXPECT_TRUE(fields.has_wheel_h);
+	EXPECT_FALSE(HidMouseInterpreter::isCompactSharedWheelReport(fields.button3, fields.wheel_v, fields.wheel_h));
 	EXPECT_EQ(1, fields.mouse_x.report);
 	EXPECT_EQ(2, fields.wheel_h.report);
 
@@ -191,6 +204,29 @@ TEST(HidMouseDescriptorTest, ParseHorizontalWheelAcPan)
 	EXPECT_EQ(-4, HidReport::getValueFromData(axis_report, sizeof(axis_report), fields.mouse_y));
 	EXPECT_EQ(1, HidReport::getValueFromData(axis_report, sizeof(axis_report), fields.wheel_v));
 	EXPECT_EQ(-3, HidReport::getValueFromData(pan_report, sizeof(pan_report), fields.wheel_h));
+}
+
+TEST(HidMouseDescriptorTest, ParseCompactSharedWheelReport)
+{
+	HidReportParser parser;
+	HidItemList items;
+	t_hid_mouse_fields fields;
+	ASSERT_EQ(0, parser.decode(&items, kCompactSharedWheelDescriptor, sizeof(kCompactSharedWheelDescriptor)));
+	ASSERT_TRUE(items.locateMouseFields(fields));
+	EXPECT_TRUE(fields.has_button3);
+	EXPECT_TRUE(fields.has_wheel_v);
+	EXPECT_TRUE(fields.has_wheel_h);
+	EXPECT_TRUE(HidMouseInterpreter::isCompactSharedWheelReport(fields.button3, fields.wheel_v, fields.wheel_h));
+
+	const uint8_t clean_middle_click[] = { 0x04, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	const uint8_t contaminated_middle_click[] = { 0x04, 0x00, 0x00, 0x00, 0x00, 0xFF };
+	const uint8_t firm_press_artifact[] = { 0x00, 0x00, 0x00, 0x00, 0x01, 0x00 };
+
+	EXPECT_NE(0, HidReport::getValueFromData(clean_middle_click, sizeof(clean_middle_click), fields.button3));
+	EXPECT_EQ(0, HidReport::getValueFromData(clean_middle_click, sizeof(clean_middle_click), fields.wheel_v));
+	EXPECT_EQ(0, HidReport::getValueFromData(clean_middle_click, sizeof(clean_middle_click), fields.wheel_h));
+	EXPECT_EQ(-1, HidReport::getValueFromData(contaminated_middle_click, sizeof(contaminated_middle_click), fields.wheel_h));
+	EXPECT_EQ(1, HidReport::getValueFromData(firm_press_artifact, sizeof(firm_press_artifact), fields.wheel_v));
 }
 
 TEST(HidMouseInterpreterTest, AppliesScrollFactorAndRuntimeChanges)
@@ -229,6 +265,8 @@ TEST(HidMouseInterpreterTest, AppliesScrollFactorAndRuntimeChanges)
 TEST(HidMouseInterpreterTest, HorizontalDirectionAndMenuWheelAreSymmetric)
 {
 	EXPECT_EQ(3, HidMouseInterpreter::normalizeHorizontalWheel(-3));
+	EXPECT_EQ(-1, HidMouseInterpreter::normalizeHorizontalWheel(-1, false));
+	EXPECT_EQ(1, HidMouseInterpreter::normalizeHorizontalWheel(1, false));
 	EXPECT_EQ(3, HidMouseInterpreter::normalizeVerticalWheel(3));
 	EXPECT_EQ(8, HidMouseInterpreter::normalizeVerticalWheel(1));
 	EXPECT_EQ(-8, HidMouseInterpreter::normalizeVerticalWheel(-1));
@@ -253,27 +291,37 @@ TEST(HidMouseInterpreterTest, WheelStepAccumulationPreservesRemainder)
 	int accumulator = 0;
 
 	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
-	EXPECT_EQ(4, accumulator);
-	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
+	EXPECT_EQ(1, accumulator);
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(1, 16, accumulator));
+	EXPECT_EQ(2, accumulator);
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(6, 8, accumulator));
 	EXPECT_EQ(0, accumulator);
-	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
-	EXPECT_EQ(4, accumulator);
-	EXPECT_EQ(-1, HidMouseInterpreter::accumulateNativeWheelSteps(-3, 4, accumulator));
-	EXPECT_EQ(-4, accumulator);
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(0, 8, accumulator));
+	EXPECT_EQ(0, accumulator);
+	EXPECT_EQ(-1, HidMouseInterpreter::accumulateNativeWheelSteps(-8, 4, accumulator));
+	EXPECT_EQ(0, accumulator);
 }
 
-TEST(HidMouseInterpreterTest, HigherNativeWheelSensitivityProducesMoreSteps)
+TEST(HidMouseInterpreterTest, NativeWheelDetentsDoNotScaleWithSensitivity)
 {
 	int slow_accumulator = 0;
 	int medium_accumulator = 0;
 	int fast_accumulator = 0;
 
-	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(8, 1, slow_accumulator));
-	EXPECT_EQ(8, HidMouseInterpreter::accumulateNativeWheelSteps(8, 8, medium_accumulator));
-	EXPECT_EQ(16, HidMouseInterpreter::accumulateNativeWheelSteps(8, 16, fast_accumulator));
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(HidMouseInterpreter::normalizeVerticalWheel(1), 1, slow_accumulator));
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(HidMouseInterpreter::normalizeVerticalWheel(1), 8, medium_accumulator));
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(HidMouseInterpreter::normalizeVerticalWheel(1), 16, fast_accumulator));
 	EXPECT_EQ(0, slow_accumulator);
 	EXPECT_EQ(0, medium_accumulator);
 	EXPECT_EQ(0, fast_accumulator);
+}
+
+TEST(HidMouseInterpreterTest, MiddleClickWheelNoiseSuppressionIsCompactReportPressOnly)
+{
+	EXPECT_TRUE(HidMouseInterpreter::shouldSuppressMiddleClickWheelNoise(true, true, false));
+	EXPECT_FALSE(HidMouseInterpreter::shouldSuppressMiddleClickWheelNoise(true, true, true));
+	EXPECT_FALSE(HidMouseInterpreter::shouldSuppressMiddleClickWheelNoise(true, false, false));
+	EXPECT_FALSE(HidMouseInterpreter::shouldSuppressMiddleClickWheelNoise(false, true, false));
 }
 
 TEST(HidMouseInterpreterTest, NativeWheelBurstUsesLatestDirectionAndPulseMask)

--- a/software/io/usb/tests/usb_hid_mouse_test.cpp
+++ b/software/io/usb/tests/usb_hid_mouse_test.cpp
@@ -240,26 +240,11 @@ TEST(HidMouseInterpreterTest, HorizontalDirectionAndMenuWheelAreSymmetric)
 	EXPECT_EQ(-1, HidMouseInterpreter::scaleMenuWheelKeys(-120));
 }
 
-TEST(HidMouseInterpreterTest, MouseModeRoutingIncludesNativeWheelMode)
+TEST(HidMouseInterpreterTest, MouseModeRoutingKeepsNativeWheelSeparate)
 {
-	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesMotionToCursor(HidMouseInterpreter::MOUSE_MODE_CURSOR));
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesMotionToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE));
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesMotionToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE_CURSOR));
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesMotionToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
-
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_CURSOR));
-	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_MOUSE));
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_MOUSE_CURSOR));
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
-
-	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesWheelToCursor(HidMouseInterpreter::MOUSE_MODE_CURSOR));
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE));
 	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesWheelToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE_CURSOR));
 	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
-
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToNative(HidMouseInterpreter::MOUSE_MODE_CURSOR));
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToNative(HidMouseInterpreter::MOUSE_MODE_MOUSE));
-	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToNative(HidMouseInterpreter::MOUSE_MODE_MOUSE_CURSOR));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
 	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesWheelToNative(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
 }
 
@@ -277,27 +262,6 @@ TEST(HidMouseInterpreterTest, WheelStepAccumulationPreservesRemainder)
 	EXPECT_EQ(-4, accumulator);
 }
 
-TEST(HidMouseInterpreterTest, WheelStepAccumulationSupportsMultipleQueuedSteps)
-{
-	int accumulator = 0;
-
-	EXPECT_EQ(2, HidMouseInterpreter::accumulateNativeWheelSteps(17, 1, accumulator));
-	EXPECT_EQ(1, accumulator);
-	EXPECT_EQ(-2, HidMouseInterpreter::accumulateNativeWheelSteps(-17, 1, accumulator));
-	EXPECT_EQ(-1, accumulator);
-
-	EXPECT_EQ(16, HidMouseInterpreter::accumulateNativeWheelSteps(8, 16, accumulator));
-	EXPECT_EQ(0, accumulator);
-}
-
-TEST(HidMouseInterpreterTest, NativeWheelThresholdStaysCanonicalDetentSize)
-{
-	EXPECT_EQ(8, HidMouseInterpreter::computeNativeWheelThreshold(1));
-	EXPECT_EQ(8, HidMouseInterpreter::computeNativeWheelThreshold(4));
-	EXPECT_EQ(8, HidMouseInterpreter::computeNativeWheelThreshold(8));
-	EXPECT_EQ(8, HidMouseInterpreter::computeNativeWheelThreshold(16));
-}
-
 TEST(HidMouseInterpreterTest, HigherNativeWheelSensitivityProducesMoreSteps)
 {
 	int slow_accumulator = 0;
@@ -312,31 +276,7 @@ TEST(HidMouseInterpreterTest, HigherNativeWheelSensitivityProducesMoreSteps)
 	EXPECT_EQ(0, fast_accumulator);
 }
 
-TEST(HidMouseInterpreterTest, NativeWheelLowSensitivityKeepsSingleDetentLinear)
-{
-	int accumulator = 0;
-
-	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(8, 1, accumulator));
-	EXPECT_EQ(0, accumulator);
-}
-
-TEST(HidMouseInterpreterTest, SingleNormalizedDetentAlwaysProducesAtLeastOneNativeStep)
-{
-	for (int sensitivity = 1; sensitivity <= 16; sensitivity++) {
-		int accumulator = 0;
-		EXPECT_TRUE(HidMouseInterpreter::accumulateNativeWheelSteps(8, sensitivity, accumulator) > 0);
-	}
-}
-
-TEST(HidMouseInterpreterTest, NativeWheelAccumulatorDropsOppositeRemainder)
-{
-	int accumulator = 5;
-
-	EXPECT_EQ(-1, HidMouseInterpreter::accumulateNativeWheelSteps(-8, 1, accumulator));
-	EXPECT_EQ(0, accumulator);
-}
-
-TEST(HidMouseInterpreterTest, NativeWheelBurstUsesLatestDirection)
+TEST(HidMouseInterpreterTest, NativeWheelBurstUsesLatestDirectionAndPulseMask)
 {
 	int burst_direction = 0;
 	uint8_t burst_count = 0;
@@ -355,14 +295,23 @@ TEST(HidMouseInterpreterTest, NativeWheelBurstUsesLatestDirection)
 	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 0, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
 	EXPECT_EQ(0x08, pulse_mask);
+	EXPECT_EQ(0x17, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
 	EXPECT_EQ(1, burst_count);
 
 	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 10, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
+	EXPECT_EQ(0x1F, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
 	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 20, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
 	EXPECT_EQ(0x08, pulse_mask);
 	EXPECT_EQ(0, burst_count);
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 30, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
+	EXPECT_FALSE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 40, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE, phase);
+	EXPECT_EQ(0, burst_direction);
+	EXPECT_EQ(0, pulse_mask);
+	EXPECT_EQ(0x1F, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
 }
 
 TEST(HidMouseInterpreterTest, NativeWheelBurstSaturatesInsteadOfGrowingLatency)
@@ -373,53 +322,6 @@ TEST(HidMouseInterpreterTest, NativeWheelBurstSaturatesInsteadOfGrowingLatency)
 	HidMouseInterpreter::mergeNativeWheelBurst(8, 4, burst_direction, burst_count);
 	EXPECT_EQ(1, burst_direction);
 	EXPECT_EQ(4, burst_count);
-}
-
-TEST(HidMouseInterpreterTest, WheelPulseSequenceProducesDistinctLowAndHighPhases)
-{
-	int burst_direction = 1;
-	uint8_t burst_count = 2;
-	int phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
-	uint8_t pulse_mask = 0;
-	uint32_t next_tick = 0;
-
-	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 0, 10));
-	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
-	EXPECT_EQ(0x04, pulse_mask);
-	EXPECT_EQ(1, burst_count);
-	EXPECT_EQ(0x1B, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
-
-	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 10, 10));
-	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
-	EXPECT_EQ(0x1F, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
-
-	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 20, 10));
-	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
-	EXPECT_EQ(0x04, pulse_mask);
-	EXPECT_EQ(0, burst_count);
-
-	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 30, 10));
-	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
-
-	EXPECT_FALSE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 40, 10));
-	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE, phase);
-	EXPECT_EQ(0, burst_direction);
-	EXPECT_EQ(0, pulse_mask);
-	EXPECT_EQ(0x1F, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
-}
-
-TEST(HidMouseInterpreterTest, WheelPulseDirectionSelectsDownBit)
-{
-	int burst_direction = -1;
-	uint8_t burst_count = 1;
-	int phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
-	uint8_t pulse_mask = 0;
-	uint32_t next_tick = 0;
-
-	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 0, 10));
-	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
-	EXPECT_EQ(0x08, pulse_mask);
-	EXPECT_EQ(0x17, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
 }
 
 TEST(HidMouseInterpreterTest, SingleDetentVerticalWheelNormalizesToUsableStep)

--- a/software/io/usb/tests/usb_hid_mouse_test.cpp
+++ b/software/io/usb/tests/usb_hid_mouse_test.cpp
@@ -291,26 +291,24 @@ TEST(HidMouseInterpreterTest, WheelStepAccumulationPreservesRemainder)
 	int accumulator = 0;
 
 	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
-	EXPECT_EQ(1, accumulator);
-	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(1, 16, accumulator));
-	EXPECT_EQ(2, accumulator);
-	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(6, 8, accumulator));
+	EXPECT_EQ(4, accumulator);
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
 	EXPECT_EQ(0, accumulator);
-	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(0, 8, accumulator));
-	EXPECT_EQ(0, accumulator);
-	EXPECT_EQ(-1, HidMouseInterpreter::accumulateNativeWheelSteps(-8, 4, accumulator));
-	EXPECT_EQ(0, accumulator);
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
+	EXPECT_EQ(4, accumulator);
+	EXPECT_EQ(-1, HidMouseInterpreter::accumulateNativeWheelSteps(-3, 4, accumulator));
+	EXPECT_EQ(-4, accumulator);
 }
 
-TEST(HidMouseInterpreterTest, NativeWheelDetentsDoNotScaleWithSensitivity)
+TEST(HidMouseInterpreterTest, HigherNativeWheelSensitivityProducesMoreSteps)
 {
 	int slow_accumulator = 0;
 	int medium_accumulator = 0;
 	int fast_accumulator = 0;
 
 	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(HidMouseInterpreter::normalizeVerticalWheel(1), 1, slow_accumulator));
-	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(HidMouseInterpreter::normalizeVerticalWheel(1), 8, medium_accumulator));
-	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(HidMouseInterpreter::normalizeVerticalWheel(1), 16, fast_accumulator));
+	EXPECT_EQ(8, HidMouseInterpreter::accumulateNativeWheelSteps(HidMouseInterpreter::normalizeVerticalWheel(1), 8, medium_accumulator));
+	EXPECT_EQ(16, HidMouseInterpreter::accumulateNativeWheelSteps(HidMouseInterpreter::normalizeVerticalWheel(1), 16, fast_accumulator));
 	EXPECT_EQ(0, slow_accumulator);
 	EXPECT_EQ(0, medium_accumulator);
 	EXPECT_EQ(0, fast_accumulator);

--- a/software/io/usb/tests/usb_hid_mouse_test.cpp
+++ b/software/io/usb/tests/usb_hid_mouse_test.cpp
@@ -267,34 +267,35 @@ TEST(HidMouseInterpreterTest, WheelStepAccumulationPreservesRemainder)
 {
 	int accumulator = 0;
 
-	EXPECT_EQ(0, HidMouseInterpreter::accumulateWheelSteps(3, 8, accumulator));
-	EXPECT_EQ(3, accumulator);
-	EXPECT_EQ(0, HidMouseInterpreter::accumulateWheelSteps(3, 8, accumulator));
-	EXPECT_EQ(6, accumulator);
-	EXPECT_EQ(1, HidMouseInterpreter::accumulateWheelSteps(3, 8, accumulator));
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
+	EXPECT_EQ(4, accumulator);
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
 	EXPECT_EQ(0, accumulator);
-	EXPECT_EQ(-1, HidMouseInterpreter::accumulateWheelSteps(-9, 8, accumulator));
-	EXPECT_EQ(0, accumulator);
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateNativeWheelSteps(1, 4, accumulator));
+	EXPECT_EQ(4, accumulator);
+	EXPECT_EQ(-1, HidMouseInterpreter::accumulateNativeWheelSteps(-3, 4, accumulator));
+	EXPECT_EQ(-4, accumulator);
 }
 
 TEST(HidMouseInterpreterTest, WheelStepAccumulationSupportsMultipleQueuedSteps)
 {
 	int accumulator = 0;
 
-	EXPECT_EQ(1, HidMouseInterpreter::accumulateWheelSteps(17, 8, accumulator));
-	EXPECT_EQ(8, accumulator);
-	EXPECT_EQ(-1, HidMouseInterpreter::accumulateWheelSteps(-17, 8, accumulator));
-	EXPECT_EQ(0, accumulator);
+	EXPECT_EQ(2, HidMouseInterpreter::accumulateNativeWheelSteps(17, 1, accumulator));
+	EXPECT_EQ(1, accumulator);
+	EXPECT_EQ(-2, HidMouseInterpreter::accumulateNativeWheelSteps(-17, 1, accumulator));
+	EXPECT_EQ(-1, accumulator);
 
-	EXPECT_EQ(8, HidMouseInterpreter::accumulateWheelSteps(8, 16, accumulator));
+	EXPECT_EQ(16, HidMouseInterpreter::accumulateNativeWheelSteps(8, 16, accumulator));
 	EXPECT_EQ(0, accumulator);
 }
 
-TEST(HidMouseInterpreterTest, NativeWheelThresholdMatchesExistingSensitivityDirection)
+TEST(HidMouseInterpreterTest, NativeWheelThresholdStaysCanonicalDetentSize)
 {
-	EXPECT_EQ(16, HidMouseInterpreter::computeNativeWheelThreshold(1));
-	EXPECT_EQ(9, HidMouseInterpreter::computeNativeWheelThreshold(8));
-	EXPECT_EQ(1, HidMouseInterpreter::computeNativeWheelThreshold(16));
+	EXPECT_EQ(8, HidMouseInterpreter::computeNativeWheelThreshold(1));
+	EXPECT_EQ(8, HidMouseInterpreter::computeNativeWheelThreshold(4));
+	EXPECT_EQ(8, HidMouseInterpreter::computeNativeWheelThreshold(8));
+	EXPECT_EQ(8, HidMouseInterpreter::computeNativeWheelThreshold(16));
 }
 
 TEST(HidMouseInterpreterTest, HigherNativeWheelSensitivityProducesMoreSteps)
@@ -303,53 +304,119 @@ TEST(HidMouseInterpreterTest, HigherNativeWheelSensitivityProducesMoreSteps)
 	int medium_accumulator = 0;
 	int fast_accumulator = 0;
 
-	EXPECT_EQ(0, HidMouseInterpreter::accumulateWheelSteps(8, 1, slow_accumulator));
-	EXPECT_EQ(0, HidMouseInterpreter::accumulateWheelSteps(8, 8, medium_accumulator));
-	EXPECT_EQ(8, HidMouseInterpreter::accumulateWheelSteps(8, 16, fast_accumulator));
-	EXPECT_EQ(8, slow_accumulator);
-	EXPECT_EQ(8, medium_accumulator);
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(8, 1, slow_accumulator));
+	EXPECT_EQ(8, HidMouseInterpreter::accumulateNativeWheelSteps(8, 8, medium_accumulator));
+	EXPECT_EQ(16, HidMouseInterpreter::accumulateNativeWheelSteps(8, 16, fast_accumulator));
+	EXPECT_EQ(0, slow_accumulator);
+	EXPECT_EQ(0, medium_accumulator);
 	EXPECT_EQ(0, fast_accumulator);
 }
 
-TEST(HidMouseInterpreterTest, WheelPulseSequenceProducesDistinctLowAndHighPhases)
+TEST(HidMouseInterpreterTest, NativeWheelLowSensitivityKeepsSingleDetentLinear)
 {
-	int pending_steps = 2;
+	int accumulator = 0;
+
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateNativeWheelSteps(8, 1, accumulator));
+	EXPECT_EQ(0, accumulator);
+}
+
+TEST(HidMouseInterpreterTest, SingleNormalizedDetentAlwaysProducesAtLeastOneNativeStep)
+{
+	for (int sensitivity = 1; sensitivity <= 16; sensitivity++) {
+		int accumulator = 0;
+		EXPECT_TRUE(HidMouseInterpreter::accumulateNativeWheelSteps(8, sensitivity, accumulator) > 0);
+	}
+}
+
+TEST(HidMouseInterpreterTest, NativeWheelAccumulatorDropsOppositeRemainder)
+{
+	int accumulator = 5;
+
+	EXPECT_EQ(-1, HidMouseInterpreter::accumulateNativeWheelSteps(-8, 1, accumulator));
+	EXPECT_EQ(0, accumulator);
+}
+
+TEST(HidMouseInterpreterTest, NativeWheelBurstUsesLatestDirection)
+{
+	int burst_direction = 0;
+	uint8_t burst_count = 0;
 	int phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
 	uint8_t pulse_mask = 0;
 	uint32_t next_tick = 0;
 
-	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 0, 10));
+	HidMouseInterpreter::mergeNativeWheelBurst(4, 4, burst_direction, burst_count);
+	EXPECT_EQ(1, burst_direction);
+	EXPECT_EQ(4, burst_count);
+
+	HidMouseInterpreter::mergeNativeWheelBurst(-2, 4, burst_direction, burst_count);
+	EXPECT_EQ(-1, burst_direction);
+	EXPECT_EQ(2, burst_count);
+
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 0, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
+	EXPECT_EQ(0x08, pulse_mask);
+	EXPECT_EQ(1, burst_count);
+
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 10, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 20, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
+	EXPECT_EQ(0x08, pulse_mask);
+	EXPECT_EQ(0, burst_count);
+}
+
+TEST(HidMouseInterpreterTest, NativeWheelBurstSaturatesInsteadOfGrowingLatency)
+{
+	int burst_direction = 0;
+	uint8_t burst_count = 0;
+
+	HidMouseInterpreter::mergeNativeWheelBurst(8, 4, burst_direction, burst_count);
+	EXPECT_EQ(1, burst_direction);
+	EXPECT_EQ(4, burst_count);
+}
+
+TEST(HidMouseInterpreterTest, WheelPulseSequenceProducesDistinctLowAndHighPhases)
+{
+	int burst_direction = 1;
+	uint8_t burst_count = 2;
+	int phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
+	uint8_t pulse_mask = 0;
+	uint32_t next_tick = 0;
+
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 0, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
 	EXPECT_EQ(0x04, pulse_mask);
-	EXPECT_EQ(1, pending_steps);
+	EXPECT_EQ(1, burst_count);
 	EXPECT_EQ(0x1B, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
 
-	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 10, 10));
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 10, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
 	EXPECT_EQ(0x1F, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
 
-	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 20, 10));
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 20, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
 	EXPECT_EQ(0x04, pulse_mask);
-	EXPECT_EQ(0, pending_steps);
+	EXPECT_EQ(0, burst_count);
 
-	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 30, 10));
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 30, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
 
-	EXPECT_FALSE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 40, 10));
+	EXPECT_FALSE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 40, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE, phase);
+	EXPECT_EQ(0, burst_direction);
 	EXPECT_EQ(0, pulse_mask);
 	EXPECT_EQ(0x1F, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
 }
 
 TEST(HidMouseInterpreterTest, WheelPulseDirectionSelectsDownBit)
 {
-	int pending_steps = -1;
+	int burst_direction = -1;
+	uint8_t burst_count = 1;
 	int phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
 	uint8_t pulse_mask = 0;
 	uint32_t next_tick = 0;
 
-	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 0, 10));
+	EXPECT_TRUE(HidMouseInterpreter::advanceNativeWheelBurst(burst_direction, burst_count, phase, pulse_mask, next_tick, 0, 10));
 	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
 	EXPECT_EQ(0x08, pulse_mask);
 	EXPECT_EQ(0x17, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));

--- a/software/io/usb/tests/usb_hid_mouse_test.cpp
+++ b/software/io/usb/tests/usb_hid_mouse_test.cpp
@@ -240,6 +240,121 @@ TEST(HidMouseInterpreterTest, HorizontalDirectionAndMenuWheelAreSymmetric)
 	EXPECT_EQ(-1, HidMouseInterpreter::scaleMenuWheelKeys(-120));
 }
 
+TEST(HidMouseInterpreterTest, MouseModeRoutingIncludesNativeWheelMode)
+{
+	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesMotionToCursor(HidMouseInterpreter::MOUSE_MODE_CURSOR));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesMotionToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesMotionToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE_CURSOR));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesMotionToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
+
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_CURSOR));
+	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_MOUSE));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_MOUSE_CURSOR));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToPointer(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
+
+	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesWheelToCursor(HidMouseInterpreter::MOUSE_MODE_CURSOR));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE));
+	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesWheelToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE_CURSOR));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToCursor(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
+
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToNative(HidMouseInterpreter::MOUSE_MODE_CURSOR));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToNative(HidMouseInterpreter::MOUSE_MODE_MOUSE));
+	EXPECT_FALSE(HidMouseInterpreter::mouseModeRoutesWheelToNative(HidMouseInterpreter::MOUSE_MODE_MOUSE_CURSOR));
+	EXPECT_TRUE(HidMouseInterpreter::mouseModeRoutesWheelToNative(HidMouseInterpreter::MOUSE_MODE_MOUSE_WHEEL));
+}
+
+TEST(HidMouseInterpreterTest, WheelStepAccumulationPreservesRemainder)
+{
+	int accumulator = 0;
+
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateWheelSteps(3, 8, accumulator));
+	EXPECT_EQ(3, accumulator);
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateWheelSteps(3, 8, accumulator));
+	EXPECT_EQ(6, accumulator);
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateWheelSteps(3, 8, accumulator));
+	EXPECT_EQ(0, accumulator);
+	EXPECT_EQ(-1, HidMouseInterpreter::accumulateWheelSteps(-9, 8, accumulator));
+	EXPECT_EQ(0, accumulator);
+}
+
+TEST(HidMouseInterpreterTest, WheelStepAccumulationSupportsMultipleQueuedSteps)
+{
+	int accumulator = 0;
+
+	EXPECT_EQ(1, HidMouseInterpreter::accumulateWheelSteps(17, 8, accumulator));
+	EXPECT_EQ(8, accumulator);
+	EXPECT_EQ(-1, HidMouseInterpreter::accumulateWheelSteps(-17, 8, accumulator));
+	EXPECT_EQ(0, accumulator);
+
+	EXPECT_EQ(8, HidMouseInterpreter::accumulateWheelSteps(8, 16, accumulator));
+	EXPECT_EQ(0, accumulator);
+}
+
+TEST(HidMouseInterpreterTest, NativeWheelThresholdMatchesExistingSensitivityDirection)
+{
+	EXPECT_EQ(16, HidMouseInterpreter::computeNativeWheelThreshold(1));
+	EXPECT_EQ(9, HidMouseInterpreter::computeNativeWheelThreshold(8));
+	EXPECT_EQ(1, HidMouseInterpreter::computeNativeWheelThreshold(16));
+}
+
+TEST(HidMouseInterpreterTest, HigherNativeWheelSensitivityProducesMoreSteps)
+{
+	int slow_accumulator = 0;
+	int medium_accumulator = 0;
+	int fast_accumulator = 0;
+
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateWheelSteps(8, 1, slow_accumulator));
+	EXPECT_EQ(0, HidMouseInterpreter::accumulateWheelSteps(8, 8, medium_accumulator));
+	EXPECT_EQ(8, HidMouseInterpreter::accumulateWheelSteps(8, 16, fast_accumulator));
+	EXPECT_EQ(8, slow_accumulator);
+	EXPECT_EQ(8, medium_accumulator);
+	EXPECT_EQ(0, fast_accumulator);
+}
+
+TEST(HidMouseInterpreterTest, WheelPulseSequenceProducesDistinctLowAndHighPhases)
+{
+	int pending_steps = 2;
+	int phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
+	uint8_t pulse_mask = 0;
+	uint32_t next_tick = 0;
+
+	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 0, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
+	EXPECT_EQ(0x04, pulse_mask);
+	EXPECT_EQ(1, pending_steps);
+	EXPECT_EQ(0x1B, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
+
+	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 10, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
+	EXPECT_EQ(0x1F, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
+
+	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 20, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
+	EXPECT_EQ(0x04, pulse_mask);
+	EXPECT_EQ(0, pending_steps);
+
+	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 30, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_HIGH, phase);
+
+	EXPECT_FALSE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 40, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE, phase);
+	EXPECT_EQ(0, pulse_mask);
+	EXPECT_EQ(0x1F, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
+}
+
+TEST(HidMouseInterpreterTest, WheelPulseDirectionSelectsDownBit)
+{
+	int pending_steps = -1;
+	int phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
+	uint8_t pulse_mask = 0;
+	uint32_t next_tick = 0;
+
+	EXPECT_TRUE(HidMouseInterpreter::advanceWheelPulse(pending_steps, phase, pulse_mask, next_tick, 0, 10));
+	EXPECT_EQ(HidMouseInterpreter::WHEEL_PULSE_PHASE_LOW, phase);
+	EXPECT_EQ(0x08, pulse_mask);
+	EXPECT_EQ(0x17, HidMouseInterpreter::applyWheelPulseMask(0x1F, phase, pulse_mask));
+}
+
 TEST(HidMouseInterpreterTest, SingleDetentVerticalWheelNormalizesToUsableStep)
 {
 	int axis_remainder = 0;

--- a/software/io/usb/usb_hid.cc
+++ b/software/io/usb/usb_hid.cc
@@ -1085,6 +1085,14 @@ void UsbHidDriver :: interrupt_handler()
         bool left_button_pressed = previous_left_button_pressed;
         bool right_button_pressed = (mouse_joy & 0x01) == 0;
         uint8_t previous_mouse_joy = mouse_joy;
+        bool previous_middle_button_pressed = (previous_mouse_joy & 0x02) == 0;
+        bool compact_shared_wheel_report = descriptor_mouse &&
+                                           has_button3 &&
+                                           has_wheel_v &&
+                                           has_wheel_h &&
+                                           HidMouseInterpreter::isCompactSharedWheelReport(rep_button3,
+                                                                                           rep_wheel_v,
+                                                                                           rep_wheel_h);
 
         if (descriptor_mouse) {
             bool axis_report = HidReport::hasValue(irq_data, data_len, rep_mouse_x) || HidReport::hasValue(irq_data, data_len, rep_mouse_y);
@@ -1163,7 +1171,15 @@ void UsbHidDriver :: interrupt_handler()
             bool reversed_wheel = usb_hid_get_wheel_direction() == WHEEL_DIRECTION_REVERSED;
             int scroll_factor = usb_hid_get_scroll_factor();
             uint8_t output_mouse_joy = mouse_joy;
-            int wheel_h_normalized = HidMouseInterpreter::normalizeHorizontalWheel(wheel_h);
+            bool middle_button_pressed = (mouse_joy & 0x02) == 0;
+            if (HidMouseInterpreter::shouldSuppressMiddleClickWheelNoise(compact_shared_wheel_report,
+                                                                         middle_button_pressed,
+                                                                         previous_middle_button_pressed)) {
+                wheel_v = 0;
+                wheel_h = 0;
+            }
+            int wheel_h_normalized = HidMouseInterpreter::normalizeHorizontalWheel(wheel_h,
+                                                                                   !compact_shared_wheel_report);
             int wheel_v_normalized = HidMouseInterpreter::normalizeVerticalWheel(wheel_v);
             int wheel_h_keys = HidMouseInterpreter::applyWheelDirection(wheel_h_normalized, reversed_wheel);
             int wheel_v_keys = HidMouseInterpreter::applyWheelDirection(wheel_v_normalized, reversed_wheel);

--- a/software/io/usb/usb_hid.cc
+++ b/software/io/usb/usb_hid.cc
@@ -683,6 +683,7 @@ UsbHidDriver :: UsbHidDriver(UsbInterface *intf) : UsbDriver(intf)
     native_wheel_queue_tail = 0;
     native_wheel_base_joy = 0x1F;
     native_wheel_output_active = 0;
+    wheel_pulse_timer = xTimerCreate("HidWheel", 1, pdFALSE, this, UsbHidDriver :: S_wheel_pulse_timer);
     memset(keyboard_data, 0, sizeof(keyboard_data));
     memset(&rep_button1, 0, sizeof(rep_button1));
     memset(&rep_button2, 0, sizeof(rep_button2));
@@ -725,6 +726,83 @@ UsbHidDriver :: UsbHidDriver(UsbInterface *intf) : UsbDriver(intf)
 
 UsbHidDriver :: ~UsbHidDriver()
 {
+    if (wheel_pulse_timer) {
+        xTimerStop(wheel_pulse_timer, 0);
+        xTimerDelete(wheel_pulse_timer, 0);
+        wheel_pulse_timer = NULL;
+    }
+}
+
+void UsbHidDriver :: S_wheel_pulse_timer(TimerHandle_t a)
+{
+    UsbHidDriver *driver = (UsbHidDriver *)pvTimerGetTimerID(a);
+    if (driver) {
+        driver->service_native_wheel_timer();
+    }
+}
+
+void UsbHidDriver :: service_native_wheel_timer(void)
+{
+#if U64
+    uint32_t now_ticks = (uint32_t)xTaskGetTickCount();
+    uint32_t delay_ticks = 0;
+    uint8_t output_mouse_joy;
+    bool active;
+
+    if (!mouse || !HidMouseInterpreter::mouseModeRoutesWheelToNative(usb_hid_get_mouse_mode())) {
+        portENTER_CRITICAL();
+        output_mouse_joy = HidMouseInterpreter::applyWheelPulseMask(native_wheel_base_joy,
+                                                                    HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE,
+                                                                    0);
+        usb_hid_reset_native_wheel_state(wheel_step_accumulator,
+                                         wheel_pulse_phase,
+                                         wheel_pulse_mask,
+                                         wheel_pulse_next_tick,
+                                         wheel_pulse_burst_direction,
+                                         wheel_pulse_burst_count);
+        native_wheel_output_active = 0;
+        portEXIT_CRITICAL();
+
+        C64_JOY1_SWOUT = output_mouse_joy;
+        if (wheel_pulse_timer) {
+            xTimerStop(wheel_pulse_timer, 0);
+        }
+        return;
+    }
+
+    portENTER_CRITICAL();
+    output_mouse_joy = HidMouseInterpreter::applyWheelPulseMask(native_wheel_base_joy,
+                                                                HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE,
+                                                                0);
+    if ((wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
+        (wheel_pulse_burst_count != 0)) {
+        output_mouse_joy = usb_hid_service_native_wheel(output_mouse_joy,
+                                                        wheel_pulse_burst_direction,
+                                                        wheel_pulse_burst_count,
+                                                        wheel_pulse_phase,
+                                                        wheel_pulse_mask,
+                                                        wheel_pulse_next_tick,
+                                                        now_ticks);
+    }
+    active = (wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
+             (wheel_pulse_burst_count != 0);
+    native_wheel_output_active = active ? 1 : 0;
+    if (active) {
+        int32_t remaining = (int32_t)(wheel_pulse_next_tick - now_ticks);
+        delay_ticks = (remaining > 0) ? (uint32_t)remaining : 1;
+    }
+    portEXIT_CRITICAL();
+
+    C64_JOY1_SWOUT = output_mouse_joy;
+    if (!wheel_pulse_timer) {
+        return;
+    }
+    if (active) {
+        xTimerChangePeriod(wheel_pulse_timer, delay_ticks, 0);
+    } else {
+        xTimerStop(wheel_pulse_timer, 0);
+    }
+#endif
 }
 
 bool UsbHidDriver :: has_active_report_keyboard(void) const
@@ -905,6 +983,9 @@ void UsbHidDriver :: install(UsbInterface *intf)
 
 void UsbHidDriver :: disable()
 {
+    if (wheel_pulse_timer) {
+        xTimerStop(wheel_pulse_timer, 0);
+    }
     if ((host) && (irq_transaction > 0)) {
 	host->free_input_pipe(irq_transaction);
         irq_transaction = 0;
@@ -998,6 +1079,9 @@ void UsbHidDriver :: poll(void)
                                                                 0);
 
     if (!HidMouseInterpreter::mouseModeRoutesWheelToNative(usb_hid_get_mouse_mode())) {
+        if (wheel_pulse_timer) {
+            xTimerStop(wheel_pulse_timer, 0);
+        }
         if ((wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
             (wheel_pulse_burst_count != 0) ||
             (wheel_step_accumulator != 0) ||
@@ -1014,21 +1098,9 @@ void UsbHidDriver :: poll(void)
         return;
     }
 
-    if ((wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
-        (wheel_pulse_burst_count != 0)) {
-        output_mouse_joy = usb_hid_service_native_wheel(output_mouse_joy,
-                                                        wheel_pulse_burst_direction,
-                                                        wheel_pulse_burst_count,
-                                                        wheel_pulse_phase,
-                                                        wheel_pulse_mask,
-                                                        wheel_pulse_next_tick,
-                                                        (uint32_t)xTaskGetTickCount());
+    if (had_native_wheel_input) {
+        service_native_wheel_timer();
     }
-
-    usb_hid_set_native_wheel_output_active(native_wheel_output_active,
-                                           (wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
-                                           (wheel_pulse_burst_count != 0));
-    C64_JOY1_SWOUT = output_mouse_joy;
 #endif
 }
 

--- a/software/io/usb/usb_hid.cc
+++ b/software/io/usb/usb_hid.cc
@@ -1068,10 +1068,12 @@ void UsbHidDriver :: poll(void)
                                            native_wheel_delta,
                                            output_mouse_joy)) {
         had_native_wheel_input = true;
+        portENTER_CRITICAL();
         HidMouseInterpreter::mergeNativeWheelBurst(native_wheel_delta,
                                                    USB_HID_MOUSE_WHEEL_BURST_LIMIT,
                                                    wheel_pulse_burst_direction,
                                                    wheel_pulse_burst_count);
+        portEXIT_CRITICAL();
     }
 
     output_mouse_joy = HidMouseInterpreter::applyWheelPulseMask(output_mouse_joy,

--- a/software/io/usb/usb_hid.cc
+++ b/software/io/usb/usb_hid.cc
@@ -45,6 +45,7 @@ static const uint32_t USB_HID_MENU_WHEEL_FAST_GAP_TICKS = (pdMS_TO_TICKS(30) > 0
 static const uint32_t USB_HID_MENU_WHEEL_SLOW_GAP_TICKS = (pdMS_TO_TICKS(90) > 0) ? pdMS_TO_TICKS(90) : USB_HID_MENU_WHEEL_FAST_GAP_TICKS;
 static const uint32_t USB_HID_MENU_WHEEL_RESET_GAP_TICKS = (pdMS_TO_TICKS(210) > 0) ? pdMS_TO_TICKS(210) : USB_HID_MENU_WHEEL_SLOW_GAP_TICKS;
 static const uint32_t USB_HID_MOUSE_WHEEL_PULSE_TICKS = (pdMS_TO_TICKS(50) > 0) ? pdMS_TO_TICKS(50) : 1;
+static const uint8_t USB_HID_MOUSE_WHEEL_BURST_LIMIT = 16;
 static const int USB_HID_MENU_WHEEL_EXTRA_STEP_THRESHOLD = 15;
 static const int USB_HID_MENU_MAX_PENDING_VERTICAL_KEYS = 2;
 
@@ -397,35 +398,118 @@ static void usb_hid_set_mouse_button(uint8_t& mouse_joy, uint8_t mask, bool pres
 }
 
 static void usb_hid_reset_native_wheel_state(int& wheel_step_accumulator,
-                                             int& wheel_pulse_pending_steps,
                                              int& wheel_pulse_phase,
                                              uint8_t& wheel_pulse_mask,
-                                             uint32_t& wheel_pulse_next_tick)
+                                             uint32_t& wheel_pulse_next_tick,
+                                             int& wheel_pulse_burst_direction,
+                                             uint8_t& wheel_pulse_burst_count)
 {
     wheel_step_accumulator = 0;
-    wheel_pulse_pending_steps = 0;
     wheel_pulse_phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
     wheel_pulse_mask = 0;
     wheel_pulse_next_tick = 0;
+    wheel_pulse_burst_direction = 0;
+    wheel_pulse_burst_count = 0;
 }
 
 static uint8_t usb_hid_service_native_wheel(uint8_t mouse_joy,
-                                            int& wheel_pulse_pending_steps,
+                                            int& wheel_pulse_burst_direction,
+                                            uint8_t& wheel_pulse_burst_count,
                                             int& wheel_pulse_phase,
                                             uint8_t& wheel_pulse_mask,
                                             uint32_t& wheel_pulse_next_tick,
                                             uint32_t now_ticks)
 {
-    HidMouseInterpreter::advanceWheelPulse(wheel_pulse_pending_steps,
-                                           wheel_pulse_phase,
-                                           wheel_pulse_mask,
-                                           wheel_pulse_next_tick,
-                                           now_ticks,
-                                           USB_HID_MOUSE_WHEEL_PULSE_TICKS);
+    HidMouseInterpreter::advanceNativeWheelBurst(wheel_pulse_burst_direction,
+                                                 wheel_pulse_burst_count,
+                                                 wheel_pulse_phase,
+                                                 wheel_pulse_mask,
+                                                 wheel_pulse_next_tick,
+                                                 now_ticks,
+                                                 USB_HID_MOUSE_WHEEL_PULSE_TICKS);
 
     return HidMouseInterpreter::applyWheelPulseMask(mouse_joy,
                                                     wheel_pulse_phase,
                                                     wheel_pulse_mask);
+}
+
+static void usb_hid_publish_native_wheel_input(int *pending_queue,
+                                               uint8_t queue_size,
+                                               uint8_t& queue_head,
+                                               uint8_t& queue_tail,
+                                               uint8_t& base_joy,
+                                               int wheel_delta,
+                                               uint8_t output_mouse_joy)
+{
+    portENTER_CRITICAL();
+    base_joy = output_mouse_joy;
+    if (wheel_delta != 0) {
+        uint8_t next_head = queue_head + 1;
+        if (next_head >= queue_size) {
+            next_head = 0;
+        }
+        if (next_head == queue_tail) {
+            uint8_t last = (queue_head == 0) ? (queue_size - 1) : (queue_head - 1);
+            pending_queue[last] += wheel_delta;
+        } else {
+            pending_queue[queue_head] = wheel_delta;
+            queue_head = next_head;
+        }
+    }
+    portEXIT_CRITICAL();
+}
+
+static bool usb_hid_take_native_wheel_input(int *pending_queue,
+                                            uint8_t queue_size,
+                                            uint8_t& queue_head,
+                                            uint8_t& queue_tail,
+                                            uint8_t& base_joy,
+                                            int& wheel_delta,
+                                            uint8_t& output_mouse_joy)
+{
+    bool have_delta = false;
+    portENTER_CRITICAL();
+    output_mouse_joy = base_joy;
+    if (queue_tail != queue_head) {
+        wheel_delta = pending_queue[queue_tail];
+        queue_tail++;
+        if (queue_tail >= queue_size) {
+            queue_tail = 0;
+        }
+        have_delta = true;
+    } else {
+        wheel_delta = 0;
+    }
+    portEXIT_CRITICAL();
+    return have_delta;
+}
+
+static void usb_hid_clear_native_wheel_input(uint8_t& queue_head,
+                                             uint8_t& queue_tail,
+                                             uint8_t& base_joy,
+                                             uint8_t output_mouse_joy)
+{
+    portENTER_CRITICAL();
+    queue_head = 0;
+    queue_tail = 0;
+    base_joy = output_mouse_joy;
+    portEXIT_CRITICAL();
+}
+
+static void usb_hid_set_native_wheel_output_active(uint8_t& output_active, bool active)
+{
+    portENTER_CRITICAL();
+    output_active = active ? 1 : 0;
+    portEXIT_CRITICAL();
+}
+
+static bool usb_hid_get_native_wheel_output_active(uint8_t& output_active)
+{
+    bool active;
+    portENTER_CRITICAL();
+    active = output_active != 0;
+    portEXIT_CRITICAL();
+    return active;
 }
 
 static void usb_hid_find_sibling_active_report_functions(UsbDevice *device, UsbInterface *skip,
@@ -594,6 +678,11 @@ UsbHidDriver :: UsbHidDriver(UsbInterface *intf) : UsbDriver(intf)
     descriptor_mouse = false;
     mouse_x = mouse_y = 0;
     mouse_joy = 0x1F;
+    memset(native_wheel_delta_queue, 0, sizeof(native_wheel_delta_queue));
+    native_wheel_queue_head = 0;
+    native_wheel_queue_tail = 0;
+    native_wheel_base_joy = 0x1F;
+    native_wheel_output_active = 0;
     memset(keyboard_data, 0, sizeof(keyboard_data));
     memset(&rep_button1, 0, sizeof(rep_button1));
     memset(&rep_button2, 0, sizeof(rep_button2));
@@ -622,10 +711,11 @@ UsbHidDriver :: UsbHidDriver(UsbInterface *intf) : UsbDriver(intf)
     wheel_key_h_remainder = 0;
     wheel_key_v_remainder = 0;
     wheel_step_accumulator = 0;
-    wheel_pulse_pending_steps = 0;
     wheel_pulse_phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
     wheel_pulse_mask = 0;
     wheel_pulse_next_tick = 0;
+    wheel_pulse_burst_direction = 0;
+    wheel_pulse_burst_count = 0;
     pointer_sensitivity_setting = -1;
     pointer_sensitivity_remainder_x = 0;
     pointer_sensitivity_remainder_y = 0;
@@ -826,7 +916,13 @@ void UsbHidDriver :: disable()
         mouse_registered = false;
         usb_hid_apply_mouse_output_enable();
     }
+
     mouse_joy = 0x1F;
+    usb_hid_clear_native_wheel_input(native_wheel_queue_head,
+                                     native_wheel_queue_tail,
+                                     native_wheel_base_joy,
+                                     0x1F);
+    usb_hid_set_native_wheel_output_active(native_wheel_output_active, false);
 #if U64
     if (usb_hid_active_mouse_interfaces == 0) {
         C64_JOY1_SWOUT = 0x1F;
@@ -846,10 +942,11 @@ void UsbHidDriver :: disable()
     wheel_key_h_remainder = 0;
     wheel_key_v_remainder = 0;
     wheel_step_accumulator = 0;
-    wheel_pulse_pending_steps = 0;
     wheel_pulse_phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
     wheel_pulse_mask = 0;
     wheel_pulse_next_tick = 0;
+    wheel_pulse_burst_direction = 0;
+    wheel_pulse_burst_count = 0;
     pointer_sensitivity_setting = -1;
     pointer_sensitivity_remainder_x = 0;
     pointer_sensitivity_remainder_y = 0;
@@ -878,36 +975,60 @@ void UsbHidDriver :: poll(void)
         return;
     }
 
+    uint8_t output_mouse_joy = 0x1F;
+    int native_wheel_delta = 0;
+    bool had_native_wheel_input = false;
+
+    while (usb_hid_take_native_wheel_input(native_wheel_delta_queue,
+                                           sizeof(native_wheel_delta_queue) / sizeof(native_wheel_delta_queue[0]),
+                                           native_wheel_queue_head,
+                                           native_wheel_queue_tail,
+                                           native_wheel_base_joy,
+                                           native_wheel_delta,
+                                           output_mouse_joy)) {
+        had_native_wheel_input = true;
+        HidMouseInterpreter::mergeNativeWheelBurst(native_wheel_delta,
+                                                   USB_HID_MOUSE_WHEEL_BURST_LIMIT,
+                                                   wheel_pulse_burst_direction,
+                                                   wheel_pulse_burst_count);
+    }
+
+    output_mouse_joy = HidMouseInterpreter::applyWheelPulseMask(output_mouse_joy,
+                                                                HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE,
+                                                                0);
+
     if (!HidMouseInterpreter::mouseModeRoutesWheelToNative(usb_hid_get_mouse_mode())) {
         if ((wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
-            (wheel_pulse_pending_steps != 0) ||
-            (wheel_step_accumulator != 0)) {
+            (wheel_pulse_burst_count != 0) ||
+            (wheel_step_accumulator != 0) ||
+            had_native_wheel_input) {
             usb_hid_reset_native_wheel_state(wheel_step_accumulator,
-                                             wheel_pulse_pending_steps,
                                              wheel_pulse_phase,
                                              wheel_pulse_mask,
-                                             wheel_pulse_next_tick);
-            C64_JOY1_SWOUT = HidMouseInterpreter::applyWheelPulseMask(mouse_joy,
-                                                                      HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE,
-                                                                      0);
-            C64_PADDLE_1_X = mouse_x & 0x7F;
-            C64_PADDLE_1_Y = mouse_y & 0x7F;
+                                             wheel_pulse_next_tick,
+                                             wheel_pulse_burst_direction,
+                                             wheel_pulse_burst_count);
+            C64_JOY1_SWOUT = output_mouse_joy;
         }
+        usb_hid_set_native_wheel_output_active(native_wheel_output_active, false);
         return;
     }
 
     if ((wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
-        (wheel_pulse_pending_steps != 0)) {
-        uint8_t output_mouse_joy = usb_hid_service_native_wheel(mouse_joy,
-                                                                wheel_pulse_pending_steps,
-                                                                wheel_pulse_phase,
-                                                                wheel_pulse_mask,
-                                                                wheel_pulse_next_tick,
-                                                                (uint32_t)xTaskGetTickCount());
-        C64_JOY1_SWOUT = output_mouse_joy;
-        C64_PADDLE_1_X = mouse_x & 0x7F;
-        C64_PADDLE_1_Y = mouse_y & 0x7F;
+        (wheel_pulse_burst_count != 0)) {
+        output_mouse_joy = usb_hid_service_native_wheel(output_mouse_joy,
+                                                        wheel_pulse_burst_direction,
+                                                        wheel_pulse_burst_count,
+                                                        wheel_pulse_phase,
+                                                        wheel_pulse_mask,
+                                                        wheel_pulse_next_tick,
+                                                        (uint32_t)xTaskGetTickCount());
     }
+
+    usb_hid_set_native_wheel_output_active(native_wheel_output_active,
+                                           (wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
+                                           (wheel_pulse_burst_count != 0));
+    C64_JOY1_SWOUT = output_mouse_joy;
 #endif
 }
 
@@ -1042,7 +1163,6 @@ void UsbHidDriver :: interrupt_handler()
             bool reversed_wheel = usb_hid_get_wheel_direction() == WHEEL_DIRECTION_REVERSED;
             int scroll_factor = usb_hid_get_scroll_factor();
             uint8_t output_mouse_joy = mouse_joy;
-            uint32_t now_ticks = (uint32_t)xTaskGetTickCount();
             int wheel_h_normalized = HidMouseInterpreter::normalizeHorizontalWheel(wheel_h);
             int wheel_v_normalized = HidMouseInterpreter::normalizeVerticalWheel(wheel_v);
             int wheel_h_keys = HidMouseInterpreter::applyWheelDirection(wheel_h_normalized, reversed_wheel);
@@ -1088,6 +1208,7 @@ void UsbHidDriver :: interrupt_handler()
                     wheel_axis_v_remainder = 0;
                     wheel_key_h_remainder = 0;
                     wheel_key_v_remainder = 0;
+                    uint32_t now_ticks = (uint32_t)xTaskGetTickCount();
                     int menu_wheel_h = usb_hid_filter_menu_wheel_step(HidMouseInterpreter::scaleMenuWheelKeys(wheel_h_keys), menu_wheel_h_latch);
                     int menu_wheel_v = HidMouseInterpreter::scaleMenuWheelBurst(
                         wheel_v_keys,
@@ -1116,11 +1237,7 @@ void UsbHidDriver :: interrupt_handler()
                     menu_wheel_v_last_tick = 0;
                     wheel_axis_h_remainder = 0;
                     wheel_axis_v_remainder = 0;
-                    usb_hid_reset_native_wheel_state(wheel_step_accumulator,
-                                                     wheel_pulse_pending_steps,
-                                                     wheel_pulse_phase,
-                                                     wheel_pulse_mask,
-                                                     wheel_pulse_next_tick);
+                    wheel_step_accumulator = 0;
                     usb_hid_queue_wheel_keys(
                         HidMouseInterpreter::scaleHorizontalWheelKeys(wheel_h_keys, scroll_factor, wheel_key_h_remainder),
                         HidMouseInterpreter::scaleVerticalWheelKeys(wheel_v_keys, scroll_factor, wheel_key_v_remainder));
@@ -1133,11 +1250,7 @@ void UsbHidDriver :: interrupt_handler()
                     menu_wheel_v_last_tick = 0;
                     wheel_key_h_remainder = 0;
                     wheel_key_v_remainder = 0;
-                    usb_hid_reset_native_wheel_state(wheel_step_accumulator,
-                                                     wheel_pulse_pending_steps,
-                                                     wheel_pulse_phase,
-                                                     wheel_pulse_mask,
-                                                     wheel_pulse_next_tick);
+                    wheel_step_accumulator = 0;
                     HidMouseInterpreter::applyWheelAxisDeltas(
                         mouse_x,
                         mouse_y,
@@ -1154,11 +1267,19 @@ void UsbHidDriver :: interrupt_handler()
                     wheel_axis_v_remainder = 0;
                     wheel_key_h_remainder = 0;
                     wheel_key_v_remainder = 0;
-                    int wheel_steps = HidMouseInterpreter::accumulateWheelSteps(
-                        wheel_v_normalized,
-                        scroll_factor,
-                        wheel_step_accumulator);
-                    wheel_pulse_pending_steps += HidMouseInterpreter::applyWheelDirection(wheel_steps, reversed_wheel);
+                    int wheel_steps = HidMouseInterpreter::applyWheelDirection(
+                        HidMouseInterpreter::accumulateNativeWheelSteps(
+                            wheel_v_normalized,
+                            scroll_factor,
+                            wheel_step_accumulator),
+                        reversed_wheel);
+                    usb_hid_publish_native_wheel_input(native_wheel_delta_queue,
+                                                       sizeof(native_wheel_delta_queue) / sizeof(native_wheel_delta_queue[0]),
+                                                       native_wheel_queue_head,
+                                                       native_wheel_queue_tail,
+                                                       native_wheel_base_joy,
+                                                       wheel_steps,
+                                                       output_mouse_joy);
                 }
             } else {
                 menu_wheel_h_latch = 0;
@@ -1166,25 +1287,33 @@ void UsbHidDriver :: interrupt_handler()
             }
 
             if (HidMouseInterpreter::mouseModeRoutesWheelToNative(mouse_mode)) {
-                output_mouse_joy = usb_hid_service_native_wheel(output_mouse_joy,
-                                                                wheel_pulse_pending_steps,
-                                                                wheel_pulse_phase,
-                                                                wheel_pulse_mask,
-                                                                wheel_pulse_next_tick,
-                                                                now_ticks);
-            } else {
-                usb_hid_reset_native_wheel_state(wheel_step_accumulator,
-                                                 wheel_pulse_pending_steps,
-                                                 wheel_pulse_phase,
-                                                 wheel_pulse_mask,
-                                                 wheel_pulse_next_tick);
                 output_mouse_joy = HidMouseInterpreter::applyWheelPulseMask(output_mouse_joy,
                                                                             HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE,
                                                                             0);
+                usb_hid_publish_native_wheel_input(native_wheel_delta_queue,
+                                                   sizeof(native_wheel_delta_queue) / sizeof(native_wheel_delta_queue[0]),
+                                                   native_wheel_queue_head,
+                                                   native_wheel_queue_tail,
+                                                   native_wheel_base_joy,
+                                                   0,
+                                                   output_mouse_joy);
+                if (!usb_hid_get_native_wheel_output_active(native_wheel_output_active)) {
+                    C64_JOY1_SWOUT = output_mouse_joy;
+                }
+            } else {
+                output_mouse_joy = HidMouseInterpreter::applyWheelPulseMask(output_mouse_joy,
+                                                                            HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE,
+                                                                            0);
+                usb_hid_clear_native_wheel_input(native_wheel_queue_head,
+                                                 native_wheel_queue_tail,
+                                                 native_wheel_base_joy,
+                                                 output_mouse_joy);
             }
 
 #if U64
-            C64_JOY1_SWOUT = output_mouse_joy;
+            if (!HidMouseInterpreter::mouseModeRoutesWheelToNative(mouse_mode)) {
+                C64_JOY1_SWOUT = output_mouse_joy;
+            }
             C64_PADDLE_1_X = mouse_x & 0x7F;
             C64_PADDLE_1_Y = mouse_y & 0x7F;
 #else

--- a/software/io/usb/usb_hid.cc
+++ b/software/io/usb/usb_hid.cc
@@ -1402,7 +1402,7 @@ void UsbHidDriver :: interrupt_handler()
 
 #if U64
             if (!HidMouseInterpreter::mouseModeRoutesWheelToNative(mouse_mode)) {
-                C64_JOY1_SWOUT = output_mouse_joy;
+            C64_JOY1_SWOUT = output_mouse_joy;
             }
             C64_PADDLE_1_X = mouse_x & 0x7F;
             C64_PADDLE_1_Y = mouse_y & 0x7F;

--- a/software/io/usb/usb_hid.cc
+++ b/software/io/usb/usb_hid.cc
@@ -44,6 +44,7 @@ enum {
 static const uint32_t USB_HID_MENU_WHEEL_FAST_GAP_TICKS = (pdMS_TO_TICKS(30) > 0) ? pdMS_TO_TICKS(30) : 1;
 static const uint32_t USB_HID_MENU_WHEEL_SLOW_GAP_TICKS = (pdMS_TO_TICKS(90) > 0) ? pdMS_TO_TICKS(90) : USB_HID_MENU_WHEEL_FAST_GAP_TICKS;
 static const uint32_t USB_HID_MENU_WHEEL_RESET_GAP_TICKS = (pdMS_TO_TICKS(210) > 0) ? pdMS_TO_TICKS(210) : USB_HID_MENU_WHEEL_SLOW_GAP_TICKS;
+static const uint32_t USB_HID_MOUSE_WHEEL_PULSE_TICKS = (pdMS_TO_TICKS(50) > 0) ? pdMS_TO_TICKS(50) : 1;
 static const int USB_HID_MENU_WHEEL_EXTRA_STEP_THRESHOLD = 15;
 static const int USB_HID_MENU_MAX_PENDING_VERTICAL_KEYS = 2;
 
@@ -395,6 +396,38 @@ static void usb_hid_set_mouse_button(uint8_t& mouse_joy, uint8_t mask, bool pres
     }
 }
 
+static void usb_hid_reset_native_wheel_state(int& wheel_step_accumulator,
+                                             int& wheel_pulse_pending_steps,
+                                             int& wheel_pulse_phase,
+                                             uint8_t& wheel_pulse_mask,
+                                             uint32_t& wheel_pulse_next_tick)
+{
+    wheel_step_accumulator = 0;
+    wheel_pulse_pending_steps = 0;
+    wheel_pulse_phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
+    wheel_pulse_mask = 0;
+    wheel_pulse_next_tick = 0;
+}
+
+static uint8_t usb_hid_service_native_wheel(uint8_t mouse_joy,
+                                            int& wheel_pulse_pending_steps,
+                                            int& wheel_pulse_phase,
+                                            uint8_t& wheel_pulse_mask,
+                                            uint32_t& wheel_pulse_next_tick,
+                                            uint32_t now_ticks)
+{
+    HidMouseInterpreter::advanceWheelPulse(wheel_pulse_pending_steps,
+                                           wheel_pulse_phase,
+                                           wheel_pulse_mask,
+                                           wheel_pulse_next_tick,
+                                           now_ticks,
+                                           USB_HID_MOUSE_WHEEL_PULSE_TICKS);
+
+    return HidMouseInterpreter::applyWheelPulseMask(mouse_joy,
+                                                    wheel_pulse_phase,
+                                                    wheel_pulse_mask);
+}
+
 static void usb_hid_find_sibling_active_report_functions(UsbDevice *device, UsbInterface *skip,
                                                          bool& report_keyboard, bool& report_mouse)
 {
@@ -588,6 +621,11 @@ UsbHidDriver :: UsbHidDriver(UsbInterface *intf) : UsbDriver(intf)
     wheel_axis_v_remainder = 0;
     wheel_key_h_remainder = 0;
     wheel_key_v_remainder = 0;
+    wheel_step_accumulator = 0;
+    wheel_pulse_pending_steps = 0;
+    wheel_pulse_phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
+    wheel_pulse_mask = 0;
+    wheel_pulse_next_tick = 0;
     pointer_sensitivity_setting = -1;
     pointer_sensitivity_remainder_x = 0;
     pointer_sensitivity_remainder_y = 0;
@@ -807,6 +845,11 @@ void UsbHidDriver :: disable()
     wheel_axis_v_remainder = 0;
     wheel_key_h_remainder = 0;
     wheel_key_v_remainder = 0;
+    wheel_step_accumulator = 0;
+    wheel_pulse_pending_steps = 0;
+    wheel_pulse_phase = HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE;
+    wheel_pulse_mask = 0;
+    wheel_pulse_next_tick = 0;
     pointer_sensitivity_setting = -1;
     pointer_sensitivity_remainder_x = 0;
     pointer_sensitivity_remainder_y = 0;
@@ -830,6 +873,42 @@ void UsbHidDriver :: deinstall(UsbInterface *intf)
 
 void UsbHidDriver :: poll(void)
 {
+#if U64
+    if (!mouse) {
+        return;
+    }
+
+    if (!HidMouseInterpreter::mouseModeRoutesWheelToNative(usb_hid_get_mouse_mode())) {
+        if ((wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
+            (wheel_pulse_pending_steps != 0) ||
+            (wheel_step_accumulator != 0)) {
+            usb_hid_reset_native_wheel_state(wheel_step_accumulator,
+                                             wheel_pulse_pending_steps,
+                                             wheel_pulse_phase,
+                                             wheel_pulse_mask,
+                                             wheel_pulse_next_tick);
+            C64_JOY1_SWOUT = HidMouseInterpreter::applyWheelPulseMask(mouse_joy,
+                                                                      HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE,
+                                                                      0);
+            C64_PADDLE_1_X = mouse_x & 0x7F;
+            C64_PADDLE_1_Y = mouse_y & 0x7F;
+        }
+        return;
+    }
+
+    if ((wheel_pulse_phase != HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE) ||
+        (wheel_pulse_pending_steps != 0)) {
+        uint8_t output_mouse_joy = usb_hid_service_native_wheel(mouse_joy,
+                                                                wheel_pulse_pending_steps,
+                                                                wheel_pulse_phase,
+                                                                wheel_pulse_mask,
+                                                                wheel_pulse_next_tick,
+                                                                (uint32_t)xTaskGetTickCount());
+        C64_JOY1_SWOUT = output_mouse_joy;
+        C64_PADDLE_1_X = mouse_x & 0x7F;
+        C64_PADDLE_1_Y = mouse_y & 0x7F;
+    }
+#endif
 }
 
 void UsbHidDriver :: interrupt_handler()
@@ -963,6 +1042,7 @@ void UsbHidDriver :: interrupt_handler()
             bool reversed_wheel = usb_hid_get_wheel_direction() == WHEEL_DIRECTION_REVERSED;
             int scroll_factor = usb_hid_get_scroll_factor();
             uint8_t output_mouse_joy = mouse_joy;
+            uint32_t now_ticks = (uint32_t)xTaskGetTickCount();
             int wheel_h_normalized = HidMouseInterpreter::normalizeHorizontalWheel(wheel_h);
             int wheel_v_normalized = HidMouseInterpreter::normalizeVerticalWheel(wheel_v);
             int wheel_h_keys = HidMouseInterpreter::applyWheelDirection(wheel_h_normalized, reversed_wheel);
@@ -1008,7 +1088,6 @@ void UsbHidDriver :: interrupt_handler()
                     wheel_axis_v_remainder = 0;
                     wheel_key_h_remainder = 0;
                     wheel_key_v_remainder = 0;
-                    uint32_t now_ticks = (uint32_t)xTaskGetTickCount();
                     int menu_wheel_h = usb_hid_filter_menu_wheel_step(HidMouseInterpreter::scaleMenuWheelKeys(wheel_h_keys), menu_wheel_h_latch);
                     int menu_wheel_v = HidMouseInterpreter::scaleMenuWheelBurst(
                         wheel_v_keys,
@@ -1037,6 +1116,11 @@ void UsbHidDriver :: interrupt_handler()
                     menu_wheel_v_last_tick = 0;
                     wheel_axis_h_remainder = 0;
                     wheel_axis_v_remainder = 0;
+                    usb_hid_reset_native_wheel_state(wheel_step_accumulator,
+                                                     wheel_pulse_pending_steps,
+                                                     wheel_pulse_phase,
+                                                     wheel_pulse_mask,
+                                                     wheel_pulse_next_tick);
                     usb_hid_queue_wheel_keys(
                         HidMouseInterpreter::scaleHorizontalWheelKeys(wheel_h_keys, scroll_factor, wheel_key_h_remainder),
                         HidMouseInterpreter::scaleVerticalWheelKeys(wheel_v_keys, scroll_factor, wheel_key_v_remainder));
@@ -1049,15 +1133,54 @@ void UsbHidDriver :: interrupt_handler()
                     menu_wheel_v_last_tick = 0;
                     wheel_key_h_remainder = 0;
                     wheel_key_v_remainder = 0;
+                    usb_hid_reset_native_wheel_state(wheel_step_accumulator,
+                                                     wheel_pulse_pending_steps,
+                                                     wheel_pulse_phase,
+                                                     wheel_pulse_mask,
+                                                     wheel_pulse_next_tick);
                     HidMouseInterpreter::applyWheelAxisDeltas(
                         mouse_x,
                         mouse_y,
                         HidMouseInterpreter::scaleHorizontalWheelAxisDelta(wheel_h_axis, scroll_factor, wheel_axis_h_remainder),
                         HidMouseInterpreter::scaleVerticalWheelAxisDelta(wheel_v_axis, scroll_factor, wheel_axis_v_remainder));
+                } else if (HidMouseInterpreter::mouseModeRoutesWheelToNative(mouse_mode)) {
+                    menu_wheel_h_latch = 0;
+                    menu_wheel_v_latch = 0;
+                    menu_wheel_v_mode = HidMouseInterpreter::MENU_WHEEL_MODE_PRECISE;
+                    menu_wheel_v_burst_accumulator = 0;
+                    menu_wheel_v_burst_direction = 0;
+                    menu_wheel_v_last_tick = 0;
+                    wheel_axis_h_remainder = 0;
+                    wheel_axis_v_remainder = 0;
+                    wheel_key_h_remainder = 0;
+                    wheel_key_v_remainder = 0;
+                    int wheel_steps = HidMouseInterpreter::accumulateWheelSteps(
+                        wheel_v_normalized,
+                        scroll_factor,
+                        wheel_step_accumulator);
+                    wheel_pulse_pending_steps += HidMouseInterpreter::applyWheelDirection(wheel_steps, reversed_wheel);
                 }
             } else {
                 menu_wheel_h_latch = 0;
                 menu_wheel_v_latch = 0;
+            }
+
+            if (HidMouseInterpreter::mouseModeRoutesWheelToNative(mouse_mode)) {
+                output_mouse_joy = usb_hid_service_native_wheel(output_mouse_joy,
+                                                                wheel_pulse_pending_steps,
+                                                                wheel_pulse_phase,
+                                                                wheel_pulse_mask,
+                                                                wheel_pulse_next_tick,
+                                                                now_ticks);
+            } else {
+                usb_hid_reset_native_wheel_state(wheel_step_accumulator,
+                                                 wheel_pulse_pending_steps,
+                                                 wheel_pulse_phase,
+                                                 wheel_pulse_mask,
+                                                 wheel_pulse_next_tick);
+                output_mouse_joy = HidMouseInterpreter::applyWheelPulseMask(output_mouse_joy,
+                                                                            HidMouseInterpreter::WHEEL_PULSE_PHASE_IDLE,
+                                                                            0);
             }
 
 #if U64

--- a/software/io/usb/usb_hid.h
+++ b/software/io/usb/usb_hid.h
@@ -60,6 +60,11 @@ class UsbHidDriver : public UsbDriver
     int wheel_axis_v_remainder;
     int wheel_key_h_remainder;
     int wheel_key_v_remainder;
+    int wheel_step_accumulator;
+    int wheel_pulse_pending_steps;
+    int wheel_pulse_phase;
+    uint8_t wheel_pulse_mask;
+    uint32_t wheel_pulse_next_tick;
     int pointer_sensitivity_setting;
     int pointer_sensitivity_remainder_x;
     int pointer_sensitivity_remainder_y;

--- a/software/io/usb/usb_hid.h
+++ b/software/io/usb/usb_hid.h
@@ -32,6 +32,11 @@ class UsbHidDriver : public UsbDriver
     bool descriptor_mouse;
     int16_t mouse_x, mouse_y;
     uint8_t mouse_joy;
+    int native_wheel_delta_queue[8];
+    uint8_t native_wheel_queue_head;
+    uint8_t native_wheel_queue_tail;
+    uint8_t native_wheel_base_joy;
+    uint8_t native_wheel_output_active;
     uint8_t keyboard_data[8];
     HidItemList report_items;
     t_item_location rep_button1;
@@ -61,10 +66,11 @@ class UsbHidDriver : public UsbDriver
     int wheel_key_h_remainder;
     int wheel_key_v_remainder;
     int wheel_step_accumulator;
-    int wheel_pulse_pending_steps;
     int wheel_pulse_phase;
     uint8_t wheel_pulse_mask;
     uint32_t wheel_pulse_next_tick;
+    int wheel_pulse_burst_direction;
+    uint8_t wheel_pulse_burst_count;
     int pointer_sensitivity_setting;
     int pointer_sensitivity_remainder_x;
     int pointer_sensitivity_remainder_y;

--- a/software/io/usb/usb_hid.h
+++ b/software/io/usb/usb_hid.h
@@ -4,6 +4,8 @@
 #include "usb_base.h"
 #include "usb_device.h"
 #include "hid_decoder.h"
+#include "FreeRTOS.h"
+#include "timers.h"
 
 struct t_usb_hid_status_snapshot
 {
@@ -37,6 +39,7 @@ class UsbHidDriver : public UsbDriver
     uint8_t native_wheel_queue_tail;
     uint8_t native_wheel_base_joy;
     uint8_t native_wheel_output_active;
+    TimerHandle_t wheel_pulse_timer;
     uint8_t keyboard_data[8];
     HidItemList report_items;
     t_item_location rep_button1;
@@ -76,6 +79,8 @@ class UsbHidDriver : public UsbDriver
     int pointer_sensitivity_remainder_y;
     int adaptive_accel_ema_x16;
     int adaptive_accel_scale_factor;
+    static void S_wheel_pulse_timer(TimerHandle_t a);
+    void service_native_wheel_timer(void);
 
 public:
 	static UsbDriver *test_driver(UsbInterface *intf);

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -254,7 +254,7 @@ static const char *dvi_hdmi[] = { "Auto", "HDMI", "DVI" };
 static const char *video_sel[] = { "CVBS + SVideo", "RGB" };
 static const char *color_sel[] = { "PAL", "NTSC", "PAL-60", "NTSC-50", "PAL-60/L", "NTSC-50/L" };
 static const char *mouse_acceleration_modes[] = { "Off", "Adaptive" };
-static const char *mouse_modes[] = { "Cursor", "Mouse", "Cursor + Mouse" };
+static const char *mouse_modes[] = { "Cursor", "Mouse", "Mouse + Cursor", "Mouse + Wheel" };
 static const char *wheel_directions[] = { "Normal", "Reversed" };
 
 static const char *sid_types[] = { "None", "6581", "8580", "FPGASID", "SwinSID Ultimate", "ARMSID", "ARM2SID", "SidFx", "FPGASID Dukestah", "PDsid", "SIDKick (Teensy)", "SIDKick Pico" };
@@ -318,7 +318,7 @@ struct t_cfg_definition u64_cfg[] = {
 #else
     { CFG_JOYSWAP,              CFG_TYPE_ENUM, "Joystick Swapper",             "%s", joyswaps,     0,  1, 0 },
 #endif
-    { CFG_MOUSE_MODE,           CFG_TYPE_ENUM, "Mouse Mode",                   "%s", mouse_modes,       0,  2, 1 },
+    { CFG_MOUSE_MODE,           CFG_TYPE_ENUM, "Mouse Mode",                   "%s", mouse_modes,       0,  3, 1 },
     { CFG_MOUSE_SENSITIVITY,    CFG_TYPE_VALUE, "Mouse Sensitivity",           "%d", NULL,              1, 16, 8 },
     { CFG_MOUSE_ACCELERATION,   CFG_TYPE_ENUM, "Mouse Acceleration",           "%s", mouse_acceleration_modes, 0,  1, 0 },
     { CFG_SCROLL_FACTOR,        CFG_TYPE_VALUE, "Mouse Wheel Sensitivity",     "%d", NULL,              1, 16, 8 },


### PR DESCRIPTION
This PR adds support for native mouse wheel mapping, i.e. a mapping from physical mouse wheel to C64 software-side mouse wheel using https://wiki.icomp.de/wiki/Micromys_Protocol

## Menu Option

To support this feature cleanly, a new **Mouse Mode** value **Mouse + Wheel** was added.  

The goal of the UX terminology in the mouse menu was a consistent abstraction without requiring knowledge of the Micromys protocol or other hardware details, such as 1351 mouse, etc. 

### Mouse Mode Overview

The following table illustrates how the mouse features are mapped depending on the chosen mode. All modes fit a slightly different use case and user profile:

| Mode             | Pointer         | Vertical Wheel        | Horizontal Wheel     | Use Case |
|------------------|-----------------|-----------------------|----------------------|----------|
| Cursor           | Cursor keys     | Cursor up/down        | Cursor left/right    | Keyboard-driven apps |
| Mouse            | 1351 pointer    | Pointer up/down       | Pointer left/right   | All traditional mouse-enabled software, e.g. various games, classic GEOS usage with wheel as pointer, etc. |
| Mouse + Cursor   | 1351 pointer    | Cursor up/down        | Cursor left/right    | Hybrid use case, e.g. interacting with GEOS via the mouse pointer and scrolling through large documents in geoWRITE |
| Mouse + Wheel    | 1351 pointer    | Micromys wheel events | Not supported by Micromys    | Modern mouse-enabled software such as GUI64, C64 OS, etc. |

Before settling on the current mouse mode names, I experimented with various ways to express these concepts and also considered these alternatives:
- Separate "Mouse Mode" and "Wheel Mode" options. This however would introduce multiple redundant and/or useless options and seemed more confusing from a UX perspective.
- Label it "Mouse Mapping" instead of "Mouse Mode": "Mapping" is not necessarily clearer than "mode".
- Explicit references to 1351 or Micromys: These may make sense for people deeply familiar with the subject matter (very few people had a 1351 mouse back in the 1980s, and GUI64 / C64 OS are recent developments), so using these terms would require an additional documentation for many people. Mouse, Cursor, and to a lesser degree Cursor Wheel are meanwhile very widely used terms.
- Label "Mouse" as "Mouse Pointer": The longer term is not any clearer.

## Behaviour

Please note that the Micromys protocol does not allow for more wheel rotations than 20/s. As a consequence, when changing sensitivity of the wheel, you will (depending on your mouse) notice that you will need less wheel actuations to continuously scroll, but the maximum scrolling speed won't increase. This is a limitation of the protocol, not of the implementation. 

However, even as it stands, using a sensitivity of 8 (default on a new install) saves your finger quite significantly when using an old school mouse without free-spinning wheel.

## Implementation

- I tried to make this as minimal invasive as I could and went through a lot of stages to trim down the code surface. 
- I introduced a new timer since the existing USB timer has a too long interval to be useful for resetting the wheel-related bits after 50ms, and I did not want for this implementation to affect other parts of the USB stack by changing the overall frequency of the USB polling. 

## Demo

Demo with GUI64 v1.9: https://youtu.be/JUPZbZ-IrFU

## Remaining Work

This is currently still WIP and not yet merge-ready.

TODO:
- [x] Test against GUI64 1.9 (which came with C64U FE as of March 2026)
- [x] Regression test to ensure no unwanted bugs were introduced
- [x] Test against C64OS (thanks @markusC64 and @gillham )
