### PR TITLE
Harden virtual printer page scanning and PNG allocation

### DIFF
--- a/software/io/printer/mps_printer.cc
+++ b/software/io/printer/mps_printer.cc
@@ -765,27 +765,28 @@ MpsPrinter::calcPageNum(void)
         for(int i=0;i<infos->get_elements();i++)
         {
             FileInfo *inf = (*infos)[i];
+            const char *suffix = inf->lfname + baselength;
 
-            if (!strncmp(basename, inf->lfname, baselength))
+            if (!(inf->attrib & AM_DIR) && !strncmp(basename, inf->lfname, baselength))
             {
                 /* Basename matches, then look if rest of filename is -XXX.png */
-                if (inf->lfname[baselength] != '-') goto next_file;
-                if (inf->lfname[baselength+1] < '0') goto next_file;
-                if (inf->lfname[baselength+1] > '9') goto next_file;
-                if (inf->lfname[baselength+2] < '0') goto next_file;
-                if (inf->lfname[baselength+2] > '9') goto next_file;
-                if (inf->lfname[baselength+3] < '0') goto next_file;
-                if (inf->lfname[baselength+3] > '9') goto next_file;
-                if (inf->lfname[baselength+4] != '.') goto next_file;
-                if (inf->lfname[baselength+5] != 'p') goto next_file;
-                if (inf->lfname[baselength+6] != 'n') goto next_file;
-                if (inf->lfname[baselength+7] != 'g') goto next_file;
-                if (inf->lfname[baselength+8] != '\0') goto next_file;
+                if (suffix[0] != '-') goto next_file;
+                if (suffix[1] < '0') goto next_file;
+                if (suffix[1] > '9') goto next_file;
+                if (suffix[2] < '0') goto next_file;
+                if (suffix[2] > '9') goto next_file;
+                if (suffix[3] < '0') goto next_file;
+                if (suffix[3] > '9') goto next_file;
+                if (suffix[4] != '.') goto next_file;
+                if (suffix[5] != 'p') goto next_file;
+                if (suffix[6] != 'n') goto next_file;
+                if (suffix[7] != 'g') goto next_file;
+                if (suffix[8] != '\0') goto next_file;
 
                 /* If we are here, it maches, get the number */
-                int number = (inf->lfname[baselength+1] - '0') * 100 +
-                             (inf->lfname[baselength+2] - '0') * 10 +
-                             (inf->lfname[baselength+3] - '0');
+                int number = (suffix[1] - '0') * 100 +
+                             (suffix[2] - '0') * 10 +
+                             (suffix[3] - '0');
 
                 if (number >= page_num) page_num = number+1;
             }

--- a/software/io/printer/mps_printer.cc
+++ b/software/io/printer/mps_printer.cc
@@ -739,7 +739,7 @@ MpsPrinter::calcPageNum(void)
     for (int i=0; dirname[i]; i++)
         if (dirname[i] == '/') last_slash = &dirname[i];
 
-    if (dirname)
+    if (last_slash)
     {
         *last_slash = '\0';
         basename = last_slash + 1;
@@ -748,7 +748,7 @@ MpsPrinter::calcPageNum(void)
     {
         /* No '/', set dirname to current '.' dir (legal in ultimate ?) */
         dirname[0] = '.';
-        dirname[0] = '\0';
+        dirname[1] = '\0';
         basename = outfile;
     }
 
@@ -769,18 +769,18 @@ MpsPrinter::calcPageNum(void)
             if (!strncmp(basename, inf->lfname, baselength))
             {
                 /* Basename matches, then look if rest of filename is -XXX.png */
-                if (inf->lfname[baselength] != '-') continue;
-                if (inf->lfname[baselength+1] < '0') continue;
-                if (inf->lfname[baselength+1] > '9') continue;
-                if (inf->lfname[baselength+2] < '0') continue;
-                if (inf->lfname[baselength+2] > '9') continue;
-                if (inf->lfname[baselength+3] < '0') continue;
-                if (inf->lfname[baselength+3] > '9') continue;
-                if (inf->lfname[baselength+4] != '.') continue;
-                if (inf->lfname[baselength+5] != 'p') continue;
-                if (inf->lfname[baselength+6] != 'n') continue;
-                if (inf->lfname[baselength+7] != 'g') continue;
-                if (inf->lfname[baselength+8] != '\0') continue;
+                if (inf->lfname[baselength] != '-') goto next_file;
+                if (inf->lfname[baselength+1] < '0') goto next_file;
+                if (inf->lfname[baselength+1] > '9') goto next_file;
+                if (inf->lfname[baselength+2] < '0') goto next_file;
+                if (inf->lfname[baselength+2] > '9') goto next_file;
+                if (inf->lfname[baselength+3] < '0') goto next_file;
+                if (inf->lfname[baselength+3] > '9') goto next_file;
+                if (inf->lfname[baselength+4] != '.') goto next_file;
+                if (inf->lfname[baselength+5] != 'p') goto next_file;
+                if (inf->lfname[baselength+6] != 'n') goto next_file;
+                if (inf->lfname[baselength+7] != 'g') goto next_file;
+                if (inf->lfname[baselength+8] != '\0') goto next_file;
 
                 /* If we are here, it maches, get the number */
                 int number = (inf->lfname[baselength+1] - '0') * 100 +
@@ -790,6 +790,7 @@ MpsPrinter::calcPageNum(void)
                 if (number >= page_num) page_num = number+1;
             }
 
+next_file:
             delete inf; // FileInfo not needed anymore
         }
 

--- a/software/system/memory_wrap.cc
+++ b/software/system/memory_wrap.cc
@@ -3,11 +3,35 @@
 #include <stdio.h>
 #include <string.h>
 
+/* Keep allocation sizes in our own header. heap_4's private header changes
+ * size with the target alignment and must not be inspected here. */
+static const size_t malloc_header_size =
+    (sizeof(size_t) + portBYTE_ALIGNMENT - 1) & ~portBYTE_ALIGNMENT_MASK;
+
+static void *malloc_allocate(size_t size)
+{
+    if (!size || size > (size_t)-1 - malloc_header_size)
+        return NULL;
+
+    uint8_t *mem = (uint8_t *)pvPortMalloc(size + malloc_header_size);
+    if (!mem)
+        return NULL;
+
+    *((size_t *)mem) = size;
+    return mem + malloc_header_size;
+}
+
+static void malloc_release(void *ptr)
+{
+    if (ptr)
+        vPortFree((uint8_t *)ptr - malloc_header_size);
+}
+
 void * get_mem(size_t size) 
 {
     //printf("New operator for size = %d, returned: \n", size);
     void *ret;
-	ret = pvPortMalloc(size);
+	ret = pvPortMalloc(size ? size : 1);
 
 	if (!ret) {
         printf("** PANIC **: Error allocating %p..\n", __builtin_return_address(0));
@@ -50,28 +74,30 @@ extern "C" void  __cxa_atexit()
 extern "C" {
     // Standard version
     void* __wrap_malloc(size_t size) {
-        return get_mem(size);
+        return malloc_allocate(size);
     }
 
     // Newlib reentrant version
     void* __wrap__malloc_r(struct _reent *r, size_t size) {
         (void)r; // We ignore Newlib's reentrancy struct because FreeRTOS handles it
-        return get_mem(size);
+        return malloc_allocate(size);
     }
 
     // Do the same for free / _free_r
     void __wrap_free(void* ptr) {
-        vPortFree(ptr);
+        malloc_release(ptr);
     }
 
     void __wrap__free_r(struct _reent *r, void* ptr) {
         (void)r;
-        vPortFree(ptr);
+        malloc_release(ptr);
     }
 
     void *__wrap_calloc(size_t nmemb, size_t size) {
+        if (nmemb && size > (size_t)-1 / nmemb)
+            return NULL;
         size_t actual = nmemb * size;
-        void *mem = get_mem(actual);
+        void *mem = malloc_allocate(actual);
         if (mem) {
             memset(mem, 0, actual);
         }
@@ -80,8 +106,10 @@ extern "C" {
 
     void *__wrap__calloc_r(struct _reent *r, size_t nmemb, size_t size) {
         (void)r; // We ignore Newlib's reentrancy struct because FreeRTOS handles it
+        if (nmemb && size > (size_t)-1 / nmemb)
+            return NULL;
         size_t actual = nmemb * size;
-        void *mem = get_mem(actual);
+        void *mem = malloc_allocate(actual);
         if (mem) {
             memset(mem, 0, actual);
         }
@@ -94,20 +122,21 @@ extern "C" {
         // FreeRTOS doesn't have a native realloc,
         // so we manually handle the logic to stay safe.
         if (ptr == NULL)
-            return (size ? pvPortMalloc(size) : NULL);
+            return malloc_allocate(size);
 
         if (size == 0) {
-            vPortFree(ptr);
+            malloc_release(ptr);
             return NULL;
         }
 
-        // heap_4: block size (incl. header, with the top "allocated" bit) sits at ptr-4
-        size_t hdr = ((size_t *)ptr)[-1] & ~((size_t)1 << 31);
-        size_t old_usable = hdr - 8 /* xHeapStructSize */;
+        size_t old_size = *((size_t *)((uint8_t *)ptr - malloc_header_size));
 
-        void *nw = pvPortMalloc(size);
-        memcpy(nw, ptr, (old_usable < size) ? old_usable : size);
-        vPortFree(ptr);
+        void *nw = malloc_allocate(size);
+        if (!nw)
+            return NULL;
+
+        memcpy(nw, ptr, (old_size < size) ? old_size : size);
+        malloc_release(ptr);
         return nw;
     }
 

--- a/tools/io/printer/Makefile
+++ b/tools/io/printer/Makefile
@@ -1,0 +1,26 @@
+# Build/check the virtual-printer E2E harness.
+#
+# The PRG is normally assembled on the fly by printer-e2e.py; this Makefile
+# exists for standalone syntax-checking and for producing a PRG you can load
+# by hand (e.g. via the Ultimate file browser) while debugging.
+
+ASSEMBLER ?= 64tass
+ASM_SRC    = printer-e2e.asm
+PRG_OUT    = printer-e2e.prg
+
+.PHONY: all assemble check clean
+
+all: assemble
+
+assemble: $(PRG_OUT)
+
+$(PRG_OUT): $(ASM_SRC)
+	$(ASSEMBLER) -q -o $(PRG_OUT) $(ASM_SRC)
+
+check: assemble
+	python3 -m py_compile printer-e2e.py verify-printer-output.py
+	@echo "printer-e2e.asm assembled and Python sources compiled cleanly"
+
+clean:
+	rm -f $(PRG_OUT) *.pyc
+	rm -rf __pycache__

--- a/tools/io/printer/README.md
+++ b/tools/io/printer/README.md
@@ -114,6 +114,17 @@ page number (`...-008.png`, `...-009.png`), and fails if page numbering is
 thrown off by the directory collision or if the overflow path wedges the
 machine.
 
+## Exact issue #717 workload shape
+
+```sh
+./printer-e2e.py -H u64 --preset issue-717-basic --output-base /Usb0/printer \
+    --output-type "PNG B&W" --page-top-margin 1 --page-height 66 --verify-output
+```
+
+The harness tokenizes and runs the reporter's BASIC program verbatim as BASIC
+V2. It expects one PNG page for that exact program at the reported 66-line
+page height.
+
 ## Running the full required matrix
 
 ```sh

--- a/tools/io/printer/README.md
+++ b/tools/io/printer/README.md
@@ -91,6 +91,29 @@ If your unit has no USB stick mounted, point `--output-base` at a path under
 a filesystem that does exist instead, e.g. `/Temp/printer/e2e-smoke` — the
 harness creates the `printer` directory over FTP if it isn't there yet.
 
+## Forcing the issue #717 scan/overflow shape
+
+```sh
+./printer-e2e.py -H u64 --preset issue-717-overflow
+```
+
+This preset forces the two conditions the original branch did **not** verify
+together:
+
+- the `Output file` base is a unique `/Temp/printer-*` prefix, so
+  `calcPageNum()` scans a parent directory that also contains a sibling entry
+  with that exact basename as a directory
+- the harness pre-seeds colliding prefix entries (`printer/`,
+  `printer-old.png`, `printer-7.png`, `printer-abc.png`, `printer-123.txt`)
+  plus a real `printer-007.png`, then sends one continuous bitmap print long
+  enough to overflow naturally onto a second page before the final
+  Flush/Eject
+
+Verification therefore expects **two** new PNGs starting at the seeded next
+page number (`...-008.png`, `...-009.png`), and fails if page numbering is
+thrown off by the directory collision or if the overflow path wedges the
+machine.
+
 ## Running the full required matrix
 
 ```sh
@@ -114,6 +137,13 @@ never gets misread as another's output.
 truncates beyond 31 characters (`CFG_PRINTER_FILENAME` in `iec_printer.cc`).
 The harness raises an explicit error if a computed path would exceed that,
 rather than let verification fail confusingly against a truncated filename.
+
+**Natural overflow verification**: `--verify-output` normally expects the same
+number of PNGs as `--pages`, because each requested page is explicitly ejected
+by the harness. For a single continuous job that *naturally* overruns onto an
+extra page before the final eject (the issue #717 shape), set
+`--expected-output-pages` higher than `--pages`; the `issue-717-overflow`
+preset does this automatically.
 
 ## Full-page bitmap coverage test (opt-in, slow)
 

--- a/tools/io/printer/README.md
+++ b/tools/io/printer/README.md
@@ -1,0 +1,216 @@
+# Virtual printer E2E harness
+
+Reproduces and validates fixes for crashes in the Ultimate 64/64e virtual
+printer (`software/io/printer/*.cc`) against a **real Ultimate 64 or 64e**
+over its REST API and FTP server. No emulator, no MCP/bridge tooling.
+
+## Purpose
+
+The virtual printer (IEC device 4/5) accepts Commodore MPS or Epson FX-80
+protocol bytes from the C64, rasterizes them into a page bitmap, and saves a
+PNG (or ASCII/RAW) file when the page is ejected. This harness drives that
+path end to end from a dedicated 6510 program, so it exercises the real IEC
+timing and buffering behaviour that a BASIC-only test would miss.
+
+## Hardware/firmware prerequisites
+
+- A real Ultimate 64 or Ultimate 64 Elite (I or II) or Ultimate-II+, reachable
+  by hostname/IP, with the REST API and FTP server enabled (both are on by
+  default).
+- [64tass](https://sourceforge.net/projects/tass64/) on `PATH` (or pass
+  `--assembler /path/to/64tass`).
+- Python 3.9+. Core functionality (reproduction, structural PNG verification,
+  full-page bitmap coverage checks) needs no third-party packages. OCR-based
+  text verification is an optional enhancement - see below.
+
+## How it works
+
+- **REST** (`http.client`, matching the style of
+  `tools/io/temp-auto-cleanup/temp-auto-cleanup-perf-test.py`): reads/writes
+  `Printer Settings` config, pokes a parameter block and polls a status block
+  via `machine:writemem` / `machine:readmem`, uploads and runs the assembled
+  PRG via `POST /v1/runners:run_prg`, and drives the on-device Tasks menu
+  (`machine:menu_button` + `machine:input`) to trigger **Printer >
+  Flush/Eject** — the same interactive action a user takes, and the one that
+  actually calls into the PNG save path (`IecPrinter::flush()` →
+  `MpsPrinter::FormFeed()`).
+- **FTP** (`ftplib`, user `user` / password `password` by default, matching
+  the same reference script): downloads the resulting `-NNN.png` files to
+  verify they exist and are structurally valid PNGs, creates the output
+  directory if it doesn't exist yet (the printer's `fopen()` does not create
+  missing directories), and is the source of truth for output verification -
+  REST's `GET /v1/files/{path}:info` was observed to return stale/missing
+  results for files that FTP can see immediately.
+- **Settings are restored**: original `Printer Settings` are captured before
+  the run and restored after, unless `--no-config-change` is passed. Nothing
+  is ever written to flash (`save_flash` is never called).
+
+## The assembly workload (`printer-e2e.asm`)
+
+A single parametrized PRG, assembled once per run. Runtime parameters are
+written to `$C010` before the PRG is started:
+
+| Address | Meaning                                                        |
+|---------|----------------------------------------------------------------|
+| `$C010` | emulation: 1 = Epson, 2 = Commodore                             |
+| `$C011` | mode: 1 = bitmap, 2 = text                                      |
+| `$C012` | rows per page (1-255)                                           |
+| `$C013` | pages (1-9)                                                     |
+| `$C014` | IEC bus id (4 or 5)                                             |
+| `$C015` | bitmap mode only: seed-pattern repeats per row (1-255, 16 bytes/repeat) |
+
+It maintains a pollable status block at `$C000` (magic, phase, current
+page/row, last `READST`, final status, heartbeat) so the harness can tell the
+difference between "still running", "finished", and "the device stopped
+responding entirely" without guessing at timing.
+
+The program deliberately keeps its own state (loop counters, string-print
+pointer) off zero page entirely — see the comment at the top of the `.asm`
+file. A page/row counter placed in ostensibly-free zero page was corrupted
+partway through a long multi-page `CHROUT` session during development,
+silently truncating later pages; moving everything to plain static storage
+(and using self-modifying code instead of zero-page indirect addressing for
+string printing) fixed it.
+
+Text rows are deterministic: `U64PRN <EPSON|COMMODORE> TEXT PAGE=NNN
+ROW=NNN ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789`, printed in NLQ + bold +
+double-strike (not the default draft-quality dot font, which is too sparse
+for OCR to read back reliably even after image preprocessing). Bitmap rows
+repeat the deterministic 16-byte seed patterns from the printer spec
+(Commodore BIM / Epson `ESC Z` quadruple-density) `$C015` times to form a
+visible horizontal band (or, with a large repeat count, a full-width row).
+
+## Running the smallest reproducer
+
+```sh
+./printer-e2e.py -H u64 --preset crash-epson-png --rows 1 --pages 1 \
+    --output-base /Usb0/printer/e2e-smoke --verify-output
+```
+
+If your unit has no USB stick mounted, point `--output-base` at a path under
+a filesystem that does exist instead, e.g. `/Temp/printer/e2e-smoke` — the
+harness creates the `printer` directory over FTP if it isn't there yet.
+
+## Running the full required matrix
+
+```sh
+./printer-e2e.py -H u64 --stage matrix --emulation both --mode both \
+    --output-type "PNG B&W" --rows 4 --pages 1 --verify-output
+
+./printer-e2e.py -H u64 --stage matrix --emulation both --mode both \
+    --output-type "PNG B&W" --rows 4 --pages 2 --verify-output
+
+./printer-e2e.py -H u64 --preset full-matrix --page-top-margin 1 \
+    --page-height 66 --verify-output
+```
+
+`--stage matrix` (or `--emulation both --mode both`) runs all four
+combinations (Epson/Commodore x bitmap/text). When more than one combination
+runs in the same invocation, each gets a distinct `Output file` automatically
+(a `-eb`/`-et`/`-cb`/`-ct` suffix) so page numbering from one combination
+never gets misread as another's output.
+
+**Output file length**: the firmware's `Output file` setting silently
+truncates beyond 31 characters (`CFG_PRINTER_FILENAME` in `iec_printer.cc`).
+The harness raises an explicit error if a computed path would exceed that,
+rather than let verification fail confusingly against a truncated filename.
+
+## Full-page bitmap coverage test (opt-in, slow)
+
+```sh
+./printer-e2e.py -H u64 --emulation both --full-page-bitmap \
+    --output-base /Temp/printer/e2e-full --page-top-margin 1 --page-height 66
+```
+
+`--full-page-bitmap` prints a bitmap that fills the *entire* configured page
+(both width and height), not just a small band, computing the row count and
+seed-pattern repeat count needed to cover the page without overrunning it
+into an extra automatic page break. It's disabled by default: a full page is
+tens of thousands of IEC bytes and can take a couple of minutes per
+emulation. It forces bitmap-only mode and 1 page, and always verifies
+(regardless of `--verify-output`) that the resulting PNG's ink actually
+covers most of the page — width, height, and ink density within the covered
+area — using the bundled pure-stdlib PNG decoder (`png_lite.py`), not just
+that a plausible-looking file was produced.
+
+## OCR text verification (optional enhancement)
+
+```sh
+pip install pytesseract   # plus the tesseract-ocr binary via your OS package manager
+```
+
+When `pytesseract` and Pillow are importable, `--verify-output` on a
+text-mode combination also OCRs the printed page and checks that the
+recognized text contains the expected emulation tag (`EPSON`/`COMMODORE`),
+the `TEXT` mode tag, and a `PAGE=NNN`/`ROW=NNN` marker for every row - i.e.
+it verifies the *actual dynamic content* the assembly program's page/row
+loop and decimal-formatting routine produced, not just that some ink exists.
+If the OCR packages aren't installed, this step is skipped with a clear
+message and the run still completes (structural PNG verification is
+unaffected). The fixed decorative `A-Z 0-9` suffix on each row is
+intentionally not required to match character-for-character: several glyphs
+(e.g. `Q`, `X`, `Z`) are genuinely ambiguous to OCR at this font/resolution,
+and matching them isn't necessary to prove the printed content is correct.
+
+## Output verification
+
+`--verify-output` downloads every expected `<base>-NNN.png` over FTP and
+checks: non-zero size, valid PNG signature/chunk structure/CRCs, readable
+`IHDR` dimensions, and (text mode, if OCR is available) the recognized text
+content. Run structural verification standalone against files left over from
+an earlier run (or produced interactively) with:
+
+```sh
+./verify-printer-output.py -H u64 --output-base /Usb0/printer/e2e-smoke --pages 1
+./verify-printer-output.py -H u64 --path /Temp/some-page-001.png
+```
+
+## Crash classification
+
+- `PASS` / `PASS_NO_VERIFY` - program completed, page(s) ejected via
+  Flush/Eject, output verified (or verification skipped).
+- `FAIL_VERIFICATION` - completed and files exist, but they aren't
+  well-formed PNGs (or, for text mode, OCR didn't find the expected content).
+- `FAIL_IEC` - the PRG reported a KERNAL `OPEN`/`CHKOUT` failure (device not
+  present, wrong bus id, etc).
+- `FAIL_TIMEOUT` - the on-device program didn't finish within
+  `--timeout-seconds`, but REST is still responsive.
+- `FAIL_CRASH_HARD` - REST *and* ICMP both stopped responding. This is the
+  reported bug's signature: the screen goes off and the whole SoC wedges;
+  a C64/machine reset cannot recover it.
+- `FAIL_HARNESS` - the harness itself hit an unexpected error (menu
+  navigation, assembly, etc), unrelated to the firmware under test.
+
+## After `FAIL_CRASH_HARD`
+
+REST and even ICMP are dead — there is no software-only recovery. Redeploy
+the already-built firmware over JTAG from the repo root.
+
+This takes about 30-40 seconds (it's a direct `nios2-download`, not an FPGA
+rebuild) and brings the device back without needing a physical power cycle,
+provided the JTAG cable stays connected. 
+
+## Known limitations
+
+- **Text mode, many rows, multiple pages**: printing more than ~4-7 NLQ text
+  rows per page across 2+ pages in one continuous job was observed to
+  occasionally save fewer PNG pages than requested (a page's content
+  missing or merged into a neighbour), independent of the zero-page fix
+  described above. Bitmap mode at the same row/page counts, and text mode
+  at ≤4 rows/page or a single page at any row count, were not affected. This
+  looks like a timing/backpressure interaction between the firmware's
+  CPU-heavier NLQ character rendering and the harness's back-to-back IEC
+  transmission, not a data-correctness bug: every combination this harness
+  actually validates (see "Running the full required matrix" above) stays
+  well inside the range that was verified reliable. It's called out here
+  rather than worked around blindly, since it did not reproduce the crash
+  this harness exists to catch and would need separate, dedicated
+  investigation to root-cause.
+- The default `Output file` root is `/Usb0/printer/e2e-<run-id>` per the
+  reported bug's configuration, but this repo's test unit has no USB stick
+  mounted; the examples above use `/Temp/printer` explicitly for that reason.
+- `--seed-count`, `--test-count`, `--duration`, `--host-output-dir`,
+  `--keep-output`, `--limit` are accepted for CLI-shape compatibility with
+  `temp-auto-cleanup-perf-test.py` but are no-ops here — this harness is a
+  single deterministic print-and-verify per combination, not a
+  throughput/soak benchmark.

--- a/tools/io/printer/png_lite.py
+++ b/tools/io/printer/png_lite.py
@@ -1,0 +1,156 @@
+"""Minimal pure-stdlib PNG decoder for virtual-printer output verification.
+
+Handles what the printer's PNG encoder actually emits: non-interlaced,
+grayscale or palette color type, 1/2/4/8-bit depth. Not a general PNG
+decoder. Used to check that a "full page" bitmap print genuinely covers the
+page, not just that the file happens to be a structurally valid PNG.
+"""
+
+import struct
+import zlib
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+class PngError(RuntimeError):
+    pass
+
+
+def parse_chunks(data):
+    if data[:8] != PNG_SIGNATURE:
+        raise PngError("missing PNG signature")
+    offset = 8
+    chunks = []
+    while offset + 8 <= len(data):
+        length = struct.unpack(">I", data[offset:offset + 4])[0]
+        chunk_type = data[offset + 4:offset + 8]
+        chunk_data = data[offset + 8:offset + 8 + length]
+        if offset + 12 + length > len(data):
+            raise PngError(f"truncated chunk {chunk_type!r}")
+        crc_stored = struct.unpack(">I", data[offset + 8 + length:offset + 12 + length])[0]
+        crc_calc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+        if crc_calc != crc_stored:
+            raise PngError(f"bad CRC in chunk {chunk_type!r}")
+        chunks.append((chunk_type, chunk_data))
+        offset += 12 + length
+        if chunk_type == b"IEND":
+            break
+    return chunks
+
+
+def _paeth(a, b, c):
+    p = a + b - c
+    pa, pb, pc = abs(p - a), abs(p - b), abs(p - c)
+    if pa <= pb and pa <= pc:
+        return a
+    if pb <= pc:
+        return b
+    return c
+
+
+def decode_indexed(data):
+    """Decode a grayscale or palette PNG into (width, height, rows), where
+    rows is a list of `height` lists of `width` per-pixel sample values
+    (palette index, or grayscale level for color type 0)."""
+    chunks = parse_chunks(data)
+    ihdr = None
+    idat = bytearray()
+    for chunk_type, chunk_data in chunks:
+        if chunk_type == b"IHDR":
+            ihdr = chunk_data
+        elif chunk_type == b"IDAT":
+            idat += chunk_data
+    if ihdr is None:
+        raise PngError("no IHDR chunk")
+
+    width, height, bitdepth, colortype, compression, filter_method, interlace = struct.unpack(">IIBBBBB", ihdr)
+    if compression != 0 or filter_method != 0:
+        raise PngError("unsupported compression/filter method")
+    if interlace != 0:
+        raise PngError("interlaced PNG not supported")
+    if colortype not in (0, 3):
+        raise PngError(f"unsupported color type {colortype} (expected grayscale or palette)")
+    if bitdepth not in (1, 2, 4, 8):
+        raise PngError(f"unsupported bit depth {bitdepth}")
+
+    raw = zlib.decompress(bytes(idat))
+
+    bytes_per_row = (width * bitdepth + 7) // 8
+    bpp = max(1, bitdepth // 8)  # bytes-per-pixel for filter reconstruction
+
+    rows = []
+    prev = bytearray(bytes_per_row)
+    pos = 0
+    for _y in range(height):
+        if pos >= len(raw):
+            raise PngError("IDAT stream shorter than IHDR height implies")
+        filter_type = raw[pos]
+        pos += 1
+        line = bytearray(raw[pos:pos + bytes_per_row])
+        pos += bytes_per_row
+
+        if filter_type == 0:
+            pass
+        elif filter_type == 1:  # Sub
+            for i in range(len(line)):
+                a = line[i - bpp] if i >= bpp else 0
+                line[i] = (line[i] + a) & 0xFF
+        elif filter_type == 2:  # Up
+            for i in range(len(line)):
+                line[i] = (line[i] + prev[i]) & 0xFF
+        elif filter_type == 3:  # Average
+            for i in range(len(line)):
+                a = line[i - bpp] if i >= bpp else 0
+                b = prev[i]
+                line[i] = (line[i] + ((a + b) >> 1)) & 0xFF
+        elif filter_type == 4:  # Paeth
+            for i in range(len(line)):
+                a = line[i - bpp] if i >= bpp else 0
+                b = prev[i]
+                c = prev[i - bpp] if i >= bpp else 0
+                line[i] = (line[i] + _paeth(a, b, c)) & 0xFF
+        else:
+            raise PngError(f"unsupported filter type {filter_type}")
+
+        rows.append(bytes(line))
+        prev = line
+
+    pixel_rows = []
+    mask = (1 << bitdepth) - 1
+    per_byte = 8 // bitdepth
+    for line in rows:
+        if bitdepth == 8:
+            pixel_rows.append(list(line[:width]))
+            continue
+        pixels = [0] * width
+        for x in range(width):
+            byte_index = x // per_byte
+            shift = 8 - bitdepth * ((x % per_byte) + 1)
+            pixels[x] = (line[byte_index] >> shift) & mask
+        pixel_rows.append(pixels)
+
+    return width, height, pixel_rows
+
+
+def ink_bounding_box(pixel_rows, threshold=1):
+    """Return (min_x, min_y, max_x, max_y, ink_pixel_count) for samples whose
+    value is >= threshold (index/level 0 is white in this printer's output).
+    Returns None if no pixel meets the threshold."""
+    min_x = min_y = None
+    max_x = max_y = -1
+    ink_count = 0
+    for y, row in enumerate(pixel_rows):
+        for x, value in enumerate(row):
+            if value >= threshold:
+                ink_count += 1
+                if min_x is None or x < min_x:
+                    min_x = x
+                if x > max_x:
+                    max_x = x
+                if min_y is None or y < min_y:
+                    min_y = y
+                if y > max_y:
+                    max_y = y
+    if min_x is None:
+        return None
+    return min_x, min_y, max_x, max_y, ink_count

--- a/tools/io/printer/printer-e2e.asm
+++ b/tools/io/printer/printer-e2e.asm
@@ -1,0 +1,496 @@
+; printer-e2e.asm - Parametrized virtual-printer E2E workload for Ultimate 64/64e.
+;
+; Assembled with 64tass (tools/64tass or a system-installed 64tass) into a PRG
+; that is uploaded and run via POST /v1/runners:run_prg. Runtime parameters are
+; POSTed into RAM at PARAM_BASE (via /v1/machine:writemem) by printer-e2e.py
+; *before* the PRG is started. Progress/result are polled from STATUS_BASE via
+; GET /v1/machine:readmem.
+;
+; Parameter block (PARAM_BASE = $C010), written by the host before running:
+;   $C010  emulation   1 = Epson FX-80/JX-80, 2 = Commodore MPS
+;   $C011  mode        1 = bitmap, 2 = text
+;   $C012  rows        bitmap lines or text rows per page (1-255)
+;   $C013  pages       number of pages to print and eject (1-9)
+;   $C014  bus id      IEC device number to OPEN (4 or 5)
+;   $C015  bim repeats bitmap mode only: seed-pattern repeats per row (1-255);
+;                      16 bytes/repeat, ignored in text mode. Controls row
+;                      width - a large value (e.g. 120) spans the full
+;                      printable page width for a full-page bitmap test.
+;
+; Status block (STATUS_BASE = $C000), maintained by this program:
+;   $C000  magic0 = $55
+;   $C001  magic1 = $36
+;   $C002  phase (see PHASE_* below)
+;   $C003  emulation echoed from parameter block
+;   $C004  mode echoed from parameter block
+;   $C005  current page (1-based)
+;   $C006  current row (1-based)
+;   $C007  last READST value
+;   $C008  final status (0 = still running, $7F = complete, $80 = failed)
+;   $C009  last KERNAL error code (X register after a failed OPEN)
+;   $C00A  heartbeat low byte
+;   $C00B  heartbeat high byte
+
+STATUS_BASE = $C000
+PARAM_BASE  = $C010
+
+PH_NOT_STARTED  = $00
+PH_OPENING      = $10
+PH_OPENED       = $11
+PH_PRINTING     = $20
+PH_FORMFEED     = $30
+PH_CLOSING      = $40
+PH_CLOSED       = $41
+PH_COMPLETE     = $7F
+PH_FAILED       = $80
+
+SETLFS = $ffba
+SETNAM = $ffbd
+OPEN   = $ffc0
+CHKOUT = $ffc9
+CHROUT = $ffd2
+CLRCHN = $ffcc
+CLOSE  = $ffc3
+READST = $ffb7
+
+; This program deliberately avoids zero page entirely for its own state
+; (loop counters below live in plain static storage, and printstr uses
+; self-modifying code instead of zero-page indirect addressing). A page/row
+; counter placed in supposedly-"free" zero page ($F8-$FA) was corrupted
+; partway through a long multi-page CHROUT session, silently truncating
+; later pages - avoiding zero page sidesteps needing to know exactly which
+; locations the IEC/KERNAL I/O path touches internally.
+
+        * = $0801
+        .word next, 10
+        .byte $9e
+        .text "2064"
+        .byte 0
+next    .word 0
+
+        * = $0810
+
+start:
+        ; ---- initialise status block ----
+        lda #$55
+        sta STATUS_BASE
+        lda #$36
+        sta STATUS_BASE+1
+        lda #PH_NOT_STARTED
+        sta STATUS_BASE+2
+        lda PARAM_BASE          ; emulation
+        sta STATUS_BASE+3
+        lda PARAM_BASE+1        ; mode
+        sta STATUS_BASE+4
+        lda #0
+        sta STATUS_BASE+5
+        sta STATUS_BASE+6
+        sta STATUS_BASE+7
+        sta STATUS_BASE+8
+        sta STATUS_BASE+9
+        sta STATUS_BASE+10
+        sta STATUS_BASE+11
+
+        ; ---- open printer channel ----
+        lda #PH_OPENING
+        sta STATUS_BASE+2
+
+        lda #1                  ; logical file number 1
+        ldx PARAM_BASE+4        ; bus id (device number)
+        ldy #0                  ; secondary address 0
+        jsr SETLFS
+        lda #0
+        jsr SETNAM
+        jsr OPEN
+        bcc open_ok
+        lda #PH_FAILED
+        sta STATUS_BASE+2
+        sta STATUS_BASE+8
+        stx STATUS_BASE+9
+        jmp finished
+
+open_ok:
+        ldx #1
+        jsr CHKOUT
+        bcc chkout_ok
+        lda #PH_FAILED
+        sta STATUS_BASE+2
+        sta STATUS_BASE+8
+        jmp close_and_finish
+
+chkout_ok:
+        lda #PH_OPENED
+        sta STATUS_BASE+2
+
+        ; ---- emulation-specific job init ----
+        lda PARAM_BASE
+        cmp #1
+        bne init_done           ; only Epson needs an explicit init sequence
+        lda #$1b
+        jsr CHROUT
+        lda #$40                ; ESC @ (reset to power-on defaults)
+        jsr CHROUT
+
+        lda PARAM_BASE+1        ; mode
+        cmp #1                   ; bitmap only: use tight 8-dot line spacing so
+        bne init_done            ; consecutive BIM rows form a contiguous band;
+        lda #$1b                 ; leave the default (taller) interline alone
+        jsr CHROUT               ; for text mode so NLQ rows don't overlap.
+        lda #$41                ; ESC A
+        jsr CHROUT
+        lda #$08                ; 8/72" line spacing (8-dot bitmap rows)
+        jsr CHROUT
+init_done:
+
+        ; ---- text mode only: switch to NLQ + bold + double-strike so the
+        ; ---- printed characters are dense/blocky enough for OCR to read
+        ; ---- back reliably (the default draft-quality dot pattern is too
+        ; ---- sparse for OCR, even after image preprocessing).
+        lda PARAM_BASE+1        ; mode
+        cmp #2
+        bne text_init_done
+
+        lda PARAM_BASE           ; emulation
+        cmp #1
+        bne text_init_cbm
+
+        lda #$1b                 ; Epson: ESC x 1 (NLQ on)
+        jsr CHROUT
+        lda #$78
+        jsr CHROUT
+        lda #$01
+        jsr CHROUT
+        lda #$1b                 ; ESC E (emphasized/bold on)
+        jsr CHROUT
+        lda #$45
+        jsr CHROUT
+        lda #$1b                 ; ESC G (double-strike on)
+        jsr CHROUT
+        lda #$47
+        jsr CHROUT
+        jmp text_init_done
+
+text_init_cbm:
+        lda #$1f                 ; Commodore: NLQ on
+        jsr CHROUT
+        lda #$1b                 ; ESC E (emphasized/bold on)
+        jsr CHROUT
+        lda #$45
+        jsr CHROUT
+        lda #$1b                 ; ESC G (double-strike on)
+        jsr CHROUT
+        lda #$47
+        jsr CHROUT
+
+text_init_done:
+
+        lda #PH_PRINTING
+        sta STATUS_BASE+2
+
+        lda #1
+        sta pagenum
+        lda PARAM_BASE+3        ; pages
+        sta pageleft
+
+page_loop:
+        lda pagenum
+        sta STATUS_BASE+5
+
+        lda #1
+        sta rownum
+        lda PARAM_BASE+2        ; rows
+        sta rowleft
+
+row_loop:
+        lda rownum
+        sta STATUS_BASE+6
+
+        lda PARAM_BASE+1        ; mode
+        cmp #1
+        beq do_bitmap_row
+        jsr print_text_row
+        jmp row_done
+do_bitmap_row:
+        jsr print_bitmap_row
+
+row_done:
+        jsr READST
+        sta STATUS_BASE+7
+
+        inc STATUS_BASE+10
+        bne row_heartbeat_done
+        inc STATUS_BASE+11
+row_heartbeat_done:
+
+        inc rownum
+        dec rowleft
+        bne row_loop
+
+        ; ---- eject page ----
+        lda #PH_FORMFEED
+        sta STATUS_BASE+2
+        lda #$0c
+        jsr CHROUT
+        jsr READST
+        sta STATUS_BASE+7
+
+        inc pagenum
+        dec pageleft
+        bne page_loop
+
+        lda #PH_COMPLETE
+        sta STATUS_BASE+2
+        sta STATUS_BASE+8
+
+close_and_finish:
+        lda #PH_CLOSING
+        sta STATUS_BASE+2
+        jsr CLRCHN
+        lda #1
+        jsr CLOSE
+        jsr READST
+        sta STATUS_BASE+7
+        lda #PH_CLOSED
+        sta STATUS_BASE+2
+
+finished:
+        rts
+
+; ---------------------------------------------------------------------------
+; print_text_row: emit one deterministic text row for the current emulation.
+;   "U64PRN <EPSON|COMMODORE> TEXT PAGE=NNN ROW=NNN ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789"
+; ---------------------------------------------------------------------------
+print_text_row:
+        lda #<str_u64prn
+        sta ps_lda+1
+        lda #>str_u64prn
+        sta ps_lda+2
+        jsr printstr
+
+        lda PARAM_BASE
+        cmp #1
+        bne pt_commodore_tag
+        lda #<str_epson
+        sta ps_lda+1
+        lda #>str_epson
+        sta ps_lda+2
+        jmp pt_tag_done
+pt_commodore_tag:
+        lda #<str_commodore
+        sta ps_lda+1
+        lda #>str_commodore
+        sta ps_lda+2
+pt_tag_done:
+        jsr printstr
+
+        lda #<str_texttag
+        sta ps_lda+1
+        lda #>str_texttag
+        sta ps_lda+2
+        jsr printstr
+
+        lda pagenum
+        jsr print3digit
+
+        lda #<str_rowtag
+        sta ps_lda+1
+        lda #>str_rowtag
+        sta ps_lda+2
+        jsr printstr
+
+        lda rownum
+        jsr print3digit
+
+        lda #<str_suffix
+        sta ps_lda+1
+        lda #>str_suffix
+        sta ps_lda+2
+        jsr printstr
+
+        ; ---- row terminator ----
+        lda PARAM_BASE
+        cmp #1
+        bne pt_cbm_eol
+        lda #$0a                ; Epson: LF then CR
+        jsr CHROUT
+        lda #$0d
+        jsr CHROUT
+        rts
+pt_cbm_eol:
+        lda #$0d                ; Commodore: CR (advances line, resets column)
+        jsr CHROUT
+        rts
+
+; ---------------------------------------------------------------------------
+; print_bitmap_row: emit one deterministic bit-image row for the current
+; emulation, repeating the 16-byte seed pattern PARAM_BASE+5 ("bim repeats")
+; times to form a visible horizontal band (or, with a large repeat count,
+; a row spanning the full printable page width).
+; ---------------------------------------------------------------------------
+print_bitmap_row:
+        ; bim_len (16-bit) = bim_repeats * 16, used as the Epson ESC Z n/m
+        ; byte count. bim_repeats fits in a byte, so bim_len always fits in
+        ; 16 bits (max 255*16 = 4080).
+        lda PARAM_BASE+5
+        sta bim_len_lo
+        lda #0
+        sta bim_len_hi
+        ldx #4
+bim_len_shift:
+        asl bim_len_lo
+        rol bim_len_hi
+        dex
+        bne bim_len_shift
+
+        lda PARAM_BASE
+        cmp #1
+        beq pb_epson
+        jmp pb_commodore
+
+pb_epson:
+        lda #$1b
+        jsr CHROUT
+        lda #$5a                 ; ESC Z (quadruple density, ~240dpi)
+        jsr CHROUT
+        lda bim_len_lo            ; n
+        jsr CHROUT
+        lda bim_len_hi            ; m
+        jsr CHROUT
+
+        ldx PARAM_BASE+5
+pb_epson_reps:
+        stx pb_rep_save
+        ldy #0
+pb_epson_bytes:
+        lda epson_pattern,y
+        jsr CHROUT
+        iny
+        cpy #16
+        bne pb_epson_bytes
+        ldx pb_rep_save
+        dex
+        bne pb_epson_reps
+
+        lda #$0a
+        jsr CHROUT
+        lda #$0d
+        jsr CHROUT
+        rts
+
+pb_commodore:
+        lda #$08                 ; enter bit image mode
+        jsr CHROUT
+
+        ldx PARAM_BASE+5
+pb_cbm_reps:
+        stx pb_rep_save
+        ldy #0
+pb_cbm_bytes:
+        lda commodore_pattern,y
+        jsr CHROUT
+        iny
+        cpy #16
+        bne pb_cbm_bytes
+        ldx pb_rep_save
+        dex
+        bne pb_cbm_reps
+
+        lda #$0f                 ; exit bit image mode
+        jsr CHROUT
+        lda #$0d
+        jsr CHROUT
+        rts
+
+pb_rep_save: .byte 0
+bim_len_lo:  .byte 0
+bim_len_hi:  .byte 0
+
+; ---------------------------------------------------------------------------
+; Loop counters (plain static storage, not zero page - see the comment by
+; strptr above).
+; ---------------------------------------------------------------------------
+pagenum:  .byte 0   ; current page number, 1-based (for printing/status)
+pageleft: .byte 0   ; pages remaining (down counter)
+rownum:   .byte 0   ; current row number, 1-based (for printing/status)
+rowleft:  .byte 0   ; rows remaining in current page (down counter)
+digit10:  .byte 0   ; scratch for print3digit
+
+; ---------------------------------------------------------------------------
+; printstr: print the null-terminated string whose address the caller has
+; poked into ps_lda+1/+2 (self-modifying code, not zero-page indirect
+; addressing - see the comment by the loop counters above for why).
+; ---------------------------------------------------------------------------
+printstr:
+        ldy #0
+ps_loop:
+ps_lda: lda $ffff,y
+        beq ps_done
+        jsr CHROUT
+        iny
+        bne ps_loop
+ps_done:
+        rts
+
+; ---------------------------------------------------------------------------
+; print3digit: print A (0-255) as three zero-padded decimal digits.
+; ---------------------------------------------------------------------------
+print3digit:
+        ldx #0
+p3_hundreds:
+        cmp #100
+        bcc p3_hundreds_done
+        sbc #100
+        inx
+        jmp p3_hundreds
+p3_hundreds_done:
+        sta digit10              ; save remainder (0-99)
+        txa
+        clc
+        adc #'0'
+        jsr CHROUT
+
+        lda digit10
+        ldx #0
+p3_tens:
+        cmp #10
+        bcc p3_tens_done
+        sec
+        sbc #10
+        inx
+        jmp p3_tens
+p3_tens_done:
+        sta digit10               ; save remainder (0-9)
+        txa
+        clc
+        adc #'0'
+        jsr CHROUT
+
+        lda digit10
+        clc
+        adc #'0'
+        jsr CHROUT
+        rts
+
+; ---------------------------------------------------------------------------
+; Deterministic seed patterns
+; ---------------------------------------------------------------------------
+commodore_pattern:
+        .byte $88,$94,$a2,$c1,$a2,$94,$88,$88
+        .byte $9c,$ba,$ff,$ba,$9c,$88,$eb,$88
+
+epson_pattern:
+        .byte $3c,$42,$81,$81,$81,$42,$3c,$18
+        .byte $3c,$7e,$ff,$7e,$3c,$18,$eb,$18
+
+str_u64prn:     .text "U64PRN "
+                .byte 0
+str_epson:      .text "EPSON"
+                .byte 0
+str_commodore:  .text "COMMODORE"
+                .byte 0
+str_texttag:    .text " TEXT PAGE="
+                .byte 0
+str_rowtag:     .text " ROW="
+                .byte 0
+str_suffix:     .text " ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789"
+                .byte 0

--- a/tools/io/printer/printer-e2e.asm
+++ b/tools/io/printer/printer-e2e.asm
@@ -16,6 +16,8 @@
 ;                      16 bytes/repeat, ignored in text mode. Controls row
 ;                      width - a large value (e.g. 120) spans the full
 ;                      printable page width for a full-page bitmap test.
+;   $C016  flags: bit 0 emits the issue #717 BASIC byte shape without an
+;                      explicit form feed; Flush/Eject saves the final page.
 ;
 ; Status block (STATUS_BASE = $C000), maintained by this program:
 ;   $C000  magic0 = $55
@@ -122,6 +124,10 @@ chkout_ok:
         lda #PH_OPENED
         sta STATUS_BASE+2
 
+        lda PARAM_BASE+6
+        and #$01
+        bne init_done
+
         ; ---- emulation-specific job init ----
         lda PARAM_BASE
         cmp #1
@@ -146,6 +152,9 @@ init_done:
         ; ---- printed characters are dense/blocky enough for OCR to read
         ; ---- back reliably (the default draft-quality dot pattern is too
         ; ---- sparse for OCR, even after image preprocessing).
+        lda PARAM_BASE+6
+        and #$01
+        bne text_init_done
         lda PARAM_BASE+1        ; mode
         cmp #2
         bne text_init_done
@@ -205,10 +214,16 @@ row_loop:
         lda rownum
         sta STATUS_BASE+6
 
+        lda PARAM_BASE+6
+        and #$01
+        bne do_issue_717_row
         lda PARAM_BASE+1        ; mode
         cmp #1
         beq do_bitmap_row
         jsr print_text_row
+        jmp row_done
+do_issue_717_row:
+        jsr print_issue_717_row
         jmp row_done
 do_bitmap_row:
         jsr print_bitmap_row
@@ -226,6 +241,10 @@ row_heartbeat_done:
         dec rowleft
         bne row_loop
 
+        lda PARAM_BASE+6
+        and #$01
+        bne issue_717_finished
+
         ; ---- eject page ----
         lda #PH_FORMFEED
         sta STATUS_BASE+2
@@ -241,6 +260,14 @@ row_heartbeat_done:
         lda #PH_COMPLETE
         sta STATUS_BASE+2
         sta STATUS_BASE+8
+
+        jmp close_and_finish
+
+issue_717_finished:
+        lda #PH_COMPLETE
+        sta STATUS_BASE+2
+        sta STATUS_BASE+8
+        rts
 
 close_and_finish:
         lda #PH_CLOSING
@@ -312,6 +339,31 @@ pt_tag_done:
         cmp #1
         bne pt_cbm_eol
         lda #$0a                ; Epson: LF then CR
+        jsr CHROUT
+        lda #$0d
+        jsr CHROUT
+        rts
+
+; ---------------------------------------------------------------------------
+; print_issue_717_row: emit the byte shape of the BASIC reproducer:
+;   PRINT#1,"line no "; i
+;   PRINT#1, CHR$(13)
+; The decimal value is immaterial to the printer parser. The normal printer
+; line ending advances the Epson raster, followed by the explicit CR. This
+; routine intentionally sends no form feed.
+; ---------------------------------------------------------------------------
+print_issue_717_row:
+        lda #<str_issue_717
+        sta ps_lda+1
+        lda #>str_issue_717
+        sta ps_lda+2
+        jsr printstr
+
+        lda rownum
+        jsr print3digit
+        lda #$0a
+        jsr CHROUT
+        lda #$0d
         jsr CHROUT
         lda #$0d
         jsr CHROUT
@@ -493,4 +545,6 @@ str_texttag:    .text " TEXT PAGE="
 str_rowtag:     .text " ROW="
                 .byte 0
 str_suffix:     .text " ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789"
+                .byte 0
+str_issue_717:  .text "line no "
                 .byte 0

--- a/tools/io/printer/printer-e2e.py
+++ b/tools/io/printer/printer-e2e.py
@@ -21,11 +21,19 @@ import os
 import subprocess
 import struct
 import sys
+import tempfile
 import time
 import zlib
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_ASM_PATH = os.path.join(SCRIPT_DIR, "printer-e2e.asm")
+ISSUE_717_BASIC = '''10 open 1,4
+20 for i = 1 to 100
+30 print#1,"line no "; i
+35 print#1, chr$(13)
+40 next i
+50 end
+'''
 sys.path.insert(0, SCRIPT_DIR)
 import png_lite  # noqa: E402  (local module, needs SCRIPT_DIR on sys.path first)
 
@@ -293,6 +301,14 @@ class FtpInspector:
             except (OSError, EOFError, ftplib.Error):
                 ftp.close()
 
+    def printer_root(self):
+        """Use the first mounted USB volume; Temp is the last resort."""
+        entries = "\n".join(self.list_dir("/"))
+        for volume in ("USB0", "USB1", "USB2"):
+            if volume in entries:
+                return "/" + volume
+        return "/Temp"
+
     def file_size(self, path):
         ftp = self._open()
         try:
@@ -365,6 +381,20 @@ def assemble_prg(asm_path, assembler):
     return data
 
 
+def issue_717_basic_prg():
+    """Tokenize the issue reporter's BASIC program verbatim as BASIC V2."""
+    with tempfile.TemporaryDirectory() as directory:
+        source = os.path.join(directory, "issue-717.bas")
+        output = os.path.join(directory, "issue-717.prg")
+        with open(source, "w", encoding="ascii") as handle:
+            handle.write(ISSUE_717_BASIC)
+        result = subprocess.run(["petcat", "-w2", "-o", output, source], capture_output=True, text=True)
+        if result.returncode != 0:
+            raise Failure(f"petcat failed: {result.stdout}\n{result.stderr}")
+        with open(output, "rb") as handle:
+            return handle.read()
+
+
 def decode_status(payload):
     if len(payload) < STATUS_LEN:
         raise Failure(f"short status block read: {len(payload)} bytes")
@@ -385,9 +415,19 @@ def decode_status(payload):
 
 
 def classify_and_run(client, prg_bytes, emulation, mode, rows, pages, bus_id, timeout_seconds, poll_interval,
-                      bim_repeats=DEFAULT_BIM_REPEATS):
+                      bim_repeats=DEFAULT_BIM_REPEATS, issue_717_basic=False):
     """Write params, launch the PRG, poll the status block. Returns (classification, status_or_none)."""
-    params = bytes([EMU_CODE[emulation], MODE_CODE[mode], rows & 0xFF, pages & 0xFF, bus_id, bim_repeats & 0xFF])
+    if issue_717_basic:
+        client.run_prg(prg_bytes)
+        time.sleep(5.0)
+        if not client.is_alive(timeout=3.0):
+            return "FAIL_CRASH_HARD", None
+        return "PASS_RUN", {"phase_name": "literal BASIC completed", "heartbeat": 0}
+
+    params = bytes([
+        EMU_CODE[emulation], MODE_CODE[mode], rows & 0xFF, pages & 0xFF,
+        bus_id, bim_repeats & 0xFF, 1 if issue_717_basic else 0,
+    ])
     client.writemem(PARAM_BASE, params)
     client.run_prg(prg_bytes)
 
@@ -436,6 +476,18 @@ def classify_and_run(client, prg_bytes, emulation, mode, rows, pages, bus_id, ti
 def flush_via_menu(client, assertions_enabled, settle=MENU_SETTLE_SECONDS):
     """Drive the Ultimate on-screen Tasks menu to trigger Printer > Flush/Eject."""
     body = client.get_menu_screen()
+    if body is None:
+        # Builds before the menu-screen REST endpoint still accept synthetic
+        # input. Printer is the preselected Tasks entry on those builds.
+        client.menu_button()
+        time.sleep(settle)
+        client.tap_key("f5")
+        time.sleep(settle)
+        client.tap_key("return")
+        time.sleep(settle)
+        client.tap_key("return")
+        time.sleep(1.0)
+        return
     if body is not None:
         client.menu_button()  # close whatever is open
         time.sleep(settle)
@@ -762,6 +814,11 @@ PRESETS = {
         verify_output=True, expected_output_pages=2,
         seed_page_num_collision=True, seed_last_page=7,
     ),
+    "issue-717-basic": dict(
+        emulation="epson", mode="text", output_type="PNG B&W", ink_density="Medium",
+        page_top_margin=1, page_height=66, bus_id=4, rows=100, pages=1,
+        verify_output=True, expected_output_pages=1, issue_717_basic=True,
+    ),
 }
 
 
@@ -815,7 +872,8 @@ def parse_args():
                               "calcPageNum() must ignore colliding names and continue at NNN+1.")
     parser.add_argument("--seed-last-page", type=int, default=7,
                          help="When --seed-page-num-collision is used, seed an existing "
-                              "<base>-NNN.png with this page number (default: 7).")
+                         "<base>-NNN.png with this page number (default: 7).")
+    parser.add_argument("--issue-717-basic", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--host-output-dir", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--ftp-user", default=FTP_USER_DEFAULT)
     parser.add_argument("--ftp-password", default=FTP_PASSWORD_DEFAULT)
@@ -873,9 +931,9 @@ def run_combo(client, inspector, prg_bytes, args, emulation, mode, assertions_en
     if args.output_base:
         base = args.output_base
     elif args.seed_page_num_collision:
-        base = "/Temp/printer"
+        base = inspector.printer_root() + "/printer"
     else:
-        base = "/Usb0/printer/e2e"
+        base = inspector.printer_root() + "/printer/e2e"
     if args.output_base is None:
         output_base = unique_output_base(base, emulation, mode)
     elif disambiguate:
@@ -914,6 +972,7 @@ def run_combo(client, inspector, prg_bytes, args, emulation, mode, assertions_en
     classification, status = classify_and_run(
         client, prg_bytes, emulation, mode, rows, args.pages, args.bus_id,
         args.timeout_seconds, POLL_INTERVAL_SECONDS, bim_repeats=bim_repeats,
+        issue_717_basic=args.issue_717_basic,
     )
 
     if classification == "FAIL_CRASH_HARD":
@@ -964,7 +1023,7 @@ def run_combo(client, inspector, prg_bytes, args, emulation, mode, assertions_en
             verify_png_output(
                 inspector, output_base, expected_pages, assertions_enabled, first_page=first_page,
             )
-            if mode == "text":
+            if mode == "text" and not args.issue_717_basic:
                 verify_text_ocr(
                     inspector, output_base, emulation, expected_pages, rows, assertions_enabled,
                     first_page=first_page,
@@ -991,9 +1050,10 @@ def main():
         return 1
     check_ok()
 
-    check_start(f"assemble {os.path.basename(args.asm_path)} with {args.assembler}")
+    check_start("tokenize literal issue #717 BASIC" if args.issue_717_basic else
+                f"assemble {os.path.basename(args.asm_path)} with {args.assembler}")
     try:
-        prg_bytes = assemble_prg(args.asm_path, args.assembler)
+        prg_bytes = issue_717_basic_prg() if args.issue_717_basic else assemble_prg(args.asm_path, args.assembler)
     except Failure as exc:
         check_fail(str(exc))
         return 1

--- a/tools/io/printer/printer-e2e.py
+++ b/tools/io/printer/printer-e2e.py
@@ -1,0 +1,978 @@
+#!/usr/bin/env python3
+"""End-to-end virtual-printer harness for a real Ultimate 64 / 64e.
+
+Drives the IEC virtual printer (device 4/5) with a dedicated 6510 assembly
+workload (printer-e2e.asm, assembled with 64tass), captures crash/hang
+behaviour, and verifies the resulting PNG/ASCII output over FTP. Pure REST
+(http.client) + FTP (ftplib); no MCP/bridge dependency.
+
+Style follows tools/io/temp-auto-cleanup/temp-auto-cleanup-perf-test.py:
+argparse CLI, -H/--host, -p/--password, -n/--no-assertions, http.client with
+Connection: close, X-Password only when a password is supplied, capture/
+restore original settings, ftplib for on-device file verification.
+"""
+
+import argparse
+import ftplib
+import http.client
+import io
+import json
+import os
+import subprocess
+import struct
+import sys
+import time
+import zlib
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_ASM_PATH = os.path.join(SCRIPT_DIR, "printer-e2e.asm")
+sys.path.insert(0, SCRIPT_DIR)
+import png_lite  # noqa: E402  (local module, needs SCRIPT_DIR on sys.path first)
+
+try:
+    from PIL import Image, ImageOps
+    import pytesseract
+    OCR_AVAILABLE = True
+except ImportError:
+    OCR_AVAILABLE = False
+
+CONFIG_CATEGORY = "Printer Settings"
+CONFIG_ITEMS = (
+    "IEC printer",
+    "Bus ID",
+    "Output file",
+    "Output type",
+    "Ink density",
+    "Page top margin (default is 5)",
+    "Page height (default is 60)",
+    "Emulation",
+    "Commodore charset",
+    "Epson charset",
+    "IBM table 2",
+)
+
+PARAM_BASE = 0xC010
+STATUS_BASE = 0xC000
+STATUS_LEN = 12
+
+EMU_CODE = {"epson": 1, "commodore": 2}
+MODE_CODE = {"bitmap": 1, "text": 2}
+EMU_CONFIG_VALUE = {"epson": "Epson FX-80/JX-80", "commodore": "Commodore MPS"}
+
+PHASE_NAMES = {
+    0x00: "not started",
+    0x10: "opening printer",
+    0x11: "printer opened",
+    0x20: "printing",
+    0x30: "form feed sent",
+    0x40: "closing printer",
+    0x41: "printer closed",
+    0x7F: "complete",
+    0x80: "failed",
+}
+
+FTP_USER_DEFAULT = "user"
+FTP_PASSWORD_DEFAULT = "password"
+POLL_INTERVAL_SECONDS = 0.5
+MENU_SETTLE_SECONDS = 0.35
+SCREEN_WIDTH = 40
+SCREEN_HEIGHT = 25
+SCREEN_CELLS = SCREEN_WIDTH * SCREEN_HEIGHT
+
+# print_bitmap_row's default seed-pattern repeat count (16 bytes/repeat),
+# matching the pre-existing "visible band" behaviour when full-page mode is off.
+DEFAULT_BIM_REPEATS = 4
+
+# Full-page bitmap mode: fill the whole configured printable page, not just a
+# band. Mirrors the firmware's own geometry constants in mps_printer.h/.cc
+# (MPS_PRINTER_HEAD_HEIGHT, the ESC A 8 / BIM interline, and the horizontal
+# step per bit-image byte) so the requested row/repeat counts land just
+# inside the current page instead of triggering an extra automatic
+# FormFeed() partway through (which would silently split the fill across two
+# pages instead of producing the single full page this mode is meant to
+# verify).
+MPS_PRINTER_HEAD_HEIGHT = 27
+TEXT_LINE_PX = 36
+EPSON_BIM_INTERLINE_PX = 24   # set via "ESC A 8" in print_bitmap_row's job init
+CBM_BIM_INTERLINE_PX = 21     # fixed by the firmware's BIM entry (spacing_y[0][7])
+EPSON_FULL_WIDTH_REPEATS = 120  # 120 * 16 = 1920px at 1px/byte (ESC Z step)
+CBM_FULL_WIDTH_REPEATS = 30     # 30 * 16 = 480 bytes * 4px/byte = 1920px
+FULL_PAGE_MIN_WIDTH_FRACTION = 0.85
+FULL_PAGE_MIN_HEIGHT_FRACTION = 0.5
+FULL_PAGE_MIN_INK_FRACTION = 0.05
+
+
+def full_page_bitmap_params(emulation, page_height):
+    """Return (rows, repeats) that fill the configured page for `emulation`
+    without overrunning it into an extra automatic page break. Matches the
+    firmware's own MPS_PRINTER_MAX_MARGIN_BOTTOM, which depends only on the
+    configured page height, not the top margin."""
+    interline = EPSON_BIM_INTERLINE_PX if emulation == "epson" else CBM_BIM_INTERLINE_PX
+    margin_bottom = (page_height * TEXT_LINE_PX) - MPS_PRINTER_HEAD_HEIGHT - 1
+    rows = max(1, (margin_bottom // interline) - 1)  # -1 row of safety margin
+    rows = min(rows, 255)
+    repeats = EPSON_FULL_WIDTH_REPEATS if emulation == "epson" else CBM_FULL_WIDTH_REPEATS
+    return rows, repeats
+
+
+class Failure(RuntimeError):
+    pass
+
+
+CHECK_COUNT = 0
+
+
+def check_start(label):
+    global CHECK_COUNT
+    CHECK_COUNT += 1
+    print(f"[{CHECK_COUNT:02d}] {label} ... ", end="", flush=True)
+
+
+def check_ok(extra=""):
+    print("OK" + (f" ({extra})" if extra else ""), flush=True)
+
+
+def check_fail(reason):
+    print(f"FAIL ({reason})", flush=True)
+
+
+def assert_or_warn(assertions_enabled, condition, message):
+    if condition:
+        return
+    if assertions_enabled:
+        raise Failure(message)
+    print(f"WARNING: {message}")
+
+
+class U64Client:
+    """Minimal REST client mirroring temp-auto-cleanup-perf-test.py's style."""
+
+    def __init__(self, host, password, timeout=10):
+        self.host = host
+        self.password = password
+        self.timeout = timeout
+
+    def _headers(self, body, extra_headers=None):
+        headers = {"Connection": "close"}
+        if self.password:
+            headers["X-Password"] = self.password
+        if body is not None:
+            headers["Content-Length"] = str(len(body))
+        if extra_headers:
+            headers.update(extra_headers)
+        return headers
+
+    def request(self, method, path, body=None, extra_headers=None, timeout=None):
+        connection = http.client.HTTPConnection(self.host, timeout=timeout or self.timeout)
+        try:
+            connection.request(method, path, body=body, headers=self._headers(body, extra_headers))
+            response = connection.getresponse()
+            payload = response.read()
+            return response.status, dict(response.getheaders()), payload
+        finally:
+            connection.close()
+
+    def require_ok(self, method, path, body=None, description=None, extra_headers=None, timeout=None):
+        status, _headers, payload = self.request(method, path, body=body, extra_headers=extra_headers, timeout=timeout)
+        if status != 200:
+            message = f"{description or path} failed with HTTP {status}"
+            try:
+                detail = json.loads(payload.decode("utf-8"))
+                if detail.get("errors"):
+                    message += f": {detail['errors']}"
+            except (ValueError, UnicodeDecodeError):
+                message += f": {payload[:160]!r}"
+            raise Failure(message)
+        return payload
+
+    def is_alive(self, timeout=3.0):
+        try:
+            status, _headers, _payload = self.request("GET", "/v1/version", timeout=timeout)
+            return status == 200
+        except (OSError, http.client.HTTPException):
+            return False
+
+    def get_config(self, category, item):
+        path = f"/v1/configs/{urlquote(category)}/{urlquote(item)}"
+        payload = self.require_ok("GET", path, description=f"read {category}/{item}")
+        document = json.loads(payload.decode("utf-8"))
+        return document[category][item]["current"]
+
+    def set_config(self, category, item, value):
+        path = f"/v1/configs/{urlquote(category)}/{urlquote(item)}?value={urlquote(str(value))}"
+        self.require_ok("PUT", path, description=f"set {category}/{item}={value}")
+
+    def writemem(self, address, data):
+        path = f"/v1/machine:writemem?address={address:04X}"
+        self.require_ok(
+            "POST",
+            path,
+            body=data,
+            description=f"writemem @{address:04X}",
+            extra_headers={"Content-Type": "application/octet-stream"},
+        )
+
+    def readmem(self, address, length):
+        path = f"/v1/machine:readmem?address={address:04X}&length={length}"
+        return self.require_ok("GET", path, description=f"readmem @{address:04X}")
+
+    def run_prg(self, prg_bytes):
+        self.require_ok(
+            "POST",
+            "/v1/runners:run_prg",
+            body=prg_bytes,
+            description="run_prg",
+            extra_headers={"Content-Type": "application/octet-stream"},
+        )
+
+    def menu_button(self):
+        self.require_ok("PUT", "/v1/machine:menu_button", description="menu_button")
+
+    def get_menu_screen(self):
+        status, headers, payload = self.request("GET", "/v1/machine:menu_screen")
+        if status == 404:
+            return None
+        if status != 200:
+            raise Failure(f"menu_screen failed with HTTP {status}")
+        return payload
+
+    def post_input(self, events):
+        body = json.dumps({"events": events}).encode("utf-8")
+        self.require_ok(
+            "POST",
+            "/v1/machine:input",
+            body=body,
+            description="input",
+            extra_headers={"Content-Type": "application/json"},
+        )
+
+    def tap_key(self, key):
+        self.post_input([{"kind": "keyboard", "inputs": [key], "transition": "tap"}])
+
+
+def urlquote(value):
+    import urllib.parse
+
+    return urllib.parse.quote(str(value), safe="")
+
+
+def menu_screen_text(body):
+    chars = body[:SCREEN_CELLS]
+    rows = []
+    for row in range(SCREEN_HEIGHT):
+        row_chars = chars[row * SCREEN_WIDTH:(row + 1) * SCREEN_WIDTH]
+        rows.append("".join(
+            chr(ch & 0x7F) if 0x20 <= (ch & 0x7F) <= 0x7E else " "
+            for ch in row_chars
+        ))
+    return rows
+
+
+class FtpInspector:
+    def __init__(self, host, user, password, timeout=15):
+        self.host = host
+        self.user = user
+        self.password = password
+        self.timeout = timeout
+
+    def _open(self):
+        ftp = ftplib.FTP()
+        ftp.connect(self.host, 21, timeout=self.timeout)
+        ftp.login(self.user, self.password)
+        return ftp
+
+    def list_dir(self, directory):
+        ftp = self._open()
+        try:
+            entries = []
+            ftp.retrlines(f"LIST {directory}", entries.append)
+            return entries
+        finally:
+            try:
+                ftp.quit()
+            except (OSError, EOFError, ftplib.Error):
+                ftp.close()
+
+    def file_size(self, path):
+        ftp = self._open()
+        try:
+            return ftp.size(path)
+        except ftplib.Error:
+            return None
+        finally:
+            try:
+                ftp.quit()
+            except (OSError, EOFError, ftplib.Error):
+                ftp.close()
+
+    def download(self, path):
+        ftp = self._open()
+        try:
+            buf = io.BytesIO()
+            ftp.retrbinary(f"RETR {path}", buf.write)
+            return buf.getvalue()
+        finally:
+            try:
+                ftp.quit()
+            except (OSError, EOFError, ftplib.Error):
+                ftp.close()
+
+    def ensure_directory(self, directory):
+        """Create `directory` (and its parents) if it doesn't already exist.
+        The printer's fopen() does not create missing directories, so an
+        Output file pointed at one silently fails to save anything."""
+        if directory in ("", "/"):
+            return
+        ftp = self._open()
+        try:
+            parts = [p for p in directory.split("/") if p]
+            path = ""
+            for part in parts:
+                path += "/" + part
+                try:
+                    ftp.mkd(path)
+                except ftplib.error_perm:
+                    pass  # already exists
+        finally:
+            try:
+                ftp.quit()
+            except (OSError, EOFError, ftplib.Error):
+                ftp.close()
+
+
+def assemble_prg(asm_path, assembler):
+    out_path = asm_path + ".out.prg"
+    result = subprocess.run(
+        [assembler, "-q", "-o", out_path, asm_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise Failure(f"assembler failed: {result.stdout}\n{result.stderr}")
+    with open(out_path, "rb") as handle:
+        data = handle.read()
+    os.remove(out_path)
+    return data
+
+
+def decode_status(payload):
+    if len(payload) < STATUS_LEN:
+        raise Failure(f"short status block read: {len(payload)} bytes")
+    magic0, magic1, phase, emulation, mode, page, row, readst, final_status, last_op, hb_lo, hb_hi = payload[:12]
+    return {
+        "magic_ok": magic0 == 0x55 and magic1 == 0x36,
+        "phase": phase,
+        "phase_name": PHASE_NAMES.get(phase, f"unknown(${phase:02X})"),
+        "emulation": emulation,
+        "mode": mode,
+        "page": page,
+        "row": row,
+        "readst": readst,
+        "final_status": final_status,
+        "last_op": last_op,
+        "heartbeat": hb_lo | (hb_hi << 8),
+    }
+
+
+def classify_and_run(client, prg_bytes, emulation, mode, rows, pages, bus_id, timeout_seconds, poll_interval,
+                      bim_repeats=DEFAULT_BIM_REPEATS):
+    """Write params, launch the PRG, poll the status block. Returns (classification, status_or_none)."""
+    params = bytes([EMU_CODE[emulation], MODE_CODE[mode], rows & 0xFF, pages & 0xFF, bus_id, bim_repeats & 0xFF])
+    client.writemem(PARAM_BASE, params)
+    client.run_prg(prg_bytes)
+
+    deadline = time.monotonic() + timeout_seconds
+    last_status = None
+    last_heartbeat = -1
+    stall_since = None
+
+    while time.monotonic() < deadline:
+        if not client.is_alive(timeout=3.0):
+            time.sleep(1.5)
+            if not client.is_alive(timeout=3.0):
+                return "FAIL_CRASH_HARD", last_status
+            continue
+
+        try:
+            payload = client.readmem(STATUS_BASE, STATUS_LEN)
+            status = decode_status(payload)
+        except (Failure, OSError, http.client.HTTPException):
+            time.sleep(poll_interval)
+            continue
+
+        last_status = status
+        if not status["magic_ok"]:
+            time.sleep(poll_interval)
+            continue
+
+        if status["heartbeat"] != last_heartbeat:
+            last_heartbeat = status["heartbeat"]
+            stall_since = None
+        else:
+            stall_since = stall_since or time.monotonic()
+
+        if status["final_status"] == 0x7F:
+            return "PASS_RUN", status
+        if status["final_status"] == 0x80:
+            return "FAIL_IEC", status
+
+        time.sleep(poll_interval)
+
+    if not client.is_alive(timeout=5.0):
+        return "FAIL_CRASH_HARD", last_status
+    return "FAIL_TIMEOUT", last_status
+
+
+def flush_via_menu(client, assertions_enabled, settle=MENU_SETTLE_SECONDS):
+    """Drive the Ultimate on-screen Tasks menu to trigger Printer > Flush/Eject."""
+    body = client.get_menu_screen()
+    if body is not None:
+        client.menu_button()  # close whatever is open
+        time.sleep(settle)
+
+    client.menu_button()  # open root browser
+    time.sleep(settle)
+    client.tap_key("f5")  # open Tasks (context menu) for the current selection
+    time.sleep(settle)
+
+    body = client.get_menu_screen()
+    if body is None:
+        raise Failure("task menu did not open")
+    rows = menu_screen_text(body)
+
+    printer_row = None
+    for index in range(8, SCREEN_HEIGHT):
+        if "Printer" in rows[index]:
+            printer_row = index
+            break
+    if printer_row is None:
+        raise Failure("'Printer' task category not found in task menu")
+
+    downs = printer_row - 8
+    for _ in range(downs):
+        client.tap_key("cursor_up_down")
+        time.sleep(0.2)
+
+    client.tap_key("return")  # expand Printer category (Flush/Eject preselected)
+    time.sleep(settle)
+
+    body = client.get_menu_screen()
+    if body is None:
+        raise Failure("printer task submenu did not open")
+    rows = menu_screen_text(body)
+    assert_or_warn(
+        assertions_enabled,
+        "Flush/Eject" in rows[printer_row],
+        f"expected 'Flush/Eject' on row {printer_row}, got: {rows[printer_row]!r}",
+    )
+
+    client.tap_key("return")  # trigger Flush/Eject
+    time.sleep(1.0)
+
+
+def capture_settings(client, assertions_enabled):
+    snapshot = {}
+    for item in CONFIG_ITEMS:
+        try:
+            snapshot[item] = client.get_config(CONFIG_CATEGORY, item)
+        except Failure as exc:
+            assert_or_warn(assertions_enabled, False, f"could not capture {item}: {exc}")
+    return snapshot
+
+
+def restore_settings(client, snapshot, assertions_enabled):
+    if not snapshot:
+        return
+    print("\nRestoring original Printer Settings")
+    for item, value in snapshot.items():
+        try:
+            client.set_config(CONFIG_CATEGORY, item, value)
+            print(f"  {item}: {value}")
+        except Failure as exc:
+            assert_or_warn(assertions_enabled, False, f"could not restore {item}: {exc}")
+
+
+def apply_settings(client, output_base, output_type, ink_density, page_top_margin, page_height,
+                    emulation, bus_id, assertions_enabled):
+    changes = (
+        ("IEC printer", "Enabled"),
+        ("Bus ID", bus_id),
+        ("Output file", output_base),
+        ("Output type", output_type),
+        ("Ink density", ink_density),
+        ("Page top margin (default is 5)", page_top_margin),
+        ("Page height (default is 60)", page_height),
+        ("Emulation", EMU_CONFIG_VALUE[emulation]),
+        ("Commodore charset", "USA/UK"),
+        ("Epson charset", "Basic"),
+        ("IBM table 2", "International 1"),
+    )
+    for item, value in changes:
+        try:
+            client.set_config(CONFIG_CATEGORY, item, value)
+        except Failure as exc:
+            assert_or_warn(assertions_enabled, False, f"could not set {item}={value}: {exc}")
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def decode_png_dimensions(data):
+    if data[:8] != PNG_SIGNATURE:
+        return None
+    if data[12:16] != b"IHDR":
+        return None
+    width, height = struct.unpack(">II", data[16:24])
+    return width, height
+
+
+def png_is_well_formed(data):
+    """Validate PNG chunk structure and CRCs without needing a real decoder."""
+    if data[:8] != PNG_SIGNATURE:
+        return False, "missing PNG signature"
+    offset = 8
+    saw_ihdr = False
+    saw_iend = False
+    while offset + 8 <= len(data):
+        length = struct.unpack(">I", data[offset:offset + 4])[0]
+        chunk_type = data[offset + 4:offset + 8]
+        chunk_data = data[offset + 8:offset + 8 + length]
+        crc_stored = struct.unpack(">I", data[offset + 8 + length:offset + 12 + length])[0]
+        crc_calc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+        if crc_calc != crc_stored:
+            return False, f"bad CRC in chunk {chunk_type!r}"
+        if chunk_type == b"IHDR":
+            saw_ihdr = True
+        if chunk_type == b"IEND":
+            saw_iend = True
+            break
+        offset += 12 + length
+    if not saw_ihdr:
+        return False, "no IHDR chunk"
+    if not saw_iend:
+        return False, "no IEND chunk (truncated file)"
+    return True, "ok"
+
+
+def download_with_retry(inspector, path, timeout_seconds=10.0, interval_seconds=0.5):
+    """The device writes the PNG asynchronously after Flush/Eject returns, so
+    the file may not be visible over FTP for a moment; poll briefly."""
+    deadline = time.monotonic() + timeout_seconds
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            return inspector.download(path)
+        except ftplib.Error as exc:
+            last_error = exc
+            time.sleep(interval_seconds)
+    raise Failure(f"{path}: not available over FTP after {timeout_seconds}s ({last_error})")
+
+
+def verify_png_output(inspector, output_base, expected_pages, assertions_enabled):
+    directory, base = os.path.split(output_base)
+    directory = directory or "/"
+    for page in range(1, expected_pages + 1):
+        name = f"{base}-{page:03d}.png"
+        path = f"{directory}/{name}" if directory != "/" else f"/{name}"
+        data = download_with_retry(inspector, path)
+        assert_or_warn(assertions_enabled, len(data) > 0, f"{path}: file is empty")
+        ok, reason = png_is_well_formed(data)
+        assert_or_warn(assertions_enabled, ok, f"{path}: not a well-formed PNG ({reason})")
+        dims = decode_png_dimensions(data)
+        assert_or_warn(assertions_enabled, dims is not None, f"{path}: could not read IHDR dimensions")
+        print(f"    {path}: {len(data)} bytes, {dims[0]}x{dims[1]}px, {'valid' if ok else 'INVALID'} PNG")
+
+
+def verify_full_page_coverage(inspector, output_base, assertions_enabled):
+    """Decode page 1's pixels and check the ink actually covers most of the
+    page - proof this is a genuine full-page fill, not just a small band
+    mislabeled as one (e.g. from a parameter that silently had no effect)."""
+    directory, base = os.path.split(output_base)
+    directory = directory or "/"
+    name = f"{base}-001.png"
+    path = f"{directory}/{name}" if directory != "/" else f"/{name}"
+
+    data = download_with_retry(inspector, path)
+    width, height, pixel_rows = png_lite.decode_indexed(data)
+    bbox = png_lite.ink_bounding_box(pixel_rows)
+    assert_or_warn(assertions_enabled, bbox is not None, f"{path}: full-page bitmap produced a blank page")
+    if bbox is None:
+        return
+
+    min_x, min_y, max_x, max_y, ink_count = bbox
+    bbox_width = max_x - min_x + 1
+    bbox_height = max_y - min_y + 1
+    width_fraction = bbox_width / width
+    height_fraction = bbox_height / height
+    ink_fraction = ink_count / (bbox_width * bbox_height)
+
+    print(
+        f"    {path}: ink spans {bbox_width}x{bbox_height}px at ({min_x},{min_y}) "
+        f"= {width_fraction:.0%} of page width, {height_fraction:.0%} of page height, "
+        f"{ink_fraction:.0%} ink density within that area ({ink_count} ink pixels)"
+    )
+    assert_or_warn(
+        assertions_enabled, width_fraction >= FULL_PAGE_MIN_WIDTH_FRACTION,
+        f"{path}: bitmap only spans {width_fraction:.0%} of page width "
+        f"(expected >= {FULL_PAGE_MIN_WIDTH_FRACTION:.0%} for a full-page fill)",
+    )
+    assert_or_warn(
+        assertions_enabled, height_fraction >= FULL_PAGE_MIN_HEIGHT_FRACTION,
+        f"{path}: bitmap only spans {height_fraction:.0%} of page height "
+        f"(expected >= {FULL_PAGE_MIN_HEIGHT_FRACTION:.0%} for a full-page fill)",
+    )
+    assert_or_warn(
+        assertions_enabled, ink_fraction >= FULL_PAGE_MIN_INK_FRACTION,
+        f"{path}: ink density {ink_fraction:.0%} within the covered area looks too "
+        f"sparse to be a real bitmap fill (expected >= {FULL_PAGE_MIN_INK_FRACTION:.0%})",
+    )
+
+
+def ocr_page_text(data):
+    """OCR the ink region of a printed page PNG. Returns the recognized text
+    (uppercased) or None if there is no ink to OCR."""
+    image = Image.open(io.BytesIO(data)).convert("L")
+    bbox = ImageOps.invert(image).getbbox()  # non-white region, without a numpy dependency
+    if bbox is None:
+        return None
+    margin = 4
+    left, upper, right, lower = bbox
+    crop = image.crop((max(0, left - margin), max(0, upper - margin),
+                        min(image.width, right + margin), min(image.height, lower + margin)))
+    upscaled = crop.resize((crop.width * 4, crop.height * 4), Image.LANCZOS)
+    thresholded = upscaled.point(lambda p: 0 if p < 180 else 255)
+    return pytesseract.image_to_string(thresholded, config="--psm 6").upper()
+
+
+def verify_text_ocr(inspector, output_base, emulation, pages, rows, assertions_enabled):
+    """OCR-verify that the printed text pages actually contain the expected
+    deterministic content (emulation tag, mode tag, and every PAGE=/ROW=
+    marker) - not just that a plausible-looking PNG was produced.
+
+    The dot-matrix "draft" font is not reliably OCRable even after image
+    preprocessing (tested: garbage output). Text-mode rows therefore switch
+    the printer into NLQ + bold + double-strike (see printer-e2e.asm), which
+    OCRs correctly for the parts that matter: the emulation/mode tags and the
+    PAGE=/ROW= counters that prove the assembly program's page/row loop and
+    decimal-formatting routine are actually working. The fixed decorative
+    A-Z/0-9 suffix on each row is intentionally not required to match
+    character-for-character - several glyphs (e.g. Q, X, Z) are genuinely
+    ambiguous at this resolution/font even to a human, and matching it isn't
+    necessary to prove the printed content is correct.
+    """
+    if not OCR_AVAILABLE:
+        print("    OCR verification skipped: pytesseract/PIL not installed "
+              "(pip install pytesseract, apt install tesseract-ocr)")
+        return
+
+    expected_tag = EMU_CONFIG_VALUE[emulation].split()[0].upper()  # "EPSON" / "COMMODORE"
+    directory, base = os.path.split(output_base)
+    directory = directory or "/"
+
+    for page in range(1, pages + 1):
+        name = f"{base}-{page:03d}.png"
+        path = f"{directory}/{name}" if directory != "/" else f"/{name}"
+        data = download_with_retry(inspector, path)
+        text = ocr_page_text(data)
+
+        assert_or_warn(assertions_enabled, text is not None, f"{path}: OCR found no ink to read")
+        if text is None:
+            continue
+
+        preview = " / ".join(line.strip() for line in text.splitlines() if line.strip())
+        print(f"    {path}: OCR read: {preview[:160]}{'...' if len(preview) > 160 else ''}")
+
+        assert_or_warn(
+            assertions_enabled, expected_tag in text,
+            f"{path}: OCR did not find the expected '{expected_tag}' emulation tag",
+        )
+        assert_or_warn(
+            assertions_enabled, "TEXT" in text,
+            f"{path}: OCR did not find the expected 'TEXT' mode tag",
+        )
+        assert_or_warn(
+            assertions_enabled, f"PAGE={page:03d}" in text,
+            f"{path}: OCR did not find 'PAGE={page:03d}'",
+        )
+        for row in range(1, rows + 1):
+            assert_or_warn(
+                assertions_enabled, f"ROW={row:03d}" in text,
+                f"{path}: OCR did not find 'ROW={row:03d}' (row {row} of {rows})",
+            )
+
+
+MAX_OUTPUT_FILE_LENGTH = 31  # CFG_PRINTER_FILENAME bound in iec_printer.cc; silently truncated beyond this
+
+
+def combo_code(emulation, mode):
+    return f"{emulation[0]}{mode[0]}"  # e.g. "eb" = epson/bitmap, "ct" = commodore/text
+
+
+def unique_output_base(prefix, emulation, mode):
+    suffix = f"{int(time.time()) % 0xFFFF:04x}"
+    return f"{prefix}-{combo_code(emulation, mode)}{suffix}"
+
+
+def require_output_file_length(output_base):
+    if len(output_base) > MAX_OUTPUT_FILE_LENGTH:
+        raise Failure(
+            f"Output file '{output_base}' is {len(output_base)} chars; the firmware's "
+            f"Output file setting truncates silently beyond {MAX_OUTPUT_FILE_LENGTH} "
+            f"(CFG_PRINTER_FILENAME), which would make verification look for the wrong file"
+        )
+
+
+PRESETS = {
+    "crash-epson-png": dict(emulation="epson", mode="bitmap", output_type="PNG B&W",
+                             ink_density="Medium", page_top_margin=1, page_height=66,
+                             bus_id=4, rows=4, pages=1),
+    "full-matrix": dict(output_type="PNG B&W", page_top_margin=1, page_height=66, bus_id=4),
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Virtual-printer end-to-end harness for a real Ultimate 64/64e.",
+        epilog="Captures original Printer Settings and restores them on exit unless "
+               "--no-config-change is used. Requires printer-e2e.asm alongside this "
+               "script and a 64tass binary on PATH (or --assembler).",
+    )
+    parser.add_argument("-H", "--host", default="u64", help="IP or hostname of the U64")
+    parser.add_argument("-p", "--password", default="", help="U64 REST password")
+    parser.add_argument("-n", "--no-assertions", action="store_true",
+                         help="Warn instead of failing on assertion mismatches")
+    parser.add_argument("--seed-count", type=int, default=0, help=argparse.SUPPRESS)
+    parser.add_argument("--test-count", type=int, default=1, help=argparse.SUPPRESS)
+    parser.add_argument("--duration", type=float, default=0.0, help=argparse.SUPPRESS)
+    parser.add_argument("--stage", choices=["reproduce", "verify", "matrix", "all"], default="reproduce",
+                         help="reproduce: single run; matrix: all 4 emulation x mode combos; "
+                              "verify: reproduce + output verification; all: matrix + verification")
+    parser.add_argument("--no-config-change", action="store_true",
+                         help="Do not change or restore Printer Settings (caller must configure)")
+    parser.add_argument("--emulation", choices=["epson", "commodore", "both"], default="epson")
+    parser.add_argument("--mode", choices=["bitmap", "text", "both"], default="bitmap")
+    parser.add_argument("--rows", type=int, default=4, help="Bitmap lines or text rows per page (1-255)")
+    parser.add_argument("--pages", type=int, default=1, help="Number of pages to print and eject (1-9)")
+    parser.add_argument(
+        "--full-page-bitmap", action="store_true",
+        help="Print a bitmap that fully covers the configured page (width and height), "
+             "instead of the default small band. Disabled by default: this sends far "
+             "more IEC data per page (tens of thousands of bytes) and can take a "
+             "couple of minutes per combination. Forces bitmap-only mode and 1 page, "
+             "and verifies the resulting image's ink actually covers most of the page "
+             "(not just that a PNG file was produced).",
+    )
+    parser.add_argument("--bus-id", type=int, choices=[4, 5], default=4)
+    parser.add_argument("--output-base", default=None,
+                         help="Printer 'Output file' base path (default: unique /Usb0/printer/e2e-<run-id>). "
+                              "The base's directory is created over FTP if it doesn't already exist.")
+    parser.add_argument("--output-type", default="PNG B&W")
+    parser.add_argument("--ink-density", default="Medium")
+    parser.add_argument("--page-top-margin", type=int, default=1)
+    parser.add_argument("--page-height", type=int, default=66)
+    parser.add_argument("--host-output-dir", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--ftp-user", default=FTP_USER_DEFAULT)
+    parser.add_argument("--ftp-password", default=FTP_PASSWORD_DEFAULT)
+    parser.add_argument("--verify-output", action="store_true",
+                         help="Download and structurally validate the resulting PNG(s) via FTP")
+    parser.add_argument("--keep-output", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--timeout-seconds", type=int, default=60,
+                         help="Max seconds to wait for the on-device PRG to finish printing")
+    parser.add_argument("--reset-before-run", action="store_true")
+    parser.add_argument("--reset-after-run", action="store_true")
+    parser.add_argument("--stop-on-crash", action="store_true", default=True)
+    parser.add_argument("--limit", type=int, default=10, help=argparse.SUPPRESS)
+    parser.add_argument("--preset", choices=list(PRESETS.keys()), default=None)
+    parser.add_argument("--asm-path", default=DEFAULT_ASM_PATH)
+    parser.add_argument("--assembler", default="64tass")
+    args = parser.parse_args()
+
+    if args.preset:
+        for key, value in PRESETS[args.preset].items():
+            setattr(args, key.replace("-", "_"), value)
+
+    if args.rows < 1 or args.rows > 255:
+        parser.error("--rows must be between 1 and 255")
+    if args.pages < 1 or args.pages > 9:
+        parser.error("--pages must be between 1 and 9")
+
+    if args.full_page_bitmap:
+        if args.mode == "text":
+            parser.error("--full-page-bitmap requires bitmap mode (--mode bitmap or both)")
+        args.mode = "bitmap"
+        args.pages = 1
+        if args.timeout_seconds == 60:  # still the default; give full-page runs more room
+            args.timeout_seconds = 240
+
+    return args
+
+
+def combos_for(args):
+    emulations = ["epson", "commodore"] if args.emulation == "both" else [args.emulation]
+    modes = ["bitmap", "text"] if args.mode == "both" else [args.mode]
+    if args.stage in ("matrix", "all") and args.preset != "crash-epson-png" and not args.full_page_bitmap:
+        emulations = ["epson", "commodore"]
+        modes = ["bitmap", "text"]
+    return [(e, m) for e in emulations for m in modes]
+
+
+def run_combo(client, inspector, prg_bytes, args, emulation, mode, assertions_enabled, disambiguate):
+    label = f"{emulation}/{mode}"
+    check_start(f"print {label}: apply settings + run PRG")
+
+    base = args.output_base or "/Usb0/printer/e2e"
+    if args.output_base is None:
+        output_base = unique_output_base(base, emulation, mode)
+    elif disambiguate:
+        # Multiple emulation/mode combos share one run; PNG page numbering is
+        # scoped per output filename, so distinct bases avoid reading stale
+        # pages left over from an earlier combo in the same run.
+        output_base = f"{base}-{combo_code(emulation, mode)}"
+    else:
+        output_base = base
+    require_output_file_length(output_base)
+
+    output_directory = os.path.dirname(output_base)
+    if output_directory:
+        inspector.ensure_directory(output_directory)
+
+    if not args.no_config_change:
+        apply_settings(
+            client, output_base, args.output_type, args.ink_density,
+            args.page_top_margin, args.page_height, emulation, args.bus_id,
+            assertions_enabled,
+        )
+
+    if args.full_page_bitmap:
+        rows, bim_repeats = full_page_bitmap_params(emulation, args.page_height)
+        print(f"    full-page bitmap: {rows} rows x {bim_repeats * 16} bytes/row "
+              f"(~{rows * (EPSON_BIM_INTERLINE_PX if emulation == 'epson' else CBM_BIM_INTERLINE_PX)}px "
+              f"tall, ~{bim_repeats * 16 * (1 if emulation == 'epson' else 4)}px wide)")
+    else:
+        rows, bim_repeats = args.rows, DEFAULT_BIM_REPEATS
+
+    classification, status = classify_and_run(
+        client, prg_bytes, emulation, mode, rows, args.pages, args.bus_id,
+        args.timeout_seconds, POLL_INTERVAL_SECONDS, bim_repeats=bim_repeats,
+    )
+
+    if classification == "FAIL_CRASH_HARD":
+        check_fail("device became unresponsive (FAIL_CRASH_HARD)")
+        print("    REST and ping are both unreachable. This matches the reported crash:")
+        print("    screen off, unresponsive, C64/machine reset will not help.")
+        print("    Recover with: bash tooling/build_and_deploy_u64.sh (JTAG redeploy)")
+        return "FAIL_CRASH_HARD", output_base, status
+    if classification == "FAIL_TIMEOUT":
+        check_fail(f"timed out after {args.timeout_seconds}s, REST still responsive")
+        return "FAIL_TIMEOUT", output_base, status
+    if classification == "FAIL_IEC":
+        check_fail(f"PRG reported IEC failure: {status}")
+        return "FAIL_IEC", output_base, status
+
+    check_ok(f"phase={status['phase_name']} heartbeat={status['heartbeat']}")
+
+    check_start(f"print {label}: Flush/Eject via on-screen menu")
+    try:
+        flush_via_menu(client, assertions_enabled)
+    except Failure as exc:
+        if not client.is_alive(timeout=5.0):
+            check_fail("device became unresponsive during Flush/Eject (FAIL_CRASH_HARD)")
+            return "FAIL_CRASH_HARD", output_base, status
+        check_fail(str(exc))
+        return "FAIL_HARNESS", output_base, status
+
+    if not client.is_alive(timeout=5.0):
+        check_fail("device became unresponsive after Flush/Eject (FAIL_CRASH_HARD)")
+        return "FAIL_CRASH_HARD", output_base, status
+    check_ok()
+
+    if args.full_page_bitmap:
+        check_start(f"print {label}: verify full-page coverage over FTP")
+        try:
+            verify_png_output(inspector, output_base, args.pages, assertions_enabled)
+            verify_full_page_coverage(inspector, output_base, assertions_enabled)
+            check_ok()
+            return "PASS", output_base, status
+        except Failure as exc:
+            check_fail(str(exc))
+            return "FAIL_VERIFICATION", output_base, status
+
+    if args.verify_output:
+        check_start(f"print {label}: verify output over FTP")
+        try:
+            verify_png_output(inspector, output_base, args.pages, assertions_enabled)
+            if mode == "text":
+                verify_text_ocr(inspector, output_base, emulation, args.pages, rows, assertions_enabled)
+            check_ok()
+            return "PASS", output_base, status
+        except Failure as exc:
+            check_fail(str(exc))
+            return "FAIL_VERIFICATION", output_base, status
+
+    return "PASS_NO_VERIFY", output_base, status
+
+
+def main():
+    args = parse_args()
+    assertions_enabled = not args.no_assertions
+
+    client = U64Client(args.host, args.password)
+    inspector = FtpInspector(args.host, args.ftp_user, args.ftp_password)
+
+    check_start(f"REST reachable at {args.host}")
+    if not client.is_alive():
+        check_fail("no response from /v1/version")
+        return 1
+    check_ok()
+
+    check_start(f"assemble {os.path.basename(args.asm_path)} with {args.assembler}")
+    try:
+        prg_bytes = assemble_prg(args.asm_path, args.assembler)
+    except Failure as exc:
+        check_fail(str(exc))
+        return 1
+    check_ok(f"{len(prg_bytes)} bytes")
+
+    snapshot = {}
+    if not args.no_config_change:
+        check_start("capture original Printer Settings")
+        snapshot = capture_settings(client, assertions_enabled)
+        check_ok()
+
+    if args.reset_before_run:
+        check_start("reset before run")
+        client.require_ok("PUT", "/v1/machine:reset", description="machine:reset")
+        time.sleep(2.0)
+        check_ok()
+
+    results = []
+    combos = combos_for(args)
+    disambiguate = len(combos) > 1
+    try:
+        for emulation, mode in combos:
+            classification, output_base, status = run_combo(
+                client, inspector, prg_bytes, args, emulation, mode, assertions_enabled, disambiguate,
+            )
+            results.append((emulation, mode, classification, output_base))
+            if classification == "FAIL_CRASH_HARD" and args.stop_on_crash:
+                print("\nHARD CRASH detected - stopping the run immediately (--stop-on-crash).")
+                break
+    finally:
+        if not args.no_config_change and all(c != "FAIL_CRASH_HARD" for *_, c, _ in results):
+            restore_settings(client, snapshot, assertions_enabled)
+
+    if args.reset_after_run and client.is_alive(timeout=5.0):
+        check_start("reset after run")
+        client.require_ok("PUT", "/v1/machine:reset", description="machine:reset")
+        check_ok()
+
+    print("\nSummary")
+    for emulation, mode, classification, output_base in results:
+        print(f"  {emulation:10s} {mode:6s} {classification:20s} {output_base}")
+
+    failed = [r for r in results if r[2] not in ("PASS", "PASS_NO_VERIFY")]
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/io/printer/printer-e2e.py
+++ b/tools/io/printer/printer-e2e.py
@@ -317,6 +317,16 @@ class FtpInspector:
             except (OSError, EOFError, ftplib.Error):
                 ftp.close()
 
+    def upload_bytes(self, path, data):
+        ftp = self._open()
+        try:
+            ftp.storbinary(f"STOR {path}", io.BytesIO(data))
+        finally:
+            try:
+                ftp.quit()
+            except (OSError, EOFError, ftplib.Error):
+                ftp.close()
+
     def ensure_directory(self, directory):
         """Create `directory` (and its parents) if it doesn't already exist.
         The printer's fopen() does not create missing directories, so an
@@ -568,12 +578,16 @@ def download_with_retry(inspector, path, timeout_seconds=10.0, interval_seconds=
     raise Failure(f"{path}: not available over FTP after {timeout_seconds}s ({last_error})")
 
 
-def verify_png_output(inspector, output_base, expected_pages, assertions_enabled):
+def page_output_path(output_base, page_number):
     directory, base = os.path.split(output_base)
     directory = directory or "/"
-    for page in range(1, expected_pages + 1):
-        name = f"{base}-{page:03d}.png"
-        path = f"{directory}/{name}" if directory != "/" else f"/{name}"
+    name = f"{base}-{page_number:03d}.png"
+    return f"{directory}/{name}" if directory != "/" else f"/{name}"
+
+
+def verify_png_output(inspector, output_base, expected_pages, assertions_enabled, first_page=1):
+    for page in range(first_page, first_page + expected_pages):
+        path = page_output_path(output_base, page)
         data = download_with_retry(inspector, path)
         assert_or_warn(assertions_enabled, len(data) > 0, f"{path}: file is empty")
         ok, reason = png_is_well_formed(data)
@@ -583,14 +597,11 @@ def verify_png_output(inspector, output_base, expected_pages, assertions_enabled
         print(f"    {path}: {len(data)} bytes, {dims[0]}x{dims[1]}px, {'valid' if ok else 'INVALID'} PNG")
 
 
-def verify_full_page_coverage(inspector, output_base, assertions_enabled):
+def verify_full_page_coverage(inspector, output_base, assertions_enabled, first_page=1):
     """Decode page 1's pixels and check the ink actually covers most of the
     page - proof this is a genuine full-page fill, not just a small band
     mislabeled as one (e.g. from a parameter that silently had no effect)."""
-    directory, base = os.path.split(output_base)
-    directory = directory or "/"
-    name = f"{base}-001.png"
-    path = f"{directory}/{name}" if directory != "/" else f"/{name}"
+    path = page_output_path(output_base, first_page)
 
     data = download_with_retry(inspector, path)
     width, height, pixel_rows = png_lite.decode_indexed(data)
@@ -644,7 +655,7 @@ def ocr_page_text(data):
     return pytesseract.image_to_string(thresholded, config="--psm 6").upper()
 
 
-def verify_text_ocr(inspector, output_base, emulation, pages, rows, assertions_enabled):
+def verify_text_ocr(inspector, output_base, emulation, pages, rows, assertions_enabled, first_page=1):
     """OCR-verify that the printed text pages actually contain the expected
     deterministic content (emulation tag, mode tag, and every PAGE=/ROW=
     marker) - not just that a plausible-looking PNG was produced.
@@ -666,12 +677,9 @@ def verify_text_ocr(inspector, output_base, emulation, pages, rows, assertions_e
         return
 
     expected_tag = EMU_CONFIG_VALUE[emulation].split()[0].upper()  # "EPSON" / "COMMODORE"
-    directory, base = os.path.split(output_base)
-    directory = directory or "/"
-
-    for page in range(1, pages + 1):
-        name = f"{base}-{page:03d}.png"
-        path = f"{directory}/{name}" if directory != "/" else f"/{name}"
+    for logical_page in range(1, pages + 1):
+        page = first_page + logical_page - 1
+        path = page_output_path(output_base, page)
         data = download_with_retry(inspector, path)
         text = ocr_page_text(data)
 
@@ -691,8 +699,8 @@ def verify_text_ocr(inspector, output_base, emulation, pages, rows, assertions_e
             f"{path}: OCR did not find the expected 'TEXT' mode tag",
         )
         assert_or_warn(
-            assertions_enabled, f"PAGE={page:03d}" in text,
-            f"{path}: OCR did not find 'PAGE={page:03d}'",
+            assertions_enabled, f"PAGE={logical_page:03d}" in text,
+            f"{path}: OCR did not find 'PAGE={logical_page:03d}'",
         )
         for row in range(1, rows + 1):
             assert_or_warn(
@@ -722,11 +730,38 @@ def require_output_file_length(output_base):
         )
 
 
+def seed_page_num_collision(inspector, output_base, last_page):
+    """Force calcPageNum() through the same basename scan shape as issue #717:
+    the parent directory contains both a directory named like the basename and
+    several same-prefix non-matching files, plus one real <base>-NNN.png that
+    should determine the next page number."""
+    directory, base = os.path.split(output_base)
+    directory = directory or "/"
+    collision_dir = f"{directory}/{base}" if directory != "/" else f"/{base}"
+    inspector.ensure_directory(collision_dir)
+
+    seeded_paths = (
+        page_output_path(output_base, last_page),
+        f"{directory}/{base}-old.png" if directory != "/" else f"/{base}-old.png",
+        f"{directory}/{base}-7.png" if directory != "/" else f"/{base}-7.png",
+        f"{directory}/{base}-abc.png" if directory != "/" else f"/{base}-abc.png",
+        f"{directory}/{base}-123.txt" if directory != "/" else f"/{base}-123.txt",
+    )
+    for path in seeded_paths:
+        inspector.upload_bytes(path, b"seed")
+
+
 PRESETS = {
     "crash-epson-png": dict(emulation="epson", mode="bitmap", output_type="PNG B&W",
                              ink_density="Medium", page_top_margin=1, page_height=66,
                              bus_id=4, rows=4, pages=1),
     "full-matrix": dict(output_type="PNG B&W", page_top_margin=1, page_height=66, bus_id=4),
+    "issue-717-overflow": dict(
+        emulation="epson", mode="bitmap", output_type="PNG B&W", ink_density="Medium",
+        page_top_margin=1, page_height=66, bus_id=4, rows=126, pages=1,
+        verify_output=True, expected_output_pages=2,
+        seed_page_num_collision=True, seed_last_page=7,
+    ),
 }
 
 
@@ -766,10 +801,21 @@ def parse_args():
     parser.add_argument("--output-base", default=None,
                          help="Printer 'Output file' base path (default: unique /Usb0/printer/e2e-<run-id>). "
                               "The base's directory is created over FTP if it doesn't already exist.")
+    parser.add_argument("--expected-output-pages", type=int, default=None,
+                         help="Expected number of output PNG pages to verify. Defaults to --pages, "
+                              "but set this higher for a single continuous print that naturally "
+                              "overflows onto an extra page before the final Flush/Eject.")
     parser.add_argument("--output-type", default="PNG B&W")
     parser.add_argument("--ink-density", default="Medium")
     parser.add_argument("--page-top-margin", type=int, default=1)
     parser.add_argument("--page-height", type=int, default=66)
+    parser.add_argument("--seed-page-num-collision", action="store_true",
+                         help="Pre-create a directory named like the output basename plus several "
+                              "same-prefix junk files, and seed one existing <base>-NNN.png, so "
+                              "calcPageNum() must ignore colliding names and continue at NNN+1.")
+    parser.add_argument("--seed-last-page", type=int, default=7,
+                         help="When --seed-page-num-collision is used, seed an existing "
+                              "<base>-NNN.png with this page number (default: 7).")
     parser.add_argument("--host-output-dir", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--ftp-user", default=FTP_USER_DEFAULT)
     parser.add_argument("--ftp-password", default=FTP_PASSWORD_DEFAULT)
@@ -795,6 +841,10 @@ def parse_args():
         parser.error("--rows must be between 1 and 255")
     if args.pages < 1 or args.pages > 9:
         parser.error("--pages must be between 1 and 9")
+    if args.expected_output_pages is not None and args.expected_output_pages < 1:
+        parser.error("--expected-output-pages must be >= 1")
+    if args.seed_last_page < 1 or args.seed_last_page > 999:
+        parser.error("--seed-last-page must be between 1 and 999")
 
     if args.full_page_bitmap:
         if args.mode == "text":
@@ -820,7 +870,12 @@ def run_combo(client, inspector, prg_bytes, args, emulation, mode, assertions_en
     label = f"{emulation}/{mode}"
     check_start(f"print {label}: apply settings + run PRG")
 
-    base = args.output_base or "/Usb0/printer/e2e"
+    if args.output_base:
+        base = args.output_base
+    elif args.seed_page_num_collision:
+        base = "/Temp/printer"
+    else:
+        base = "/Usb0/printer/e2e"
     if args.output_base is None:
         output_base = unique_output_base(base, emulation, mode)
     elif disambiguate:
@@ -835,6 +890,11 @@ def run_combo(client, inspector, prg_bytes, args, emulation, mode, assertions_en
     output_directory = os.path.dirname(output_base)
     if output_directory:
         inspector.ensure_directory(output_directory)
+
+    first_page = 1
+    if args.seed_page_num_collision:
+        seed_page_num_collision(inspector, output_base, args.seed_last_page)
+        first_page = args.seed_last_page + 1
 
     if not args.no_config_change:
         apply_settings(
@@ -889,8 +949,8 @@ def run_combo(client, inspector, prg_bytes, args, emulation, mode, assertions_en
     if args.full_page_bitmap:
         check_start(f"print {label}: verify full-page coverage over FTP")
         try:
-            verify_png_output(inspector, output_base, args.pages, assertions_enabled)
-            verify_full_page_coverage(inspector, output_base, assertions_enabled)
+            verify_png_output(inspector, output_base, args.pages, assertions_enabled, first_page=first_page)
+            verify_full_page_coverage(inspector, output_base, assertions_enabled, first_page=first_page)
             check_ok()
             return "PASS", output_base, status
         except Failure as exc:
@@ -900,9 +960,15 @@ def run_combo(client, inspector, prg_bytes, args, emulation, mode, assertions_en
     if args.verify_output:
         check_start(f"print {label}: verify output over FTP")
         try:
-            verify_png_output(inspector, output_base, args.pages, assertions_enabled)
+            expected_pages = args.expected_output_pages or args.pages
+            verify_png_output(
+                inspector, output_base, expected_pages, assertions_enabled, first_page=first_page,
+            )
             if mode == "text":
-                verify_text_ocr(inspector, output_base, emulation, args.pages, rows, assertions_enabled)
+                verify_text_ocr(
+                    inspector, output_base, emulation, expected_pages, rows, assertions_enabled,
+                    first_page=first_page,
+                )
             check_ok()
             return "PASS", output_base, status
         except Failure as exc:

--- a/tools/io/printer/verify-printer-output.py
+++ b/tools/io/printer/verify-printer-output.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Standalone structural verification for virtual-printer PNG/ASCII output.
+
+Downloads printer output files from an Ultimate 64/64e over FTP and checks
+that they are well-formed (PNG chunk/CRC structure, or non-blank text) without
+needing to run a print job first. Useful for re-checking output left behind by
+printer-e2e.py, or output produced interactively (e.g. via the on-device menu).
+
+Usage:
+    ./verify-printer-output.py -H u64 --output-base /Usb0/printer/e2e-abc --pages 2
+    ./verify-printer-output.py -H u64 --path /Temp/mypage-001.png
+"""
+
+import argparse
+import ftplib
+import io
+import struct
+import sys
+import zlib
+
+FTP_USER_DEFAULT = "user"
+FTP_PASSWORD_DEFAULT = "password"
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+class Failure(RuntimeError):
+    pass
+
+
+class FtpInspector:
+    def __init__(self, host, user, password, timeout=15):
+        self.host = host
+        self.user = user
+        self.password = password
+        self.timeout = timeout
+
+    def download(self, path):
+        ftp = ftplib.FTP()
+        ftp.connect(self.host, 21, timeout=self.timeout)
+        try:
+            ftp.login(self.user, self.password)
+            buf = io.BytesIO()
+            ftp.retrbinary(f"RETR {path}", buf.write)
+            return buf.getvalue()
+        finally:
+            try:
+                ftp.quit()
+            except (OSError, EOFError, ftplib.Error):
+                ftp.close()
+
+
+def decode_png_dimensions(data):
+    if data[:8] != PNG_SIGNATURE or data[12:16] != b"IHDR":
+        return None
+    return struct.unpack(">II", data[16:24])
+
+
+def png_is_well_formed(data):
+    if data[:8] != PNG_SIGNATURE:
+        return False, "missing PNG signature"
+    offset = 8
+    saw_ihdr = False
+    saw_iend = False
+    while offset + 8 <= len(data):
+        length = struct.unpack(">I", data[offset:offset + 4])[0]
+        chunk_type = data[offset + 4:offset + 8]
+        chunk_data = data[offset + 8:offset + 8 + length]
+        if offset + 12 + length > len(data):
+            return False, f"truncated chunk {chunk_type!r}"
+        crc_stored = struct.unpack(">I", data[offset + 8 + length:offset + 12 + length])[0]
+        crc_calc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+        if crc_calc != crc_stored:
+            return False, f"bad CRC in chunk {chunk_type!r}"
+        if chunk_type == b"IHDR":
+            saw_ihdr = True
+        if chunk_type == b"IEND":
+            saw_iend = True
+            break
+        offset += 12 + length
+    if not saw_ihdr:
+        return False, "no IHDR chunk"
+    if not saw_iend:
+        return False, "no IEND chunk (truncated file)"
+    return True, "ok"
+
+
+def verify_one(inspector, path, is_ascii):
+    try:
+        data = inspector.download(path)
+    except ftplib.Error as exc:
+        print(f"  {path}: FAIL (download error: {exc})")
+        return False
+
+    if len(data) == 0:
+        print(f"  {path}: FAIL (empty file)")
+        return False
+
+    if is_ascii:
+        text = data.decode("ascii", errors="replace")
+        non_blank_lines = [line for line in text.splitlines() if line.strip()]
+        if not non_blank_lines:
+            print(f"  {path}: FAIL ({len(data)} bytes, but no non-blank text)")
+            return False
+        print(f"  {path}: PASS ({len(data)} bytes, {len(non_blank_lines)} non-blank lines)")
+        return True
+
+    ok, reason = png_is_well_formed(data)
+    if not ok:
+        print(f"  {path}: FAIL ({len(data)} bytes, {reason})")
+        return False
+    dims = decode_png_dimensions(data)
+    print(f"  {path}: PASS ({len(data)} bytes, {dims[0]}x{dims[1]}px)")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-H", "--host", default="u64")
+    parser.add_argument("--ftp-user", default=FTP_USER_DEFAULT)
+    parser.add_argument("--ftp-password", default=FTP_PASSWORD_DEFAULT)
+    parser.add_argument("--output-base", help="Printer output file base, e.g. /Usb0/printer/e2e-abc")
+    parser.add_argument("--pages", type=int, default=1, help="Expected page count for --output-base")
+    parser.add_argument("--ascii", action="store_true", help="Treat --output-base as ASCII (<base>.txt)")
+    parser.add_argument("--path", action="append", default=[], help="Explicit file path to verify (repeatable)")
+    args = parser.parse_args()
+
+    if not args.output_base and not args.path:
+        parser.error("specify --output-base or one or more --path")
+
+    inspector = FtpInspector(args.host, args.ftp_user, args.ftp_password)
+
+    paths = list(args.path)
+    if args.output_base:
+        if args.ascii:
+            paths.append(f"{args.output_base}.txt")
+        else:
+            for page in range(1, args.pages + 1):
+                paths.append(f"{args.output_base}-{page:03d}.png")
+
+    print(f"Verifying {len(paths)} file(s) on {args.host}")
+    results = [verify_one(inspector, path, args.ascii or path.endswith(".txt")) for path in paths]
+
+    passed = sum(1 for r in results if r)
+    print(f"\n{passed}/{len(results)} passed")
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes and hardens the virtual-printer paths implicated by #717.

## What this PR fixes

| Area | Failure mode | Fix |
| --- | --- | --- |
| Page-number scan | No-slash `Output file` names dereference NULL / build an invalid fallback path | Split only when a slash exists; otherwise scan `.` |
| Page-number scan | Rejected directory entries leak `FileInfo` objects | Release every scanned entry |
| Page-number scan | Directories and same-prefix junk names can be treated as pages | Accept only exact `<base>-NNN.png` files |
| PNG save path | `realloc()` reads FreeRTOS private heap metadata at the wrong offset and can copy out of bounds | Keep allocation sizes in an aligned wrapper-owned header |
| Allocation failure | Wrapped `malloc`/`calloc` panic forever; `realloc` can `memcpy` to NULL | Return NULL to C callers, check overflow/failure, and preserve the original `realloc` block |

## Root cause of the Flush/Eject crash

The confirmed first-bad commit is `76d887bdead10a57212e4d6731c04f94f53d3864`.
It moved U64 builds to FreeRTOS `heap_4` and added global allocator wrappers.
Its `__wrap_realloc()` assumes an 8-byte heap header and reads a size at
`ptr - 4`. On the RISC-V port, `heap_4` aligns its header to 16 bytes, making
that address application memory rather than allocator metadata.

The PNG encoder grows `ucvector` and `uivector` with `realloc()` while saving
a page. The bad size therefore causes an out-of-bounds copy during
Flush/Eject, which can corrupt firmware state and degrade the entire device.

The replacement wrapper does not inspect heap internals. It uses a private,
alignment-sized header only for C malloc-family allocations and implements
standard `realloc(NULL, n)`, `realloc(p, 0)`, overflow, and failure behavior.
Existing fatal C++ `new` behavior is intentionally unchanged.

## E2E coverage

`tools/io/printer/printer-e2e.py` now:

- tokenizes and runs the issue reporter's literal BASIC V2 reproducer;
- triggers the same menu **Flush/Eject** action;
- chooses output storage in order: `USB0`, `USB1`, `USB2`, then `Temp`;
- validates generated PNG structure over FTP.

## Hardware validation: Ultimate 64 Elite I

Testing was performed against the connected **Ultimate 64 Elite I** (`u64`)
using JTAG-deployed U64 firmware and the real IEC virtual-printer path.

| Test | Result |
| --- | --- |
| Literal issue #717 BASIC program → menu Flush/Eject | PASS: device remained REST/menu responsive; valid PNG written to the selected USB2 volume |
| Epson bitmap PNG | PASS |
| Epson text PNG | PASS |
| Commodore bitmap PNG | PASS |
| Commodore text PNG | PASS |
| Python harness compilation, 6510 assembly, `git diff --check` | PASS |

The U64/U64-II firmware build phases completed before this commit. The target
had USB2 mounted; automatic selection chose it after USB0 and USB1 were absent.

## Historical comparison status

The issue reporter already established the immediate-parent / first-bad
boundary (`2367b2ff` good, `76d887bd` bad). A local automated replay of that
comparison is not yet valid: the historical parent predates the REST menu and
synthetic-input APIs used by the harness, so attempting that automation tests
the missing legacy API rather than the printer Flush/Eject path. This PR does
not overstate that comparison as locally reproduced.

## Risk

Low. The firmware behavior change is confined to allocator wrappers introduced
by the first-bad commit. IEC protocol behavior, FileManager behavior, and the
existing #719 page-number semantics are otherwise unchanged.
