### PR TITLE
Fix externally reachable network-stack crashes

### DIFF
--- a/software/api/routes.h
+++ b/software/api/routes.h
@@ -155,7 +155,7 @@ public:
         char msg[200];
         va_list ap;
         va_start(ap, fmt);
-        vsprintf(msg, fmt, ap);
+        vsnprintf(msg, sizeof(msg), fmt, ap);
         va_end(ap);
         errors->add(msg);
     }

--- a/software/system/small_printf.cc
+++ b/software/system/small_printf.cc
@@ -288,9 +288,24 @@ extern "C" int snprintf(char *str, size_t size, const char *fmt, ...)
 	char *pnt = str;
 	
     va_start(ap, fmt);
-    ret = _my_vnprintf(_string_write_char, (void **)&pnt, size-1, fmt, ap);
-    _string_write_char(0, (void **)&pnt);
+    /* size==0: write nothing (size-1 would underflow to a huge maxlen and the
+       NUL below would write past a zero-length buffer). */
+    ret = _my_vnprintf(_string_write_char, (void **)&pnt, size ? size - 1 : 0, fmt, ap);
+    if (size) {
+        _string_write_char(0, (void **)&pnt);
+    }
     va_end(ap);
+    return (ret);
+}
+
+extern "C" int vsnprintf(char *str, size_t size, const char *fmt, va_list ap)
+{
+    char *pnt = str;
+    /* size==0: write nothing (see snprintf above). */
+    int ret = _my_vnprintf(_string_write_char, (void **)&pnt, size ? size - 1 : 0, fmt, ap);
+    if (size) {
+        _string_write_char(0, (void **)&pnt);
+    }
     return (ret);
 }
 

--- a/software/system/small_printf.h
+++ b/software/system/small_printf.h
@@ -11,6 +11,7 @@ extern "C" {
 int printf(const char *fmt, ...);
 int sprintf(char *, const char *fmt, ...);
 int snprintf(char *, size_t len, const char *fmt, ...);
+int vsnprintf(char *, size_t len, const char *fmt, va_list ap);
 int _my_vnprintf(void (*putc)(char c, void **param), void **param, size_t maxlen, const char *fmt, va_list ap);
 int _my_vprintf(void (*putc)(char c, void **param), void **param, const char *fmt, va_list ap);
 


### PR DESCRIPTION
## Summary

This PR fixes two network-stack defects found during testing on real Ultimate 64 hardware.

Both issues can be triggered by an unauthenticated client on the local network. The fixes are deliberately small and limited to the failing paths. This PR does **not** add throughput limits, refactor the network stack, or increase resource pools.

### 1. Fix REST `error()` stack overflow

The REST `error()` helper in `software/api/routes.h` formatted client-controlled input into a fixed-size buffer:

```c
char msg[200]
```

It used unbounded `vsprintf`, which meant that a single request with an over-long query parameter, JSON key, or JSON value could overflow the HTTP task stack.

On hardware, this took the whole device off the network:

* 100% ping loss
* REST, FTP, and Telnet unreachable
* reset required

The fix adds bounded `vsnprintf` support to `software/system/small_printf`, matching the existing `snprintf` pattern, and changes the REST path to use:

```c
vsnprintf(msg, sizeof(msg), ...)
```

There is no behaviour change for valid requests.

### 2. Harden `MicroHttpServer`

This PR also bumps the `software/httpd` submodule to include the current MicroHttpServer hardening fixes; see https://github.com/GideonZ/MicroHttpServer/pull/5

## Verification

A/B tested on real Ultimate 64 hardware with the ViviPi network-stack scripts ([`scripts/u64/ab-test/`](https://github.com/chrisgleissner/vivipi/tree/main/scripts/u64/ab-test)), run once against baseline (unpatched) and once against patched firmware:

* [`network_stack_ab.py`](https://github.com/chrisgleissner/vivipi/blob/main/scripts/u64/ab-test/network_stack_ab.py) — drives the flood and health-probes every listener, emitting JSON/Markdown run summaries.
* [`slowloris_test.py`](https://github.com/chrisgleissner/vivipi/blob/main/scripts/u64/ab-test/slowloris_test.py) — mixed-traffic test for the per-connection idle reaper.
* [`netstack_force.py`](https://github.com/chrisgleissner/vivipi/blob/main/scripts/u64/ab-test/netstack_force.py) — single-shot forcing probes for individual wedge/crash vectors.

The flood combines:

* HTTP connection churn (partial request + abort)
* malformed request floods:
  * more than 20 headers
  * negative `Content-Length`
  * truncated `%` escapes

while health-probing REST, FTP, Telnet, DMA, and Ident and mutating SID volume through both `PUT` and `POST /v1/configs` with read-back.

### Before this PR (unpatched)

* rapid connection churn wedged REST, FTP, Telnet and DMA at **t = 4.0 s** (261 churn requests)
* all four stayed at **0% availability** for the rest of the run; only the UDP identify listener survived
* no self-recovery; a reset was required
* one oversized REST request could take the whole device off the network

### After this PR (patched)

A 10-minute soak driving churn + malformed floods:

* **77,645 HTTP flood requests at ~129/s** (49,888 connection-churn + 27,757 malformed)
* **1,555 all-listener health probes** (216 per listener)
* **259 config mutations** through `PUT` and `POST`, all with successful read-back

Results:

* no wedge, no crash, no leak; all 8 listeners healthy at the end
* REST, FTP, DMA, Ident and config read-backs at **100%**; REST p50 ~46 ms
* Telnet stayed at **100%** as well (slower under load, p50 ~1 s)
* the oversized REST request now returns **HTTP 400** and the device stays reachable
* the only failure was **1 recoverable connect timeout** (see below)

## Remaining Load-Test Findings

The only failure during the patched soak was recoverable and load-induced. It was not fixed because doing so would require increasing resource limits, which may not be appropriate for the more constrained U2 cartridge variant. It caused no wedge, crash, or permanent loss of service.

### Rare self-clearing connect delay

One health probe recorded a single multi-second connect timeout (~8 s), and the next probe was immediate. This is finite TCP accept back-pressure, not a firmware lock-up:

* `httpd` is single-threaded and accepts one connection per loop
* the accept mailbox is 8 deep (`DEFAULT_ACCEPTMBOX_SIZE`)
* if a slow request holds the loop, a SYN can be dropped and retried by TCP, and the retry delay can be around 8 seconds
* the device keeps serving, the next probe is immediate, and the effect scales purely with the synthetic connect rate; a normal client does not reach this pattern

This was also tested by temporarily increasing the relevant limits:

* `MEMP_NUM_TCP_PCB`: 30 -> 64
* `MEMP_NUM_NETCONN`: 16 -> 32
* `MAX_HTTP_CLIENT`: 4 -> 8

Those changes did not remove the rare delay, so they were reverted instead of inflating resource pools on firmware that also ships for the U2.

### Telnet latency under extreme flood

Telnet is a lower-priority task by design: it yields to network services and 1541 emulation. Under a saturating HTTP flood it slows down (p50 around 1 s in this run) and, under heavier floods, its probe can exceed a 10 s client timeout. This is expected priority behaviour; Telnet recovers fully once the flood stops and never wedges.

## Related PR

https://github.com/GideonZ/MicroHttpServer/pull/5


