### PR TITLE
Add menu screen REST API

### DIFF
--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -229,15 +229,17 @@ API_CALL(GET, machine, readmem, NULL, ARRAY( { {"address", P_REQUIRED}, {"length
 API_CALL(GET, machine, menu_screen, NULL, ARRAY( {  }))
 {
     const int screen_size = UserInterface::ACTIVE_SCREEN_MATRIX_BYTES;
-    uint8_t buffer[UserInterface::ACTIVE_SCREEN_MATRIX_BYTES];
+    uint8_t *buffer = new uint8_t[screen_size];
 
     if (UserInterface::copy_active_screen_matrix(buffer, screen_size)) {
         StreamRamFile *rf = resp->add_attachment();
         rf->write(buffer, screen_size);
+        delete[] buffer;
         resp->binary_response();
     } else {
         resp->error("Menu screen unavailable.");
         resp->json_response(HTTP_NOT_FOUND);
+        delete[] buffer;
     }
 }
 

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -4,10 +4,12 @@
 #include "subsys.h"
 #include "c64.h"
 #include "c64_subsys.h"
+#include "userinterface.h"
 #if U64
 #include "keyboard_usb.h"
 #include "joystick_output.h"
 extern "C" void route_input_note_menu_button(void);
+extern "C" bool push_active_menu_button(void) __attribute__((weak));
 #endif
 
 #define MENU_C64_PAUSE      0x640B
@@ -28,6 +30,10 @@ API_CALL(PUT, machine, menu_button, NULL, ARRAY( {  }))
 {
 #if U64
     route_input_note_menu_button();
+    if (push_active_menu_button && push_active_menu_button()) {
+        resp->json_response(HTTP_OK);
+        return;
+    }
 #endif
     SubsysCommand *cmd = new SubsysCommand(NULL, SUBSYSID_C64, C64_PUSH_BUTTON, 0);
     SubsysResultCode_t retval = cmd->execute();
@@ -217,6 +223,21 @@ API_CALL(GET, machine, readmem, NULL, ARRAY( { {"address", P_REQUIRED}, {"length
         resp->error(SubsysCommand::error_string(retval.status));
         resp->json_response(SubsysCommand::http_response_map(retval.status));
         delete[] buffer;
+    }
+}
+
+API_CALL(GET, machine, menu_screen, NULL, ARRAY( {  }))
+{
+    const int screen_size = UserInterface::ACTIVE_SCREEN_MATRIX_BYTES;
+    uint8_t buffer[UserInterface::ACTIVE_SCREEN_MATRIX_BYTES];
+
+    if (UserInterface::copy_active_screen_matrix(buffer, screen_size)) {
+        StreamRamFile *rf = resp->add_attachment();
+        rf->write(buffer, screen_size);
+        resp->binary_response();
+    } else {
+        resp->error("Menu screen unavailable.");
+        resp->json_response(HTTP_NOT_FOUND);
     }
 }
 

--- a/software/application/ultimate/ultimate.cc
+++ b/software/application/ultimate/ultimate.cc
@@ -50,6 +50,15 @@ C64_Subsys *c64_subsys;
 StreamTextLog textLog(96*1024);
 Syslog syslog;
 
+extern "C" bool push_active_menu_button(void)
+{
+    if (overlay && overlay->is_accessible()) {
+        overlay->setButtonPushed();
+        return true;
+    }
+    return false;
+}
+
 extern "C" void (*custom_outbyte)(int c);
 
 extern "C" {

--- a/software/io/c64/screen.cc
+++ b/software/io/c64/screen.cc
@@ -96,10 +96,11 @@ void Screen_MemMappedCharMatrix :: restore(void)
     if(!backup_size) {
         return;
     }
-	memcpy(char_base, backup_chars, backup_size);
-	memcpy(color_base, backup_color, backup_size);
     resize_cell_colour_codes();
-	memcpy(cell_colour_codes, backup_color, backup_size);
+    int copy_size = (backup_size < cell_colour_codes_size) ? backup_size : cell_colour_codes_size;
+	memcpy(char_base, backup_chars, copy_size);
+	memcpy(color_base, backup_color, copy_size);
+	memcpy(cell_colour_codes, backup_color, copy_size);
 	move_cursor(backup_x, backup_y);
 	delete[] backup_chars;
 	delete[] backup_color;

--- a/software/io/c64/screen.cc
+++ b/software/io/c64/screen.cc
@@ -13,7 +13,7 @@ extern "C" {
 
 
 /**
- * Basic screen implementation, on a memory mapped character grid and a memory mapped attribute grid
+ * Basic screen implementation, on a memory mapped character grid and a memory mapped colour grid
  */
 Screen_MemMappedCharMatrix :: Screen_MemMappedCharMatrix(char *b, char *c, int sx, int sy)
 {
@@ -21,6 +21,8 @@ Screen_MemMappedCharMatrix :: Screen_MemMappedCharMatrix(char *b, char *c, int s
 
 	char_base  = b;
     color_base = c;
+    cell_colour_codes = 0;
+    cell_colour_codes_size = 0;
 
     size_x     = sx;
     size_y     = sy;
@@ -38,12 +40,40 @@ Screen_MemMappedCharMatrix :: Screen_MemMappedCharMatrix(char *b, char *c, int s
     backup_chars = 0;
     backup_color = 0;
     backup_x = backup_y = backup_size = 0;
+    resize_cell_colour_codes();
+}
+
+Screen_MemMappedCharMatrix :: ~Screen_MemMappedCharMatrix()
+{
+    delete[] cell_colour_codes;
+}
+
+void Screen_MemMappedCharMatrix :: resize_cell_colour_codes(void)
+{
+    int size = size_x * size_y;
+    if ((size <= 0) || ((size == cell_colour_codes_size) && cell_colour_codes)) {
+        return;
+    }
+
+    char *old_cell_colour_codes = cell_colour_codes;
+    int old_size = cell_colour_codes_size;
+
+    cell_colour_codes = new char[size];
+    memset(cell_colour_codes, 15, size);
+
+    if (old_cell_colour_codes) {
+        int copy_size = old_size < size ? old_size : size;
+        memcpy(cell_colour_codes, old_cell_colour_codes, copy_size);
+        delete[] old_cell_colour_codes;
+    }
+    cell_colour_codes_size = size;
 }
 
 void Screen_MemMappedCharMatrix :: update_size(int sx, int sy)
 {
     size_x = sx;
     size_y = sy;
+    resize_cell_colour_codes();
 }
 
 void Screen_MemMappedCharMatrix :: backup(void)
@@ -56,8 +86,9 @@ void Screen_MemMappedCharMatrix :: backup(void)
 	backup_color = new char[backup_size];
 	backup_x = cursor_x;
 	backup_y = cursor_y;
+    resize_cell_colour_codes();
 	memcpy(backup_chars, char_base, backup_size);
-	memcpy(backup_color, color_base, backup_size);
+	memcpy(backup_color, cell_colour_codes, backup_size);
 }
 
 void Screen_MemMappedCharMatrix :: restore(void)
@@ -67,10 +98,32 @@ void Screen_MemMappedCharMatrix :: restore(void)
     }
 	memcpy(char_base, backup_chars, backup_size);
 	memcpy(color_base, backup_color, backup_size);
+    resize_cell_colour_codes();
+	memcpy(cell_colour_codes, backup_color, backup_size);
 	move_cursor(backup_x, backup_y);
 	delete[] backup_chars;
 	delete[] backup_color;
     backup_size = 0;
+}
+
+bool Screen_MemMappedCharMatrix :: copy_matrix(uint8_t *chars, uint8_t *colors, int max_cells, int *width, int *height)
+{
+    int cells = size_x * size_y;
+    if (width) {
+        *width = size_x;
+    }
+    if (height) {
+        *height = size_y;
+    }
+    if ((max_cells < cells) || !chars || !colors) {
+        return false;
+    }
+    if (!cell_colour_codes || (cell_colour_codes_size < cells)) {
+        return false;
+    }
+    memcpy(chars, char_base, cells);
+    memcpy(colors, cell_colour_codes, cells);
+    return true;
 }
 
 void  Screen_MemMappedCharMatrix :: cursor_visible(int a) {
@@ -111,32 +164,46 @@ void Screen_MemMappedCharMatrix :: scroll_up()
 	}
 	char *b = char_base;
     char *c = color_base;
+    resize_cell_colour_codes();
+    char *s = cell_colour_codes;
     for(int y=0;y<size_y-1;y++) {
         for(int x=0;x<size_x;x++) {
             b[x] = b[x+size_x];
             c[x] = c[x+size_x];
+            s[x] = s[x+size_x];
         }
         b+=size_x;
         c+=size_x;
+        s+=size_x;
     }
-    for(int x=0;x<size_x;x++)
+    for(int x=0;x<size_x;x++) {
         b[x] = 0;
+        c[x] = 15;
+        s[x] = 15;
+    }
 }
 
 void Screen_MemMappedCharMatrix :: scroll_down()
 {
     char *b = &char_base[(size_y-2)*size_x];
     char *c = &color_base[(size_y-2)*size_x];
+    resize_cell_colour_codes();
+    char *s = &cell_colour_codes[(size_y-2)*size_x];
     for(int y=0;y<size_y-1;y++) {
         for(int x=0;x<size_x;x++) {
             b[x+size_x] = b[x];
             c[x+size_x] = c[x];
+            s[x+size_x] = s[x];
         }
         b-=size_x;
         c-=size_x;
+        s-=size_x;
     }
-    for(int x=0;x<size_x;x++)
+    for(int x=0;x<size_x;x++) {
         b[x+size_x] = 0;
+        c[x+size_x] = 15;
+        s[x+size_x] = 15;
+    }
 }
 
 void Screen_MemMappedCharMatrix :: repeat(char a, int len)
@@ -225,7 +292,9 @@ void Screen_MemMappedCharMatrix :: output_raw(char c)
             else
                 char_base[pointer] = c & 0x7F;
 
-            color_base[pointer] = (char)(color | background << 4);
+            char cell_colour_code = (char)((color & 15) | ((background & 15) << 4));
+            color_base[pointer] = cell_colour_code;
+            cell_colour_codes[pointer] = cell_colour_code;
             pointer ++;
             cursor_x++;
 
@@ -278,8 +347,10 @@ void Screen_MemMappedCharMatrix :: clear() {
 	reverse_mode(0);
 	set_color(15);
 	int size = get_size_x() * get_size_y();
+    resize_cell_colour_codes();
 	memset(char_base, 32, size);
 	memset(color_base, 15, size);
+	memset(cell_colour_codes, 15, size);
     move_cursor(0, 0);
 }
 

--- a/software/io/c64/screen.h
+++ b/software/io/c64/screen.h
@@ -1,6 +1,8 @@
 #ifndef SCREEN_H
 #define SCREEN_H
 
+#include <stdint.h>
+
 #define CHR_LOWER_RIGHT_CORNER  0x01
 #define CHR_HORIZONTAL_LINE     0x02
 #define CHR_LOWER_LEFT_CORNER   0x03
@@ -53,6 +55,7 @@ public:
 
     // raw
     virtual void output_raw(char c) { }
+    virtual bool copy_matrix(uint8_t *chars, uint8_t *colors, int max_cells, int *width, int *height) { return false; }
 
     // Synchronization
     virtual void sync(void) { }
@@ -74,6 +77,8 @@ class Screen_MemMappedCharMatrix : public Screen
 
 	char *char_base;
     char *color_base;
+    char *cell_colour_codes;
+    int cell_colour_codes_size;
 
 	int size_x;
 	int size_y;
@@ -86,6 +91,9 @@ class Screen_MemMappedCharMatrix : public Screen
 	// private stuff
 	void scroll_up(void);
     void scroll_down(void);
+    void resize_cell_colour_codes(void);
+    Screen_MemMappedCharMatrix(const Screen_MemMappedCharMatrix &);
+    Screen_MemMappedCharMatrix &operator=(const Screen_MemMappedCharMatrix &);
 
 protected:
     // draw mode
@@ -100,7 +108,7 @@ protected:
     void output_raw(char c);
 public:
     Screen_MemMappedCharMatrix(char *, char *, int, int);
-    ~Screen_MemMappedCharMatrix() { }
+    ~Screen_MemMappedCharMatrix();
 
     void backup(void);
     void restore(void);
@@ -123,6 +131,7 @@ public:
     int  output(const char *c);
     void repeat(char c, int rep);
     void output_fixed_length(const char *string, int offset_x, int width);
+    bool copy_matrix(uint8_t *chars, uint8_t *colors, int max_cells, int *width, int *height);
 };
 
 class Window

--- a/software/io/usb/usb_hid.cc
+++ b/software/io/usb/usb_hid.cc
@@ -1296,7 +1296,7 @@ void UsbHidDriver :: interrupt_handler()
                 }
                 if (right_button_pressed) {
                     if (!menu_right_button_consumed) {
-                        usb_hid_queue_menu_key(KEY_BREAK, 1, 1);
+                        usb_hid_queue_menu_key(KEY_LEFT, 1, 1);
                         menu_right_button_consumed = true;
                     }
                 } else {

--- a/software/monitor/run_machine_monitor.cc
+++ b/software/monitor/run_machine_monitor.cc
@@ -13,6 +13,9 @@ void UserInterface :: run_machine_monitor(MemoryBackend *backend)
     int ret = 0;
     while(!ret && host->exists()) {
         ret = monitor->poll(0);
+        if (!ret && pollMenuButtonPush()) {
+            break;
+        }
     }
     bool do_go = monitor->consume_pending_go(&go_address);
     monitor->deinit();

--- a/software/test/user_interface/src/screen_snapshot_test.cc
+++ b/software/test/user_interface/src/screen_snapshot_test.cc
@@ -1,0 +1,102 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "screen.h"
+
+static const int MATRIX_WIDTH = 3;
+static const int MATRIX_HEIGHT = 2;
+static const int MATRIX_CELLS = MATRIX_WIDTH * MATRIX_HEIGHT;
+
+extern "C" void outbyte(int b)
+{
+    char c = (char)b;
+    fwrite(&c, 1, 1, stdout);
+}
+
+static int fail(const char *message)
+{
+    puts(message);
+    return 1;
+}
+
+static int expect_bytes(const char *label, const uint8_t *actual, const uint8_t *expected, int len)
+{
+    if (memcmp(actual, expected, len) == 0) {
+        return 0;
+    }
+    printf("Unexpected %s bytes.\n", label);
+    for (int i = 0; i < len; i++) {
+        printf("%02X%s", actual[i], (i == len - 1) ? "\n" : " ");
+    }
+    return 1;
+}
+
+int main()
+{
+    uint8_t chars[MATRIX_CELLS] = { 0x01, 0x82, 0x03, 0x44, 0x05, 0xC6 };
+    uint8_t colors[MATRIX_CELLS] = { 0x10, 0x21, 0x32, 0x43, 0xF4, 0x8F };
+    uint8_t initial_cell_colour_codes[MATRIX_CELLS] = { 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F };
+    uint8_t out_chars[MATRIX_CELLS] = { 0 };
+    uint8_t out_colors[MATRIX_CELLS] = { 0 };
+    int width = 0;
+    int height = 0;
+
+    Screen_MemMappedCharMatrix screen((char *)(void *)chars, (char *)(void *)colors, MATRIX_WIDTH, MATRIX_HEIGHT);
+    if (!screen.copy_matrix(out_chars, out_colors, MATRIX_CELLS, &width, &height)) {
+        return fail("copy_matrix unexpectedly failed.");
+    }
+    if ((width != MATRIX_WIDTH) || (height != MATRIX_HEIGHT)) {
+        return fail("Unexpected matrix dimensions.");
+    }
+    if (expect_bytes("character", out_chars, chars, MATRIX_CELLS)) {
+        return 1;
+    }
+    if (expect_bytes("initial cell colour code", out_colors, initial_cell_colour_codes, MATRIX_CELLS)) {
+        return 1;
+    }
+
+    screen.move_cursor(0, 0);
+    screen.set_color(1);
+    screen.set_background(6);
+    screen.output('X');
+    colors[0] &= 0x0F;
+    memset(out_colors, 0, sizeof(out_colors));
+    if (!screen.copy_matrix(out_chars, out_colors, MATRIX_CELLS, &width, &height)) {
+        return fail("copy_matrix failed after writing a coloured cell.");
+    }
+    if (out_colors[0] != 0x61) {
+        printf("Unexpected cell colour code byte: %02X\n", out_colors[0]);
+        return 1;
+    }
+
+    screen.clear();
+    screen.move_cursor(0, MATRIX_HEIGHT - 1);
+    screen.set_color(1);
+    screen.set_background(6);
+    screen.output('x');
+    screen.output('y');
+    screen.output('\n');
+    memset(out_colors, 0, sizeof(out_colors));
+    if (!screen.copy_matrix(out_chars, out_colors, MATRIX_CELLS, &width, &height)) {
+        return fail("copy_matrix failed after scrolling.");
+    }
+    for (int i = MATRIX_WIDTH; i < MATRIX_CELLS; i++) {
+        if (out_colors[i] != 0x0F) {
+            printf("Unexpected blank row colour code byte at %d: %02X\n", i, out_colors[i]);
+            return 1;
+        }
+    }
+
+    width = 0;
+    height = 0;
+    if (screen.copy_matrix(out_chars, out_colors, MATRIX_CELLS - 1, &width, &height)) {
+        return fail("copy_matrix succeeded with an undersized destination.");
+    }
+    if ((width != MATRIX_WIDTH) || (height != MATRIX_HEIGHT)) {
+        return fail("Undersized copy did not report matrix dimensions.");
+    }
+
+    puts("screen_snapshot_test: OK");
+    return 0;
+}

--- a/software/userinterface/userinterface.cc
+++ b/software/userinterface/userinterface.cc
@@ -475,6 +475,20 @@ int UserInterface :: pollFocussed(void)
     return ret;
 }
 
+// Detect a menu-button push (hardware or REST) while a nested blocking screen
+// (machine monitor / help) owns the loop. The push is re-armed so that the
+// outer run_once() loop also tears the menu down, closing both layers at once
+// instead of leaving the nested screen open over a dismissed menu.
+bool UserInterface :: pollMenuButtonPush(void)
+{
+    host->checkButton();
+    if (host->buttonPush()) {
+        host->setButtonPushed();
+        return true;
+    }
+    return false;
+}
+
 void UserInterface :: appear(void)
 {
 	host->set_colors(color_bg, color_border);
@@ -732,6 +746,9 @@ void UserInterface :: run_editor(Editor *editor)
     int ret = 0;
     while(!ret && host->exists()) {
         ret = editor->poll(0);
+        if (!ret && pollMenuButtonPush()) {
+            break;
+        }
     }
     editor->deinit();
     delete editor;

--- a/software/userinterface/userinterface.cc
+++ b/software/userinterface/userinterface.cc
@@ -1,6 +1,10 @@
 #include "userinterface.h"
 #include <stdio.h>
 
+#if !defined(RUNS_ON_PC) && !defined(RECOVERYAPP)
+#include "c64.h"
+#endif
+
 #ifndef NO_FILE_ACCESS
 #include "FreeRTOS.h"
 #include "task.h"
@@ -502,6 +506,54 @@ bool UserInterface :: anyMenuActive(void)
     active = active_user_interface_count > 0;
     portEXIT_CRITICAL();
     return active;
+}
+
+static bool active_screen_read_safe(UserInterface *ui)
+{
+    if (!ui || !ui->screen) {
+        return false;
+    }
+#if !defined(RUNS_ON_PC) && !defined(RECOVERYAPP)
+    C64 *machine = C64::getMachine();
+    if (machine && ui->host == (GenericHost *)machine && !machine->is_accessible()) {
+        return false;
+    }
+#endif
+    return true;
+}
+
+bool UserInterface :: copy_active_screen_matrix(uint8_t *dest, int dest_len)
+{
+    bool copied = false;
+    if (!dest || (dest_len < ACTIVE_SCREEN_MATRIX_BYTES)) {
+        return false;
+    }
+
+    IndexedList<UserInterface *> *interfaces = get_user_interfaces();
+    // Keep the UI pointer stable while walking the shared list and making the
+    // bounded matrix copy; IndexedList mutations use the same critical section.
+    portENTER_CRITICAL();
+    for (int i = 0; i < interfaces->get_elements(); i++) {
+        UserInterface *ui = (*interfaces)[i];
+        if (!ui || !ui->is_available() || !active_screen_read_safe(ui)) {
+            continue;
+        }
+
+        int screen_width = 0;
+        int screen_height = 0;
+        if (!ui->screen->copy_matrix(dest, dest + ACTIVE_SCREEN_MATRIX_CELLS,
+                ACTIVE_SCREEN_MATRIX_CELLS, &screen_width, &screen_height)) {
+            continue;
+        }
+        if ((screen_width != ACTIVE_SCREEN_MATRIX_WIDTH) ||
+                (screen_height != ACTIVE_SCREEN_MATRIX_HEIGHT)) {
+            continue;
+        }
+        copied = true;
+        break;
+    }
+    portEXIT_CRITICAL();
+    return copied;
 }
 
 extern "C" bool userinterface_any_menu_active(void)

--- a/software/userinterface/userinterface.h
+++ b/software/userinterface/userinterface.h
@@ -73,6 +73,7 @@ private:
     void set_screen_title(void);
     void set_available(bool enable);
     int  pollFocussed(void);
+    bool pollMenuButtonPush(void);
     void peel_off(void);
     bool buttonDownFor(uint32_t ms);
     void run_editor(Editor *);

--- a/software/userinterface/userinterface.h
+++ b/software/userinterface/userinterface.h
@@ -129,6 +129,14 @@ public:
     void swapDisk(void);
     void send_keystroke(int key);
     static bool anyMenuActive(void);
+    enum {
+        ACTIVE_SCREEN_MATRIX_WIDTH = 40,
+        ACTIVE_SCREEN_MATRIX_HEIGHT = 25,
+        ACTIVE_SCREEN_MATRIX_CELLS = ACTIVE_SCREEN_MATRIX_WIDTH * ACTIVE_SCREEN_MATRIX_HEIGHT,
+        ACTIVE_SCREEN_MATRIX_PLANES = 2,
+        ACTIVE_SCREEN_MATRIX_BYTES = ACTIVE_SCREEN_MATRIX_CELLS * ACTIVE_SCREEN_MATRIX_PLANES
+    };
+    static bool copy_active_screen_matrix(uint8_t *dest, int dest_len);
 
     UIObject *get_root_object(void) { return ui_objects[0]; }
 

--- a/target/pc/linux/screensnapshottest/Makefile
+++ b/target/pc/linux/screensnapshottest/Makefile
@@ -1,0 +1,46 @@
+PRJ      =  screensnapshottest
+FINAL    =  $(RESULT)/$(PRJ)
+
+include ../../../common/environment.mk
+
+VPATH += $(PATH_SW)/test/user_interface/src
+
+CROSS     =
+CC		  = $(CROSS)gcc
+CPP		  = $(CROSS)g++
+LD		  = $(CROSS)ld
+OBJDUMP   = $(CROSS)objdump
+OBJCOPY	  = $(CROSS)objcopy
+SIZE	  = $(CROSS)size
+
+.SUFFIXES:
+
+SRCS_C   =
+
+SRCS_CC	 =  small_printf.cc \
+			screen.cc \
+			screen_snapshot_test.cc
+
+SRCS_ASM =
+SRCS_6502 =
+SRCS_BIN =
+SRCS_IEC =
+SRCS_NANO =
+
+PATH_INC =  $(addprefix -I, $(VPATH))
+OPTIONS  = -g -ffunction-sections -O0 -DRUNS_ON_PC -Wno-format -Wno-format-extra-args
+COPTIONS = $(OPTIONS) -std=c99
+CPPOPT   = $(OPTIONS) -fno-exceptions -fno-rtti -fno-threadsafe-statics
+LIBS     = -lgcc
+LFLAGS   = --gc-sections
+
+include ../../../common/rules.mk
+
+all: run
+
+$(RESULT)/$(PRJ): $(OBJS_C) $(OBJS_CC) $(OBJS_ASM) $(OBJS_6502) $(OBJS_BIN) $(OBJS_IEC) $(OBJS_NANO)
+	@echo Linking...
+	$(CPP) $(ALL_OBJS) $(LLIB) -o $(RESULT)/$(PRJ) $(LIBS)
+
+run: $(RESULT)/$(PRJ)
+	$(RESULT)/$(PRJ)

--- a/tools/api/menu_screen_test.py
+++ b/tools/api/menu_screen_test.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from typing import Dict, List, Optional, Tuple
+
+
+CHECK_COUNT = 0
+MENU_SCREEN_PATH = "/v1/machine:menu_screen"
+MENU_BUTTON_PATH = "/v1/machine:menu_button"
+INPUT_PATH = "/v1/machine:input"
+MENU_SCREEN_UNAVAILABLE = "Menu screen unavailable."
+FORBIDDEN = "Forbidden."
+SCREEN_WIDTH = 40
+SCREEN_HEIGHT = 25
+SCREEN_CELLS = SCREEN_WIDTH * SCREEN_HEIGHT
+SCREEN_PLANES = 2
+SCREEN_BYTES = SCREEN_CELLS * SCREEN_PLANES
+MENU_TOGGLE_SETTLE_SECONDS = 0.25
+MENU_CLOSE_TIMEOUT_SECONDS = 2.0
+DEFAULT_SOAK_STAGES = (10.0, 30.0, 120.0, 300.0)
+SOAK_NAVIGATION_INTERVAL_SECONDS = 0.20
+SELECTED_ROW_MIN_MARKED_CELLS = 12
+SOAK_TOP_LEVEL_SECTION_LIMIT = 64
+
+
+class Failure(RuntimeError):
+    pass
+
+
+@contextmanager
+def check(label: str):
+    global CHECK_COUNT
+    CHECK_COUNT += 1
+    print(f"[{CHECK_COUNT:02d}] {label} ... ", end="", flush=True)
+    try:
+        yield
+    except Exception:
+        print("FAIL", flush=True)
+        raise
+    print("OK", flush=True)
+
+
+def format_exception(exc: BaseException) -> str:
+    if isinstance(exc, urllib.error.URLError) and getattr(exc, "reason", None) is not None:
+        return f"{exc} ({exc.reason})"
+    return str(exc)
+
+
+class RestSession:
+    def __init__(self, host: str, password: Optional[str], timeout: float) -> None:
+        self.host = host
+        self.password = password
+        self.timeout = timeout
+
+    def url(self, path: str, params: Optional[Dict[str, object]] = None) -> str:
+        query = ""
+        if params:
+            query = "?" + urllib.parse.urlencode(params)
+        return f"http://{self.host}{path}{query}"
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, object]] = None,
+        payload: Optional[Dict[str, object]] = None,
+        use_password: bool = True,
+    ) -> Tuple[int, Dict[str, str], bytes]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        headers: Dict[str, str] = {}
+        if self.password and use_password:
+            headers["X-Password"] = self.password
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+
+        request = urllib.request.Request(self.url(path, params), data=body, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return response.status, dict(response.headers.items()), response.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, dict(exc.headers.items()), exc.read()
+        except (OSError, TimeoutError, urllib.error.URLError) as exc:
+            raise Failure(f"{method} {self.url(path, params)} failed: {format_exception(exc)}") from exc
+
+    def menu_button(self, label: str) -> None:
+        with check(label):
+            status, _, body = self.request("PUT", MENU_BUTTON_PATH)
+            if status != 200:
+                raise Failure(f"menu_button failed with HTTP {status}: {body[:160]!r}")
+        time.sleep(MENU_TOGGLE_SETTLE_SECONDS)
+
+    def menu_screen_unavailable(self) -> bool:
+        status, headers, body = self.request("GET", MENU_SCREEN_PATH)
+        if status != 404:
+            return False
+        content_type = header_value(headers, "Content-Type")
+        if "application/json" not in content_type:
+            raise Failure(f"expected application/json, got {content_type!r}")
+        require_error("menu_screen unavailable", body, MENU_SCREEN_UNAVAILABLE)
+        return True
+
+    def menu_screen_available(self) -> bool:
+        status, headers, body = self.request("GET", MENU_SCREEN_PATH)
+        if status == 404:
+            require_error("menu_screen unavailable", body, MENU_SCREEN_UNAVAILABLE)
+            return False
+        verify_binary_contract(status, headers, body)
+        return True
+
+    def wait_menu_closed(self) -> bool:
+        deadline = time.monotonic() + MENU_CLOSE_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if self.menu_screen_unavailable():
+                return True
+            time.sleep(MENU_TOGGLE_SETTLE_SECONDS)
+        return False
+
+    def wait_menu_open(self) -> bool:
+        deadline = time.monotonic() + MENU_CLOSE_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if self.menu_screen_available():
+                return True
+            time.sleep(MENU_TOGGLE_SETTLE_SECONDS)
+        return False
+
+    def close_menu(self) -> None:
+        self.menu_button("close menu")
+        if not self.wait_menu_closed():
+            raise Failure("menu remained available after REST menu_button close")
+
+    def open_menu(self) -> None:
+        self.menu_button("open menu")
+        if not self.wait_menu_open():
+            raise Failure("menu remained unavailable after REST menu_button open")
+
+    def get_menu_screen(self) -> bytes:
+        status, headers, body = self.request("GET", MENU_SCREEN_PATH)
+        verify_binary_contract(status, headers, body)
+        return body
+
+    def try_get_menu_screen(self) -> Optional[bytes]:
+        status, headers, body = self.request("GET", MENU_SCREEN_PATH)
+        if status == 404:
+            content_type = header_value(headers, "Content-Type")
+            if "application/json" not in content_type:
+                raise Failure(f"expected application/json, got {content_type!r}")
+            require_error("menu_screen unavailable", body, MENU_SCREEN_UNAVAILABLE)
+            return None
+        verify_binary_contract(status, headers, body)
+        return body
+
+    def post_events(self, events: List[Dict[str, object]]) -> Dict[str, object]:
+        status, headers, body = self.request("POST", INPUT_PATH, payload={"events": events})
+        if status != 200:
+            raise Failure(f"input event failed with HTTP {status}: {body[:160]!r}")
+        content_type = header_value(headers, "Content-Type")
+        if "application/json" not in content_type:
+            raise Failure(f"expected application/json from input event, got {content_type!r}")
+        return parse_json("input event", body)
+
+    def tap_keyboard(self, inputs: List[str]) -> None:
+        self.post_events([{"kind": "keyboard", "inputs": inputs, "transition": "tap"}])
+
+    def release_all_input(self) -> None:
+        self.post_events([{"kind": "release_all"}])
+
+    def close_menu_from_anywhere(self) -> None:
+        for _ in range(12):
+            body = self.try_get_menu_screen()
+            if body is None:
+                return
+            if "Save changes to Flash?" in menu_screen_text(body):
+                self.tap_keyboard(["cursor_left_right"])
+                time.sleep(MENU_TOGGLE_SETTLE_SECONDS)
+                self.tap_keyboard(["return"])
+                time.sleep(MENU_TOGGLE_SETTLE_SECONDS)
+                continue
+            self.tap_keyboard(["run_stop"])
+            time.sleep(MENU_TOGGLE_SETTLE_SECONDS)
+
+        if self.menu_screen_unavailable():
+            return
+        self.close_menu()
+
+
+def header_value(headers: Dict[str, str], name: str) -> str:
+    wanted = name.lower()
+    for key, value in headers.items():
+        if key.lower() == wanted:
+            return value
+    return ""
+
+
+def parse_json(label: str, body: bytes) -> Dict[str, object]:
+    try:
+        data = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise Failure(f"{label}: response body is not valid JSON: {body[:160]!r}") from exc
+    if not isinstance(data, dict):
+        raise Failure(f"{label}: expected JSON object, got {data!r}")
+    return data
+
+
+def require_error(label: str, body: bytes, message: str) -> None:
+    data = parse_json(label, body)
+    errors = data.get("errors")
+    if not isinstance(errors, list) or message not in errors:
+        raise Failure(f"{label}: expected errors to contain {message!r}, got {data!r}")
+
+
+def verify_binary_contract(status: int, headers: Dict[str, str], body: bytes) -> None:
+    if status != 200:
+        raise Failure(f"expected HTTP 200, got HTTP {status}: {body[:160]!r}")
+
+    content_type = header_value(headers, "Content-Type")
+    if "application/octet-stream" not in content_type:
+        raise Failure(f"expected application/octet-stream, got {content_type!r}")
+    if len(body) != SCREEN_BYTES:
+        raise Failure(f"expected {SCREEN_BYTES} response bytes, got {len(body)}")
+
+    chars = body[:SCREEN_CELLS]
+    attrs = body[SCREEN_CELLS:]
+    if len(chars) != SCREEN_CELLS or len(attrs) != SCREEN_CELLS:
+        raise Failure(f"response did not split into two {SCREEN_CELLS}-byte planes")
+    if len(set(chars)) == 1 and len(set(attrs)) == 1:
+        raise Failure("snapshot is trivially uniform in both planes")
+
+
+def menu_screen_text(body: bytes) -> str:
+    chars = body[:SCREEN_CELLS]
+    rows = []
+    for row in range(SCREEN_HEIGHT):
+        row_chars = chars[row * SCREEN_WIDTH:(row + 1) * SCREEN_WIDTH]
+        rows.append("".join(
+            chr(ch & 0x7F) if 0x20 <= (ch & 0x7F) <= 0x7E else " "
+            for ch in row_chars
+        ))
+    return "\n".join(rows)
+
+
+def run_contract(session: RestSession) -> None:
+    with check("GET menu_screen contract"):
+        status, headers, body = session.request("GET", MENU_SCREEN_PATH)
+        verify_binary_contract(status, headers, body)
+
+
+def run_contract_with_open_menu(session: RestSession) -> None:
+    if not session.menu_screen_unavailable():
+        session.close_menu()
+    session.open_menu()
+    try:
+        run_contract(session)
+    finally:
+        session.close_menu()
+
+
+def run_unavailable(session: RestSession) -> None:
+    with check("GET menu_screen unavailable"):
+        if not session.menu_screen_unavailable():
+            raise Failure("expected HTTP 404 unavailable state")
+
+
+def run_auth(session: RestSession) -> None:
+    if not session.password:
+        print("menu_screen_test: SKIP auth (--password not supplied)", file=sys.stderr)
+        return
+    with check("GET menu_screen auth"):
+        status, headers, body = session.request("GET", MENU_SCREEN_PATH, use_password=False)
+        if status != 403:
+            raise Failure(f"expected HTTP 403 without X-Password, got HTTP {status}")
+        content_type = header_value(headers, "Content-Type")
+        if "application/json" not in content_type:
+            raise Failure(f"expected application/json, got {content_type!r}")
+        require_error("menu_screen auth", body, FORBIDDEN)
+
+
+def parse_duration(value: str) -> float:
+    text = value.strip().lower()
+    multiplier = 1.0
+    if text.endswith("ms"):
+        multiplier = 0.001
+        text = text[:-2]
+    elif text.endswith("s"):
+        text = text[:-1]
+    elif text.endswith("m"):
+        multiplier = 60.0
+        text = text[:-1]
+
+    try:
+        duration = float(text) * multiplier
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid duration: {value!r}") from exc
+
+    if duration <= 0.0:
+        raise argparse.ArgumentTypeError("duration must be greater than zero")
+    return duration
+
+
+def parse_soak_stages(value: str) -> List[float]:
+    stages = [parse_duration(part) for part in value.split(",") if part.strip()]
+    if not stages:
+        raise argparse.ArgumentTypeError("at least one soak stage is required")
+    return stages
+
+
+def format_duration(seconds: float) -> str:
+    if seconds >= 60.0 and seconds % 60.0 == 0.0:
+        return f"{int(seconds / 60.0)}m"
+    if seconds % 1.0 == 0.0:
+        return f"{int(seconds)}s"
+    return f"{seconds:.3f}s"
+
+
+class MenuScreenInfo:
+    def __init__(self, body: bytes) -> None:
+        chars = body[:SCREEN_CELLS]
+        colors = body[SCREEN_CELLS:]
+
+        self.screen_id = hashlib.sha256(chars).digest()[:8]
+        self.rows = [
+            "".join(chr(ch & 0x7F) if 0x20 <= (ch & 0x7F) <= 0x7E else " "
+                for ch in chars[row * SCREEN_WIDTH:(row + 1) * SCREEN_WIDTH]).strip()
+            for row in range(SCREEN_HEIGHT)
+        ]
+        self.selected_row = self.find_selected_row(chars, colors)
+        self.selected_text = self.rows[self.selected_row]
+        self.text = "\n".join(self.rows)
+
+    @staticmethod
+    def find_selected_row(chars: bytes, colors: bytes) -> int:
+        best_background_row = -1
+        best_background_count = 0
+        best_reverse_row = -1
+        best_reverse_count = 0
+        best_foreground_row = -1
+        best_foreground_count = 0
+        for row in range(2, SCREEN_HEIGHT - 1):
+            background_counts: Dict[int, int] = {}
+            foreground_counts: Dict[int, int] = {}
+            reverse_count = 0
+            row_chars = chars[row * SCREEN_WIDTH + 1:(row + 1) * SCREEN_WIDTH - 1]
+            row_colors = colors[row * SCREEN_WIDTH + 1:(row + 1) * SCREEN_WIDTH - 1]
+            for ch, color_code in zip(row_chars, row_colors):
+                if ch & 0x80:
+                    reverse_count += 1
+                foreground = color_code & 0x0F
+                background = (color_code >> 4) & 0x0F
+                if background == 0:
+                    if foreground != 0x0F:
+                        foreground_counts[foreground] = foreground_counts.get(foreground, 0) + 1
+                    continue
+                background_counts[background] = background_counts.get(background, 0) + 1
+            background_count = max(background_counts.values()) if background_counts else 0
+            foreground_count = max(foreground_counts.values()) if foreground_counts else 0
+            if background_count > best_background_count:
+                best_background_count = background_count
+                best_background_row = row
+            if reverse_count > best_reverse_count:
+                best_reverse_count = reverse_count
+                best_reverse_row = row
+            if foreground_count > best_foreground_count:
+                best_foreground_count = foreground_count
+                best_foreground_row = row
+
+        if best_background_count >= SELECTED_ROW_MIN_MARKED_CELLS:
+            return best_background_row
+        if best_reverse_count >= SELECTED_ROW_MIN_MARKED_CELLS:
+            return best_reverse_row
+        if best_foreground_count >= SELECTED_ROW_MIN_MARKED_CELLS:
+            return best_foreground_row
+        raise Failure("could not locate selected menu row from colour codes")
+
+
+class MenuSoakNavigator:
+    UP = ["left_shift", "cursor_up_down"]
+    DOWN = ["cursor_up_down"]
+    F2 = ["left_shift", "f1"]
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self.started = False
+        self.mode = "rewind"
+        self.visited = set()
+        self.top_level_sections = 0
+        self.boundary_hits = 0
+        self.last_action = ""
+        self.last_screen_id: Optional[bytes] = None
+        self.last_selected_row: Optional[int] = None
+
+    def _remember_action(self, action: str, info: MenuScreenInfo) -> None:
+        self.last_action = action
+        self.last_screen_id = info.screen_id
+        self.last_selected_row = info.selected_row
+
+    def _moved_since_last_action(self, info: MenuScreenInfo) -> bool:
+        return (
+            self.last_screen_id != info.screen_id or
+            self.last_selected_row != info.selected_row
+        )
+
+    def _apply_last_action_outcome(self, info: MenuScreenInfo) -> None:
+        if not self.last_action:
+            return
+
+        moved = self._moved_since_last_action(info)
+        if self.last_action in ("up", "down"):
+            if moved:
+                self.boundary_hits = 0
+            else:
+                self.boundary_hits += 1
+        elif self.last_action == "f2":
+            self.mode = "rewind"
+            self.boundary_hits = 0
+
+        self.last_action = ""
+
+    def next_key(self, body: bytes) -> Tuple[str, List[str]]:
+        info = MenuScreenInfo(body)
+        self._apply_last_action_outcome(info)
+
+        if not self.started:
+            self.started = True
+            self._remember_action("f2", info)
+            return "enter config menu with F2", self.F2
+
+        if self.mode == "rewind":
+            if self.boundary_hits >= 2:
+                self.mode = "advance"
+                self.boundary_hits = 0
+            else:
+                self._remember_action("up", info)
+                return f"rewind selection upward from row {info.selected_row}", self.UP
+
+        visit_key = (info.screen_id, info.selected_row, info.selected_text)
+        self.visited.add(visit_key)
+
+        if self.mode == "advance" and self.boundary_hits >= 2:
+            self.boundary_hits = 0
+            self.top_level_sections += 1
+            if self.top_level_sections >= SOAK_TOP_LEVEL_SECTION_LIMIT:
+                self.top_level_sections = 0
+                self.visited.clear()
+            self.mode = "rewind" if (self.top_level_sections % 2) == 0 else "advance"
+            self._remember_action("f2", info)
+            return "switch non-mutating menu view with F2", self.F2
+
+        self._remember_action("down", info)
+        return f"move selection downward from row {info.selected_row}", self.DOWN
+
+
+def run_soak(session: RestSession, stages: List[float], navigation_interval: float) -> None:
+    if not session.menu_screen_unavailable():
+        session.close_menu()
+    session.open_menu()
+    navigator = MenuSoakNavigator()
+    try:
+        for stage in stages:
+            label = f"GET menu_screen soak {format_duration(stage)}"
+            with check(label):
+                count = 0
+                navigation_count = 0
+                reopened_count = 0
+                snapshot_hashes = set()
+                next_navigation = time.monotonic()
+                started = time.monotonic()
+                deadline = started + stage
+                while time.monotonic() < deadline:
+                    try:
+                        body = session.try_get_menu_screen()
+                    except Exception as exc:
+                        elapsed = time.monotonic() - started
+                        raise Failure(
+                            f"soak failed after {count} successful requests "
+                            f"in {elapsed:.3f}s: {exc}"
+                        ) from exc
+                    if body is None:
+                        reopened_count += 1
+                        navigator.reset()
+                        try:
+                            session.open_menu()
+                        except Exception as exc:
+                            elapsed = time.monotonic() - started
+                            raise Failure(
+                                f"menu reopen failed after {count} successful snapshots "
+                                f"in {elapsed:.3f}s: {exc}"
+                            ) from exc
+                        continue
+                    count += 1
+                    snapshot_hashes.add(hashlib.sha256(body).digest()[:8])
+
+                    now = time.monotonic()
+                    if now >= next_navigation:
+                        name, inputs = navigator.next_key(body)
+                        try:
+                            session.tap_keyboard(inputs)
+                        except Exception as exc:
+                            elapsed = time.monotonic() - started
+                            raise Failure(
+                                f"navigation {name} failed after {count} snapshots "
+                                f"in {elapsed:.3f}s: {exc}"
+                            ) from exc
+                        navigation_count += 1
+                        next_navigation = time.monotonic() + navigation_interval
+
+                elapsed = time.monotonic() - started
+                rate = count / elapsed if elapsed > 0.0 else 0.0
+                if len(snapshot_hashes) < 2:
+                    raise Failure("soak did not observe changing menu snapshots during navigation")
+                print(
+                    f"{count} snapshots, {navigation_count} keys, "
+                    f"{len(snapshot_hashes)} variants, {reopened_count} reopens, {rate:.1f}/s ",
+                    end="",
+                    flush=True,
+                )
+    finally:
+        try:
+            session.release_all_input()
+        except Exception as exc:
+            print(f"menu_screen_test: soak cleanup release_all failed: {exc}", file=sys.stderr)
+        session.close_menu_from_anywhere()
+
+
+def expand_tests(selected: Optional[List[str]]) -> List[str]:
+    if not selected:
+        selected = ["contract", "unavailable", "auth"]
+    expanded: List[str] = []
+    for name in selected:
+        names = ["contract", "unavailable", "auth"] if name == "all" else [name]
+        for item in names:
+            if item not in expanded:
+                expanded.append(item)
+    return expanded
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate /v1/machine:menu_screen on real firmware.")
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_INPUT_HOST", "u64"))
+    parser.add_argument("-r", "--rest-host", default=os.environ.get("U64_INPUT_REST_HOST"))
+    parser.add_argument(
+        "-p",
+        "--password",
+        default=os.environ.get("U64_INPUT_PASSWORD", os.environ.get("C64U_PASSWORD")),
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("U64_INPUT_TIMEOUT", "5.0")),
+    )
+    parser.add_argument(
+        "--test",
+        action="append",
+        choices=("all", "contract", "unavailable", "auth", "soak"),
+    )
+    parser.add_argument(
+        "--open-menu",
+        action="store_true",
+        help="Deprecated compatibility option; the contract check opens the menu by default.",
+    )
+    parser.add_argument(
+        "--soak-stages",
+        type=parse_soak_stages,
+        default=list(DEFAULT_SOAK_STAGES),
+        metavar="DURATIONS",
+        help="Comma-separated soak durations for --test soak, e.g. 10s,30s,2m,5m.",
+    )
+    parser.add_argument(
+        "--soak-key-interval",
+        type=parse_duration,
+        default=SOAK_NAVIGATION_INTERVAL_SECONDS,
+        metavar="DURATION",
+        help="Minimum interval between REST keyboard navigation taps during soak.",
+    )
+    args = parser.parse_args()
+
+    rest_host = args.rest_host or args.host
+    session = RestSession(rest_host, args.password, args.timeout)
+    tests = expand_tests(args.test)
+
+    if "contract" in tests:
+        run_contract_with_open_menu(session)
+    if "unavailable" in tests:
+        run_unavailable(session)
+    if "auth" in tests:
+        run_auth(session)
+    if "soak" in tests:
+        run_soak(session, args.soak_stages, args.soak_key_interval)
+
+    print(f"menu_screen_test: OK ({CHECK_COUNT} checks)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        print(f"menu_screen_test: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/api/menu_screen_test.py
+++ b/tools/api/menu_screen_test.py
@@ -23,6 +23,14 @@ SCREEN_HEIGHT = 25
 SCREEN_CELLS = SCREEN_WIDTH * SCREEN_HEIGHT
 SCREEN_PLANES = 2
 SCREEN_BYTES = SCREEN_CELLS * SCREEN_PLANES
+# Structural bounds that any genuinely-rendered menu satisfies, independent of
+# the specific menu, firmware version, or colour scheme. They reject blank or
+# garbage snapshots without pinning the test to exact menu text or layout.
+# Observed across root/context/settings/help screens: printable 176-347,
+# distinct glyphs 57-63, distinct colours 4-7; bounds keep wide margins.
+MENU_MIN_PRINTABLE_CELLS = 20
+MENU_MAX_DISTINCT_COLOURS = 32
+MENU_MAX_DISTINCT_GLYPHS = 160
 MENU_TOGGLE_SETTLE_SECONDS = 0.25
 MENU_CLOSE_TIMEOUT_SECONDS = 2.0
 DEFAULT_SOAK_STAGES = (10.0, 30.0, 120.0, 300.0)
@@ -234,6 +242,36 @@ def verify_binary_contract(status: int, headers: Dict[str, str], body: bytes) ->
         raise Failure("snapshot is trivially uniform in both planes")
 
 
+def verify_menu_content(body: bytes) -> None:
+    # Resilience over prescription: confirm the snapshot looks like a real
+    # rendered menu (readable text in a small, deliberate palette) without
+    # asserting any specific menu text, layout, or colours. This survives future
+    # menu changes yet still rejects blank screens and random/garbage data.
+    chars = body[:SCREEN_CELLS]
+    colours = body[SCREEN_CELLS:]
+
+    printable = sum(1 for ch in chars if 0x21 <= (ch & 0x7F) <= 0x7E)
+    if printable < MENU_MIN_PRINTABLE_CELLS:
+        raise Failure(
+            f"snapshot has too little readable text to be a menu: {printable} "
+            f"printable cells (need >= {MENU_MIN_PRINTABLE_CELLS})"
+        )
+
+    distinct_colours = len(set(colours))
+    if not (1 < distinct_colours <= MENU_MAX_DISTINCT_COLOURS):
+        raise Failure(
+            f"snapshot colour plane is not menu-like: {distinct_colours} distinct "
+            f"colours (expected 2..{MENU_MAX_DISTINCT_COLOURS})"
+        )
+
+    distinct_glyphs = len(set(chars))
+    if distinct_glyphs > MENU_MAX_DISTINCT_GLYPHS:
+        raise Failure(
+            f"snapshot character plane is not menu-like: {distinct_glyphs} distinct "
+            f"glyphs (expected <= {MENU_MAX_DISTINCT_GLYPHS})"
+        )
+
+
 def menu_screen_text(body: bytes) -> str:
     chars = body[:SCREEN_CELLS]
     rows = []
@@ -250,6 +288,8 @@ def run_contract(session: RestSession) -> None:
     with check("GET menu_screen contract"):
         status, headers, body = session.request("GET", MENU_SCREEN_PATH)
         verify_binary_contract(status, headers, body)
+    with check("menu_screen renders a real menu"):
+        verify_menu_content(body)
 
 
 def run_contract_with_open_menu(session: RestSession) -> None:

--- a/tools/api/menu_screen_tool.py
+++ b/tools/api/menu_screen_tool.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Dict, Optional, Tuple
+
+
+MENU_SCREEN_PATH = "/v1/machine:menu_screen"
+
+SCREEN_WIDTH = 40
+SCREEN_HEIGHT = 25
+SCREEN_CELLS = SCREEN_WIDTH * SCREEN_HEIGHT
+SCREEN_PLANES = 2
+SCREEN_BYTES = SCREEN_CELLS * SCREEN_PLANES
+
+
+class Failure(RuntimeError):
+    pass
+
+
+def format_exception(exc: BaseException) -> str:
+    if isinstance(exc, urllib.error.URLError) and getattr(exc, "reason", None) is not None:
+        return f"{exc} ({exc.reason})"
+    return str(exc)
+
+
+class RestSession:
+    def __init__(self, host: str, password: Optional[str], timeout: float) -> None:
+        self.host = host
+        self.password = password
+        self.timeout = timeout
+
+    def url(self, path: str, params: Optional[Dict[str, object]] = None) -> str:
+        query = ""
+        if params:
+            query = "?" + urllib.parse.urlencode(params)
+        return f"http://{self.host}{path}{query}"
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, object]] = None,
+        payload: Optional[Dict[str, object]] = None,
+        use_password: bool = True,
+    ) -> Tuple[int, Dict[str, str], bytes]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        headers: Dict[str, str] = {}
+
+        if self.password and use_password:
+            headers["X-Password"] = self.password
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+
+        request = urllib.request.Request(
+            self.url(path, params),
+            data=body,
+            headers=headers,
+            method=method,
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return response.status, dict(response.headers.items()), response.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, dict(exc.headers.items()), exc.read()
+        except (OSError, TimeoutError, urllib.error.URLError) as exc:
+            raise Failure(f"{method} {self.url(path, params)} failed: {format_exception(exc)}") from exc
+
+
+def header_value(headers: Dict[str, str], name: str) -> str:
+    wanted = name.lower()
+    for key, value in headers.items():
+        if key.lower() == wanted:
+            return value
+    return ""
+
+
+def c64_rgb(colour: int) -> Tuple[int, int, int]:
+    # Approximate C64 palette.
+    palette = {
+        0x0: (0, 0, 0),          # black
+        0x1: (255, 255, 255),    # white
+        0x2: (104, 55, 43),      # red
+        0x3: (112, 164, 178),    # cyan
+        0x4: (111, 61, 134),     # purple
+        0x5: (88, 141, 67),      # green
+        0x6: (53, 40, 121),      # blue
+        0x7: (184, 199, 111),    # yellow
+        0x8: (111, 79, 37),      # orange
+        0x9: (67, 57, 0),        # brown
+        0xA: (154, 103, 89),     # light red
+        0xB: (68, 68, 68),       # dark grey
+        0xC: (108, 108, 108),    # grey
+        0xD: (154, 210, 132),    # light green
+        0xE: (108, 94, 181),     # light blue
+        0xF: (149, 149, 149),    # light grey
+    }
+    return palette[colour & 0x0F]
+
+
+def fg_ansi(colour: int) -> str:
+    r, g, b = c64_rgb(colour)
+    return f"\x1b[38;2;{r};{g};{b}m"
+
+
+def bg_ansi(colour: int) -> str:
+    r, g, b = c64_rgb(colour)
+    return f"\x1b[48;2;{r};{g};{b}m"
+
+
+MENU_GLYPHS = {
+    0x00: " ",
+    0x01: "┌",
+    0x02: "─",
+    0x03: "┐",
+    0x04: "│",
+    0x05: "└",
+    0x06: "┘",
+    0x07: "╭",
+    0x08: "┬",
+    0x09: "╮",
+    0x0A: "├",
+    0x0B: "▇",
+    0x0C: "┤",
+    0x0D: "┴",
+    0x0E: "╰",
+    0x0F: "╯",
+    0x10: "α",
+    0x11: "β",
+    0x12: "▀",
+    0x13: "◆",
+}
+
+
+def menu_char_to_glyph(code: int) -> str:
+    # The menu endpoint returns raw Screen_MemMappedCharMatrix bytes. Text is
+    # stored as literal printable characters; low values are firmware UI glyphs.
+    base = code & 0x7F
+
+    if 0x20 <= base <= 0x7E:
+        return chr(base)
+
+    return MENU_GLYPHS.get(base, "?")
+
+
+def fetch_menu_screen(session: RestSession) -> bytes:
+    status, headers, body = session.request("GET", MENU_SCREEN_PATH)
+
+    if status != 200:
+        raise Failure(f"expected HTTP 200, got HTTP {status}: {body[:160]!r}")
+
+    content_type = header_value(headers, "Content-Type")
+    if "application/octet-stream" not in content_type:
+        raise Failure(f"expected application/octet-stream, got {content_type!r}")
+
+    if len(body) != SCREEN_BYTES:
+        raise Failure(f"expected {SCREEN_BYTES} response bytes, got {len(body)}")
+
+    return body
+
+
+def split_colour_byte(
+    colour_byte: int,
+    swap_colour_nibbles: bool,
+) -> Tuple[int, int]:
+    low = colour_byte & 0x0F
+    high = (colour_byte >> 4) & 0x0F
+
+    if swap_colour_nibbles:
+        foreground = high
+        background = low
+    else:
+        foreground = low
+        background = high
+
+    return foreground, background
+
+
+def render_menu_screen(
+    body: bytes,
+    clear: bool,
+    use_colour: bool,
+    swap_colour_nibbles: bool,
+) -> None:
+    chars = body[:SCREEN_CELLS]
+    colours = body[SCREEN_CELLS:]
+
+    if clear:
+        sys.stdout.write("\x1b[0m\x1b[2J\x1b[H")
+
+    last_fg: Optional[int] = None
+    last_bg: Optional[int] = None
+
+    for row in range(SCREEN_HEIGHT):
+        for col in range(SCREEN_WIDTH):
+            idx = row * SCREEN_WIDTH + col
+            screen_code = chars[idx]
+            colour_byte = colours[idx]
+
+            foreground, background = split_colour_byte(
+                colour_byte,
+                swap_colour_nibbles,
+            )
+            glyph = menu_char_to_glyph(screen_code)
+
+            # The matrix stores reverse-video cells by setting bit 7.
+            if screen_code & 0x80:
+                foreground, background = background, foreground
+
+            if use_colour:
+                if foreground != last_fg:
+                    sys.stdout.write(fg_ansi(foreground))
+                    last_fg = foreground
+                if background != last_bg:
+                    sys.stdout.write(bg_ansi(background))
+                    last_bg = background
+
+            sys.stdout.write(glyph)
+
+        if use_colour:
+            sys.stdout.write("\x1b[0m")
+            last_fg = None
+            last_bg = None
+        sys.stdout.write("\n")
+
+    if use_colour:
+        sys.stdout.write("\x1b[0m")
+
+    sys.stdout.flush()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Render /v1/machine:menu_screen as a 40x25 ANSI terminal view."
+    )
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_INPUT_HOST", "u64"))
+    parser.add_argument("-r", "--rest-host", default=os.environ.get("U64_INPUT_REST_HOST"))
+    parser.add_argument(
+        "-p",
+        "--password",
+        default=os.environ.get("U64_INPUT_PASSWORD", os.environ.get("C64U_PASSWORD")),
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("U64_INPUT_TIMEOUT", "5.0")),
+    )
+    parser.add_argument(
+        "--no-clear",
+        action="store_true",
+        help="Do not clear the terminal before rendering.",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Render glyphs only, without ANSI foreground/background colours.",
+    )
+    parser.add_argument(
+        "--swap-color-nibbles",
+        action="store_true",
+        help="Interpret high nibble as foreground and low nibble as background.",
+    )
+
+    args = parser.parse_args()
+
+    rest_host = args.rest_host or args.host
+    session = RestSession(rest_host, args.password, args.timeout)
+
+    body = fetch_menu_screen(session)
+    render_menu_screen(
+        body,
+        clear=not args.no_clear,
+        use_colour=not args.no_color,
+        swap_colour_nibbles=args.swap_color_nibbles,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        print(f"menu_screen_tool: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

This PR adds a REST endpoint for reading the currently displayed firmware menu screen:

```http
GET /v1/machine:menu_screen
```

The endpoint returns the active 40x25 text-mode screen as raw character and colour-attribute matrices. This avoids capturing the UDP video stream and converting a bitmap image back into text.

Together with the existing REST input endpoint, clients can now drive and inspect the menu entirely through REST.

## Related PRs

Documentation for the new endpoint was added to https://github.com/GideonZ/1541u-documentation/pull/27

## API Contract

### `GET /v1/machine:menu_screen`

Normal REST API password handling applies. If the device requires authentication and the request does not provide the correct `X-Password` header, the shared API router returns `403 Forbidden`.

#### `200 OK`

Returned when a readable 40x25 menu screen is active.

```http
Content-Type: application/octet-stream
Content-Disposition: attachment
Content-Length: 2000
```

The response body is exactly 2000 bytes:

|        Range |       Size | Content                         |
| -----------: | ---------: | ------------------------------- |
|     `0..999` | 1000 bytes | 40x25 character matrix          |
| `1000..1999` | 1000 bytes | 40x25 colour-attribute matrix   |

Both matrices are row-major:

```text
offset = row * 40 + column
```

Each colour-attribute byte contains both colours:

|   Bits | Meaning           |
| -----: | ----------------- |
| `0..3` | Foreground colour |
| `4..7` | Background colour |

#### `404 Not Found`

Returned when no readable menu screen is currently available.

```http
Content-Type: application/json
```

The JSON response contains the normal API `errors` array, including:

```json
{
  "errors": ["Menu screen unavailable."]
}
```

## Related Fixes

The following small fixes are part of this PR. If there are any concerns, I can place them in their own PRs, but in the interest of keeping overhead low, I co-located them. All are related to the menu screen.

### Ensure `menu_button` works consistently in Freeze and Overlay modes

This PR also fixes `PUT /v1/machine:menu_button`.

The documented behaviour is toggle semantics:

* Closed menu: open it.
* Open menu: close it.

On an Ultimate 64 Elite I in UI Overlay mode, the endpoint always opened the menu instead of toggling it. This PR makes the implementation match the documented REST API behaviour:

https://1541u-documentation.readthedocs.io/en/latest/api/api_calls.html

### Ensure `menu_button` works for help page and machine monitor

Previously, if the user entered either the help page or the machine code monitor, then pressing either the physical menu button on the device or issuing the `PUT /v1/machine:menu_button` call, the menu would not close. 

This is now fixed.

### Ascend menu hierarchy with mouse

Previously, if the user enabled menu navigation with the mouse, they could descend into menu folders via the left mouse button, but not ascend from them using the right mouse button. Instead, ascending resulted in closing the entire menu.

This is now fixed.

 ## Implementation Notes

- `Screen_MemMappedCharMatrix` now keeps a per-cell colour-attribute shadow buffer and exposes a bounded matrix-copy method. 
- `UserInterface::copy_active_screen_matrix()` selects an available active UI, verifies it is 40x25, and copies the character plane followed by the colour plane into the REST response buffer. 
- The route uses a fixed-size stack buffer and returns the shared JSON error response when no snapshot can be copied.

## Validation

Validation included:

* Host screen snapshot regression test.
* `menu_screen_test.py` in one-shot mode.
* `menu_screen_test.py` in 2-minute soak-test mode while navigating the menu through REST.
* Ran ad-hoc load test against the new endpoint, achieving an RPS of 57.
* Manual verification with `menu_screen_tool.py` in both UI Freeze and UI Overlay mode.

## Sample Images

The following side-by-side images were captured using C64 Stream:
- Streaming from an Ultimate 64 Elite I on the right side.
- Kubuntu 24.04 terminal on the left side. The terminal shows output from `menu_screen_tool.py`, which renders data returned by `GET /v1/machine:menu_screen`.

### Freeze UI Mode

<img width="1920" height="1080" alt="freeze1" src="https://github.com/user-attachments/assets/fe9ae960-323f-4ddf-9d08-98f532ce9b59" />
<img width="1920" height="1080" alt="freeze2" src="https://github.com/user-attachments/assets/b8626adb-6190-4de4-9ae3-bdfafb2e2983" />
<img width="1920" height="1080" alt="freeze3" src="https://github.com/user-attachments/assets/fecf2d2d-d594-45e8-a39e-8ecc94550b7a" />
<img width="1920" height="1080" alt="freeze4" src="https://github.com/user-attachments/assets/4e003e3b-edce-4bec-b461-ca767cfc7375" />

### Overlay UI Mode

<img width="1920" height="1080" alt="overlay1" src="https://github.com/user-attachments/assets/2f4aac61-152c-4ebc-8210-f2bb83082900" />
<img width="1920" height="1080" alt="overlay2" src="https://github.com/user-attachments/assets/2691b0e4-0f2b-4ae2-b8c5-faf9c33d7bfd" />
