### PR TITLE
Harden Passive FTP Data-Connection Lifetime and Improve FTP Throughput

### DIFF
--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -132,6 +132,35 @@ int dbg_printf(const char *fmt, ...);
 static const char *month_table[16] = { "Nul", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
         "M13", "M14", "M15" };
 
+static FTPTransferResult send_all(int socket, const char *buffer, int length)
+{
+    while (length > 0) {
+        int sent = send(socket, buffer, length, 0);
+        if (sent <= 0) {
+            return FTP_TRANSFER_ABORTED;
+        }
+        buffer += sent;
+        length -= sent;
+    }
+    return FTP_TRANSFER_OK;
+}
+
+static const char *transfer_result_message(FTPTransferResult result)
+{
+    switch (result) {
+    case FTP_TRANSFER_OK:
+        return msg226;
+    case FTP_TRANSFER_SETUP_FAILED:
+        return msg425;
+    case FTP_TRANSFER_ABORTED:
+        return msg426;
+    case FTP_TRANSFER_STORAGE_ERROR:
+        return msg452;
+    default:
+        return msg226;
+    }
+}
+
 static int EndsWith(const char *str, const char *suffix)
 {
     if (!str || !suffix)
@@ -545,10 +574,10 @@ void FTPDaemonThread::cmd_retr(const char *arg)
 
     send_msg(msg150recv, arg, st.st_size);
 
-    connection->sendfile(vfs_file);
+    FTPTransferResult result = connection->sendfile(vfs_file);
     destroy_connection();
 
-    send_msg(msg226);
+    send_msg(transfer_result_message(result));
 }
 
 void FTPDaemonThread::cmd_stor(const char *arg)
@@ -569,13 +598,10 @@ void FTPDaemonThread::cmd_stor(const char *arg)
 
     send_msg(msg150stor, arg);
 
-    bool success = connection->receivefile(vfs_file);
+    FTPTransferResult result = connection->receivefile(vfs_file);
     destroy_connection();
 
-    if (success)
-        send_msg(msg226);
-    else
-        send_msg(msg452);
+    send_msg(transfer_result_message(result));
 }
 
 void FTPDaemonThread::cmd_noop(const char *arg)
@@ -1010,45 +1036,63 @@ void FTPDataConnection::directory(int listType, vfs_dir_t *dir)
             buffer[len] = 0;
             send(actual_socket, buffer, len, 0);
 
-            // for the next iteration
             vfs_dirent = vfs_readdir(dir);
         }
     }
     vfs_closedir(dir);
 }
 
-void FTPDataConnection::sendfile(vfs_file_t *file)
+FTPTransferResult FTPDataConnection::sendfile(vfs_file_t *file)
 {
-    if (setup_connection() == ERR_OK) {
-        uint32_t read;
-        do {
-            read = vfs_read(buffer, 1024, 1, file);
-            if (read)
-                send(actual_socket, buffer, read, 0);
-        } while (read > 0);
+    FTPTransferResult result = FTP_TRANSFER_OK;
+
+    if (setup_connection() != ERR_OK) {
+        vfs_close(file);
+        return FTP_TRANSFER_SETUP_FAILED;
     }
+
+    uint32_t read;
+    do {
+        read = vfs_read(buffer, FTPD_DATA_BUFFER_SIZE, 1, file);
+        if (read) {
+            result = send_all(actual_socket, buffer, read);
+            if (result != FTP_TRANSFER_OK) {
+                break;
+            }
+        }
+    } while (read > 0);
+
     vfs_close(file);
+    return result;
 }
 
-bool FTPDataConnection::receivefile(vfs_file_t *file)
+FTPTransferResult FTPDataConnection::receivefile(vfs_file_t *file)
 {
-    bool ret = true;
-    if (setup_connection() == ERR_OK) {
-        int n;
-        do {
-            n = recv(actual_socket, buffer, 1024, 0);
-            if (n > 0) {
-                uint32_t written = vfs_write(buffer, n, 1, file);
-                if (written != n) {
-                    printf("Hmm.. written = %d. n = %d\n", written, n);
-                    ret = false;
-                    break;
-                }
-            }
-        } while (n > 0);
+    FTPTransferResult result = FTP_TRANSFER_OK;
+
+    if (setup_connection() != ERR_OK) {
+        vfs_close(file);
+        return FTP_TRANSFER_SETUP_FAILED;
     }
+
+    int n;
+    do {
+        n = recv(actual_socket, buffer, FTPD_DATA_BUFFER_SIZE, 0);
+        if (n > 0) {
+            uint32_t written = vfs_write(buffer, n, 1, file);
+            if (written != (uint32_t)n) {
+                printf("Hmm.. written = %d. n = %d\n", written, n);
+                result = FTP_TRANSFER_STORAGE_ERROR;
+                break;
+            }
+        } else if (n < 0) {
+            result = FTP_TRANSFER_ABORTED;
+            break;
+        }
+    } while (n > 0);
+
     vfs_close(file);
-    return ret;
+    return result;
 }
 
 #include "init_function.h"

--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -1051,10 +1051,14 @@ FTPTransferResult FTPDataConnection::sendfile(vfs_file_t *file)
         return FTP_TRANSFER_SETUP_FAILED;
     }
 
-    uint32_t read;
+    int read;
     do {
         read = vfs_read(buffer, FTPD_DATA_BUFFER_SIZE, 1, file);
-        if (read) {
+        if (read < 0) {
+            result = FTP_TRANSFER_ABORTED;
+            break;
+        }
+        if (read > 0) {
             result = send_all(actual_socket, buffer, read);
             if (result != FTP_TRANSFER_OK) {
                 break;

--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -250,11 +250,21 @@ FTPDaemonThread::FTPDaemonThread(int socket, uint32_t addr, uint16_t port) :
 
 FTPDaemonThread::~FTPDaemonThread()
 {
+    destroy_connection();
     if (renamefrom) {
         delete[] renamefrom;
     }
     if (vfs) {
         vfs_closefs(vfs);
+    }
+}
+
+void FTPDaemonThread::destroy_connection()
+{
+    if (connection) {
+        connection->close_connection();
+        delete connection;
+        connection = 0;
     }
 }
 
@@ -380,10 +390,7 @@ void FTPDaemonThread::cmd_port(const char *arg)
         IP4_ADDR(&dataip, (uint8_t) ip[0], (uint8_t) ip[1], (uint8_t) ip[2], (uint8_t) ip[3]);
         dataport = ((uint16_t) pHi << 8) | (uint16_t) pLo;
 
-        if (connection) {
-            connection->close_connection();
-            delete connection;
-        }
+        destroy_connection();
         connection = new FTPDataConnection(this);
         passive = 0;
         send_msg(msg200);
@@ -458,9 +465,7 @@ void FTPDaemonThread::cmd_list_common(const char *arg, int listType)
     send_msg(msg150);
 
     connection->directory(listType, vfs_dir);
-    connection->close_connection();
-    delete connection;
-    connection = 0;
+    destroy_connection();
 
     send_msg(msg226);
 }
@@ -542,9 +547,7 @@ void FTPDaemonThread::cmd_retr(const char *arg)
     send_msg(msg150recv, arg, st.st_size);
 
     connection->sendfile(vfs_file);
-    connection->close_connection();
-    delete connection;
-    connection = 0;
+    destroy_connection();
 
     send_msg(msg226);
 }
@@ -568,9 +571,7 @@ void FTPDaemonThread::cmd_stor(const char *arg)
     send_msg(msg150stor, arg);
 
     bool success = connection->receivefile(vfs_file);
-    connection->close_connection();
-    delete connection;
-    connection = 0;
+    destroy_connection();
 
     if (success)
         send_msg(msg226);
@@ -596,26 +597,17 @@ void FTPDaemonThread::cmd_feat(const char *arg)
 void FTPDaemonThread::cmd_pasv(const char *arg)
 {
     passive = 1;
-    if (connection) {
-        connection->close_connection();
-        delete connection;
-    }
+    destroy_connection();
     connection = new FTPDataConnection(this);
     if (connection->do_bind() != ERR_OK) {
-        connection->close_connection();
-        delete connection;
-        connection = 0;
+        destroy_connection();
         send_msg(msg425);
     }
 }
 
 void FTPDaemonThread::cmd_abrt(const char *arg)
 {
-    if (connection) {
-        connection->close_connection();
-        delete connection;
-        connection = 0;
-    }
+    destroy_connection();
     state = FTPD_IDLE;
 }
 
@@ -882,28 +874,38 @@ FTPDataConnection::FTPDataConnection(FTPDaemonThread *parent)
 
     vfs_dirent = 0;
     vfs_file = 0;
-    acceptTaskHandle = 0;
-    spawningTask = 0;
+}
+
+FTPDataConnection::~FTPDataConnection()
+{
+    close_connection();
 }
 
 int FTPDataConnection::setup_connection()
 {
     if (parent->passive) {
-        // The accept task bounds itself with SO_RCVTIMEO, so it always
-        // notifies within a few seconds and then self-deletes. Wait longer
-        // than that to guarantee we observe the notification and that the
-        // task has finished touching this object before we return.
-        if (ulTaskNotifyTake(pdTRUE, 8000 / portTICK_PERIOD_MS)) {
-            if (connected) {
-                return 0;
-            }
-            return -1;
-        } else {
-            printf("FTPD: Taking semaphore timed out.\n"
-                   "Number of active connections in this thread: %d\n"
-                   "Number of threads: %d\n", parent->data_connections.get_elements(), num_threads);
+        struct timeval tv;
+        tv.tv_sec = 5;
+        tv.tv_usec = 0;
+        if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv)) < 0) {
+            puts("FTPD: failed to set accept timeout");
             return -1;
         }
+
+        socklen_t clilen = sizeof(struct sockaddr_in);
+        struct sockaddr_in cli_addr;
+        actual_socket = -1;
+        connected = 0;
+
+        int s = accept(sockfd, (struct sockaddr * ) &cli_addr, &clilen);
+        if (s < 0) {
+            puts("FTPD: accept timed out or failed");
+            return -1;
+        }
+
+        actual_socket = s;
+        connected = 1;
+        return 0;
     }
     return connect_to(parent->dataip, parent->dataport);
 }
@@ -967,56 +969,12 @@ int FTPDataConnection::do_bind(void)
     } while (result < 0);
 
     result = listen(sockfd, 2);
-
-    spawningTask = xTaskGetCurrentTaskHandle();
-    BaseType_t res = xTaskCreate(FTPDataConnection::accept_data, "FTP Data", configMINIMAL_STACK_SIZE, this, PRIO_NETSERVICE,
-            &acceptTaskHandle);
-    if (res != pdPASS) {
-        puts("FTPD: failed to create passive accept task");
+    if (result < 0) {
         return -ENOTCONN;
     }
 
     parent->send_msg(msg227, parent->my_ip[0], parent->my_ip[1], parent->my_ip[2], parent->my_ip[3], port >> 8, port & 0xFF);
-    vTaskDelay(1); // allow the other task to run
     return 0;
-}
-
-// static
-void FTPDataConnection::accept_data(void *a) // task entry point
-{
-    FTPDataConnection *conn = (FTPDataConnection *) a;
-
-    // Bound the accept() call so this task always terminates. Without a
-    // timeout a client that never connects to the data channel would leave
-    // this task blocked forever, leaking tasks until the system runs out
-    // of resources. lwIP honours SO_RCVTIMEO on accept() via netconn_accept.
-    struct timeval tv;
-    tv.tv_sec = 5;
-    tv.tv_usec = 0;
-    if (setsockopt(conn->sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv)) < 0) {
-        puts("FTPD: failed to set accept timeout");
-        conn->actual_socket = -1;
-        xTaskNotifyGive(conn->spawningTask);
-        // After the notify the control thread may free `conn`. Do not touch
-        // `conn` after this point; just self-delete so no task is leaked.
-        vTaskDelete(NULL);
-    }
-
-    socklen_t clilen = sizeof(struct sockaddr_in);
-    struct sockaddr_in cli_addr;
-    int s = accept(conn->sockfd, (struct sockaddr * ) &cli_addr, &clilen);
-    if (s < 0) {
-        puts("FTPD: accept timed out or failed");
-        conn->actual_socket = -1;
-    } else {
-        conn->actual_socket = s;
-        conn->connected = 1;
-    }
-    xTaskNotifyGive(conn->spawningTask);
-
-    // After the notify the control thread may free `conn`. Do not touch
-    // `conn` after this point; just self-delete so no task is leaked.
-    vTaskDelete(NULL);
 }
 
 void FTPDataConnection::directory(int listType, vfs_dir_t *dir)

--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -262,7 +262,6 @@ FTPDaemonThread::~FTPDaemonThread()
 void FTPDaemonThread::destroy_connection()
 {
     if (connection) {
-        connection->close_connection();
         delete connection;
         connection = 0;
     }

--- a/software/network/ftpd.h
+++ b/software/network/ftpd.h
@@ -111,6 +111,7 @@ class FTPDaemonThread
 	void send_msg(const char *a, ...);
 	void dispatch_command(char *a, int length);
 	int open_dataconnection(bool passive);
+	void destroy_connection();
 public:
 	FTPDaemonThread(int sock, uint32_t addr, uint16_t port);
 	~FTPDaemonThread();
@@ -161,13 +162,10 @@ class FTPDataConnection
 
 	int setup_connection();
 	int connect_to(ip_addr_t ip, uint16_t port);
-	static void accept_data(void *); // task
-	TaskHandle_t acceptTaskHandle;
-	TaskHandle_t spawningTask;
 
 public:
 	FTPDataConnection(FTPDaemonThread *parent);
-	~FTPDataConnection() { }
+	~FTPDataConnection();
 	int do_bind(void);
 	void close_connection();
 

--- a/software/network/ftpd.h
+++ b/software/network/ftpd.h
@@ -60,9 +60,17 @@ public:
 };
 
 #define COMMAND_BUFFER_SIZE 1024
+#define FTPD_DATA_BUFFER_SIZE 8192
 
 class FTPDataConnection;
 class FTPDaemonThread;
+
+enum FTPTransferResult {
+	FTP_TRANSFER_OK = 0,
+	FTP_TRANSFER_SETUP_FAILED,
+	FTP_TRANSFER_ABORTED,
+	FTP_TRANSFER_STORAGE_ERROR
+};
 
 typedef void (FTPDaemonThread::*func_t)(const char *args);
 
@@ -158,7 +166,7 @@ class FTPDataConnection
 	FTPDaemonThread *parent;
 	int sockfd;
 	int actual_socket;
-	char buffer[1024];
+	char buffer[FTPD_DATA_BUFFER_SIZE];
 
 	int setup_connection();
 	int connect_to(ip_addr_t ip, uint16_t port);
@@ -170,7 +178,7 @@ public:
 	void close_connection();
 
 	void directory(int listType, vfs_dir_t *dir);
-	void sendfile(vfs_file_t *file);
-	bool receivefile(vfs_file_t *file);
+	FTPTransferResult sendfile(vfs_file_t *file);
+	FTPTransferResult receivefile(vfs_file_t *file);
 };
 #endif				/* __FTPD_H__ */


### PR DESCRIPTION
# Summary

This change contains:
- A fix for a passive-FTP lifetime bug that can degrade or lock up the device when a client opens a passive data connection and then abandons it or closes it incorrectly.
- An improvement of up to 70% of upload and download FTP throughput with best results for 1MiB large files.

The remainder of this description goes into further detail on both.

---

# 1. Harden Passive FTP Data-Connection Lifetime

The fix is small and local to the FTP daemon:
- remove the per-`PASV` helper task that blocked in `accept()`
- keep `PASV` behavior unchanged from the client side: open the listening socket and return `227` immediately
- perform passive `accept()` in the owning FTP control thread, with a bounded timeout
- centralize data-connection teardown
- ensure session teardown closes any still-pending passive data connection
- make `FTPDataConnection` close any remaining sockets in its destructor

This is a correctness and stability fix, not a throughput optimization.

## Problem

Passive FTP currently splits one data connection across two tasks:
- the control thread owns and deletes `FTPDataConnection`
- a helper task blocks in passive `accept()` and later notifies the control thread

That split ownership creates three lifetime bugs:
- the helper task can notify a control task that no longer exists
- the control thread can delete `FTPDataConnection` while the helper task is still blocked in `accept()`
- session teardown can leave a passive data connection pending and uncollected

These are all consequences of the same design problem: one task waits on the socket while another owns teardown.

## Reproducing The Failure

I could reproduce the failure quickly with incomplete FTP client behavior:

- Command: `./scripts/u64_connection_test.py --profile soak --mode incomplete --surface readwrite -d 0 --duration-s 7200 | tee scripts/logs/u64_connection_test/18_soak_incomplete_read_modularized.log`
- Time to failure: 5 seconds to 1 minute
- Observed result: network services degrade; in the worst runs, all listeners degrade and HDMI output stops

Representative log excerpt:

```text
2026-04-16T11:17:11Z protocol=stream result=FAIL detail="kind=video category=timeout packets=0 detail=no packets received before startup grace expired"
2026-04-16T11:17:13Z protocol=stream result=FAIL detail="kind=audio category=timeout packets=813 detail=packet stall detected idle_s=1.002"
2026-04-16T11:17:15Z protocol=http result=FAIL detail="runner=1 iteration=1 surface=readwrite op=get_version timed out latency_ms=6369"
2026-04-16T11:17:15Z protocol=ftp result=FAIL detail="runner=1 iteration=1 surface=readwrite op=ftp_pasv_only_abort timed out latency_ms=6371"
2026-04-16T11:17:15Z protocol=telnet result=FAIL detail="runner=1 iteration=1 surface=readwrite op=telnet_f2_abort timed out latency_ms=4369"
```

The failure pattern is consistent with stuck or leaked passive-mode work accumulating until unrelated services are affected.

## Approach

The fix removes split ownership. One FTP control thread now owns the passive data connection for its full lifetime.

Behavior after this change:
- `PASV` still binds, listens, and replies with `227` immediately
- the passive listening socket remains open until the transfer command uses it
- `LIST`, `NLST`, `RETR`, and `STOR` perform the passive `accept()` in the same control thread that owns teardown
- `accept()` is bounded by `SO_RCVTIMEO`, so abandoned passive sessions cannot block forever
- the listen backlog still allows the client to connect after `PASV` and before the transfer command reaches `accept()`

This is the smallest change that removes the ownership race instead of layering more coordination on top of it.

## What Changed

- removed passive helper-task state and code
- moved passive `accept()` into `setup_connection()`
- kept `PASV` responsible only for bind, listen, and `227`
- added `destroy_connection()` and routed owner-side teardown through it
- cleaned up any outstanding data connection during control-session destruction
- made `FTPDataConnection` destructor close remaining sockets

## Walkthrough of File Upload

The following sequence diagrams show side by side the old and new (as of this PR) flows for a client uploading a file to the Ultimate 64.

### Old `STOR` Sequence

```mermaid
sequenceDiagram
    participant C as FTP client
    participant L as FTP Listener task
    participant S as FTP session task
    participant H as FTP Data helper task
    participant P as Passive listen socket
    participant T as tcpip_thread

    C->>L: Open control connection
    L->>S: Spawn FTP session task
    C->>S: PASV
    S->>P: Bind and listen
    S->>H: Spawn passive helper task
    S-->>C: 227 passive endpoint
    C->>P: Open passive data connection
    H->>P: Wait in accept
    T-->>H: Deliver accepted socket
    H-->>S: Notify accepted data socket ready
    C->>S: STOR filename
    S->>S: Wait for helper completion
    S-->>C: 150 opening data connection
    C->>S: Send file payload on data socket
    S->>S: Write received data to VFS
    S->>S: Close and delete connection
    S-->>C: 226 transfer complete
```

### New `STOR` Sequence

```mermaid
sequenceDiagram
    participant C as FTP client
    participant L as FTP Listener task
    participant S as FTP session task
    participant P as Passive listen socket
    participant T as tcpip_thread

    C->>L: Open control connection
    L->>S: Spawn FTP session task
    C->>S: PASV
    S->>P: Bind and listen
    S-->>C: 227 passive endpoint
    C->>P: Open passive data connection
    C->>S: STOR filename
    S->>P: Accept in owning session task
    T-->>S: Deliver accepted data socket
    S-->>C: 150 opening data connection
    C->>S: Send file payload on data socket
    S->>S: Write received data to VFS
    S->>S: destroy_connection
    S-->>C: 226 transfer complete
```


## Protocol, Concurrency, and Performance

This patch does not change the FTP command set, reply codes, reply text, authentication, listing format, transfer semantics, or active `PORT` mode behavior.

Passive FTP still follows the same client-visible flow:
- `PASV`
- `227`
- client opens the data connection
- `LIST` / `NLST` / `RETR` / `STOR`
- server accepts and services the connection

This also does not reduce concurrent use. Each FTP control connection already runs in its own `FTPDaemonThread`, so one client waiting on its passive data connection blocks only that client. Other FTP clients continue independently.

This should not reduce normal passive-mode performance. `PASV` still returns immediately, the client still has the same opportunity to connect before the transfer command, and the removed helper task was not adding throughput; it was only adding a second owner for the same connection.

## Verifying the Fix

The same command that quickly produced the error runs now without errors. Here a log excerpt from the 15m mark:

```
2026-04-16T13:30:29Z protocol=ping result=OK detail="runner=1 iteration=3100 ping_reply_ms=8.28 latency_ms=18"
2026-04-16T13:30:29Z protocol=http result=OK detail="runner=1 iteration=3100 surface=readwrite op=mem_read_io_area http_status=200 body_bytes=16 byte=0x00 latency_ms=22"
2026-04-16T13:30:29Z protocol=ftp result=OK detail="runner=1 iteration=3100 surface=readwrite op=ftp_pasv_only_abort reply=227 latency_ms=28"
2026-04-16T13:30:29Z protocol=telnet result=OK detail="runner=1 iteration=3100 surface=readwrite op=telnet_f2_abort steps=1 bytes=5 latency_ms=271"
2026-04-16T13:30:29Z protocol=iteration result=INFO detail="runner=1 iteration=3100 runtime_s=904 host=u64 ping_median_ms=5 ping_p90_ms=16 ping_p99_ms=21 http_median_ms=22 http_p90_ms=59 http_p99_ms=71 ftp_median_ms=40 ftp_p90_ms=53 ftp_p99_ms=71 telnet_median_ms=286 telnet_p90_ms=310 telnet_p99_ms=337 stream_audio=OK,packets:225939,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0 stream_video=OK,packets:3081121,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0"
```

---

# 2. FTP Upload and Download Performance Improvement

## Scope

The current implementation changes only the FTP file-transfer path used by `RETR` and `STOR`. Control-path commands such as `LIST`, `NLST`, and `MLSD` are unchanged as they were already fast (sub-second latency for typical sized folders) and further gains would be small.

## What Changed

1. The FTP data buffer is 8 KiB.
2. Downloads use a full-buffer send loop so a partial `send()` does not truncate a chunk.
3. The download path reads 8 KiB per iteration.
4. The upload path receives 8 KiB per iteration.
5. Transfer outcomes are explicit so setup failures, aborted transfers, and storage failures are reported correctly.

These changes improve throughput by reducing the number of read, receive, and send calls needed to move the same payload. The benefit grows with transfer size because fixed per-iteration overhead is amortized across larger chunks.

## Measurement Set

The measurements were taken from `/home/chris/dev/vivipi/scripts/logs/u64_ftp_test`.

- Baseline sample count: 6 complete runs
- Improved sample count: 4 complete runs
- Metric: per-stage transfer rate in KiB/s
- Reported values: mean ± σ across runs

The results can be reproduced from the root of `https://github.com/chrisgleissner/vivipi` with:

```bash
./scripts/u64_ftp_test.py --remote-dir /USB2/test/FTP
```

## Transfer Throughput

| Test | Baseline (mean ± σ) | Improved (mean ± σ) | Δ (absolute) | Δ (%) | Signal vs Noise |
|---|---:|---:|---:|---:|---|
| 20K single | 58.5 ± 6.0 | 71.2 ± 0.4 | +12.8 | +21.8% | moderate |
| 20K multi  | 57.0 ± 2.7 | 55.0 ± 1.6 | -2.0 | -3.5% | weak |
| 200K single | 138.5 ± 3.9 | 204.5 ± 0.9 | +66.0 | +47.7% | very strong |
| 200K multi  | 115.0 ± 5.6 | 172.0 ± 11.0 | +57.0 | +49.6% | strong |
| 1M single  | 147.5 ± 16.4 | 253.5 ± 5.2 | +106.0 | +71.9% | very strong |
| 1M multi   | 134.8 ± 12.9 | 235.8 ± 10.1 | +100.9 | +74.8% | very strong |

## Aggregate Effect

- Aggregate throughput improved from `104.0 ± 5.2 KiB/s` to `189.5 ± 8.3 KiB/s`, a gain of `+85.5 KiB/s` or `+82.2%`.
- Median latency remained effectively flat: `135.2 ms` baseline vs `136.8 ms` improved.
- P90 latency changed from `269.2 ms` to `276.0 ms`, a small shift relative to the transfer-rate gain.

## Control-Path Operations

Control-path timings remained effectively unchanged:

| Operation | Baseline avg_s | Improved avg_s |
|---|---:|---:|
| CD | 0.357 | 0.365 |
| LIST | 0.135 | 0.138 |
| NLST | 0.130 | 0.133 |
| MLSD | 0.140 | 0.138 |
| DELETE | 0.072 | 0.075 |

This is consistent with the implementation: the changes are confined to file transfer rather than directory and control-command handling.

## Interpretation

- The main effect is on medium and large transfers.
- Both `200K` stages improve by about `48%` to `50%`.
- Both `1M` stages improve by about `72%` to `75%`.
- `20K single` improves, but less strongly because fixed costs still dominate a larger share of the transfer.
- `20K multi` is effectively flat and does not show a meaningful directional change.

Overall, the measurements show a clear and statistically strong improvement for sustained transfer workloads, which is the expected outcome of moving from very small transfer quanta to 8 KiB chunks.

## RAM Impact

The 8 KiB FTP buffer is a local per-session allocation, not a firmware-wide shared pool increase. Relative to a 1 KiB buffer, the added cost is `7168` bytes per active FTP session.

That cost is modest compared with other buffers already present elsewhere in the firmware, including:

- an RMII receive buffer pool
- a USB AX88772 packet buffer block
- a 200000-byte socket DMA load buffer
- a 32768-byte file-copy buffer
- a 16384-byte zero-fill helper buffer

For that reason, the current 8 KiB choice is unlikely to create meaningful RAM pressure for other stakeholders as long as it remains FTP-local and is not expanded into broader always-resident shared network pools.


--- 

## 3. Final Verification

As this PR contains two changes (hardening and performance improvement), I ran a final extensive soak test on the overall fix. Here are the results.

### Test Report

The following runs the exact same test driver against first the branch of this PR, demonstrating successful operation of the Ping/HTTP/FTP/Telnet endpoints. It is then run against master, demonstrating rapid failure.

- Test driver execution: `./scripts/u64_connection_test.py --profile soak --mode incomplete --surface readwrite -d 0 --duration-s 7200`
- ViviPi release containing test driver: https://github.com/chrisgleissner/vivipi/releases/tag/0.3.9

#### Successful Run

- 1541ultimate Git ID: 96eb8d15 (Branch: `fix/ftp-passive-lifetime`, latest version as of 17 April 2026 15:46UTC)
- Runtime: 7032s (ca. 2h)
- Errors: 0

Verification of errors:
```
chris@mickey:~/dev/vivipi$ grep -e OK scripts/logs/u64_connection_test/40_soak_incomplete_ftp_hardening_perf_patch.log | wc -l
25880
chris@mickey:~/dev/vivipi$ grep -e FAIL scripts/logs/u64_connection_test/40_soak_incomplete_ftp_hardening_perf_patch.log | wc -l
0
```

Tail of logs:
```
chris@mickey:~/dev/vivipi$ tail scripts/logs/u64_connection_test/40_soak_incomplete_ftp_hardening_perf_patch.log
2026-04-17T14:38:50Z protocol=ping result=OK detail="runner=1 iteration=51750 ping_reply_ms=1.62 latency_ms=4"
2026-04-17T14:38:50Z protocol=http result=OK detail="runner=1 iteration=51750 surface=readwrite op=set_vol_ultisid_1_0_db from=+1 dB to=0 dB latency_ms=74"
2026-04-17T14:38:50Z protocol=ftp result=OK detail="runner=1 iteration=51750 surface=readwrite op=ftp_partial_list_root command=LIST . bytes=60 latency_ms=79"
2026-04-17T14:38:50Z protocol=telnet result=OK detail="runner=1 iteration=51750 surface=readwrite op=telnet_f2_abort steps=1 bytes=5 latency_ms=139"
2026-04-17T14:38:50Z protocol=iteration result=INFO detail="runner=1 iteration=51750 runtime_s=7031 host=u64 ping_median_ms=11 ping_p90_ms=17 ping_p99_ms=22 http_median_ms=26 http_p90_ms=61 http_p99_ms=84 ftp_median_ms=44 ftp_p90_ms=62 ftp_p99_ms=79 telnet_median_ms=125 telnet_p90_ms=145 telnet_p99_ms=157 stream_audio=OK,packets:1760126,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0 stream_video=OK,packets:24005521,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0"
2026-04-17T14:38:51Z protocol=ping result=OK detail="runner=1 iteration=51760 ping_reply_ms=1.64 latency_ms=3"
2026-04-17T14:38:51Z protocol=http result=OK detail="runner=1 iteration=51760 surface=readwrite op=get_configs http_status=200 body_bytes=447 json_type=dict latency_ms=32"
2026-04-17T14:38:51Z protocol=ftp result=OK detail="runner=1 iteration=51760 surface=readwrite op=ftp_pasv_only_abort reply=227 latency_ms=43"
2026-04-17T14:38:51Z protocol=telnet result=OK detail="runner=1 iteration=51760 surface=readwrite op=telnet_partial_f2_prefix_abort steps=1 bytes=2 latency_ms=132"
2026-04-17T14:38:51Z protocol=iteration result=INFO detail="runner=1 iteration=51760 runtime_s=7032 host=u64 ping_median_ms=11 ping_p90_ms=17 ping_p99_ms=22 http_median_ms=26 http_p90_ms=61 http_p99_ms=84 ftp_median_ms=44 ftp_p90_ms=62 ftp_p99_ms=79 telnet_median_ms=125 telnet_p90_ms=145 telnet_p99_ms=157 stream_audio=OK,packets:1760455,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0 stream_video=OK,packets:24010001,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0"
```

#### Failing Run

- 1541ultimate Git ID: f1f5c575 (Branch: `master`, latest version as of 17 April 2026 15:46UTC)
- Runtime: 20s
- Errors: Permanently non-responsive Ping/HTTP/FTP/Telnet endpoints. Permanently non-responsive menu button. Non-responsive USB keyboard. VHL emulated C64 continues to operate and reacts to keyboard presses on C64 keyboard.

Entire logs with post-test verification:
```
chris@mickey:~/dev/vivipi$ ./scripts/u64_connection_test.py --profile soak --mode incomplete --surface readwrite -d 0 --duration-s 7200 | tee scripts/logs/u64_connection_test/40_soak_incomplete_ftp_hardening_perf_patch_baseline_f1f5c.log
2026-04-17T14:49:57Z protocol=config result=INFO detail="host=u64 http=80/v1/version telnet=23 ftp=21 user=anonymous sample_every=10 verbose=0 call_gap_ms=0 profile=soak probes=ping,http,ftp,telnet schedule=concurrent runners=1 duration_s=7200 surfaces=ping:smoke,http:readwrite,ftp:readwrite,telnet:readwrite correctness=ping:complete,http:complete,ftp:incomplete,telnet:incomplete streams=audio,video overrides=duration-s,surface,mode"
2026-04-17T14:49:57Z protocol=stream result=INFO detail="kind=audio listening=192.168.1.185:52778 expected_sources=192.168.1.13"
2026-04-17T14:49:57Z protocol=stream result=INFO detail="kind=video listening=192.168.1.185:36082 expected_sources=192.168.1.13"
2026-04-17T14:49:57Z protocol=stream result=INFO detail="kind=audio enabled destination=192.168.1.185:52778"
2026-04-17T14:49:57Z protocol=stream result=INFO detail="kind=video enabled destination=192.168.1.185:36082"
2026-04-17T14:49:58Z protocol=ping result=OK detail="runner=1 iteration=10 ping_reply_ms=1.97 latency_ms=4"
2026-04-17T14:49:58Z protocol=http result=OK detail="runner=1 iteration=10 surface=readwrite op=mem_write_screen_exclam http_status=200 verified=0x21 latency_ms=30"
2026-04-17T14:49:58Z protocol=ftp result=OK detail="runner=1 iteration=10 surface=readwrite op=ftp_partial_nlst_root command=NLST . bytes=6 latency_ms=44"
2026-04-17T14:49:58Z protocol=telnet result=OK detail="runner=1 iteration=10 surface=readwrite op=telnet_right_arrow_abort steps=2 bytes=8 latency_ms=116"
2026-04-17T14:49:58Z protocol=iteration result=INFO detail="runner=1 iteration=10 runtime_s=1 host=u64 ping_median_ms=5 ping_p90_ms=8 ping_p99_ms=11 http_median_ms=24 http_p90_ms=30 http_p99_ms=61 ftp_median_ms=40 ftp_p90_ms=51 ftp_p99_ms=65 telnet_median_ms=103 telnet_p90_ms=133 telnet_p99_ms=142 stream_audio=OK,packets:253,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0 stream_video=OK,packets:3074,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0"
2026-04-17T14:50:07Z protocol=ping result=OK detail="runner=1 iteration=20 ping_reply_ms=3.66 latency_ms=6"
2026-04-17T14:50:07Z protocol=http result=OK detail="runner=1 iteration=20 surface=readwrite op=set_vol_ultisid_1_plus_1_db from=+1 dB to=+1 dB latency_ms=190"
2026-04-17T14:50:07Z protocol=ftp result=FAIL detail="runner=1 iteration=20 surface=readwrite op=ftp_partial_nlst_root timed out latency_ms=4977"
2026-04-17T14:50:07Z protocol=telnet result=OK detail="runner=1 iteration=20 surface=readwrite op=telnet_f2_abort steps=1 bytes=5 latency_ms=177"
2026-04-17T14:50:07Z protocol=iteration result=INFO detail="runner=1 iteration=20 runtime_s=9 host=u64 ping_median_ms=5 ping_p90_ms=11 ping_p99_ms=12 http_median_ms=26 http_p90_ms=132 http_p99_ms=381 ftp_median_ms=43 ftp_p90_ms=478 ftp_p99_ms=4977 telnet_median_ms=109 telnet_p90_ms=177 telnet_p99_ms=186 stream_audio=OK,packets:2400,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0 stream_video=OK,packets:32359,lost:0,reordered:0,size_errs:0,header_errs:0,structure_errs:0,timeout_errs:0"
2026-04-17T14:50:24Z protocol=ping result=FAIL detail="runner=1 iteration=21 PING u64 (192.168.1.13) 56(84) bytes of data. latency_ms=2003"
2026-04-17T14:50:24Z protocol=http result=FAIL detail="runner=1 iteration=21 surface=readwrite op=mem_read_debug_register timed out latency_ms=16865"
2026-04-17T14:50:24Z protocol=ftp result=FAIL detail="runner=1 iteration=21 surface=readwrite op=ftp_pasv_only_abort timed out latency_ms=16865"
2026-04-17T14:50:24Z protocol=telnet result=FAIL detail="runner=1 iteration=21 surface=readwrite op=telnet_partial_f2_prefix_abort timed out latency_ms=11860"
^C^C^CException ignored in: <module 'threading' from '/usr/lib/python3.12/threading.py'>
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1622, in _shutdown
    lock.acquire()
KeyboardInterrupt: 
^CException ignored in atexit callback: <function cleanup_self_files at 0x7a2c457fd580>
Traceback (most recent call last):
  File "/home/chris/dev/vivipi/scripts/u64_ftp.py", line 285, in cleanup_self_files
    ftp.connect(settings.host, settings.ftp_port, timeout=8)
  File "/usr/lib/python3.12/ftplib.py", line 158, in connect
    self.sock = socket.create_connection((self.host, self.port), self.timeout,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/socket.py", line 837, in create_connection
    sock.connect(sa)
KeyboardInterrupt: 

chris@mickey:~/dev/vivipi$ ^C
chris@mickey:~/dev/vivipi$ ping u64
PING u64 (192.168.1.13) 56(84) bytes of data.
^C
--- u64 ping statistics ---
3 packets transmitted, 0 received, 100% packet loss, time 2039ms

chris@mickey:~/dev/vivipi$ curl u64
^C
chris@mickey:~/dev/vivipi$ telnet u64
Trying 192.168.1.13...
telnet: Unable to connect to remote host: No route to host
chris@mickey:~/dev/vivipi$ ftp u64
ftp: Can't connect to `192.168.1.13:21': No route to host
ftp: Can't connect to `u64:ftp'
ftp> by
chris@mickey:~/dev/vivipi$ 
```