### PR TITLE
Machine code monitor fixes

### DIFF
--- a/doc/machine_code_monitor.md
+++ b/doc/machine_code_monitor.md
@@ -18,7 +18,7 @@ Open the built-in help with `F3` or `?`.
 To close the monitor:
 
 - Press `C=+O` again.
-- Press `ESC` when no edit operation or popup is active.
+- Press `RUN/STOP` when no edit operation or popup is active.
 
 ## Screen Layout
 
@@ -348,7 +348,7 @@ Cartridges can further affect the CPU-visible memory map through the expansion-p
 All views support editing:
 
 - `E`: enter edit mode.
-- `C=+E` or `ESC`: leave edit mode.
+- `C=+E` or `RUN/STOP`: leave edit mode.
 
 Edit behavior is view-specific:
 
@@ -406,7 +406,7 @@ The ASCII and Screen rows in the number tool use the same mappings as the ASCII 
 
 In the Number popup, press `+`, `-`, `*`, or `/` to open the calculator. The expression is initialized with the current value and the selected operator.
 
-Press `Return` or `=` to evaluate the expression. Press `ESC` to cancel. On success, the popup returns to the compact conversion layout and refreshes all rows with the result.
+Press `Return` or `=` to evaluate the expression. Press `RUN/STOP` to cancel. On success, the popup returns to the compact conversion layout and refreshes all rows with the result.
 
 Expressions may contain one or more values separated by `+`, `-`, `*`, or `/`.  * and / are evaluated before + and -. Division is unsigned integer division and truncates toward zero.
 
@@ -447,7 +447,7 @@ The monitor includes direct bulk memory commands:
 `Hunt` opens a result picker:
 
 - `Return`: jump to the selected match.
-- `ESC`: close the picker.
+- `RUN/STOP`: close the picker.
 
 ## File I/O
 

--- a/software/monitor/assembler_6502.cc
+++ b/software/monitor/assembler_6502.cc
@@ -70,6 +70,16 @@ static void canonicalize_mnem(uint8_t opcode, const char *t, char *m)
     else if (!strcmp(m, "LSE")) strcpy(m, "SRE");
     else if (!strcmp(m, "DCM")) strcpy(m, "DCP");
     else if (!strcmp(m, "INS")) strcpy(m, "ISC");
+    else if (!strcmp(m, "ISB")) strcpy(m, "ISC");
+    else if (!strcmp(m, "KIL")) strcpy(m, "JAM");
+    else if (!strcmp(m, "XAA")) strcpy(m, "ANE");
+    else if (!strcmp(m, "AHX")) strcpy(m, "SHA");
+    else if (!strcmp(m, "AXS")) strcpy(m, "SBX");
+    else if (!strcmp(m, "ASR")) strcpy(m, "ALR");
+    else if (!strcmp(m, "LXA")) strcpy(m, "LAX");
+    else if (!strcmp(m, "SHS")) strcpy(m, "TAS");
+    else if (!strcmp(m, "LAE")) strcpy(m, "LAS");
+    else if (!strcmp(m, "LDS")) strcpy(m, "LAS");
 }
 
 struct ReverseEntry {
@@ -329,6 +339,7 @@ bool monitor_lookup_opcode(const char *mnemonic, AsmAddrMode mode,
     while (mnemonic[n] && n < 3) { m[n] = up(mnemonic[n]); n++; }
     m[n] = 0;
     if (n != 3) return false;
+    canonicalize_mnem(0, m, m);
     int idx = find_mnem(m);
     if (idx < 0) return false;
     const ReverseEntry &e = reverse_table[idx][mode];

--- a/software/monitor/disassembler_6502.cc
+++ b/software/monitor/disassembler_6502.cc
@@ -51,10 +51,10 @@ static const char *const opcode_templates[256] = {
 
     "NOP*#        ", "STA ($nn,X)  ", "NOP*#        ", "SAX*($nn,X)  ",
     "STY $nn      ", "STA $nn      ", "STX $nn      ", "SAX*$nn      ",
-    "DEY          ", "NOP*#        ", "TXA          ", "XAA*         ",
+    "DEY          ", "NOP*#        ", "TXA          ", "XAA*#        ",
     "STY $nnnn    ", "STA $nnnn    ", "STX $nnnn    ", "SAX*$nnnn    ",
 
-    "BCC          ", "STA ($nn),Y  ", "HLT*         ", "AHX*($nn),Y  ",
+    "BCC rel      ", "STA ($nn),Y  ", "HLT*         ", "AHX*($nn),Y  ",
     "STY $nn,X    ", "STA $nn,X    ", "STX $nn,Y    ", "SAX*$nn,Y    ",
     "TYA          ", "STA $nnnn,Y  ", "TXS          ", "TAS*$nnnn,Y  ",
     "SHY*$nnnn,X  ", "STA $nnnn,X  ", "SHX*$nnnn,Y  ", "AHX*$nnnn,Y  ",
@@ -64,17 +64,17 @@ static const char *const opcode_templates[256] = {
     "TAY          ", "LDA #        ", "TAX          ", "LAX*#        ",
     "LDY $nnnn    ", "LDA $nnnn    ", "LDX $nnnn    ", "LAX*$nnnn    ",
 
-    "BCS          ", "LDA ($nn),Y  ", "HLT*         ", "LAX*($nn),Y  ",
+    "BCS rel      ", "LDA ($nn),Y  ", "HLT*         ", "LAX*($nn),Y  ",
     "LDY $nn,X    ", "LDA $nn,X    ", "LDX $nn,Y    ", "LAX*$nn,Y    ",
     "CLV          ", "LDA $nnnn,Y  ", "TSX          ", "LAS*$nnnn,Y  ",
     "LDY $nnnn,X  ", "LDA $nnnn,X  ", "LDX $nnnn,Y  ", "LAX*$nnnn,Y  ",
 
     "CPY #        ", "CMP ($nn,X)  ", "NOP*#        ", "DCM*($nn,X)  ",
     "CPY $nn      ", "CMP $nn      ", "DEC $nn      ", "DCM*$nn      ",
-    "INY          ", "CMP #        ", "DEX          ", "AXS*# (used!)",
+    "INY          ", "CMP #        ", "DEX          ", "AXS*#        ",
     "CPY $nnnn    ", "CMP $nnnn    ", "DEC $nnnn    ", "DCM*$nnnn    ",
 
-    "BNE          ", "CMP ($nn),Y  ", "HLT*         ", "DCM*($nn),Y  ",
+    "BNE rel      ", "CMP ($nn),Y  ", "HLT*         ", "DCM*($nn),Y  ",
     "NOP*$nn,X    ", "CMP $nn,X    ", "DEC $nn,X    ", "DCM*$nn,X    ",
     "CLD          ", "CMP $nnnn,Y  ", "NOP*         ", "DCM*$nnnn,Y  ",
     "NOP*$nnnn,X  ", "CMP $nnnn,X  ", "DEC $nnnn,X  ", "DCM*$nnnn,X  ",
@@ -84,8 +84,8 @@ static const char *const opcode_templates[256] = {
     "INX          ", "SBC #        ", "NOP          ", "SBC*#        ",
     "CPX $nnnn    ", "SBC $nnnn    ", "INC $nnnn    ", "INS*$nnnn    ",
 
-    "BEQ          ", "SBC ($nn),Y  ", "HLT*         ", "INS*($nn),Y  ",
-    "NOP*$nn,S    ", "SBC $nn,X    ", "INC $nn,X    ", "INS*$nn,X    ",
+    "BEQ rel      ", "SBC ($nn),Y  ", "HLT*         ", "INS*($nn),Y  ",
+    "NOP*$nn,X    ", "SBC $nn,X    ", "INC $nn,X    ", "INS*$nn,X    ",
     "SED          ", "SBC $nnnn,Y  ", "NOP*         ", "INS*$nnnn,Y  ",
     "NOP*$nnnn,X  ", "SBC $nnnn,X  ", "INC $nnnn,X  ", "INS*$nnnn,X  "
 };
@@ -137,9 +137,6 @@ uint8_t operand_length(const char *templ)
 {
     const char *spec = operand_spec(templ);
 
-    if ((templ[0] == 'B') && (templ[1] != 'R')) {
-        return 1;
-    }
     if (*spec == 0 || !strncmp(spec, "A", 1)) {
         return 0;
     }
@@ -153,8 +150,7 @@ uint8_t operand_length(const char *templ)
     }
     if (!strncmp(spec, "($nn,X)", 7) || !strncmp(spec, "($nn),Y", 7) ||
         !strncmp(spec, "$nn,Y", 5) || !strncmp(spec, "$nn,X", 5) ||
-        !strncmp(spec, "$nn,S", 5) || !strncmp(spec, "$nn", 3) ||
-        !strncmp(spec, "#", 1)) {
+        !strncmp(spec, "$nn", 3) || !strncmp(spec, "#", 1)) {
         return 1;
     }
     return 0;
@@ -183,12 +179,6 @@ void format_operand(uint8_t opcode, uint16_t pc, const uint8_t *bytes, uint8_t l
 
     while (*spec == ' ') {
         spec++;
-    }
-    if (templ[0] == 'B' && templ[1] != 'R') {
-        *has_target = true;
-        *target = (uint16_t)(pc + 2 + (int8_t)bytes[1]);
-        sprintf(operand, "$%04x", *target);
-        return;
     }
     if (*spec == 0) {
         return;
@@ -243,10 +233,6 @@ void format_operand(uint8_t opcode, uint16_t pc, const uint8_t *bytes, uint8_t l
     }
     if (!strncmp(spec, "$nn,X", 5)) {
         sprintf(operand, "$%02x,X", bytes[1]);
-        return;
-    }
-    if (!strncmp(spec, "$nn,S", 5)) {
-        sprintf(operand, "$%02x,S", bytes[1]);
         return;
     }
     if (!strncmp(spec, "$nn", 3)) {

--- a/software/monitor/disassembler_6502.cc
+++ b/software/monitor/disassembler_6502.cc
@@ -9,85 +9,85 @@ extern "C" {
 namespace {
 
 static const char *const opcode_templates[256] = {
-    "BRK          ", "ORA ($nn,X)  ", "HLT*         ", "ASO*($nn,X)  ",
-    "NOP*$nn      ", "ORA $nn      ", "ASL $nn      ", "ASO*$nn      ",
+    "BRK          ", "ORA ($nn,X)  ", "JAM*         ", "SLO*($nn,X)  ",
+    "NOP*$nn      ", "ORA $nn      ", "ASL $nn      ", "SLO*$nn      ",
     "PHP          ", "ORA #        ", "ASL A        ", "ANC*#        ",
-    "NOP*$nnnn    ", "ORA $nnnn    ", "ASL $nnnn    ", "ASO*$nnnn    ",
+    "NOP*$nnnn    ", "ORA $nnnn    ", "ASL $nnnn    ", "SLO*$nnnn    ",
 
-    "BPL rel      ", "ORA ($nn),Y  ", "HLT*         ", "ASO*($nn),Y  ",
-    "NOP*$nn,X    ", "ORA $nn,X    ", "ASL $nn,X    ", "ASO*$nn,X    ",
-    "CLC          ", "ORA $nnnn,Y  ", "NOP*         ", "ASO*$nnnn,Y  ",
-    "NOP*$nnnn,X  ", "ORA $nnnn,X  ", "ASL $nnnn,X  ", "ASO*$nnnn,X  ",
+    "BPL rel      ", "ORA ($nn),Y  ", "JAM*         ", "SLO*($nn),Y  ",
+    "NOP*$nn,X    ", "ORA $nn,X    ", "ASL $nn,X    ", "SLO*$nn,X    ",
+    "CLC          ", "ORA $nnnn,Y  ", "NOP*         ", "SLO*$nnnn,Y  ",
+    "NOP*$nnnn,X  ", "ORA $nnnn,X  ", "ASL $nnnn,X  ", "SLO*$nnnn,X  ",
 
-    "JSR $nnnn    ", "AND ($nn,X)  ", "HLT*         ", "RLA*($nn,X)  ",
+    "JSR $nnnn    ", "AND ($nn,X)  ", "JAM*         ", "RLA*($nn,X)  ",
     "BIT $nn      ", "AND $nn      ", "ROL $nn      ", "RLA*$nn      ",
     "PLP          ", "AND #        ", "ROL A        ", "ANC*#        ",
     "BIT $nnnn    ", "AND $nnnn    ", "ROL $nnnn    ", "RLA*$nnnn    ",
 
-    "BMI rel      ", "AND ($nn),Y  ", "HLT*         ", "RLA*($nn),Y  ",
+    "BMI rel      ", "AND ($nn),Y  ", "JAM*         ", "RLA*($nn),Y  ",
     "NOP*$nn,X    ", "AND $nn,X    ", "ROL $nn,X    ", "RLA*$nn,X    ",
     "SEC          ", "AND $nnnn,Y  ", "NOP*         ", "RLA*$nnnn,Y  ",
     "NOP*$nnnn,X  ", "AND $nnnn,X  ", "ROL $nnnn,X  ", "RLA*$nnnn,X  ",
 
-    "RTI          ", "EOR ($nn,X)  ", "HLT*         ", "LSE*($nn,X)  ",
-    "NOP*$nn      ", "EOR $nn      ", "LSR $nn      ", "LSE*$nn      ",
+    "RTI          ", "EOR ($nn,X)  ", "JAM*         ", "SRE*($nn,X)  ",
+    "NOP*$nn      ", "EOR $nn      ", "LSR $nn      ", "SRE*$nn      ",
     "PHA          ", "EOR #        ", "LSR A        ", "ALR*#        ",
-    "JMP $nnnn    ", "EOR $nnnn    ", "LSR $nnnn    ", "LSE*$nnnn    ",
+    "JMP $nnnn    ", "EOR $nnnn    ", "LSR $nnnn    ", "SRE*$nnnn    ",
 
-    "BVC rel      ", "EOR ($nn),Y  ", "HLT*         ", "LSE*($nn),Y  ",
-    "NOP $nn,X    ", "EOR $nn,X    ", "LSR $nn,X    ", "LSE*$nn,X    ",
-    "CLI          ", "EOR $nnnn,Y  ", "NOP*         ", "LSE*$nnnn,Y  ",
-    "NOP*$nnnn,X  ", "EOR $nnnn,X  ", "LSR $nnnn,X  ", "LSE*$nnnn,X  ",
+    "BVC rel      ", "EOR ($nn),Y  ", "JAM*         ", "SRE*($nn),Y  ",
+    "NOP*$nn,X    ", "EOR $nn,X    ", "LSR $nn,X    ", "SRE*$nn,X    ",
+    "CLI          ", "EOR $nnnn,Y  ", "NOP*         ", "SRE*$nnnn,Y  ",
+    "NOP*$nnnn,X  ", "EOR $nnnn,X  ", "LSR $nnnn,X  ", "SRE*$nnnn,X  ",
 
-    "RTS          ", "ADC ($nn,X)  ", "HLT*         ", "RRA*($nn,X)  ",
+    "RTS          ", "ADC ($nn,X)  ", "JAM*         ", "RRA*($nn,X)  ",
     "NOP*$nn      ", "ADC $nn      ", "ROR $nn      ", "RRA*$nn      ",
     "PLA          ", "ADC #        ", "ROR A        ", "ARR*#        ",
     "JMP ($nnnn)  ", "ADC $nnnn    ", "ROR $nnnn    ", "RRA*$nnnn    ",
 
-    "BVS rel      ", "ADC ($nn),Y  ", "HLT*         ", "RRA*($nn),Y  ",
-    "NOP $nn,X    ", "ADC $nn,X    ", "ROR $nn,X    ", "RRA*$nn,X    ",
+    "BVS rel      ", "ADC ($nn),Y  ", "JAM*         ", "RRA*($nn),Y  ",
+    "NOP*$nn,X    ", "ADC $nn,X    ", "ROR $nn,X    ", "RRA*$nn,X    ",
     "SEI          ", "ADC $nnnn,Y  ", "NOP*         ", "RRA*$nnnn,Y  ",
     "NOP*$nnnn,X  ", "ADC $nnnn,X  ", "ROR $nnnn,X  ", "RRA*$nnnn,X  ",
 
     "NOP*#        ", "STA ($nn,X)  ", "NOP*#        ", "SAX*($nn,X)  ",
     "STY $nn      ", "STA $nn      ", "STX $nn      ", "SAX*$nn      ",
-    "DEY          ", "NOP*#        ", "TXA          ", "XAA*#        ",
+    "DEY          ", "NOP*#        ", "TXA          ", "ANE*#        ",
     "STY $nnnn    ", "STA $nnnn    ", "STX $nnnn    ", "SAX*$nnnn    ",
 
-    "BCC rel      ", "STA ($nn),Y  ", "HLT*         ", "AHX*($nn),Y  ",
+    "BCC rel      ", "STA ($nn),Y  ", "JAM*         ", "SHA*($nn),Y  ",
     "STY $nn,X    ", "STA $nn,X    ", "STX $nn,Y    ", "SAX*$nn,Y    ",
     "TYA          ", "STA $nnnn,Y  ", "TXS          ", "TAS*$nnnn,Y  ",
-    "SHY*$nnnn,X  ", "STA $nnnn,X  ", "SHX*$nnnn,Y  ", "AHX*$nnnn,Y  ",
+    "SHY*$nnnn,X  ", "STA $nnnn,X  ", "SHX*$nnnn,Y  ", "SHA*$nnnn,Y  ",
 
     "LDY #        ", "LDA ($nn,X)  ", "LDX #        ", "LAX*($nn,X)  ",
     "LDY $nn      ", "LDA $nn      ", "LDX $nn      ", "LAX*$nn      ",
     "TAY          ", "LDA #        ", "TAX          ", "LAX*#        ",
     "LDY $nnnn    ", "LDA $nnnn    ", "LDX $nnnn    ", "LAX*$nnnn    ",
 
-    "BCS rel      ", "LDA ($nn),Y  ", "HLT*         ", "LAX*($nn),Y  ",
+    "BCS rel      ", "LDA ($nn),Y  ", "JAM*         ", "LAX*($nn),Y  ",
     "LDY $nn,X    ", "LDA $nn,X    ", "LDX $nn,Y    ", "LAX*$nn,Y    ",
     "CLV          ", "LDA $nnnn,Y  ", "TSX          ", "LAS*$nnnn,Y  ",
     "LDY $nnnn,X  ", "LDA $nnnn,X  ", "LDX $nnnn,Y  ", "LAX*$nnnn,Y  ",
 
-    "CPY #        ", "CMP ($nn,X)  ", "NOP*#        ", "DCM*($nn,X)  ",
-    "CPY $nn      ", "CMP $nn      ", "DEC $nn      ", "DCM*$nn      ",
-    "INY          ", "CMP #        ", "DEX          ", "AXS*#        ",
-    "CPY $nnnn    ", "CMP $nnnn    ", "DEC $nnnn    ", "DCM*$nnnn    ",
+    "CPY #        ", "CMP ($nn,X)  ", "NOP*#        ", "DCP*($nn,X)  ",
+    "CPY $nn      ", "CMP $nn      ", "DEC $nn      ", "DCP*$nn      ",
+    "INY          ", "CMP #        ", "DEX          ", "SBX*#        ",
+    "CPY $nnnn    ", "CMP $nnnn    ", "DEC $nnnn    ", "DCP*$nnnn    ",
 
-    "BNE rel      ", "CMP ($nn),Y  ", "HLT*         ", "DCM*($nn),Y  ",
-    "NOP*$nn,X    ", "CMP $nn,X    ", "DEC $nn,X    ", "DCM*$nn,X    ",
-    "CLD          ", "CMP $nnnn,Y  ", "NOP*         ", "DCM*$nnnn,Y  ",
-    "NOP*$nnnn,X  ", "CMP $nnnn,X  ", "DEC $nnnn,X  ", "DCM*$nnnn,X  ",
+    "BNE rel      ", "CMP ($nn),Y  ", "JAM*         ", "DCP*($nn),Y  ",
+    "NOP*$nn,X    ", "CMP $nn,X    ", "DEC $nn,X    ", "DCP*$nn,X    ",
+    "CLD          ", "CMP $nnnn,Y  ", "NOP*         ", "DCP*$nnnn,Y  ",
+    "NOP*$nnnn,X  ", "CMP $nnnn,X  ", "DEC $nnnn,X  ", "DCP*$nnnn,X  ",
 
-    "CPX #        ", "SBC ($nn,X)  ", "NOP*#        ", "INS*($nn,X)  ",
-    "CPX $nn      ", "SBC $nn      ", "INC $nn      ", "INS*$nn      ",
+    "CPX #        ", "SBC ($nn,X)  ", "NOP*#        ", "ISC*($nn,X)  ",
+    "CPX $nn      ", "SBC $nn      ", "INC $nn      ", "ISC*$nn      ",
     "INX          ", "SBC #        ", "NOP          ", "SBC*#        ",
-    "CPX $nnnn    ", "SBC $nnnn    ", "INC $nnnn    ", "INS*$nnnn    ",
+    "CPX $nnnn    ", "SBC $nnnn    ", "INC $nnnn    ", "ISC*$nnnn    ",
 
-    "BEQ rel      ", "SBC ($nn),Y  ", "HLT*         ", "INS*($nn),Y  ",
-    "NOP*$nn,X    ", "SBC $nn,X    ", "INC $nn,X    ", "INS*$nn,X    ",
-    "SED          ", "SBC $nnnn,Y  ", "NOP*         ", "INS*$nnnn,Y  ",
-    "NOP*$nnnn,X  ", "SBC $nnnn,X  ", "INC $nnnn,X  ", "INS*$nnnn,X  "
+    "BEQ rel      ", "SBC ($nn),Y  ", "JAM*         ", "ISC*($nn),Y  ",
+    "NOP*$nn,X    ", "SBC $nn,X    ", "INC $nn,X    ", "ISC*$nn,X    ",
+    "SED          ", "SBC $nnnn,Y  ", "NOP*         ", "ISC*$nnnn,Y  ",
+    "NOP*$nnnn,X  ", "SBC $nnnn,X  ", "INC $nnnn,X  ", "ISC*$nnnn,X  "
 };
 
 static const uint16_t illegal_map[16] = {

--- a/software/monitor/disassembler_6502.cc
+++ b/software/monitor/disassembler_6502.cc
@@ -123,16 +123,6 @@ void canonicalize_mnemonic(uint8_t opcode, const char *templ, char *mnemonic)
     }
 }
 
-const char *operand_spec(const char *templ)
-{
-    const char *spec = templ + 4;
-
-    while (*spec == ' ') {
-        spec++;
-    }
-    return spec;
-}
-
 uint8_t operand_length(const char *templ)
 {
     const char *spec = operand_spec(templ);
@@ -244,6 +234,18 @@ void format_operand(uint8_t opcode, uint16_t pc, const uint8_t *bytes, uint8_t l
     trim_operand(operand);
 }
 
+}
+
+// Defined with external linkage (declared in the header) so the monitor can
+// classify operands the same way the decoder does.
+const char *operand_spec(const char *templ)
+{
+    const char *spec = templ + 4;
+
+    while (*spec == ' ') {
+        spec++;
+    }
+    return spec;
 }
 
 void disassemble_6502(uint16_t pc, const uint8_t *bytes, bool illegal_enabled, Disassembled6502 *out)

--- a/software/monitor/disassembler_6502.h
+++ b/software/monitor/disassembler_6502.h
@@ -21,4 +21,9 @@ void disassemble_6502(uint16_t pc, const uint8_t *bytes, bool illegal_enabled, D
 const char *disassembler_6502_template(uint8_t opcode);
 bool        disassembler_6502_is_illegal(uint8_t opcode);
 
+// Returns the operand-spec portion of an opcode template (the text following
+// the mnemonic). Shared so callers classify operands the same way the decoder
+// does, instead of re-deriving the offset into the template by hand.
+const char *operand_spec(const char *templ);
+
 #endif

--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -4509,25 +4509,50 @@ bool MachineMonitor :: asm_edit_history_pop()
 // after the 3-letter mnemonic into opcode_operand[] and on commit asks the
 // assembler to turn the full "MNEM operand" string into bytes.
 
-void MachineMonitor :: opcode_picker_open(char seed)
+bool MachineMonitor :: opcode_prefix_is_valid(const char *prefix)
 {
+    if (!prefix || !prefix[0]) {
+        return false;
+    }
+    // The opcode candidate collector is the single source of truth for the
+    // monitor's supported mnemonic set (and honours the illegal-opcode policy).
+    // A non-empty prefix is valid iff at least one candidate matches it. Use a
+    // local scratch buffer so the live picker candidate list is not disturbed.
+    uint8_t scratch[256];
+    return monitor_collect_opcode_candidates(prefix, state.illegal_enabled,
+                                             scratch, (int)sizeof(scratch)) > 0;
+}
+
+bool MachineMonitor :: opcode_picker_open(char seed)
+{
+    char up = 0;
+    if (seed >= 'a' && seed <= 'z') up = (char)(seed - 'a' + 'A');
+    else if (seed >= 'A' && seed <= 'Z') up = seed;
+
+    // Reject a seed letter that cannot begin any supported mnemonic (e.g. G/H/
+    // Z): the picker stays closed so the invalid character is not accepted.
+    if (up) {
+        char trial[2] = { up, 0 };
+        if (!opcode_prefix_is_valid(trial)) {
+            return false;
+        }
+    }
+
     opcode_picker_active = true;
     opcode_drawn_rows = 0;
     opcode_prefix_len = 0;
     opcode_prefix[0] = 0;
     opcode_operand_len = 0;
     opcode_operand[0] = 0;
-    if (seed) {
-        char up = (seed >= 'a' && seed <= 'z') ? (char)(seed - 'a' + 'A') : seed;
-        if ((up >= 'A' && up <= 'Z')) {
-            opcode_prefix[0] = up;
-            opcode_prefix[1] = 0;
-            opcode_prefix_len = 1;
-        }
+    if (up) {
+        opcode_prefix[0] = up;
+        opcode_prefix[1] = 0;
+        opcode_prefix_len = 1;
     }
     opcode_selected = 0;
     opcode_top = 0;
     opcode_picker_refilter();
+    return true;
 }
 
 void MachineMonitor :: opcode_picker_close()
@@ -4610,10 +4635,14 @@ int MachineMonitor :: opcode_picker_handle_key(int key)
     }
     if (key == KEY_RETURN) {
         if (opcode_operand_len > 0) {
+            // A typed operand must assemble cleanly. If it does not, stay in the
+            // picker so the user can correct the incomplete/invalid operand
+            // instead of silently committing the bare highlighted opcode and
+            // advancing past the mistake.
             if (opcode_picker_commit_typed()) {
                 draw();
-                return 0;
             }
+            return 0;
         }
         opcode_picker_commit();
         draw();
@@ -4656,6 +4685,19 @@ int MachineMonitor :: opcode_picker_handle_key(int key)
     bool is_letter = ((key >= 'A' && key <= 'Z') || (key >= 'a' && key <= 'z'));
     if (is_letter && opcode_prefix_len < 3) {
         char up = (key >= 'a' && key <= 'z') ? (char)(key - 'a' + 'A') : (char)key;
+        // Validate the prospective mnemonic before mutating any editor state.
+        // The new character is only accepted if "<current prefix><up>" remains a
+        // prefix of (or an exact) supported mnemonic. Invalid input is rejected
+        // here so it never changes the buffer, cursor, operand, candidate list,
+        // or bleeds into the operand field.
+        char trial[5];
+        int t = 0;
+        for (; t < opcode_prefix_len && t < 3; t++) trial[t] = opcode_prefix[t];
+        trial[t++] = up;
+        trial[t] = 0;
+        if (!opcode_prefix_is_valid(trial)) {
+            return 0;
+        }
         opcode_prefix[opcode_prefix_len++] = up;
         opcode_prefix[opcode_prefix_len] = 0;
         opcode_selected = 0;
@@ -5021,6 +5063,23 @@ int MachineMonitor :: handle_key(int key)
             uint8_t part_count = asm_edit_part_count(state.current_addr);
             bool branch = asm_is_branch(state.current_addr) && insn_len == 2;
             if (asm_edit_part >= part_count) asm_edit_part = 0;
+            if (key == KEY_RETURN) {
+                // ASM edit mode: RETURN commits the current line and advances to
+                // the next logical disassembly line. The byte editor edits memory
+                // live, so the current instruction is always a complete, valid
+                // line; advancing is the commit. The next address is derived from
+                // the decoder's instruction length via step_disassembly(), so it
+                // is correct for one-, two-, and three-byte instructions.
+                // (The opcode picker, when open, handles RETURN itself and is
+                // dispatched before this block, so partial/invalid mnemonic entry
+                // never reaches here.)
+                asm_edit_pending = 0;
+                step_disassembly(1);
+                asm_edit_part = 0;
+                asm_edit_history_reset(state.current_addr);
+                draw();
+                return 0;
+            }
             if (key == KEY_LEFT) {
                 if (asm_edit_part > 0) {
                     asm_edit_part--;
@@ -5140,8 +5199,12 @@ int MachineMonitor :: handle_key(int key)
                 return 0;
             }
             if (asm_edit_part == 0 && ((key >= 'A' && key <= 'Z') || (key >= 'a' && key <= 'z'))) {
-                opcode_picker_open((char)key);
-                draw();
+                // Opening the picker also validates the first mnemonic letter.
+                // An invalid first letter (no supported mnemonic starts with it)
+                // is rejected: the picker stays closed and the key is a no-op.
+                if (opcode_picker_open((char)key)) {
+                    draw();
+                }
                 return 0;
             }
         }

--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -3229,13 +3229,13 @@ bool MachineMonitor :: asm_is_branch(uint16_t address)
 {
     uint8_t op = canonical_read(address);
     const char *templ = disassembler_6502_template(op);
+    const char *spec;
     if (!templ) return false;
-    // Mirror the disassembler's own rule (disassembler_6502.cc): any B*
-    // mnemonic other than BRK is a relative branch. Some templates spell
-    // out "rel" explicitly while others (BCC/BCS/BNE/BEQ) do not, so we
-    // test the leading mnemonic rather than relying on "rel" being present.
-    if (templ[0] == 'B' && templ[1] != 'R') return true;
-    return strstr(templ, "rel") != NULL;
+    spec = templ + 4;
+    while (*spec == ' ') {
+        spec++;
+    }
+    return strncmp(spec, "rel", 3) == 0;
 }
 
 // Number of editable parts presented in the ASM edit cursor for the

--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -3772,6 +3772,27 @@ void MachineMonitor :: refresh_popup_overlay()
     screen->sync();
 }
 
+void MachineMonitor :: refresh_opcode_overlay()
+{
+    // Scrolling the opcode dropdown changes only the overlay box itself; its
+    // anchor, size, and the surrounding disassembly/header/status are unchanged.
+    // Repaint just the box rather than the whole screen. On a full-refresh
+    // (telnet/VT100) screen refresh_popup_overlay() falls back to a full draw()
+    // that emits ~1.5 KB per keystroke; under cursor-key autorepeat that flood
+    // overwhelms the telnet output path and aborts the connection. The box-only
+    // repaint matches the on-device (Freeze/Overlay) incremental path and keeps
+    // per-keystroke output small. Safe for scrolling because the box size is
+    // constant, so no stale rows are left behind.
+    if (!window || !screen) {
+        return;
+    }
+    if (!opcode_picker_active) {
+        return;
+    }
+    draw_opcode_picker();
+    screen->sync();
+}
+
 void MachineMonitor :: draw_hex_row(int y, uint16_t addr, const uint8_t *bytes)
 {
     char line[MONITOR_MEMORY_ROW_16_CHARS + 1];
@@ -4650,12 +4671,12 @@ int MachineMonitor :: opcode_picker_handle_key(int key)
     }
     if (key == KEY_DOWN) {
         if (opcode_selected + 1 < opcode_candidate_count) opcode_selected++;
-        refresh_popup_overlay();
+        refresh_opcode_overlay();
         return 0;
     }
     if (key == KEY_UP) {
         if (opcode_selected > 0) opcode_selected--;
-        refresh_popup_overlay();
+        refresh_opcode_overlay();
         return 0;
     }
     if (key == KEY_BACK || key == KEY_DELETE) {

--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -3229,13 +3229,10 @@ bool MachineMonitor :: asm_is_branch(uint16_t address)
 {
     uint8_t op = canonical_read(address);
     const char *templ = disassembler_6502_template(op);
-    const char *spec;
     if (!templ) return false;
-    spec = templ + 4;
-    while (*spec == ' ') {
-        spec++;
-    }
-    return strncmp(spec, "rel", 3) == 0;
+    // Reuse the decoder's operand-spec accessor so branch classification stays
+    // consistent with disassembly if the template layout ever changes.
+    return strncmp(operand_spec(templ), "rel", 3) == 0;
 }
 
 // Number of editable parts presented in the ASM edit cursor for the

--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -41,8 +41,8 @@ static const char *const monitor_help_lines[] = {
     "Bookmarks:  C=+B List   C=+0-9 Jump",
     "",
     "Open monitor:  C=+O",
-    "Close monitor: C=+O/ESC",
-    "Leave edit:    C=+E/ESC",
+    "Close monitor: C=+O/RSTOP",
+    "Leave edit:    C=+E/RSTOP",
     "Copy/Paste:    C=+C / C=+V",
     "Follow/Return: RETURN",
     NULL
@@ -3475,7 +3475,7 @@ void MachineMonitor :: draw_header()
 
     const char *right = NULL;
     if (!help_visible) {
-        if (hunt_picker_active) right = "ENTER jumps  ESC exits";
+        if (hunt_picker_active) right = "ENTER jumps RSTOP exits";
         else if (edit_mode) right = "Edit";
     }
     if (right && (help_visible || hunt_picker_active)) {

--- a/software/monitor/machine_monitor.h
+++ b/software/monitor/machine_monitor.h
@@ -267,7 +267,8 @@ class MachineMonitor : public UIObject
     void hunt_picker_jump();
     int hunt_picker_handle_key(int key);
     void draw_opcode_picker();
-    void opcode_picker_open(char seed);
+    bool opcode_picker_open(char seed);
+    bool opcode_prefix_is_valid(const char *prefix);
     void opcode_picker_close();
     void opcode_picker_refilter();
     void opcode_picker_commit();

--- a/software/monitor/machine_monitor.h
+++ b/software/monitor/machine_monitor.h
@@ -251,6 +251,7 @@ class MachineMonitor : public UIObject
     void draw_bookmark_popup();
     void draw_number_picker();
     void refresh_popup_overlay();
+    void refresh_opcode_overlay();
     void draw_hex();
     void draw_ascii();
     void draw_screen_codes();

--- a/software/monitor/u64_memory_backend.cc
+++ b/software/monitor/u64_memory_backend.cc
@@ -16,9 +16,9 @@ namespace {
 // arrays they were only byte-aligned; depending on .bss layout they could land on an
 // unaligned address, causing an unaligned 32-bit store trap on Nios2 when the KERNAL ROM
 // cache is loaded on monitor entry. Force word alignment to keep the DMA target valid.
-static uint8_t monitor_basic_rom[8192] __attribute__((aligned(4)));
-static uint8_t monitor_kernal_rom[8192] __attribute__((aligned(4)));
-static uint8_t monitor_char_rom[4096] __attribute__((aligned(4)));
+alignas(4) static uint8_t monitor_basic_rom[8192];
+alignas(4) static uint8_t monitor_kernal_rom[8192];
+alignas(4) static uint8_t monitor_char_rom[4096];
 
 static void snapshot_u64_rom(volatile uint8_t *src, uint8_t *dst, uint16_t len)
 {

--- a/software/monitor/u64_memory_backend.cc
+++ b/software/monitor/u64_memory_backend.cc
@@ -11,9 +11,14 @@ extern uint8_t _default_chars_bin_start[4096];
 
 namespace {
 
-static uint8_t monitor_basic_rom[8192];
-static uint8_t monitor_kernal_rom[8192];
-static uint8_t monitor_char_rom[4096];
+// These buffers are filled by the flash/filesystem read path (S25FLxxxL_Flash::read_page),
+// which writes 32-bit words and therefore requires 4-byte alignment. As plain uint8_t
+// arrays they were only byte-aligned; depending on .bss layout they could land on an
+// unaligned address, causing an unaligned 32-bit store trap on Nios2 when the KERNAL ROM
+// cache is loaded on monitor entry. Force word alignment to keep the DMA target valid.
+static uint8_t monitor_basic_rom[8192] __attribute__((aligned(4)));
+static uint8_t monitor_kernal_rom[8192] __attribute__((aligned(4)));
+static uint8_t monitor_char_rom[4096] __attribute__((aligned(4)));
 
 static void snapshot_u64_rom(volatile uint8_t *src, uint8_t *dst, uint16_t len)
 {

--- a/software/test/monitor/machine_monitor_test.cc
+++ b/software/test/monitor/machine_monitor_test.cc
@@ -2660,7 +2660,10 @@ static int test_number_shortcut_routing(void)
         CaptureScreen screen;
         FakeMemoryBackend backend;
         char line[19];
-        const int keys[] = { 'J', 'A', 'E', 'L', 'N', KEY_BREAK, KEY_BREAK, KEY_BREAK };
+        // "IN" is a valid mnemonic prefix (INC/INX/INY); the point of this test
+        // is that N routes into the opcode picker rather than opening the Number
+        // popup while the picker is active.
+        const int keys[] = { 'J', 'A', 'E', 'I', 'N', KEY_BREAK, KEY_BREAK, KEY_BREAK };
         FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
 
         ui.screen = &screen;
@@ -2678,7 +2681,7 @@ static int test_number_shortcut_routing(void)
         if (expect(!find_popup_rect(screen, NULL, NULL, NULL, NULL),
                    "Opcode completion popup must keep N as mnemonic input instead of opening Number.")) return 1;
         screen.get_slice(16, 4, 18, line);
-        if (expect(strstr(line, " LN_") == line,
+        if (expect(strstr(line, " IN_") == line,
                    "While the opcode picker is active, N must continue editing the mnemonic prefix.")) return 1;
         if (expect(mon.poll(0) == 0, "ASM popup N-routing test: RUN/STOP should close the picker first.")) return 1;
         if (expect(mon.poll(0) == 0, "ASM popup N-routing test: RUN/STOP should leave edit mode next.")) return 1;
@@ -6274,6 +6277,263 @@ static int test_restricted_backend_guards_platform_features(void)
     return 0;
 }
 
+// Bug 1: invalid mnemonic text must be rejected before it mutates the opcode
+// picker's edit state. Valid prefixes/mnemonics are accepted; anything that is
+// not a prefix of (or an exact) supported mnemonic is refused without touching
+// the buffer, cursor, operand, candidate list, or memory.
+static int test_asm_edit_rejects_invalid_mnemonic(void)
+{
+    // Block A: "AD" is a valid prefix (ADC); appending "D" (-> "ADD") is not a
+    // supported mnemonic prefix and must be rejected without any visible or
+    // memory change.
+    {
+        TestUserInterface ui;
+        CaptureScreen screen;
+        CaptureScreen snapshot;
+        FakeMemoryBackend backend;
+        char header[19];
+        char candidate[39];
+        const int keys[] = { 'J', 'A', 'E', 'A', 'D', 'D', KEY_BREAK, KEY_BREAK, KEY_BREAK };
+        FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+
+        ui.screen = &screen;
+        ui.keyboard = &kb;
+        ui.set_prompt("C000", 1);
+        monitor_reset_saved_state();
+
+        BackendMachineMonitor mon(&ui, &backend);
+        mon.init(&screen, &kb);
+        if (expect(mon.poll(0) == 0, "Invalid mnemonic test: goto failed.")) return 1;
+        if (expect(mon.poll(0) == 0, "Invalid mnemonic test: ASM view switch failed.")) return 1;
+        if (expect(mon.poll(0) == 0, "Invalid mnemonic test: edit mode entry failed.")) return 1;
+        if (expect(mon.poll(0) == 0, "Invalid mnemonic test: 'A' must open the picker.")) return 1;
+        if (expect(mon.poll(0) == 0, "Invalid mnemonic test: 'D' must extend prefix to AD.")) return 1;
+        screen.get_slice(16, 4, 18, header);
+        if (expect(strstr(header, " AD_") == header,
+                   "Valid prefix AD must be accepted into the mnemonic field.")) return 1;
+        screen.get_slice(1, 5, 38, candidate);
+        if (expect(strstr(candidate, "ADC") != NULL,
+                   "Valid prefix AD must show the ADC completion candidate.")) return 1;
+
+        // Snapshot the accepted "AD" state, then feed the invalid third letter.
+        snapshot = screen;
+        if (expect(mon.poll(0) == 0, "Invalid mnemonic test: invalid 'D' must be consumed as a no-op.")) return 1;
+        if (expect_screens_equal(snapshot, screen,
+                                 "Invalid mnemonic ADD must not change the rendered edit state.")) return 1;
+        screen.get_slice(16, 4, 18, header);
+        if (expect(strstr(header, " AD_") == header,
+                   "Rejected ADD must leave the mnemonic field at AD.")) return 1;
+        if (expect(backend.read(0xC000) == 0x00,
+                   "Rejected ADD must not write memory.")) return 1;
+        mon.deinit();
+    }
+
+    // Block B: repeating "A" (-> "AA") is not a valid prefix and is rejected.
+    {
+        TestUserInterface ui;
+        CaptureScreen screen;
+        CaptureScreen snapshot;
+        FakeMemoryBackend backend;
+        char header[19];
+        const int keys[] = { 'J', 'A', 'E', 'A', 'A', KEY_BREAK, KEY_BREAK, KEY_BREAK };
+        FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+
+        ui.screen = &screen;
+        ui.keyboard = &kb;
+        ui.set_prompt("C000", 1);
+        monitor_reset_saved_state();
+
+        BackendMachineMonitor mon(&ui, &backend);
+        mon.init(&screen, &kb);
+        for (int i = 0; i < 4; i++) {
+            if (expect(mon.poll(0) == 0, "AA-reject test: setup key sequence failed.")) return 1;
+        }
+        screen.get_slice(16, 4, 18, header);
+        if (expect(strstr(header, " A_") == header,
+                   "AA-reject test: first 'A' must be accepted as the prefix.")) return 1;
+        snapshot = screen;
+        if (expect(mon.poll(0) == 0, "AA-reject test: second 'A' must be consumed as a no-op.")) return 1;
+        if (expect_screens_equal(snapshot, screen,
+                                 "Repeated A (AA) must not change the rendered edit state.")) return 1;
+        screen.get_slice(16, 4, 18, header);
+        if (expect(strstr(header, " A_") == header,
+                   "Rejected AA must leave the mnemonic field at A.")) return 1;
+        mon.deinit();
+    }
+
+    // Block C: a first letter that begins no supported mnemonic (G) is rejected
+    // and never opens the picker; a following valid letter (L) still works.
+    {
+        TestUserInterface ui;
+        CaptureScreen screen;
+        CaptureScreen snapshot;
+        FakeMemoryBackend backend;
+        char header[19];
+        const int keys[] = { 'J', 'A', 'E', 'G', 'L', KEY_BREAK, KEY_BREAK, KEY_BREAK };
+        FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+
+        ui.screen = &screen;
+        ui.keyboard = &kb;
+        ui.set_prompt("C000", 1);
+        monitor_reset_saved_state();
+
+        BackendMachineMonitor mon(&ui, &backend);
+        mon.init(&screen, &kb);
+        if (expect(mon.poll(0) == 0, "Invalid first-letter test: goto failed.")) return 1;
+        if (expect(mon.poll(0) == 0, "Invalid first-letter test: ASM view switch failed.")) return 1;
+        if (expect(mon.poll(0) == 0, "Invalid first-letter test: edit mode entry failed.")) return 1;
+        snapshot = screen;
+        if (expect(mon.poll(0) == 0, "Invalid first-letter test: 'G' must be a no-op.")) return 1;
+        if (expect_screens_equal(snapshot, screen,
+                                 "Invalid first letter G must not open the picker or change the screen.")) return 1;
+        if (expect(backend.read(0xC000) == 0x00,
+                   "Invalid first letter G must not write memory.")) return 1;
+        if (expect(mon.poll(0) == 0, "Invalid first-letter test: 'L' must open the picker.")) return 1;
+        screen.get_slice(16, 4, 18, header);
+        if (expect(strstr(header, " L_") == header,
+                   "A valid first letter after a rejected one must still open the mnemonic field.")) return 1;
+        mon.deinit();
+    }
+
+    // Block D: backspace/delete still recovers after partial valid input.
+    {
+        TestUserInterface ui;
+        CaptureScreen screen;
+        FakeMemoryBackend backend;
+        char header[19];
+        const int keys[] = { 'J', 'A', 'E', 'L', 'D', KEY_DELETE, KEY_BREAK, KEY_BREAK, KEY_BREAK };
+        FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+
+        ui.screen = &screen;
+        ui.keyboard = &kb;
+        ui.set_prompt("C000", 1);
+        monitor_reset_saved_state();
+
+        BackendMachineMonitor mon(&ui, &backend);
+        mon.init(&screen, &kb);
+        for (int i = 0; i < 5; i++) {
+            if (expect(mon.poll(0) == 0, "Backspace recovery test: setup key sequence failed.")) return 1;
+        }
+        screen.get_slice(16, 4, 18, header);
+        if (expect(strstr(header, " LD_") == header,
+                   "Backspace recovery test: prefix must read LD before delete.")) return 1;
+        if (expect(mon.poll(0) == 0, "Backspace recovery test: delete must be accepted.")) return 1;
+        screen.get_slice(16, 4, 18, header);
+        if (expect(strstr(header, " L_") == header,
+                   "Backspace must reduce the mnemonic prefix back to L.")) return 1;
+        mon.deinit();
+    }
+
+    return 0;
+}
+
+// Bug 2: RETURN in ASM edit mode commits the current line and advances to the
+// next logical disassembly line (length-correct for 1/2/3-byte instructions),
+// and never advances on rejected/invalid input.
+static int test_asm_edit_return_advances(void)
+{
+    struct Case {
+        const char *prompt;
+        uint16_t addr;
+        uint8_t bytes[3];
+        int len;
+        const char *expect_header;
+    } cases[] = {
+        { "C000", 0xC000, { 0xEA, 0x00, 0x00 }, 1, "MONITOR ASM $C001" }, // NOP
+        { "C100", 0xC100, { 0xA9, 0x42, 0x00 }, 2, "MONITOR ASM $C102" }, // LDA #$42
+        { "C200", 0xC200, { 0xAD, 0x00, 0x10 }, 3, "MONITOR ASM $C203" }, // LDA $1000
+    };
+
+    for (int c = 0; c < (int)(sizeof(cases) / sizeof(cases[0])); c++) {
+        TestUserInterface ui;
+        CaptureScreen screen;
+        FakeMemoryBackend backend;
+        char header[39];
+        const int keys[] = { 'J', 'A', 'E', KEY_RETURN, KEY_BREAK };
+        FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+
+        ui.screen = &screen;
+        ui.keyboard = &kb;
+        ui.set_prompt(cases[c].prompt, 1);
+        for (int i = 0; i < cases[c].len; i++) {
+            backend.write((uint16_t)(cases[c].addr + i), cases[c].bytes[i]);
+        }
+        monitor_reset_saved_state();
+
+        BackendMachineMonitor mon(&ui, &backend);
+        mon.init(&screen, &kb);
+        if (expect(mon.poll(0) == 0, "Return-advance test: goto failed.")) return 1;
+        if (expect(mon.poll(0) == 0, "Return-advance test: ASM view switch failed.")) return 1;
+        if (expect(mon.poll(0) == 0, "Return-advance test: edit mode entry failed.")) return 1;
+        if (expect(mon.poll(0) == 0, "Return-advance test: RETURN must advance, not exit.")) return 1;
+        screen.get_slice(1, 3, 38, header);
+        if (expect(strstr(header, cases[c].expect_header) == header,
+                   "RETURN in ASM edit mode must advance to the next logical instruction line.")) return 1;
+        mon.deinit();
+    }
+
+    // Invalid mnemonic input must not advance or commit: after a rejected third
+    // letter the cursor stays on the original line and memory is untouched.
+    {
+        TestUserInterface ui;
+        CaptureScreen screen;
+        FakeMemoryBackend backend;
+        char header[39];
+        const int keys[] = { 'J', 'A', 'E', 'A', 'D', 'D', KEY_BREAK, KEY_BREAK, KEY_BREAK };
+        FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+
+        ui.screen = &screen;
+        ui.keyboard = &kb;
+        ui.set_prompt("C000", 1);
+        monitor_reset_saved_state();
+
+        BackendMachineMonitor mon(&ui, &backend);
+        mon.init(&screen, &kb);
+        for (int i = 0; i < 6; i++) {
+            if (expect(mon.poll(0) == 0, "Return no-advance test: setup key sequence failed.")) return 1;
+        }
+        screen.get_slice(1, 3, 38, header);
+        if (expect(strstr(header, "MONITOR ASM $C000") == header,
+                   "Rejected invalid mnemonic input must not advance the edit cursor.")) return 1;
+        if (expect(backend.read(0xC000) == 0x00,
+                   "Rejected invalid mnemonic input must not commit bytes.")) return 1;
+        mon.deinit();
+    }
+
+    // A typed operand that fails to assemble must not commit bytes or advance;
+    // the picker stays open so the user can correct it (LDA #999 is out of range
+    // for an immediate byte).
+    {
+        TestUserInterface ui;
+        CaptureScreen screen;
+        FakeMemoryBackend backend;
+        char header[39];
+        const int keys[] = {
+            'J', 'A', 'E', 'L', 'D', 'A', '#', '9', '9', '9', KEY_RETURN, KEY_BREAK, KEY_BREAK, KEY_BREAK
+        };
+        FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+
+        ui.screen = &screen;
+        ui.keyboard = &kb;
+        ui.set_prompt("C000", 1);
+        monitor_reset_saved_state();
+
+        BackendMachineMonitor mon(&ui, &backend);
+        mon.init(&screen, &kb);
+        for (int i = 0; i < 11; i++) {
+            if (expect(mon.poll(0) == 0, "Return invalid-operand test: setup key sequence failed.")) return 1;
+        }
+        screen.get_slice(1, 3, 38, header);
+        if (expect(strstr(header, "MONITOR ASM $C000") == header,
+                   "RETURN on an unassemblable typed operand must not advance the edit cursor.")) return 1;
+        if (expect(backend.read(0xC000) == 0x00,
+                   "RETURN on an unassemblable typed operand must not commit bytes.")) return 1;
+        mon.deinit();
+    }
+
+    return 0;
+}
+
 int main()
 {
     if (test_disassembler()) return 1;
@@ -6312,6 +6572,8 @@ int main()
     if (test_asm_number_popup_targets_operands()) return 1;
     if (test_asm_number_popup_illegal_and_invalid_rows()) return 1;
     if (test_asm_edit_assemble_at_cursor()) return 1;
+    if (test_asm_edit_rejects_invalid_mnemonic()) return 1;
+    if (test_asm_edit_return_advances()) return 1;
     if (test_asm_edit_direct_typing()) return 1;
     if (test_asm_edit_direct_typing_immediate()) return 1;
     if (test_asm_edit_branch_two_parts()) return 1;

--- a/software/test/monitor/machine_monitor_test.cc
+++ b/software/test/monitor/machine_monitor_test.cc
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "assembler_6502.h"
 #include "disassembler_6502.h"
 #include "monitor_init.h"
 #include "machine_monitor_test_support.h"
@@ -308,20 +309,202 @@ static int test_disassembler(void)
                    "Relative branch target disassembly failed.")) return 1;
     }
 
-    const uint8_t xaa_imm[] = { 0x8B, 0x44, 0x00 };
-    disassemble_6502(0x3000, xaa_imm, true, &decoded);
-    if (expect(decoded.length == 2 && strcmp(decoded.text, "XAA #$44") == 0,
-               "XAA immediate disassembly failed.")) return 1;
+    const uint8_t ane_imm[] = { 0x8B, 0x44, 0x00 };
+    disassemble_6502(0x3000, ane_imm, true, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "ANE #$44") == 0,
+               "ANE immediate disassembly failed.")) return 1;
 
-    const uint8_t axs_imm[] = { 0xCB, 0x44, 0x00 };
-    disassemble_6502(0x3000, axs_imm, true, &decoded);
-    if (expect(decoded.length == 2 && strcmp(decoded.text, "AXS #$44") == 0,
-               "AXS immediate disassembly failed.")) return 1;
+    const uint8_t sbx_imm[] = { 0xCB, 0x44, 0x00 };
+    disassemble_6502(0x3000, sbx_imm, true, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "SBX #$44") == 0,
+               "SBX immediate disassembly failed.")) return 1;
 
     const uint8_t nop_f4_zpx[] = { 0xF4, 0x44, 0x00 };
     disassemble_6502(0x3000, nop_f4_zpx, true, &decoded);
     if (expect(decoded.length == 2 && strcmp(decoded.text, "NOP $44,X") == 0,
                "F4 zeropage,X disassembly failed.")) return 1;
+
+    return 0;
+}
+
+static uint8_t test_template_operand_length(const char *templ)
+{
+    const char *spec = operand_spec(templ);
+
+    if (*spec == 0 || !strncmp(spec, "A", 1)) return 0;
+    if (!strncmp(spec, "rel", 3)) return 1;
+    if (!strncmp(spec, "($nnnn,X)", 9) || !strncmp(spec, "($nnnn)", 7) ||
+        !strncmp(spec, "(ABS,X)", 7) || !strncmp(spec, "$nnnn,Y", 7) ||
+        !strncmp(spec, "$nnnn,X", 7) || !strncmp(spec, "$nnnn", 5)) {
+        return 2;
+    }
+    if (!strncmp(spec, "($nn,X)", 7) || !strncmp(spec, "($nn),Y", 7) ||
+        !strncmp(spec, "$nn,Y", 5) || !strncmp(spec, "$nn,X", 5) ||
+        !strncmp(spec, "$nn,S", 5) || !strncmp(spec, "$nn", 3) ||
+        !strncmp(spec, "#", 1)) {
+        return 1;
+    }
+    return 0;
+}
+
+static bool is_ambiguous_roundtrip_opcode(uint8_t opcode)
+{
+    switch (opcode) {
+        case 0x02: return false;
+        case 0x12: case 0x22: case 0x32: case 0x42: case 0x52:
+        case 0x62: case 0x72: case 0x92: case 0xB2: case 0xD2:
+        case 0xF2:
+        case 0x04: case 0x0C: case 0x14: case 0x1A: case 0x1C:
+        case 0x34: case 0x3A: case 0x3C: case 0x44: case 0x54:
+        case 0x5A: case 0x5C: case 0x64: case 0x74: case 0x7A:
+        case 0x7C: case 0x80: case 0x82: case 0x89: case 0xC2:
+        case 0xD4: case 0xDA: case 0xDC: case 0xE2: case 0xF4:
+        case 0xFA: case 0xFC:
+        case 0x2B:
+        case 0xEB:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static int expect_disassembly(uint8_t opcode, uint8_t b1, uint8_t b2,
+                              const char *expected, uint8_t expected_length)
+{
+    Disassembled6502 decoded;
+    const uint8_t bytes[] = { opcode, b1, b2 };
+
+    disassemble_6502(0xC000, bytes, true, &decoded);
+    if (expect(decoded.valid, "Opcode must disassemble with illegal opcodes enabled.")) return 1;
+    if (expect(decoded.length == expected_length, "Disassembly length mismatch.")) return 1;
+    if (expect(decoded.operand_bytes == expected_length - 1, "Disassembly operand length mismatch.")) return 1;
+    if (expect(strcmp(decoded.text, expected) == 0, "Disassembly text mismatch.")) return 1;
+    return 0;
+}
+
+static int expect_assembly(const char *line, const uint8_t *bytes, uint8_t length, bool illegal)
+{
+    AsmInsn insn;
+    MonitorError err = MONITOR_OK;
+
+    if (expect(monitor_assemble_line(line, illegal, 0xC000, &insn, &err), "Assembly input must encode.")) return 1;
+    if (expect(insn.length == length, "Assembly length mismatch.")) return 1;
+    for (uint8_t i = 0; i < length; i++) {
+        if (expect(insn.bytes[i] == bytes[i], "Assembly byte mismatch.")) return 1;
+    }
+    return 0;
+}
+
+static int test_illegal_opcode_normalization(void)
+{
+    static const struct {
+        uint8_t opcode;
+        uint8_t b1;
+        uint8_t b2;
+        uint8_t length;
+        const char *text;
+    } disasm_cases[] = {
+        { 0x02, 0x12, 0x34, 1, "JAM" }, { 0x12, 0x12, 0x34, 1, "JAM" },
+        { 0x22, 0x12, 0x34, 1, "JAM" }, { 0x32, 0x12, 0x34, 1, "JAM" },
+        { 0x42, 0x12, 0x34, 1, "JAM" }, { 0x52, 0x12, 0x34, 1, "JAM" },
+        { 0x62, 0x12, 0x34, 1, "JAM" }, { 0x72, 0x12, 0x34, 1, "JAM" },
+        { 0x92, 0x12, 0x34, 1, "JAM" }, { 0xB2, 0x12, 0x34, 1, "JAM" },
+        { 0xD2, 0x12, 0x34, 1, "JAM" }, { 0xF2, 0x12, 0x34, 1, "JAM" },
+
+        { 0x03, 0x12, 0x34, 2, "SLO ($12,X)" }, { 0x07, 0x12, 0x34, 2, "SLO $12" },
+        { 0x0F, 0x34, 0x12, 3, "SLO $1234" }, { 0x13, 0x12, 0x34, 2, "SLO ($12),Y" },
+        { 0x17, 0x12, 0x34, 2, "SLO $12,X" }, { 0x1B, 0x34, 0x12, 3, "SLO $1234,Y" },
+        { 0x1F, 0x34, 0x12, 3, "SLO $1234,X" },
+
+        { 0x43, 0x12, 0x34, 2, "SRE ($12,X)" }, { 0x47, 0x12, 0x34, 2, "SRE $12" },
+        { 0x4F, 0x34, 0x12, 3, "SRE $1234" }, { 0x53, 0x12, 0x34, 2, "SRE ($12),Y" },
+        { 0x57, 0x12, 0x34, 2, "SRE $12,X" }, { 0x5B, 0x34, 0x12, 3, "SRE $1234,Y" },
+        { 0x5F, 0x34, 0x12, 3, "SRE $1234,X" },
+
+        { 0xC3, 0x12, 0x34, 2, "DCP ($12,X)" }, { 0xC7, 0x12, 0x34, 2, "DCP $12" },
+        { 0xCF, 0x34, 0x12, 3, "DCP $1234" }, { 0xD3, 0x12, 0x34, 2, "DCP ($12),Y" },
+        { 0xD7, 0x12, 0x34, 2, "DCP $12,X" }, { 0xDB, 0x34, 0x12, 3, "DCP $1234,Y" },
+        { 0xDF, 0x34, 0x12, 3, "DCP $1234,X" },
+
+        { 0xE3, 0x12, 0x34, 2, "ISC ($12,X)" }, { 0xE7, 0x12, 0x34, 2, "ISC $12" },
+        { 0xEF, 0x34, 0x12, 3, "ISC $1234" }, { 0xF3, 0x12, 0x34, 2, "ISC ($12),Y" },
+        { 0xF7, 0x12, 0x34, 2, "ISC $12,X" }, { 0xFB, 0x34, 0x12, 3, "ISC $1234,Y" },
+        { 0xFF, 0x34, 0x12, 3, "ISC $1234,X" },
+
+        { 0x8B, 0x12, 0x34, 2, "ANE #$12" },
+        { 0x93, 0x12, 0x34, 2, "SHA ($12),Y" },
+        { 0x9F, 0x34, 0x12, 3, "SHA $1234,Y" },
+        { 0xCB, 0x12, 0x34, 2, "SBX #$12" },
+        { 0x54, 0x12, 0x34, 2, "NOP $12,X" },
+        { 0x74, 0x12, 0x34, 2, "NOP $12,X" },
+
+        { 0x1A, 0x12, 0x34, 1, "NOP" }, { 0x3A, 0x12, 0x34, 1, "NOP" },
+        { 0x5A, 0x12, 0x34, 1, "NOP" }, { 0x7A, 0x12, 0x34, 1, "NOP" },
+        { 0xDA, 0x12, 0x34, 1, "NOP" }, { 0xFA, 0x12, 0x34, 1, "NOP" },
+        { 0x04, 0x12, 0x34, 2, "NOP $12" }, { 0x44, 0x12, 0x34, 2, "NOP $12" },
+        { 0x64, 0x12, 0x34, 2, "NOP $12" },
+        { 0x14, 0x12, 0x34, 2, "NOP $12,X" }, { 0x34, 0x12, 0x34, 2, "NOP $12,X" },
+        { 0xD4, 0x12, 0x34, 2, "NOP $12,X" }, { 0xF4, 0x12, 0x34, 2, "NOP $12,X" },
+        { 0x0C, 0x34, 0x12, 3, "NOP $1234" },
+        { 0x1C, 0x34, 0x12, 3, "NOP $1234,X" }, { 0x3C, 0x34, 0x12, 3, "NOP $1234,X" },
+        { 0x5C, 0x34, 0x12, 3, "NOP $1234,X" }, { 0x7C, 0x34, 0x12, 3, "NOP $1234,X" },
+        { 0xDC, 0x34, 0x12, 3, "NOP $1234,X" }, { 0xFC, 0x34, 0x12, 3, "NOP $1234,X" },
+        { 0x80, 0x12, 0x34, 2, "NOP #$12" }, { 0x82, 0x12, 0x34, 2, "NOP #$12" },
+        { 0x89, 0x12, 0x34, 2, "NOP #$12" }, { 0xC2, 0x12, 0x34, 2, "NOP #$12" },
+        { 0xE2, 0x12, 0x34, 2, "NOP #$12" },
+
+        { 0xA3, 0x12, 0x34, 2, "LAX ($12,X)" }, { 0xB3, 0x12, 0x34, 2, "LAX ($12),Y" },
+        { 0xB7, 0x12, 0x34, 2, "LAX $12,Y" }, { 0xBF, 0x34, 0x12, 3, "LAX $1234,Y" },
+        { 0x83, 0x12, 0x34, 2, "SAX ($12,X)" }, { 0x87, 0x12, 0x34, 2, "SAX $12" },
+        { 0x8F, 0x34, 0x12, 3, "SAX $1234" }, { 0x97, 0x12, 0x34, 2, "SAX $12,Y" },
+        { 0x9B, 0x34, 0x12, 3, "TAS $1234,Y" }, { 0x9C, 0x34, 0x12, 3, "SHY $1234,X" },
+        { 0x9E, 0x34, 0x12, 3, "SHX $1234,Y" }, { 0xBB, 0x34, 0x12, 3, "LAS $1234,Y" },
+        { 0xEB, 0x12, 0x34, 2, "SBC #$12" },
+    };
+
+    for (unsigned i = 0; i < sizeof(disasm_cases) / sizeof(disasm_cases[0]); i++) {
+        if (expect_disassembly(disasm_cases[i].opcode, disasm_cases[i].b1, disasm_cases[i].b2,
+                               disasm_cases[i].text, disasm_cases[i].length)) return 1;
+    }
+
+    if (expect(strncmp(disassembler_6502_template(0x54), "NOP*", 4) == 0,
+               "Opcode $54 must retain the illegal NOP marker in the template.")) return 1;
+    if (expect(strncmp(disassembler_6502_template(0x74), "NOP*", 4) == 0,
+               "Opcode $74 must retain the illegal NOP marker in the template.")) return 1;
+
+    return 0;
+}
+
+static int test_opcode_metadata_consistency(void)
+{
+    for (int op = 0; op < 256; op++) {
+        const char *templ = disassembler_6502_template((uint8_t)op);
+        if (expect(templ != NULL && strlen(templ) >= 3, "Every opcode must have one template.")) return 1;
+
+        uint8_t expected_length = (uint8_t)(1 + test_template_operand_length(templ));
+        if (expect(expected_length >= 1 && expected_length <= 3, "Opcode template length must be 1..3.")) return 1;
+
+        const uint8_t bytes[] = { (uint8_t)op, 0x12, 0x34 };
+        Disassembled6502 decoded;
+        disassemble_6502(0xC000, bytes, true, &decoded);
+        if (expect(decoded.valid, "All opcodes must disassemble with illegal opcodes enabled.")) return 1;
+        if (expect(decoded.length == expected_length, "Template-derived length must match disassembly length.")) return 1;
+        if (expect(decoded.operand_bytes == expected_length - 1, "Template-derived operand length must match disassembly.")) return 1;
+
+        if (is_ambiguous_roundtrip_opcode((uint8_t)op)) {
+            continue;
+        }
+
+        AsmInsn insn;
+        MonitorError err = MONITOR_OK;
+        if (expect(monitor_assemble_line(decoded.text, true, 0xC000, &insn, &err),
+                   "Disassembled instruction must assemble again.")) return 1;
+        if (expect(insn.length == decoded.length, "Round-trip length mismatch.")) return 1;
+        if (expect(insn.bytes[0] == (uint8_t)op, "Round-trip opcode mismatch.")) return 1;
+        for (uint8_t i = 1; i < insn.length; i++) {
+            if (expect(insn.bytes[i] == bytes[i], "Round-trip operand byte mismatch.")) return 1;
+        }
+    }
 
     return 0;
 }
@@ -1985,8 +2168,6 @@ static int test_monitor_kernal_bank_switch_and_ram_interaction(void)
     return 0;
 }
 
-#include "assembler_6502.h"
-
 static int test_assembler_encoding(void)
 {
     AsmInsn insn;
@@ -2012,6 +2193,86 @@ static int test_assembler_encoding(void)
     // ...accepted when on.
     if (expect(monitor_assemble_line("SLO $12", true, 0xC000, &insn, &err), "SLO $12 must encode when illegal=ON")) return 1;
     if (expect(insn.length == 2 && insn.bytes[0] == 0x07 && insn.bytes[1] == 0x12, "SLO $12 -> 07 12")) return 1;
+
+    static const struct {
+        const char *line;
+        uint8_t length;
+        uint8_t bytes[3];
+    } canonical_cases[] = {
+        { "JAM", 1, { 0x02, 0x00, 0x00 } },
+        { "SLO ($12,X)", 2, { 0x03, 0x12, 0x00 } },
+        { "SLO $12", 2, { 0x07, 0x12, 0x00 } },
+        { "SLO $1234", 3, { 0x0F, 0x34, 0x12 } },
+        { "SLO ($12),Y", 2, { 0x13, 0x12, 0x00 } },
+        { "SLO $12,X", 2, { 0x17, 0x12, 0x00 } },
+        { "SLO $1234,Y", 3, { 0x1B, 0x34, 0x12 } },
+        { "SLO $1234,X", 3, { 0x1F, 0x34, 0x12 } },
+        { "SRE ($12,X)", 2, { 0x43, 0x12, 0x00 } },
+        { "SRE $12", 2, { 0x47, 0x12, 0x00 } },
+        { "SRE $1234", 3, { 0x4F, 0x34, 0x12 } },
+        { "SRE ($12),Y", 2, { 0x53, 0x12, 0x00 } },
+        { "SRE $12,X", 2, { 0x57, 0x12, 0x00 } },
+        { "SRE $1234,Y", 3, { 0x5B, 0x34, 0x12 } },
+        { "SRE $1234,X", 3, { 0x5F, 0x34, 0x12 } },
+        { "DCP ($12,X)", 2, { 0xC3, 0x12, 0x00 } },
+        { "DCP $12", 2, { 0xC7, 0x12, 0x00 } },
+        { "DCP $1234", 3, { 0xCF, 0x34, 0x12 } },
+        { "DCP ($12),Y", 2, { 0xD3, 0x12, 0x00 } },
+        { "DCP $12,X", 2, { 0xD7, 0x12, 0x00 } },
+        { "DCP $1234,Y", 3, { 0xDB, 0x34, 0x12 } },
+        { "DCP $1234,X", 3, { 0xDF, 0x34, 0x12 } },
+        { "ISC ($12,X)", 2, { 0xE3, 0x12, 0x00 } },
+        { "ISC $12", 2, { 0xE7, 0x12, 0x00 } },
+        { "ISC $1234", 3, { 0xEF, 0x34, 0x12 } },
+        { "ISC ($12),Y", 2, { 0xF3, 0x12, 0x00 } },
+        { "ISC $12,X", 2, { 0xF7, 0x12, 0x00 } },
+        { "ISC $1234,Y", 3, { 0xFB, 0x34, 0x12 } },
+        { "ISC $1234,X", 3, { 0xFF, 0x34, 0x12 } },
+        { "ANE #$12", 2, { 0x8B, 0x12, 0x00 } },
+        { "SHA ($12),Y", 2, { 0x93, 0x12, 0x00 } },
+        { "SHA $1234,Y", 3, { 0x9F, 0x34, 0x12 } },
+        { "SBX #$12", 2, { 0xCB, 0x12, 0x00 } },
+        { "SAX $12", 2, { 0x87, 0x12, 0x00 } },
+        { "SAX $1234", 3, { 0x8F, 0x34, 0x12 } },
+        { "SAX ($12,X)", 2, { 0x83, 0x12, 0x00 } },
+        { "SAX $12,Y", 2, { 0x97, 0x12, 0x00 } },
+    };
+
+    for (unsigned i = 0; i < sizeof(canonical_cases) / sizeof(canonical_cases[0]); i++) {
+        if (expect_assembly(canonical_cases[i].line, canonical_cases[i].bytes,
+                            canonical_cases[i].length, true)) return 1;
+    }
+
+    static const struct {
+        const char *alias;
+        uint8_t length;
+        uint8_t bytes[3];
+    } alias_cases[] = {
+        { "HLT", 1, { 0x02, 0x00, 0x00 } },
+        { "KIL", 1, { 0x02, 0x00, 0x00 } },
+        { "ASO $12", 2, { 0x07, 0x12, 0x00 } },
+        { "LSE $12", 2, { 0x47, 0x12, 0x00 } },
+        { "DCM $12", 2, { 0xC7, 0x12, 0x00 } },
+        { "INS $12", 2, { 0xE7, 0x12, 0x00 } },
+        { "ISB $12", 2, { 0xE7, 0x12, 0x00 } },
+        { "XAA #$12", 2, { 0x8B, 0x12, 0x00 } },
+        { "AHX ($12),Y", 2, { 0x93, 0x12, 0x00 } },
+        { "AHX $1234,Y", 3, { 0x9F, 0x34, 0x12 } },
+        { "AXS #$12", 2, { 0xCB, 0x12, 0x00 } },
+        { "ASR #$12", 2, { 0x4B, 0x12, 0x00 } },
+        { "LXA #$12", 2, { 0xAB, 0x12, 0x00 } },
+        { "SHS $1234,Y", 3, { 0x9B, 0x34, 0x12 } },
+        { "LAE $1234,Y", 3, { 0xBB, 0x34, 0x12 } },
+        { "LDS $1234,Y", 3, { 0xBB, 0x34, 0x12 } },
+    };
+
+    for (unsigned i = 0; i < sizeof(alias_cases) / sizeof(alias_cases[0]); i++) {
+        if (expect_assembly(alias_cases[i].alias, alias_cases[i].bytes,
+                            alias_cases[i].length, true)) return 1;
+    }
+
+    if (expect(!monitor_assemble_line("SAX #$12", true, 0xC000, &insn, &err),
+               "SAX immediate must not assemble to SBX.")) return 1;
 
     return 0;
 }
@@ -6016,6 +6277,8 @@ static int test_restricted_backend_guards_platform_features(void)
 int main()
 {
     if (test_disassembler()) return 1;
+    if (test_illegal_opcode_normalization()) return 1;
+    if (test_opcode_metadata_consistency()) return 1;
     if (test_memory_helpers()) return 1;
     if (test_parsers_and_formatters()) return 1;
     if (test_hunt_prompt_typed_input()) return 1;

--- a/software/test/monitor/machine_monitor_test.cc
+++ b/software/test/monitor/machine_monitor_test.cc
@@ -274,6 +274,41 @@ static int test_disassembler(void)
     disassemble_6502(0x3000, illegal_zpx, true, &decoded);
     if (expect(strcmp(decoded.text, "NOP $44,X") == 0, "Illegal zeropage,X disassembly failed.")) return 1;
 
+    const uint8_t bit_zp[] = { 0x24, 0x66, 0x00 };
+    disassemble_6502(0xBCA2, bit_zp, false, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "BIT $66") == 0,
+               "BIT zeropage disassembly failed.")) return 1;
+
+    const uint8_t bcc_rel[] = { 0x90, 0x05, 0x00 };
+    disassemble_6502(0x1000, bcc_rel, false, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "BCC $1007") == 0,
+               "BCC branch target disassembly failed.")) return 1;
+
+    const uint8_t bcs_rel[] = { 0xB0, 0x05, 0x00 };
+    disassemble_6502(0x1000, bcs_rel, false, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "BCS $1007") == 0,
+               "BCS branch target disassembly failed.")) return 1;
+
+    const uint8_t beq_rel[] = { 0xF0, 0x05, 0x00 };
+    disassemble_6502(0x1000, beq_rel, false, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "BEQ $1007") == 0,
+               "BEQ branch target disassembly failed.")) return 1;
+
+    const uint8_t xaa_imm[] = { 0x8B, 0x44, 0x00 };
+    disassemble_6502(0x3000, xaa_imm, true, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "XAA #$44") == 0,
+               "XAA immediate disassembly failed.")) return 1;
+
+    const uint8_t axs_imm[] = { 0xCB, 0x44, 0x00 };
+    disassemble_6502(0x3000, axs_imm, true, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "AXS #$44") == 0,
+               "AXS immediate disassembly failed.")) return 1;
+
+    const uint8_t nop_f4_zpx[] = { 0xF4, 0x44, 0x00 };
+    disassemble_6502(0x3000, nop_f4_zpx, true, &decoded);
+    if (expect(decoded.length == 2 && strcmp(decoded.text, "NOP $44,X") == 0,
+               "F4 zeropage,X disassembly failed.")) return 1;
+
     return 0;
 }
 
@@ -1281,8 +1316,8 @@ static int test_monitor_interaction(void)
         "Bookmarks:  C=+B List   C=+0-9 Jump",
         "",
         "Open monitor:  C=+O",
-        "Close monitor: C=+O/ESC",
-        "Leave edit:    C=+E/ESC",
+        "Close monitor: C=+O/RSTOP",
+        "Leave edit:    C=+E/RSTOP",
         "Copy/Paste:    C=+C / C=+V",
         "Follow/Return: RETURN",
         NULL

--- a/software/test/monitor/machine_monitor_test.cc
+++ b/software/test/monitor/machine_monitor_test.cc
@@ -294,6 +294,20 @@ static int test_disassembler(void)
     if (expect(decoded.length == 2 && strcmp(decoded.text, "BEQ $1007") == 0,
                "BEQ branch target disassembly failed.")) return 1;
 
+    // Exercise the remaining relative branches too, so a missing or wrong
+    // `rel` operand spec in the opcode template table is caught here.
+    const struct { uint8_t opcode; const char *text; } rel_branches[] = {
+        { 0x10, "BPL $1007" }, { 0x30, "BMI $1007" },
+        { 0x50, "BVC $1007" }, { 0x70, "BVS $1007" },
+        { 0xD0, "BNE $1007" },
+    };
+    for (unsigned i = 0; i < sizeof(rel_branches) / sizeof(rel_branches[0]); i++) {
+        const uint8_t branch_rel[] = { rel_branches[i].opcode, 0x05, 0x00 };
+        disassemble_6502(0x1000, branch_rel, false, &decoded);
+        if (expect(decoded.length == 2 && strcmp(decoded.text, rel_branches[i].text) == 0,
+                   "Relative branch target disassembly failed.")) return 1;
+    }
+
     const uint8_t xaa_imm[] = { 0x8B, 0x44, 0x00 };
     disassemble_6502(0x3000, xaa_imm, true, &decoded);
     if (expect(decoded.length == 2 && strcmp(decoded.text, "XAA #$44") == 0,

--- a/software/test/monitor/machine_monitor_test.cc
+++ b/software/test/monitor/machine_monitor_test.cc
@@ -3596,6 +3596,62 @@ static int test_space_shortcuts_match_existing_paging(void)
     return 0;
 }
 
+// Regression for the telnet opcode-dropdown scroll flood: on a full-refresh
+// screen (telnet/VT100), scrolling the opcode dropdown used to repaint the WHOLE
+// screen on every cursor keystroke. Under cursor-key autorepeat that flood
+// wedged/aborted the telnet monitor connection. A scroll keystroke must repaint
+// only the dropdown overlay (the same incremental path Freeze/Overlay use), not
+// the header, disassembly or status rows underneath it.
+static int test_opcode_picker_scroll_redraws_overlay_only(void)
+{
+    struct FullRefreshCaptureScreen : public CaptureScreen {
+        virtual bool prefers_full_refresh(void) { return true; }
+    };
+
+    TestUserInterface ui;
+    FullRefreshCaptureScreen screen;
+    FakeMemoryBackend backend;
+    // J(goto) A(asm view) E(edit) L(open big dropdown), then DOWN to scroll.
+    const int keys[] = { 'J', 'A', 'E', 'L', KEY_DOWN, KEY_BREAK, KEY_BREAK, KEY_BREAK };
+    FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+
+    ui.screen = &screen;
+    ui.keyboard = &kb;
+    ui.set_prompt("C000", 1);
+    monitor_reset_saved_state();
+
+    BackendMachineMonitor mon(&ui, &backend);
+    mon.init(&screen, &kb);
+    for (int i = 0; i < 4; i++) {
+        if (expect(mon.poll(0) == 0, "Dropdown scroll redraw test: setup (J/A/E/L) failed.")) return 1;
+    }
+    // The dropdown box is anchored to the current_addr disassembly row and spans
+    // screen columns 16..33 (window col MONITOR_DISASM_TEXT_COL=15 plus the 1-col
+    // window border). Verify the dropdown is actually showing candidates first.
+    char row[39];
+    screen.get_slice(1, 5, 38, row);
+    if (expect(strstr(row, "LD") != NULL,
+               "Dropdown scroll redraw test: expected LD* candidates for prefix L.")) return 1;
+
+    // A single scroll keystroke must touch ONLY the dropdown box columns.
+    screen.reset_write_counts();
+    if (expect(mon.poll(0) == 0, "Dropdown scroll redraw test: DOWN scroll failed.")) return 1;
+
+    int outside_box = screen.count_writes_outside_rect(16, 0, 33, 24);
+    int total = screen.count_writes_outside_rect(1000, 1000, 1000, 1000); // impossible rect => all writes
+    if (expect(total > 0,
+               "Dropdown scroll redraw test: scrolling must repaint the dropdown overlay.")) return 1;
+    if (expect(outside_box == 0,
+               "Dropdown scroll on a full-refresh (telnet) screen must repaint only the dropdown "
+               "overlay, not the whole screen (header/disassembly/status).")) return 1;
+
+    if (expect(mon.poll(0) == 0, "Dropdown scroll redraw test: RUN/STOP should close the picker first.")) return 1;
+    if (expect(mon.poll(0) == 0, "Dropdown scroll redraw test: RUN/STOP should leave edit mode next.")) return 1;
+    if (expect(mon.poll(0) == 1, "Dropdown scroll redraw test: exit failed.")) return 1;
+    mon.deinit();
+    return 0;
+}
+
 static int test_opcode_picker_refilters_live(void)
 {
     TestUserInterface ui;
@@ -6581,6 +6637,7 @@ int main()
     if (test_asm_cpu_bank_cycle_preserves_screen_row()) return 1;
     if (test_asm_page_up_keeps_screen_row()) return 1;
     if (test_space_shortcuts_match_existing_paging()) return 1;
+    if (test_opcode_picker_scroll_redraws_overlay_only()) return 1;
     if (test_opcode_picker_refilters_live()) return 1;
     if (test_opcode_picker_filters_orders_and_commits_on_enter()) return 1;
     if (test_opcode_picker_browsing_does_not_mutate_frozen_charset_backup()) return 1;

--- a/software/test/monitor/machine_monitor_test.cc
+++ b/software/test/monitor/machine_monitor_test.cc
@@ -3099,6 +3099,30 @@ static int test_asm_edit_branch_two_parts(void)
     return 0;
 }
 
+static int test_asm_edit_bit_operand_not_branch(void)
+{
+    TestUserInterface ui;
+    CaptureScreen screen;
+    FakeMemoryBackend backend;
+    backend.write(0xC000, 0x24);
+    backend.write(0xC001, 0x44);
+    const int keys[] = {
+        'J', 'A', 'E', KEY_RIGHT, '6', '6', KEY_BREAK
+    };
+    FakeKeyboard kb(keys, sizeof(keys) / sizeof(keys[0]));
+    ui.screen = &screen;
+    ui.keyboard = &kb;
+    ui.set_prompt("C000", 1);
+    BackendMachineMonitor mon(&ui, &backend);
+    mon.init(&screen, &kb);
+    for (int i = 0; i < (int)(sizeof(keys) / sizeof(keys[0])) - 1; i++) {
+        (void)mon.poll(0);
+    }
+    if (expect(backend.read(0xC000) == 0x24 && backend.read(0xC001) == 0x66,
+               "ASM BIT zeropage edit must treat operand as a byte, not a branch target")) return 1;
+    return 0;
+}
+
 static int test_asm_cpu_bank_cycle_preserves_screen_row(void)
 {
     TestUserInterface ui;
@@ -6014,6 +6038,7 @@ int main()
     if (test_asm_edit_direct_typing()) return 1;
     if (test_asm_edit_direct_typing_immediate()) return 1;
     if (test_asm_edit_branch_two_parts()) return 1;
+    if (test_asm_edit_bit_operand_not_branch()) return 1;
     if (test_asm_cpu_bank_cycle_preserves_screen_row()) return 1;
     if (test_asm_page_up_keeps_screen_row()) return 1;
     if (test_space_shortcuts_match_existing_paging()) return 1;

--- a/software/test/monitor/machine_monitor_test_support.cc
+++ b/software/test/monitor/machine_monitor_test_support.cc
@@ -528,7 +528,7 @@ int UserInterface :: string_box(const char *, char *, int, bool, bool)
     return 0;
 }
 
-int UserInterface :: string_edit(char *, int, Window *, int, int)
+int UserInterface :: string_edit(char *, int, Window *, int, int, int)
 {
     return 0;
 }

--- a/tools/developer/machine-code-monitor/monitor_test.py
+++ b/tools/developer/machine-code-monitor/monitor_test.py
@@ -59,6 +59,7 @@ KEYS = {
     "ESC": b"\x1bx",
     "ENTER": b"\r",
     "DEL": b"\x7f",
+    "BACKSPACE": b"\x08",
 }
 
 VIEW_KEYS = {
@@ -1057,6 +1058,161 @@ def run_number_arithmetic_test(session: MonitorSession, rest_host: str) -> None:
     screen.find_line_containing("MONITOR ASM $3370")
 
 
+# ---------------------------------------------------------------------------
+# Save / Load round-trip tests
+#
+# These drive the monitor's S(ave) and L(oad) commands over telnet, exercising
+# the firmware file picker (a TreeBrowser in PICK mode rendered on the same
+# VT100 screen). They round-trip a known memory pattern to two kinds of target,
+# both under the RAM-disk /Temp folder:
+#   * a plain top-level PRG file
+#   * a PRG file inside a freshly created D64 disk image
+# The pattern is written/verified through the existing REST memory API, and a
+# unique per-run token keeps each run from colliding with leftovers (the picker
+# never has to answer an "overwrite?" prompt, and the D64 is genuinely new).
+# ---------------------------------------------------------------------------
+
+def picker_path(snapshot: Snapshot) -> str:
+    """Return the directory path the file picker currently shows.
+
+    The picker prints the active path on the bottom line, below its border."""
+    for line in reversed(snapshot.lines):
+        text = line.strip()
+        if text and not text.startswith("+"):
+            return text
+    return ""
+
+
+def picker_to_root(session: MonitorSession) -> Snapshot:
+    """Walk the picker up to the filesystem root ("/").
+
+    LEFT moves one level up; at the root LEFT would close the picker, so we
+    check the path before each step and stop as soon as we reach "/"."""
+    snapshot = session.capture()
+    for _ in range(12):
+        if picker_path(snapshot) == "/":
+            return snapshot
+        snapshot = session.send_key("LEFT")
+    raise Failure(f"Unable to reach picker root; last path was {picker_path(snapshot)!r}")
+
+
+def picker_enter(session: MonitorSession, name_prefix: str) -> Snapshot:
+    """Quick-seek to the entry matching name_prefix and step into it."""
+    for ch in name_prefix:
+        session.send_char(ch)
+    return session.send_key("RIGHT")
+
+
+def clear_prompt_field(session: MonitorSession) -> None:
+    """Empty a (non-template) string prompt by sending backspaces.
+
+    The monitor's "Save as" prompt is pre-filled with the last-used name and
+    does not auto-clear on the first keystroke, so we delete it first. The
+    field is at most 35 characters, hence the generous count."""
+    session.sock.sendall(KEYS["BACKSPACE"] * 40)
+    session.capture()
+
+
+def rest_create_d64(host: str, path: str, diskname: str) -> None:
+    url = f"http://{host}/v1/files{path}:create_d64?diskname={diskname}"
+    request = urllib.request.Request(url, data=b"", method="PUT")
+    with urllib.request.urlopen(request, timeout=15.0):
+        pass
+
+
+def rest_file_exists(host: str, path: str) -> bool:
+    try:
+        with urllib.request.urlopen(f"http://{host}/v1/files{path}:info", timeout=5.0) as response:
+            return response.status == 200
+    except urllib.error.HTTPError:
+        return False
+
+
+def monitor_save(session: MonitorSession, mem_range: str, enter_dirs: List[str], filename: str) -> Snapshot:
+    """Save mem_range to filename, navigating from root through enter_dirs.
+
+    enter_dirs is a list of quick-seek prefixes to step into (e.g. ["MS"] for a
+    /Temp subtree reached from root, or ["MD"] then the D64). The final
+    directory must offer "<< Create New File >>" as its first entry."""
+    session.send_char("S")
+    session.send_text(mem_range + "\r", f"save range {mem_range}")
+    picker_to_root(session)
+    snapshot = session.send_key("RIGHT")  # step into /Temp (the first root entry)
+    for prefix in enter_dirs:
+        snapshot = picker_enter(session, prefix)
+    # The cursor defaults to "<< Create New File >>"; RIGHT picks it and the
+    # monitor then asks for the file name.
+    session.send_key("RIGHT")
+    clear_prompt_field(session)
+    snapshot = session.send_text(filename + "\r", f"save as {filename}")
+    snapshot.find_line_containing("SAVE")
+    return session.send_key("ENTER")  # dismiss the confirmation popup
+
+
+def monitor_load(session: MonitorSession, enter_dirs: List[str], filename: str) -> Snapshot:
+    """Load filename back, navigating from root through enter_dirs."""
+    session.send_char("L")
+    picker_to_root(session)
+    session.send_key("RIGHT")  # step into /Temp
+    for prefix in enter_dirs:
+        picker_enter(session, prefix)
+    for ch in filename:
+        session.send_char(ch)  # quick-seek to the file
+    session.send_key("ENTER")  # open the context menu ("Select" is first)
+    session.send_key("ENTER")  # Select -> pick the file
+    # "Load [PRG|AAAA],[Offs],[Len|AUTO]" prompt: typing the spec clears the
+    # template, so PRG mode is forced regardless of the last-used value.
+    session.send_text("PRG,0,AUTO\r", "load PRG")
+    return session.send_key("ENTER")  # dismiss the confirmation popup
+
+
+def run_save_load_topfile_test(session: MonitorSession, rest_host: str, token: str) -> None:
+    addr = 0xC000
+    pattern = bytes((0x5A, 0xA5, 0x01, 0x02, 0xDE, 0xAD, 0xBE, 0xEF,
+                     0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80))
+    name = f"MS{token}.PRG"
+
+    write_rest_memory(rest_host, addr, pattern)
+    monitor_save(session, f"{addr:04X}-{addr + len(pattern) - 1:04X}", [], name)
+    if not rest_file_exists(rest_host, f"/Temp/{name}"):
+        raise Failure(f"Saved file /Temp/{name} not found via REST")
+
+    write_rest_memory(rest_host, addr, b"\x00" * len(pattern))
+    monitor_load(session, [], f"MS{token}")
+    loaded = read_rest_memory(rest_host, addr, len(pattern))
+    if loaded != pattern:
+        raise Failure(
+            f"Top-level save/load mismatch at ${addr:04X}:\n"
+            f"  saved:  {pattern.hex().upper()}\n"
+            f"  loaded: {loaded.hex().upper()}"
+        )
+
+
+def run_save_load_d64_test(session: MonitorSession, rest_host: str, token: str) -> None:
+    addr = 0xC100
+    pattern = bytes((0x11, 0x22, 0x33, 0x44, 0xAA, 0xBB, 0xCC, 0xDD,
+                     0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02))
+    disk = f"MD{token}.D64"
+    inner = f"D{token}"
+
+    rest_create_d64(rest_host, f"/Temp/{disk}", f"MD{token}")
+    if not rest_file_exists(rest_host, f"/Temp/{disk}"):
+        raise Failure(f"D64 image /Temp/{disk} was not created")
+
+    write_rest_memory(rest_host, addr, pattern)
+    monitor_save(session, f"{addr:04X}-{addr + len(pattern) - 1:04X}", [f"MD{token}"], inner)
+
+    write_rest_memory(rest_host, addr, b"\x00" * len(pattern))
+    monitor_load(session, [f"MD{token}"], inner)
+    loaded = read_rest_memory(rest_host, addr, len(pattern))
+    if loaded != pattern:
+        raise Failure(
+            f"D64 save/load mismatch at ${addr:04X}:\n"
+            f"  saved:  {pattern.hex().upper()}\n"
+            f"  loaded: {loaded.hex().upper()}"
+        )
+
+
 def run_tests(session: MonitorSession, rest_host: str) -> None:
     snapshots = load_snapshots()
 
@@ -1197,6 +1353,14 @@ def run_tests(session: MonitorSession, rest_host: str) -> None:
 
     with check("number popup arithmetic"):
         run_number_arithmetic_test(session, rest_host)
+
+    save_load_token = f"{int(time.time()) % 100000:05d}"
+
+    with check("save/load round-trip to top-level /Temp file"):
+        run_save_load_topfile_test(session, rest_host, save_load_token)
+
+    with check("save/load round-trip to file in new /Temp D64"):
+        run_save_load_d64_test(session, rest_host, save_load_token)
 
 
 def main() -> int:

--- a/tools/developer/machine-code-monitor/monitor_test.py
+++ b/tools/developer/machine-code-monitor/monitor_test.py
@@ -1031,6 +1031,63 @@ def run_follow_return_test(session: MonitorSession, rest_host: str) -> None:
     screen.find_line_containing("MONITOR ASM $3360")
     assert_line_lacks(screen, "F0 JMP $")
 
+def run_asm_edit_validation_test(session: MonitorSession, rest_host: str) -> None:
+    # Bug 2 (Return advances) test program:
+    #   $3380: LDA #$01   A9 01     (2 bytes)
+    #   $3382: NOP        EA        (1 byte)
+    #   $3383: LDA $C000  AD 00 C0  (3 bytes)
+    write_rest_memory(rest_host, 0x3380, bytes((0xA9, 0x01, 0xEA, 0xAD, 0x00, 0xC0)))
+    screen = ensure_view(session, "ASM ")
+    screen = session.goto("3380")
+    screen = ensure_view(session, "ASM ")
+    screen.find_line_containing("MONITOR ASM $3380")
+    screen = session.send_char("e")  # enter assembly edit mode
+    screen.find_line_containing("MONITOR ASM $3380")
+    # RETURN commits the current line and advances by the instruction length.
+    screen = session.send_key("ENTER")  # past LDA #$01 (2 bytes)
+    screen.find_line_containing("MONITOR ASM $3382")
+    screen = session.send_key("ENTER")  # past NOP (1 byte)
+    screen.find_line_containing("MONITOR ASM $3383")
+    screen = session.send_key("ENTER")  # past LDA $C000 (3 bytes)
+    screen.find_line_containing("MONITOR ASM $3386")
+    screen = session.send_key("ESC")    # leave edit mode
+
+    # Bug 1 (invalid mnemonic rejected): edit a clean NOP-filled region so the
+    # opcode picker is exercised in isolation.
+    write_rest_memory(rest_host, 0x33A0, bytes([0xEA] * 8))
+    screen = ensure_view(session, "ASM ")
+    screen = session.goto("33A0")
+    screen = ensure_view(session, "ASM ")
+    screen = session.send_char("e")  # enter assembly edit mode
+    # A valid prefix is accepted and the completion list stays coherent.
+    screen = session.send_char("A")
+    screen.find_line_containing("ADC")
+    screen = session.send_char("D")
+    screen.find_line_containing(" AD_")
+    screen.find_line_containing("ADC")
+    # An invalid third letter (ADD is not a 6502 mnemonic) is rejected: the
+    # mnemonic field stays at AD and nothing bleeds into the operand area.
+    screen = session.send_char("D")
+    screen.find_line_containing(" AD_")
+    assert_line_lacks(screen, "ADD")
+    # Repeated invalid input does not overflow the field or bleed.
+    for _ in range(3):
+        screen = session.send_char("A")
+    screen.find_line_containing(" AD_")
+    assert_line_lacks(screen, "ADD")
+    assert_line_lacks(screen, "ADA")
+    screen = session.send_key("ESC")  # close the picker (stay in edit mode)
+    # A first letter that begins no supported mnemonic (G) is rejected and never
+    # joins the prefix; a following valid letter still opens the picker.
+    screen = session.send_char("G")
+    screen = session.send_char("L")
+    screen.find_line_containing(" L_")
+    assert_line_lacks(screen, "GL")
+    screen.find_line_containing("LDA")
+    screen = session.send_key("ESC")  # close the picker
+    session.send_key("ESC")           # leave edit mode
+
+
 def run_number_arithmetic_test(session: MonitorSession, rest_host: str) -> None:
     write_rest_memory(rest_host, 0x3370, bytes((0x20, 0x00, 0xC0, 0xEA)))
 
@@ -1350,6 +1407,9 @@ def run_tests(session: MonitorSession, rest_host: str) -> None:
 
     with check("follow and return navigation"):
         run_follow_return_test(session, rest_host)
+
+    with check("asm edit mnemonic validation and Return advance"):
+        run_asm_edit_validation_test(session, rest_host)
 
     with check("number popup arithmetic"):
         run_number_arithmetic_test(session, rest_host)

--- a/tools/developer/machine-code-monitor/monitor_test.py
+++ b/tools/developer/machine-code-monitor/monitor_test.py
@@ -353,6 +353,18 @@ class MonitorSession:
         self.sock.sendall(payload)
         return self.capture()
 
+    def send_key_count(self, key: str) -> Tuple[Snapshot, int]:
+        """Send a key and return (snapshot, bytes_received_during_redraw).
+
+        Used to measure per-keystroke output volume so a flood-on-scroll
+        regression (full-screen redraw per keystroke on telnet) is observable."""
+        payload = KEYS[key]
+        self.last_command = key
+        self.sock.sendall(payload)
+        self._last_drain_bytes = 0
+        self._drain_until_idle(timeout=self.timeout)
+        return self.screen.snapshot(self.last_command), self._last_drain_bytes
+
     def send_char(self, ch: str) -> Snapshot:
         self.last_command = ch
         self.sock.sendall(ch.encode("ascii"))
@@ -398,16 +410,20 @@ class MonitorSession:
     def _drain_until_idle(self, timeout: float) -> None:
         end = time.time() + timeout
         last_data = time.time()
+        drained = 0
         while time.time() < end:
             wait = min(0.5, max(0.0, end - time.time()))
             ready, _, _ = select.select([self.sock], [], [], wait)
             if not ready:
                 if time.time() - last_data >= 0.5:
+                    self._last_drain_bytes = drained
                     return
                 continue
             chunk = self.sock.recv(65536)
             if not chunk:
+                self._last_drain_bytes = drained
                 return
+            drained += len(chunk)
             self.screen.feed(chunk)
             last_data = time.time()
         raise Failure(f"Timed out waiting for telnet screen to go idle after {self.last_command}")
@@ -1088,6 +1104,76 @@ def run_asm_edit_validation_test(session: MonitorSession, rest_host: str) -> Non
     session.send_key("ESC")           # leave edit mode
 
 
+# Per-keystroke output budget for scrolling the opcode dropdown over telnet.
+# Regression guard: on a full-refresh (telnet/VT100) screen the buggy path
+# redrew the WHOLE screen on every cursor up/down keystroke (measured 1727 bytes
+# per keystroke). Under cursor-key autorepeat that flood wedged/aborted the
+# telnet monitor connection. The fix repaints only the dropdown overlay (the
+# same incremental path Freeze/Overlay already use), a few hundred bytes per
+# keystroke. The threshold sits well below a full-screen redraw and well above
+# an overlay-only repaint so it cleanly separates buggy from fixed.
+DROPDOWN_SCROLL_BYTE_BUDGET = 1000
+
+
+def run_telnet_dropdown_scroll_flood_test(session: MonitorSession, rest_host: str) -> None:
+    # Stable, deterministic playground: a run of NOPs so the disassembly is fixed
+    # and the opcode dropdown can be anchored mid-screen (so it is larger than the
+    # visible area below it and genuinely scrolls internally).
+    write_rest_memory(rest_host, 0x33C0, bytes([0xEA] * 32))
+    screen = ensure_view(session, "ASM ")
+    screen = session.goto("33C0")
+    screen = ensure_view(session, "ASM ")
+    screen.find_line_containing("MONITOR ASM $33C0")
+    screen = session.send_char("e")  # enter assembly edit mode
+    # Step the cursor down so the dropdown anchor sits low on the screen; with the
+    # large "L" candidate list this guarantees the list exceeds the visible window
+    # and scrolling pushes content past the bottom row and back.
+    for _ in range(10):
+        screen = session.send_key("DOWN")
+    screen = session.send_char("L")  # open the large opcode dropdown
+    screen.find_line_containing(" L_")
+    screen.find_line_containing("LDA")
+
+    # Bounded down/up scroll burst (scroll to the bottom and beyond, then back up,
+    # repeated a few times). Every scroll keystroke is measured. This is NOT a
+    # soak test: the per-keystroke output volume is identical for every scroll
+    # key, so a small bounded burst reliably exposes the flood.
+    max_bytes = 0
+    sample = []
+    cycles = 2
+    down_n = 12
+    up_n = 12
+    for _ in range(cycles):
+        for _ in range(down_n):
+            _, n = session.send_key_count("DOWN")
+            max_bytes = max(max_bytes, n)
+            sample.append(n)
+        for _ in range(up_n):
+            _, n = session.send_key_count("UP")
+            max_bytes = max(max_bytes, n)
+            sample.append(n)
+
+    # The dropdown must remain coherent through the whole burst.
+    screen = session.capture()
+    screen.find_line_containing(" L_")
+    screen.find_line_containing("LDA")
+
+    if max_bytes > DROPDOWN_SCROLL_BYTE_BUDGET:
+        raise Failure(
+            "Telnet opcode dropdown floods on scroll: a single cursor keystroke "
+            f"emitted up to {max_bytes} bytes (budget {DROPDOWN_SCROLL_BYTE_BUDGET}). "
+            "Scrolling must repaint only the dropdown overlay, not the whole "
+            f"screen. First samples: {sample[:8]}"
+        )
+
+    # Connection must still be alive and the monitor must still respond after the
+    # bounded scroll burst.
+    screen = session.send_key("ESC")  # close the dropdown (stays in edit mode)
+    screen.find_line_containing("MONITOR ASM")
+    screen = session.send_key("ESC")  # leave edit mode
+    screen.find_status_line()
+
+
 def run_number_arithmetic_test(session: MonitorSession, rest_host: str) -> None:
     write_rest_memory(rest_host, 0x3370, bytes((0x20, 0x00, 0xC0, 0xEA)))
 
@@ -1410,6 +1496,9 @@ def run_tests(session: MonitorSession, rest_host: str) -> None:
 
     with check("asm edit mnemonic validation and Return advance"):
         run_asm_edit_validation_test(session, rest_host)
+
+    with check("telnet opcode dropdown scroll does not flood the connection"):
+        run_telnet_dropdown_scroll_flood_test(session, rest_host)
 
     with check("number popup arithmetic"):
         run_number_arithmetic_test(session, rest_host)


### PR DESCRIPTION
## Summary

This PR contains important bug fixes and other improvements for the machine code monitor.

## What's Changed

### Bug Fixes

- **General**: Align monitor ROM buffers to 4-byte boundaries to prevent crash when opening monitor.
- **Assembly view**: Corrects 6502 disassembly operand handling for `BIT` opcode, as well as for a few illegal opcodes.
- **Assembly view in Edit mode**: Add targeted opcode overlay refresh and related tests to prevent telnet scroll flood. This screen flood caused Telnet disconnects when quickly scrolling up/down through a large opcode drop-down list.
- **Help/Docs**: Update keyboard references to use `RUN/STOP` instead of `ESC` in monitor help, header text, docs, and tests:
  - ESC is only relevant if interacting with the U64 via a modern keyboard.
  - The new wording improves consistency.

### UX Improvements

- **Assembly view**: Change undocumented opcodes to use their preferred mnemonic as per [NMOS 6510 Unintended Opcodes](https://hitmen.c02.at/files/docs/c64/NoMoreSecrets-NMOS6510UnintendedOpcodes-20162412.pdf) and [C64 Wiki](https://www.c64-wiki.com/wiki/Opcode).
- **Assembly view in Edit mode**: Prevent the user from entering invalid characters, e.g. characters that don't resolve to any valid opcode, based on whether undocumented opcodes are enabled or not. 
  - Previously, we rejected leaving the current row if invalid characters had been entered. 
  - The new behavior is more intuitive as it prevents such a scenario in the first place.

### Test Improvements

- Strengthened machine monitor E2E test with a round-trip save/load test, both for top-level and D64-hosted files

## Related PRs

Documentation for the machine code monitor was added to https://github.com/GideonZ/1541u-documentation/pull/27


## Tests

All E2E tests for the monitor, as well as for the recently added REST API for injecting keyboard and joystick events were successfully run after deploying this firmware to my Ultimate 64 Elite I via JTAG.

### Machine Code Monitor

`python3 tools/developer/machine-code-monitor/monitor_test.py --host u64 --port 23 --rest-host u64`

Output:

```
[01] initial CPU7/KERNAL monitor status ... OK
[02] telnet blocks poll mode ... OK
[03] KERNAL $E000 hex view and REST match ... OK
[04] paging away and back keeps memory view stable ... OK
[05] KERNAL disassembly formatting ... OK
[06] KERNAL $E010 REST match ... OK
[07] CPU6 RAM under BASIC write/read ... OK
[08] CPU5 RAM under KERNAL status ... OK
[09] ASCII view width and scrolling ... OK
[10] ASCII and Screen mapping semantics ... OK
[11] HEX edit writes both nibbles ... OK
[12] CPU bank cycling reaches CHAR and RAM mappings ... OK
[13] COMPARE reports differing address ... OK
[14] G executes finite loop and returns to monitor ... OK
[15] G repeated execution updates RAM sentinel ... OK
[16] G handoff preserves stable VIC state ... OK
[17] bookmarks recall, set, list, and label edit ... OK
[18] memory bookmark jump restores width 16 ... OK
[19] binary width cycling and bookmark jump restores width 4 ... OK
[20] follow and return navigation ... OK
[21] asm edit mnemonic validation and Return advance ... OK
[22] telnet opcode dropdown scroll does not flood the connection ... OK
[23] number popup arithmetic ... OK
[24] save/load round-trip to top-level /Temp file ... OK
[25] save/load round-trip to file in new /Temp D64 ... OK
monitor_test: OK (25 checks)
```

### Input REST API

`python3 tools/api/input_test.py -H u64 -r u64`

Result: `input_test: OK (44 checks)`

