### PR TITLE
Fix phantom USB keyboard presses on the C64 matrix

### DIFF
--- a/software/io/usb/keyboard_usb.cc
+++ b/software/io/usb/keyboard_usb.cc
@@ -147,6 +147,7 @@ Keyboard_USB :: Keyboard_USB()
 	rest_pending_tap_delay = 0;
 	usb_restore = 0;
 	usb_freeze = 0;
+	usb_reset = 0;
 	rest_restore = false;
 	rest_restore_overlay = 0;
 	rest_restore_hold = 0;
@@ -208,6 +209,7 @@ void Keyboard_USB :: applyMatrixState(void)
 		uint8_t local_state = (matrixEnabled && !rest_control) ? (matrix_state[i] | injected_matrix_state[i]) : 0;
 		matrix[i] = local_state | rest_state;
 	}
+	matrix[8] = matrixEnabled ? usb_reset : 0;
 	matrix[9] = (matrixEnabled ? usb_restore : 0) | (rest_restore ? 1 : 0) | (rest_restore_overlay ? 1 : 0);
 	matrix[10] = matrixEnabled ? usb_freeze : 0;
 }
@@ -354,6 +356,9 @@ bool Keyboard_USB :: PresentInLastData(uint8_t check)
 	return false;
 }
 
+// Only decodes into matrix_state; applyMatrixState() gates it on matrixEnabled.
+// Must stay callable while the matrix is disabled, so that key releases arriving
+// while the menu is open are not lost.
 void Keyboard_USB :: usb2matrix(uint8_t *kd)
 {
 	if (!matrix) {
@@ -373,11 +378,7 @@ void Keyboard_USB :: usb2matrix(uint8_t *kd)
 	const uint8_t key_locations[] = { };
 
 	// reset
-	if (modi == 0x0F) {
-		matrix[8] = 1;
-	} else {
-		matrix[8] = 0;
-	}
+	usb_reset = (modi == 0x0F) ? 1 : 0;
 
 	// Handle the modifiers
 	for(int i=0;i<8;i++) {
@@ -448,9 +449,7 @@ void Keyboard_USB :: S_rest_timer(TimerHandle_t a)
 // called from USB thread
 void Keyboard_USB :: process_data(uint8_t *kbdata)
 {
-	if(matrixEnabled) {
-		usb2matrix(kbdata);
-	}
+	usb2matrix(kbdata);
 
 	num_keys = USB_DATA_SIZE - 2;
 	for(int i=2; i<USB_DATA_SIZE; i++) {
@@ -934,6 +933,13 @@ void Keyboard_USB :: setMatrix(volatile uint8_t *matrix)
 
 void Keyboard_USB :: enableMatrix(bool enable)
 {
+	if (enable && !matrixEnabled) {
+		// Keys still queued when the menu hands the keyboard back are menu
+		// navigation; getch() would replay them onto the C64 matrix.
+		portENTER_CRITICAL();
+		injected_tail = injected_head;
+		portEXIT_CRITICAL();
+	}
 	matrixEnabled = enable;
 	if (!enable) {
 		clearInjectedMatrixState();

--- a/software/io/usb/keyboard_usb.h
+++ b/software/io/usb/keyboard_usb.h
@@ -50,6 +50,7 @@ class Keyboard_USB : public Keyboard
     uint8_t last_data[USB_DATA_SIZE];
     uint8_t usb_restore;
     uint8_t usb_freeze;
+    uint8_t usb_reset;
     bool rest_restore;
     uint8_t rest_restore_overlay;
     uint8_t rest_restore_hold;

--- a/software/io/usb/tests/usb_keyboard_queue_test.cpp
+++ b/software/io/usb/tests/usb_keyboard_queue_test.cpp
@@ -86,6 +86,155 @@ TEST(KeyboardUsbQueueTest, InjectedCursorKeyPulsesMatrix)
 	EXPECT_EQ(0x00, matrix[6]);
 }
 
+// USB HID usage 0x2C (space) maps to C64 matrix row 7, column 4.
+static const uint8_t USB_KEY_SPACE = 0x2C;
+static const uint8_t MATRIX_SPACE_ROW = 7;
+static const uint8_t MATRIX_SPACE_BIT = 0x10;
+
+TEST(KeyboardUsbMatrixTest, KeyReleasedWhileMatrixDisabledDoesNotStick)
+{
+	Keyboard_USB keyboard;
+	uint8_t matrix[11] = { 0 };
+	uint8_t press[USB_DATA_SIZE] = { 0x00, 0x00, USB_KEY_SPACE, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	uint8_t release[USB_DATA_SIZE] = { 0x00 };
+
+	keyboard.setMatrix(matrix);
+	keyboard.enableMatrix(true);
+
+	keyboard.process_data(press);
+	EXPECT_EQ(MATRIX_SPACE_BIT, matrix[MATRIX_SPACE_ROW]);
+
+	keyboard.enableMatrix(false); // menu opens while the key is still held
+	EXPECT_EQ(0x00, matrix[MATRIX_SPACE_ROW]);
+
+	keyboard.process_data(release); // key released with the menu still open
+	keyboard.enableMatrix(true);    // menu closes
+
+	EXPECT_EQ(0x00, matrix[MATRIX_SPACE_ROW]);
+}
+
+TEST(KeyboardUsbMatrixTest, ShiftReleasedWhileMatrixDisabledDoesNotStick)
+{
+	Keyboard_USB keyboard;
+	uint8_t matrix[11] = { 0 };
+	uint8_t left_shift[USB_DATA_SIZE] = { 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	uint8_t release[USB_DATA_SIZE] = { 0x00 };
+
+	keyboard.setMatrix(matrix);
+	keyboard.enableMatrix(true);
+
+	keyboard.process_data(left_shift);
+	EXPECT_EQ(0x80, matrix[1]);
+
+	keyboard.enableMatrix(false);
+	keyboard.process_data(release);
+	keyboard.enableMatrix(true);
+
+	EXPECT_EQ(0x00, matrix[1]);
+}
+
+TEST(KeyboardUsbMatrixTest, KeyStillHeldWhenMatrixIsEnabledIsReported)
+{
+	Keyboard_USB keyboard;
+	uint8_t matrix[11] = { 0 };
+	uint8_t press[USB_DATA_SIZE] = { 0x00, 0x00, USB_KEY_SPACE, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+	keyboard.setMatrix(matrix);
+	keyboard.enableMatrix(false);
+
+	keyboard.process_data(press); // pressed while the menu owns the keyboard
+	EXPECT_EQ(0x00, matrix[MATRIX_SPACE_ROW]);
+
+	keyboard.enableMatrix(true); // still physically held when the menu closes
+	EXPECT_EQ(MATRIX_SPACE_BIT, matrix[MATRIX_SPACE_ROW]);
+}
+
+TEST(KeyboardUsbMatrixTest, KeysTypedWhileMatrixDisabledDoNotReachTheMatrix)
+{
+	Keyboard_USB keyboard;
+	uint8_t matrix[11] = { 0 };
+	uint8_t press[USB_DATA_SIZE] = { 0x00, 0x00, USB_KEY_SPACE, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	uint8_t release[USB_DATA_SIZE] = { 0x00 };
+
+	keyboard.setMatrix(matrix);
+	keyboard.enableMatrix(false);
+
+	keyboard.process_data(press);
+	EXPECT_EQ(0x00, matrix[MATRIX_SPACE_ROW]);
+	keyboard.process_data(release);
+	EXPECT_EQ(0x00, matrix[MATRIX_SPACE_ROW]);
+
+	keyboard.enableMatrix(true);
+	EXPECT_EQ(0x00, matrix[MATRIX_SPACE_ROW]);
+}
+
+TEST(KeyboardUsbMatrixTest, MenuKeystrokesDoNotLeakToTheMatrixAfterTheMenuCloses)
+{
+	Keyboard_USB keyboard;
+	uint8_t matrix[11] = { 0 };
+
+	keyboard.setMatrix(matrix);
+	keyboard.enableMatrix(true);
+
+	keyboard.enableMatrix(false); // menu takes the keyboard
+	keyboard.push_head(KEY_UP);   // menu navigation (mouse wheel / REST)
+	keyboard.push_head(KEY_DOWN);
+	keyboard.enableMatrix(true);  // menu hands it back
+
+	EXPECT_EQ(-1, keyboard.getch());
+	EXPECT_EQ(0x00, matrix[0]);
+	EXPECT_EQ(0x00, matrix[6]);
+}
+
+TEST(KeyboardUsbMatrixTest, CursorKeysQueuedWhileMatrixEnabledStillReachTheMatrix)
+{
+	Keyboard_USB keyboard;
+	uint8_t matrix[11] = { 0 };
+
+	keyboard.setMatrix(matrix);
+	keyboard.enableMatrix(true);
+	keyboard.push_head(KEY_UP); // mouse cursor mode drives the C64 this way
+
+	EXPECT_EQ(KEY_UP, keyboard.getch());
+	EXPECT_EQ(0x80, matrix[0]);
+	EXPECT_EQ(0x10, matrix[6]);
+}
+
+TEST(KeyboardUsbMatrixTest, ResetRestoreAndFreezeAreGatedAndNotStale)
+{
+	Keyboard_USB keyboard;
+	uint8_t matrix[11] = { 0 };
+	uint8_t reset_combo[USB_DATA_SIZE] = { 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	uint8_t restore[USB_DATA_SIZE] = { 0x00, 0x00, 0x45, 0x00, 0x00, 0x00, 0x00, 0x00 }; // F12
+	uint8_t freeze[USB_DATA_SIZE] = { 0x00, 0x00, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00 };  // F11
+	uint8_t release[USB_DATA_SIZE] = { 0x00 };
+
+	keyboard.setMatrix(matrix);
+	keyboard.enableMatrix(true);
+
+	keyboard.process_data(reset_combo);
+	EXPECT_EQ(0x01, matrix[8]);
+	keyboard.enableMatrix(false);
+	EXPECT_EQ(0x00, matrix[8]); // reset must not stay asserted while the menu is open
+	keyboard.process_data(release);
+	keyboard.enableMatrix(true);
+	EXPECT_EQ(0x00, matrix[8]);
+
+	keyboard.process_data(restore);
+	EXPECT_EQ(0x01, matrix[9]);
+	keyboard.enableMatrix(false);
+	keyboard.process_data(release);
+	keyboard.enableMatrix(true);
+	EXPECT_EQ(0x00, matrix[9]);
+
+	keyboard.process_data(freeze);
+	EXPECT_EQ(0x01, matrix[10]);
+	keyboard.enableMatrix(false);
+	keyboard.process_data(release);
+	keyboard.enableMatrix(true);
+	EXPECT_EQ(0x00, matrix[10]);
+}
+
 TEST(KeyboardUsbQueueTest, RemoveInjectedKeyDropsPendingDirection)
 {
 	Keyboard_USB keyboard;


### PR DESCRIPTION
## Summary

Fixes three `Keyboard_USB` defects that could leave a key asserted on the C64 keyboard matrix even though no key was still held on the USB keyboard.

The common failure mode was a stale or queued keyboard state escaping back onto the live matrix after menu interaction.

## Defects fixed

### 1. Key releases were dropped while the menu was open

`process_data()` only decoded the USB report into `matrix_state` while the matrix was enabled:

```c
if(matrixEnabled) {
    usb2matrix(kbdata);
}
```

That is unsafe because the menu disables the matrix for its whole session. `ultimate.cc` calls `enableMatrix(false)`, and `run_once()` then blocks until the menu closes.

As a result, this sequence could leave a stale key asserted:

1. Hold a key.
2. Open the menu while still holding it.
3. Release the key while the menu is open.
4. Close the menu.

The release report arrives while the matrix is disabled, so it is discarded. `matrix_state` therefore still contains the key snapshot from the moment the menu opened. When the menu closes, `enableMatrix(true)` re-applies that stale snapshot to the live C64 matrix.

This does not self-correct. The HID driver sends `SET_IDLE` with duration `0`, meaning "report only on change". An idle keyboard sends no further report, so the key remains asserted until the user types again.

This is part of ordinary menu use. `context_menu.cc` and `tree_browser.cc` call `wait_free()`, which intentionally waits for all keys to be released while the matrix is disabled.

#### Reproduction

Hold a key, open the menu while still holding it, release it while the menu is open, then close the menu.

`$CB` is the KERNAL matrix code of the currently pressed key. `0x40` means no key is pressed.

```sh
curl "http://<u64>/v1/machine:readmem?address=cb&length=1"
```

Before this fix, `$CB` reports the stuck key instead of `0x40`, and stays that way.

### 2. The reset line was not masked or refreshed

`matrix[8]`, the reset line, was written directly by `usb2matrix()` instead of through `applyMatrixState()`.

Unlike restore and freeze, reset was therefore:

* not gated by `matrixEnabled`
* not cleared when the menu took over
* not refreshed consistently when the matrix was re-enabled

### 3. Queued menu keystrokes could be replayed onto the matrix

`getch()` pops the injected keystroke queue and calls `setInjectedMatrixKey()`, which writes the live matrix.

If any injected keystrokes remained queued when the menu handed the keyboard back, the main loop could replay them onto the C64 as phantom cursor keys.

The scope is intentionally narrow:

* Ordinary USB cursor-key navigation is not affected.
* USB keypresses go into `key_buffer` via `putch()`.
* `getch()` returns those keys without touching the matrix.
* Only `push_head()` entries reach `setInjectedMatrixKey()`.
* Only the four cursor keys map to matrix writes.
* All other keys hit `default:` in `setInjectedMatrixKey()` and are ignored.

The affected queued cursor keys can come from:

* mouse paths in `usb_hid.cc`, used by Menu Mouse Navigation
* the `machine:input` REST route
* `send_keystroke(KEY_RIGHT)` in:

  * `UserFileInteraction::S_enter`
  * `FileTypeTap::enter_st`
  * `network_esp32.cc`

## Fix

`usb2matrix()` now always decodes the current USB report into `matrix_state`.

`applyMatrixState()` is now the single place that decides whether that decoded state may reach the live matrix, based on `matrixEnabled`. This matches the existing model used for restore and freeze.

The reset line, `matrix[8]`, now follows the same path.

The injected keystroke queue is also dropped when the menu hands the keyboard back, preventing queued menu input from being replayed onto the C64 matrix.

`usb2matrix()` still keeps its `!matrix` early-out, so targets without a keyboard matrix remain unchanged.

## Tests

Seven test cases were added to:

```text
software/io/usb/tests/usb_keyboard_queue_test.cpp
```

Run with:

```sh
cd software/io/usb/tests && make
```

The tests cover:

* a normal key released while the matrix is disabled
* a modifier released while the matrix is disabled
* reset, restore, and freeze gating
* injected queue replay
* the guard case that keys typed while the menu owns the keyboard must still not reach the C64
* the guard case that mouse cursor mode must still drive the C64

Five of the seven tests fail without this change. All 88 tests pass with it.

The other two tests are guard cases and must pass both before and after the fix.

## Device validation

Also built and exercised on a U64 Elite via JTAG.

Validated that:

* the firmware builds cleanly
* the device boots
* the keyboard works
* the matrix stays clean across menu open and close cycles
