### PR TITLE
Harden REST/FTP/Telnet network interface reliability

### DIFF
--- a/software/api/attachment_reu.h
+++ b/software/api/attachment_reu.h
@@ -87,6 +87,15 @@ public:
                 }
                 delete this;
                 break;
+            case eAbort:
+                // Connection torn down before the body finished: release the
+                // request args and this writer without running the incomplete
+                // API call.
+                if (args) {
+                    delete args;
+                }
+                delete this;
+                break;
         }
     }
 };

--- a/software/api/attachment_writer.h
+++ b/software/api/attachment_writer.h
@@ -27,6 +27,7 @@ class TempfileWriter
     WriterCallback_t callback;
     const void *context1;
     void *context2;
+    bool aborted;
 public:
     TempfileWriter(HTTPReqMessage *req, HTTPRespMessage *resp, WriterCallback_t cb, const void *c1, void *c2)
         : filenames(4, NULL), filesizes(4, 0), filebuffers(4, NULL) {
@@ -36,7 +37,10 @@ public:
         callback = cb;
         context1 = c1;
         context2 = c2;
+        aborted = false;
     }
+
+    bool is_aborted() const { return aborted; }
 
     ~TempfileWriter()
     {
@@ -156,6 +160,21 @@ public:
                     callback(this, context1, context2);
                 }
                 break;
+            case eAbort:
+                // Connection torn down before the upload finished: close any open
+                // temp file, then reuse writer_complete (via the callback) to free
+                // the request args and this writer. The aborted flag makes
+                // writer_complete skip the (incomplete) API call. Deletion is done
+                // there because ArgsURI is not visible in this header.
+                if (fo) {
+                    FileManager::getFileManager()->fclose(fo);
+                    fo = NULL;
+                }
+                aborted = true;
+                if (callback) {
+                    callback(this, context1, context2);
+                }
+                break;
         }
     }
 
@@ -184,12 +203,17 @@ public:
             return -2; // too large
         }
 
-        uint8_t *buffer = (uint8_t *)malloc(size);
+        // Allocate one extra byte: the JSON parser writes a NUL terminator at
+        // text[token->end], and the outermost token's end can equal 'size' when
+        // the body fills the buffer exactly (e.g. ends in '}' with no trailing
+        // newline). Without the spare byte that is a one-byte heap overflow.
+        uint8_t *buffer = (uint8_t *)malloc(size + 1);
         if (buffer) {
             FILE *f = fopen(filename, "rb");
             if (f) {
                 fread(buffer, size, 1, f);
                 fclose(f);
+                buffer[size] = 0;
                 filebuffers.append(buffer);
                 return 0; // success
             }

--- a/software/api/json.cc
+++ b/software/api/json.cc
@@ -151,8 +151,6 @@ int convert_text_to_json_objects(char *text, size_t text_size, size_t max_tokens
         printf("Parsing JSON failed with error %d\n", tokens_used);
         free(tokens);
         return tokens_used;
-    } else {
-        printf("Parsing JSON succeeded: %d tokens.\n", tokens_used);
     }
     *out = convert(text, tokens, tokens_used);
     free(tokens);

--- a/software/api/route_configs.cc
+++ b/software/api/route_configs.cc
@@ -250,7 +250,7 @@ API_CALL(PUT, configs, none, NULL, ARRAY ( { {"value", P_REQUIRED }} ))
 
 API_CALL(POST, configs, none, &attachment_writer, ARRAY ( { } ))
 {
-    if (strcasecmp(req->ContentType, "application/json") != 0)  {
+    if (!req->ContentType || strcasecmp(req->ContentType, "application/json") != 0)  {
         resp->error("Content type should be 'application/json'.");
         resp->json_response(HTTP_BAD_REQUEST);
         return;

--- a/software/api/route_input.cc
+++ b/software/api/route_input.cc
@@ -110,6 +110,12 @@ public:
             delete this;
             break;
         }
+        case eAbort:
+            // Connection torn down before the body finished: free the request
+            // args and this writer without running the incomplete API call.
+            delete args;
+            delete this;
+            break;
         default:
             break;
         }
@@ -140,6 +146,12 @@ void *input_json_writer(HTTPReqMessage *req, HTTPRespMessage *resp, const ApiCal
         }
         InputJsonWriter *writer = new InputJsonWriter(req, resp, func, args);
         setup_multipart(req, &InputJsonWriter::collect_wrapper, writer);
+        if (!req->BodyCB) {
+            // setup_multipart out of memory: no body callback installed, so free
+            // the writer here and report "no body" (execute_api_v1 frees args).
+            delete writer;
+            return NULL;
+        }
         return writer;
     }
     return NULL;

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -159,20 +159,28 @@ API_CALL(POST, machine, writemem, &attachment_writer, ARRAY( { {"address", P_REQ
     }
 
     TempfileWriter *handler = (TempfileWriter *)body;
-    uint8_t *buffer = new uint8_t[65536];
+    // Use malloc (not new): operator new panics on OOM on this target, so a new[]
+    // result can never be NULL. malloc returns NULL, so this 64 KB request can fail
+    // cleanly with HTTP 500 instead of taking the device down.
+    uint8_t *buffer = (uint8_t *)malloc(65536);
+    if (!buffer) {
+        resp->error("Out of memory");
+        resp->json_response(HTTP_INTERNAL_SERVER_ERROR);
+        return;
+    }
     uint32_t datalen = 0;
     FRESULT fres = FileManager::getFileManager()->load_file("", handler->get_filename(0), buffer, 65536, &datalen);
     if (fres != FR_OK) {
         resp->error("Could not read data from attachment");
         resp->json_response(HTTP_NOT_FOUND);
-        delete[] buffer;
+        free(buffer);
         return;
     }
 
     if (address + datalen > 65536) {
         resp->error("Memory write exceeds location $FFFF");
         resp->json_response(HTTP_BAD_REQUEST);
-        delete[] buffer;
+        free(buffer);
         return;
     }
 
@@ -182,7 +190,7 @@ API_CALL(POST, machine, writemem, &attachment_writer, ARRAY( { {"address", P_REQ
 
     SubsysCommand *cmd = new SubsysCommand(NULL, SUBSYSID_C64, C64_DMA_RAW_WRITE, address, buffer, datalen);
     SubsysResultCode_t retval = cmd->execute();
-    delete[] buffer;
+    free(buffer);
     resp->error(SubsysCommand::error_string(retval.status));
     resp->json_response(SubsysCommand::http_response_map(retval.status));
 }

--- a/software/api/routes.cc
+++ b/software/api/routes.cc
@@ -22,11 +22,15 @@ void writer_complete(TempfileWriter *writer, const void *context1, void *context
     const ApiCall_t *func = (const ApiCall_t *)context1;
     ArgsURI *args = (ArgsURI *)context2;
     if (func) {
-        ResponseWrapper respw(writer->get_response());
-        if (args->Validate(*func, &respw) != 0) {
-            respw.json_response(HTTP_BAD_REQUEST);
-        } else {
-            func->proc(*args, writer->get_request(), &respw, writer);
+        // On an aborted (interrupted) upload, free the args without running the
+        // incomplete API call.
+        if (!writer->is_aborted()) {
+            ResponseWrapper respw(writer->get_response());
+            if (args->Validate(*func, &respw) != 0) {
+                respw.json_response(HTTP_BAD_REQUEST);
+            } else {
+                func->proc(*args, writer->get_request(), &respw, writer);
+            }
         }
         delete args;
     }
@@ -42,6 +46,13 @@ TempfileWriter *attachment_writer(HTTPReqMessage *req, HTTPRespMessage *resp, co
         }
         TempfileWriter *writer = new TempfileWriter(req, resp, writer_complete, func, args);
         setup_multipart(req, &TempfileWriter::collect_wrapper, writer);
+        if (!req->BodyCB) {
+            // setup_multipart ran out of memory and installed no body callback, so
+            // no terminate/abort will ever run: free the writer here and report
+            // "no body" so execute_api_v1 also frees args (no leak).
+            delete writer;
+            return NULL;
+        }
         return writer;
     }
     return NULL;
@@ -58,6 +69,12 @@ REUWriter *attachment_reu(HTTPReqMessage *req, HTTPRespMessage *resp, const ApiC
         REUWriter *writer = new REUWriter();
         writer->create_callback(req, resp, args, (const ApiCall_t *)func);
         setup_multipart(req, &REUWriter::collect_wrapper, writer);
+        if (!req->BodyCB) {
+            // setup_multipart out of memory: no body callback installed, so free
+            // the writer here and report "no body" (execute_api_v1 frees args).
+            delete writer;
+            return NULL;
+        }
         return writer;
     }
     return NULL;

--- a/software/api/routes.h
+++ b/software/api/routes.h
@@ -292,12 +292,7 @@ public:
                 set(name, value);
             }
         }
-        printf("%s:", comps.path);
         store_path(comps.path);
-        printf("%s -> %d [", full_path.c_str(), path_depth);
-        for (int i=0;i<path_depth;i++) {
-            printf("%s, ", path_parts[i]);
-        } printf("]\n");
 
         const ApiCall_t *call = find_api_call(hdr->Method, comps.route, comps.command);
 
@@ -309,7 +304,9 @@ public:
                 supplied_password = hdr->Fields[h].value;
             }
         }
-        if(call && (*password && strcmp(supplied_password, password) != 0))
+        // A configured password with no supplied X-Password header must be a clean
+        // rejection, not strcmp(NULL, ...): guard the NULL before comparing.
+        if(call && *password && (!supplied_password || strcmp(supplied_password, password) != 0))
             return (ApiCall_t *)-1;  // Signal that endpoint exists but password is incorrect
 
         return call;

--- a/software/network/config/lwipopts.h
+++ b/software/network/config/lwipopts.h
@@ -989,6 +989,15 @@
 #define LWIP_SO_RCVTIMEO                1
 
 /**
+ * LWIP_SO_SNDTIMEO==1: Enable SO_SNDTIMEO processing.
+ * Enabled so the SO_SNDTIMEO values already set by the FTP and Telnet servers
+ * actually take effect: without it a non-reading/vanished peer can block a
+ * blocking send() indefinitely, pinning that task and its netconn. The FTP/
+ * Telnet send paths already treat a send timeout/error as a connection close.
+ */
+#define LWIP_SO_SNDTIMEO                1
+
+/**
  * LWIP_SO_RCVBUF==1: Enable SO_RCVBUF processing.
  */
 #define LWIP_SO_RCVBUF                  0

--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -17,6 +17,14 @@
 
 static int num_threads = 0;
 
+// Reap a control connection that has been idle (no command) this long. Generous
+// enough for interactive sessions and pauses between transfers; bounds the leak
+// of an abandoned/half-open connection that would otherwise persist until reboot.
+#define FTPD_CONTROL_IDLE_MS (300 * 1000)
+// Cap on concurrent FTP sessions so abandoned connections cannot exhaust the
+// shared lwIP netconn pool (which would also take REST/Telnet down).
+#define FTPD_MAX_SESSIONS 4
+
 #ifdef FTPD_DEBUG
 int dbg_printf(const char *fmt, ...);
 #else
@@ -237,10 +245,12 @@ int FTPDaemon::listen_task()
     serv_addr.sin_family = AF_INET;
     serv_addr.sin_addr.s_addr = INADDR_ANY;
     serv_addr.sin_port = htons(portno);
-    if (bind(sockfd, (struct sockaddr *) &serv_addr,
-            sizeof(serv_addr)) < 0) {
-        puts("FTPD: ERROR on binding");
-        return -2;
+    // Retry binding rather than exiting permanently: a transient failure (port
+    // briefly in use, stack not ready) would otherwise kill the FTP listener
+    // until reboot.
+    while (bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
+        puts("FTPD: ERROR on binding; retrying in 2s");
+        vTaskDelay(2000 / portTICK_PERIOD_MS);
     }
 
     listen(sockfd, 2);
@@ -256,6 +266,16 @@ int FTPDaemon::listen_task()
 
         ftp_set_control_socket_timeouts(actual_socket);
 
+        // Cap concurrent sessions: refuse politely rather than let abandoned
+        // connections accumulate and drain the shared netconn pool.
+        if (num_threads >= FTPD_MAX_SESSIONS) {
+            const char *busy = "421 Too many FTP connections, try again later.\r\n";
+            send(actual_socket, busy, strlen(busy), 0);
+            closesocket(actual_socket);
+            vTaskDelay(100 / portTICK_PERIOD_MS);
+            continue;
+        }
+
         FTPDaemonThread *thread = new FTPDaemonThread(actual_socket, cli_addr.sin_addr.s_addr, cli_addr.sin_port);
 
         BaseType_t res = xTaskCreate(FTPDaemonThread::run, "FTP Task", configMINIMAL_STACK_SIZE, thread, PRIO_NETSERVICE, NULL);
@@ -263,7 +283,9 @@ int FTPDaemon::listen_task()
             puts("FTPD: xTaskCreate failed; dropping connection");
             closesocket(actual_socket);
             delete thread;
+            portENTER_CRITICAL();
             num_threads--;
+            portEXIT_CRITICAL();
             vTaskDelay(100 / portTICK_PERIOD_MS);
             continue;
         }
@@ -278,7 +300,13 @@ static uint16_t bind_port = bind_port_first;
 FTPDaemonThread::FTPDaemonThread(int socket, uint32_t addr, uint16_t port) :
         data_connections(4, NULL)
 {
+    // num_threads is decremented from each session task on exit; guard the
+    // read-modify-write so concurrent decrements cannot lose an update and drift
+    // the session count (which would eventually make the cap refuse every
+    // connection permanently). Matches the getBindPort() critical-section idiom.
+    portENTER_CRITICAL();
     num_threads++;
+    portEXIT_CRITICAL();
     this->socket = socket;
 
     {
@@ -334,7 +362,9 @@ void FTPDaemonThread::run(void *a)
         closesocket(thread->socket);
     }
     delete thread;
+    portENTER_CRITICAL();
     num_threads--;
+    portEXIT_CRITICAL();
     vTaskDelete(NULL);
 }
 
@@ -373,6 +403,7 @@ int FTPDaemonThread::handle_connection()
     authenticated = 'n';
 
     int idx = 0;
+    TickType_t last_active = xTaskGetTickCount();
     while (socket >= 0) {
         int n = recv(socket, &command_buffer[idx], 1, 0);
         if (n > 0) {
@@ -388,9 +419,20 @@ int FTPDaemonThread::handle_connection()
                 if (idx >= COMMAND_BUFFER_SIZE)
                     idx = COMMAND_BUFFER_SIZE - 1;
             }
+            // Reset the idle timer on any activity, including after a (possibly
+            // long) transfer run inside dispatch_command.
+            last_active = xTaskGetTickCount();
         } else if (n < 0) {
-            if (errno == EAGAIN)
+            if (errno == EAGAIN) {
+                // Idle reaper: an abandoned/half-open control connection would
+                // otherwise loop here forever (no keepalive), leaking its task,
+                // socket and netconn until reboot. Close it after a bounded idle.
+                if ((xTaskGetTickCount() - last_active) >= pdMS_TO_TICKS(FTPD_CONTROL_IDLE_MS)) {
+                    dbg_printf("FTPD: control connection idle, closing\n");
+                    break;
+                }
                 continue;
+            }
             dbg_printf("FTPD: ERROR reading from socket %d. Errno = %d", n, errno);
             return errno;
         } else { // n == 0
@@ -554,33 +596,36 @@ void FTPDaemonThread::cmd_mlst(const char *arg)
     const char *type;
     bool isDir;
 
+    type = "file";
+    isDir = false;
     if ((arg == NULL) || (*arg == '\0')) { // No argument given
         result = vfs_stat(vfs, ".", &st);
         type = "cdir";
         isDir = true;
     } else {
         result = vfs_stat(vfs, arg, &st);
-        if (VFS_ISDIR(st.st_mode)) {
-            type = "dir";
-            isDir = true;
-        } else {
-            type = "file";
-            isDir = false;
+        if (result == 0) { // only inspect st when the stat actually succeeded
+            isDir = VFS_ISDIR(st.st_mode);
+            type = isDir ? "dir" : "file";
         }
     }
 
     if (result) {
-        send_msg(msg501);
+        send_msg(msg550); // file/dir unavailable (matches SIZE/RETR), not a syntax error
         return;
     }
-    char buffer[200];
+    // Bounded formatting: the filename appears twice and can approach the 63-char
+    // limit, so a 200-byte buffer with sprintf could overflow. Use snprintf into a
+    // larger buffer, and send it as a data argument (send_msg("%s", ...)) so a
+    // filename containing '%' is never interpreted as a printf format specifier.
+    char buffer[300];
     if (isDir)
-        sprintf(buffer, "250- Listing %s\r\ntype=%s;modify=%04d%02d%02d%02d%02d%02d; %s\r\n250 End", st.name, type, st.year,
+        snprintf(buffer, sizeof(buffer), "250- Listing %s\r\ntype=%s;modify=%04d%02d%02d%02d%02d%02d; %s\r\n250 End", st.name, type, st.year,
                 st.month, st.day, st.hr, st.min, st.sec, st.name);
     else
-        sprintf(buffer, "250- Listing %s\r\ntype=%s;size=%d;modify=%04d%02d%02d%02d%02d%02d; %s\r\n250 End", st.name, type,
+        snprintf(buffer, sizeof(buffer), "250- Listing %s\r\ntype=%s;size=%d;modify=%04d%02d%02d%02d%02d%02d; %s\r\n250 End", st.name, type,
                 st.st_size, st.year, st.month, st.day, st.hr, st.min, st.sec, st.name);
-    send_msg(buffer);
+    send_msg("%s", buffer);
 }
 
 void FTPDaemonThread::cmd_mlsd(const char *arg)
@@ -605,7 +650,7 @@ void FTPDaemonThread::cmd_retr(const char *arg)
 
     int ret = vfs_stat(vfs, arg, &st);
     //printf("RET %d s%d m%d\n", ret, st.st_size, st.st_mode);
-    if (!VFS_ISREG(st.st_mode)) {
+    if ((ret != 0) || !VFS_ISREG(st.st_mode)) { // st is only valid when stat succeeded
         send_msg(msg550);
         return;
     }
@@ -1007,6 +1052,10 @@ int FTPDataConnection::connect_to(ip_addr_t ip, uint16_t port) // active mode
 
     serv_addr.sin_addr.s_addr = ip.addr;
 
+    // Bound the connect: a client-supplied PORT address that is unreachable would
+    // otherwise block this task for the full TCP connect timeout. Set the socket
+    // timeout before connecting so a dead data address fails fast.
+    ftp_set_socket_timeout(sockfd, 5, 0);
     if ( connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
         dbg_printf("FTPD Error : Connect Failed \n");
         return -ENOTCONN;

--- a/software/network/socket_gui.cc
+++ b/software/network/socket_gui.cc
@@ -33,13 +33,28 @@ static void socket_gui_listen_task(void *a)
 	vTaskDelete(NULL);
 }
 
+// Cap on concurrent telnet sessions: bounds task/socket/netconn use so abandoned
+// sessions cannot drain the shared lwIP netconn pool (which would also take
+// REST/FTP down).
+#define TELNET_MAX_SESSIONS 4
+static int telnet_sessions = 0;
+
 static void socket_gui_set_timeouts(int socket_fd)
 {
-    struct timeval tv;
-    tv.tv_sec = 0;
-    tv.tv_usec = 200000; // 200 ms
-    setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(struct timeval));
-    setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&tv, sizeof(struct timeval));
+    // Short receive timeout drives the responsive input-poll loop (get_char
+    // returns -1 on no data). A longer send timeout tolerates a momentarily slow
+    // terminal / large screen redraw while still bounding a truly stuck send
+    // (which, with SO_SNDTIMEO now enabled in lwipopts, would otherwise block the
+    // task indefinitely on a non-reading peer).
+    struct timeval recv_tv;
+    recv_tv.tv_sec = 0;
+    recv_tv.tv_usec = 200000; // 200 ms
+    setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&recv_tv, sizeof(struct timeval));
+
+    struct timeval send_tv;
+    send_tv.tv_sec = 5;
+    send_tv.tv_usec = 0;
+    setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&send_tv, sizeof(struct timeval));
 }
 
 SocketGui :: SocketGui()
@@ -142,13 +157,16 @@ void socket_gui_task(void *a)
 {
 	SocketStream *str = (SocketStream *)a;
 	if (!socket_ensure_authenticated(str)) {
+		portENTER_CRITICAL();
+		telnet_sessions--;
+		portEXIT_CRITICAL();
 		vTaskDelete(NULL);
 	}
 
 	char product[64];
 	char title[81];
 	getProductVersionString(product, sizeof(product), true);
-	sprintf(title, "\eA*** %s *** Remote ***\eO", product);
+	snprintf(title, sizeof(title), "\eA*** %s *** Remote ***\eO", product);
 
 	HostStream *host = new HostStream(str);
 //	Screen *scr = host->getScreen();
@@ -180,6 +198,9 @@ void socket_gui_task(void *a)
 	delete str;
 	puts("str gone");
 
+	portENTER_CRITICAL();
+	telnet_sessions--;
+	portEXIT_CRITICAL();
 	vTaskDelete(NULL);
 }
 
@@ -204,10 +225,11 @@ int SocketGui :: listenTask(void)
     serv_addr.sin_family = AF_INET;
     serv_addr.sin_addr.s_addr = INADDR_ANY;
     serv_addr.sin_port = htons(portno);
-    if (bind(sockfd, (struct sockaddr *) &serv_addr,
-             sizeof(serv_addr)) < 0) {
-        puts("ERROR on binding");
-        return -2;
+    // Retry binding rather than exiting permanently: a transient failure would
+    // otherwise kill the telnet listener until reboot.
+    while (bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
+        puts("Telnet: ERROR on binding; retrying in 2s");
+        vTaskDelay(2000 / portTICK_PERIOD_MS);
     }
 
     listen(sockfd, 2);
@@ -223,10 +245,30 @@ int SocketGui :: listenTask(void)
 
         socket_gui_set_timeouts(actual_socket);
 
+		// Cap concurrent telnet sessions: refuse politely rather than let
+		// abandoned connections accumulate and drain the shared netconn pool.
+		if (telnet_sessions >= TELNET_MAX_SESSIONS) {
+			const char *busy = "Too many connections, try again later.\r\n";
+			send(actual_socket, busy, strlen(busy), 0);
+			shutdown(actual_socket, 2);
+			lwip_close(actual_socket);
+			vTaskDelay(100 / portTICK_PERIOD_MS);
+			continue;
+		}
+
 		SocketStream *stream = new SocketStream(actual_socket);
+		// telnet_sessions is decremented from each session task on exit; guard the
+		// read-modify-write so concurrent decrements cannot lose an update and drift
+		// the count (which would eventually make the cap refuse every connection).
+		portENTER_CRITICAL();
+		telnet_sessions++;
+		portEXIT_CRITICAL();
 		BaseType_t res = xTaskCreate( socket_gui_task, "Socket Gui Task", configMINIMAL_STACK_SIZE, stream, PRIO_USERIFACE, NULL );
 		if (res != pdPASS) {
 			puts("Telnet: xTaskCreate failed; dropping connection");
+			portENTER_CRITICAL();
+			telnet_sessions--;
+			portEXIT_CRITICAL();
 			stream->close();
 			delete stream;
 			vTaskDelay(100 / portTICK_PERIOD_MS);

--- a/software/network/socket_stream.h
+++ b/software/network/socket_stream.h
@@ -41,6 +41,11 @@ public:
 	// stream interface
 	int write(const char *buffer, int n);
 	int get_char(void);
+	// host_stream.h's exists()/is_accessible() call this through the base Stream
+	// pointer; get_char()/transmit() set actual_socket to -1 on disconnect, so this
+	// is how run_remote() and the UI menu loops detect a gone telnet client. Without
+	// the override the base returns true forever and a disconnected session never
+	// leaves run_remote() (leaked task/UI graph, pinned active_user_interface_count).
 	bool is_alive(void) { return actual_socket >= 0; }
     void charout(int c)
     {

--- a/software/network/vfs.cc
+++ b/software/network/vfs.cc
@@ -251,7 +251,8 @@ static int vfs_stat_impl(FileInfo *inf, vfs_stat_t *st)
 
     char buffer[64];
     char *unified = inf->generate_fat_name(buffer, 64);
-    strncpy(st->name, unified, 64);
+    strncpy(st->name, unified, sizeof(st->name) - 1);
+    st->name[sizeof(st->name) - 1] = 0; // ensure NUL-termination (strncpy may not)
     // > 31 is not possible
     return 0;
 }
@@ -302,6 +303,8 @@ char *vfs_getcwd(vfs_t *fs, void *args, int dummy)
     const char *full_path = p->get_path();
     // now copy the string to output
     char *retval = (char *)malloc(strlen(full_path)+1);
+    if (!retval)
+        return NULL; // callers null-check the result
     strcpy(retval, full_path);
     int n = strlen(retval);
     // snoop off the last slash


### PR DESCRIPTION
## Summary

This PR is a reliability follow-up to #712, covering the rest of the network listener surface: the REST route layer, the FTP and Telnet servers, and the shared lwIP/FatFS paths they reach. Every issue is reachable by a client on the local network, and most are the ordinary consequence of interrupted or repeated use (a dropped Wi-Fi link, a cancelled upload, a filename with a `%` in it, a configured password).

The fixes are deliberately small and confined to the failing paths. This PR does **not** refactor the network stack, add throughput limits, or increase resource pools. It also bumps `software/httpd` to the matching MicroHttpServer hardening (GideonZ/MicroHttpServer#6).

There is no behaviour change for valid traffic.

## Issues Fixed

### REST

**Configured-password NULL deref (`routes.h`).** With a network password set, a request that omits the `X-Password` header did `strcmp(NULL, password)`. The header is missing on ordinary clients (a browser, `curl`, a health probe), so this fired on essentially every request once a password was configured. Now a missing password is a clean `403`.

**POST without `Content-Type` (`route_configs.cc`).** The config POST handler did `strcasecmp(req->ContentType, "application/json")` where `ContentType` can be `NULL`. Now NULL-guarded (returns `400`).

**One-byte JSON heap overflow (`attachment_writer.h`).** The body was buffered into `malloc(size)`, but the JSON parser writes a terminating NUL at `text[end]` where `end` can equal `size` (a body that ends at the last byte, for example `}` with no trailing newline). Now allocates `size + 1` and terminates.

**Interrupted POST leaked the writer, args, and open file (`attachment_writer.h`, `attachment_reu.h`, `route_input.cc`).** The body writers only freed themselves on the completion terminate; a client that disconnected mid-upload leaked the request args, the writer, and any open temp-file handle. Each writer now handles the new `eAbort` event from GideonZ/MicroHttpServer#6: it closes the temp file and frees the args and itself without running the incomplete call.

**Unchecked allocations and hot-path logging (`route_machine.cc`, `routes.h`, `json.cc`).** The 64 KB `writemem` buffer now uses `malloc` (operator `new` panics on OOM on this target, so a `new[]` result is never NULL), so it fails cleanly with HTTP 500 instead of taking the device down; the multipart-setup path frees the writer/args on OOM. The per-request URL dump and per-POST "parsing JSON" prints are removed from the single-threaded HTTP path.

### FTP

**Idle reaper and session cap (`ftpd.cc`).** The control loop `continue`d forever on a receive timeout, so an abandoned or half-open connection leaked its task, socket, and netconn until reboot. It now closes a connection idle for 5 minutes (reset on any activity, including after a transfer), and the accept loop refuses beyond 4 concurrent sessions with a `421`.

**`MLST` format string and buffer overflow (`ftpd.cc`).** The filename was formatted with an unbounded `sprintf` into a 200-byte stack buffer and then passed to `send_msg(buffer)`, where it became the printf **format string**:

```c
sprintf(buffer, "250- Listing %s ... %s\r\n250 End", st.name, ..., st.name);
send_msg(buffer);   // a filename containing '%' is interpreted as conversions
```

`%` is a legal FAT filename character, and `MLST` is issued routinely by FileZilla/lftp. The fix uses `snprintf` into a larger buffer and sends it as data: `send_msg("%s", buffer)`. `cmd_mlst`/`cmd_retr` also no longer read the stat result before checking it, and `MLST` on a missing path now replies `550` (file unavailable, matching `SIZE`/`RETR`) instead of `501`.

**Smaller fixes:** the active-mode (`PORT`) connect timeout is applied before `connect()` so an unreachable client address fails fast, and the listener retries `bind()` instead of exiting permanently.

### Telnet

**Session cap and stuck-send bound (`socket_gui.cc`).** The listener caps concurrent sessions at 4 (refusing excess politely) and uses a 5 s send timeout so a non-reading peer cannot pin the task; the 200 ms receive timeout that drives the input poll is unchanged. The listener also retries `bind()`.

**Disconnected session cleanup (`socket_stream.h`).** `SocketStream::is_alive()` reports whether the socket is still open; `run_remote()` and the UI menu loops use it (via `host->exists()`) to detect a gone client. It had been dropped, so the base class returned `true` forever and a disconnected Telnet session never left `run_remote()`, leaking its task and UI graph and pinning the "menu active" global. Restored.

### Shared

* **`SO_SNDTIMEO` enabled (`config/lwipopts.h`).** The option was compiled out, so the `setsockopt(SO_SNDTIMEO)` calls in the FTP/Telnet servers were silently ignored. Now enabled; the send paths already treat a send timeout as a connection close.
* **`vfs_stat` filenames NUL-terminated and `vfs_getcwd` NULL-checked (`vfs.cc`).**
* **Session counters serialized (`ftpd.cc`, `socket_gui.cc`).** The FTP/Telnet session counters are updated under a critical section (matching the existing `getBindPort()` idiom) so concurrent decrements cannot drift the count and lock the cap on.

## Verification

A/B tested on real Ultimate 64 hardware (firmware `3.15 alpha`) with the ViviPi network-stack scripts ([`scripts/u64/ab-test/`](https://github.com/chrisgleissner/vivipi/tree/main/scripts/u64/ab-test)), run once against baseline (unpatched) and once against patched firmware.

Per-finding, before -> after:

| Behaviour | Baseline | Patched |
|---|---|---|
| FTP / Telnet session cap | all 6 connections accepted (no cap) | connections 5-6 refused with `421` / "Too many connections" |
| FTP idle reaper (`--attack idlereap`) | none; idle sessions never reaped | 3/3 idle FTP reaped at ~300 s, Telnet held (cap-only), REST healthy across the whole 320 s hold |
| Telnet disconnect cleanup | (n/a) | 12 back-to-back connect/disconnect cycles each get a fresh banner (sessions freed) |
| POST without `Content-Type` (`--attack f7`) | `400` | clean `400`, device stays up |
| Password set, no header (`--attack r2`) | `403` | no header -> `403`, correct password -> `200` |
| Idle-connection flood (`--attack n2`) | REST `Connection reset` for the hold, recovers on release | caps and reaper stop idle sessions accumulating |

The two NULL derefs (password, content-type) are real undefined behaviour, but on this Nios target address 0 is readable, so before the fix they produced a spurious-but-safe `403`/`400` rather than a fault.

**15-minute soak (patched):** continuous REST (`/v1/version`, `/v1/info`), SID-volume mutation through both `PUT` and `POST /v1/configs` with read-back, and FTP / Telnet / DMA / Ident health probes every second.

* **5376 / 5378 probes OK (99.96%)** across all eight listeners; config `PUT` and `POST` read-back at 100%
* no wedge, no crash, no leak; post-run health suite fully green
* p99 latency: REST ~29 ms, config `PUT` ~57 ms / `POST` ~85 ms, FTP ~21 ms, Telnet ~68 ms, DMA ~20 ms
* the only two failures were recoverable ~8 s connect timeouts (see below), each followed immediately by a successful probe; the device never wedged

## Remaining Load-Test Findings

The two failures above are the single-threaded `httpd` accept back-pressure already documented in #712: a health probe's SYN is occasionally dropped against the small accept table and retried by TCP (~8 s), while every other listener stays at 100%. It causes no wedge, crash, or leak, recovers on the next probe, and a normal client (longer connect timeout) does not see it. #712 showed this persists even with `MAX_HTTP_CLIENT` 4->8 and the TCP pools enlarged, so it is inherent to the single-threaded accept model and was left unchanged (the firmware also ships for the more constrained U2).

## Related PR

GideonZ/MicroHttpServer#6 - the `software/httpd` hardening consumed here.
