### PR TITLE
Reap half-open Telnet sessions with TCP keepalive

### DIFF
--- a/software/network/config/lwipopts.h
+++ b/software/network/config/lwipopts.h
@@ -980,8 +980,11 @@
  * LWIP_TCP_KEEPALIVE==1: Enable TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT
  * options processing. Note that TCP_KEEPIDLE and TCP_KEEPINTVL have to be set
  * in seconds. (does not require sockets.c, and will affect tcp.c)
+ *
+ * Enabled so socket_gui.cc can arm per-socket keepalive and reap half-open
+ * telnet sessions (a vanished peer sends no FIN/RST and would leak its slot).
  */
-#define LWIP_TCP_KEEPALIVE              0
+#define LWIP_TCP_KEEPALIVE              1
 
 /**
  * LWIP_SO_RCVTIMEO==1: Enable SO_RCVTIMEO processing.

--- a/software/network/socket_gui.cc
+++ b/software/network/socket_gui.cc
@@ -6,6 +6,7 @@
  */
 
 #include <sys/socket.h>
+#include "lwip/sockets.h" // SO_KEEPALIVE / IPPROTO_TCP / TCP_KEEPIDLE|INTVL|CNT
 #include "socket_gui.h"
 #include "socket_stream.h"
 
@@ -55,6 +56,20 @@ static void socket_gui_set_timeouts(int socket_fd)
     send_tv.tv_sec = 5;
     send_tv.tv_usec = 0;
     setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&send_tv, sizeof(struct timeval));
+
+    // Reap half-open telnet sessions: a vanished peer (WiFi drop, powered-off
+    // phone, AP roam) sends no FIN/RST, so run_remote() would poll recv()
+    // forever and leak its TELNET_MAX_SESSIONS slot. Keepalive errors the pcb
+    // once the peer stops ACKing, so recv() fails and the slot frees (~35s:
+    // 20s idle + 3*5s). Needs LWIP_TCP_KEEPALIVE=1 in lwipopts.h.
+    int keepalive_on = 1;
+    setsockopt(socket_fd, SOL_SOCKET, SO_KEEPALIVE, (char *)&keepalive_on, sizeof(keepalive_on));
+    int keepalive_idle = 20;   // idle seconds before first probe
+    setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPIDLE, (char *)&keepalive_idle, sizeof(keepalive_idle));
+    int keepalive_intvl = 5;   // seconds between probes
+    setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPINTVL, (char *)&keepalive_intvl, sizeof(keepalive_intvl));
+    int keepalive_cnt = 3;     // unacked probes -> peer dead
+    setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPCNT, (char *)&keepalive_cnt, sizeof(keepalive_cnt));
 }
 
 SocketGui :: SocketGui()

--- a/tools/io/telnet/telnet_stale_session_test.py
+++ b/tools/io/telnet/telnet_stale_session_test.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Red/green E2E for the telnet half-open session leak.
+
+A telnet peer that vanishes at the network level (WiFi drop, powered-off phone,
+AP roam) sends no FIN/RST and never ACKs the device's keepalive probes. Without
+the fix its session slot leaks and the 4-slot listener wedges; with the fix TCP
+keepalive reaps the dead session (~35s) and capacity recovers.
+
+The vanished peer is faked by opening the victims from a throwaway IP alias,
+then deleting it so the host stops answering ARP/keepalive. Managing the alias
+needs root, so the script elevates only `ip addr add/del` via `sudo -n` (grant
+passwordless sudo for `ip`, or run under sudo).
+
+Exit 0 = GREEN (all slots reaped, full capacity recovers); non-zero = RED / setup error.
+"""
+
+import argparse
+import socket
+import subprocess
+import sys
+import time
+
+TELNET_PORT = 23
+DEFAULT_MAX_SESSIONS = 4  # mirrors TELNET_MAX_SESSIONS in software/network/socket_gui.cc
+BUSY_MARKER = b"Too many connections"
+FREE_CONFIRM_BYTES = 64  # larger than any busy reply; excess with no marker = banner
+IP_CMD = ["sudo", "-n", "ip"]  # only ip needs root
+
+
+def log(msg: str) -> None:
+    print(f"[telnet-stale-e2e] {msg}", flush=True)
+
+
+def _connect(host: str, *, source_ip: str | None = None, timeout: float = 4.0) -> socket.socket:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    if source_ip:
+        s.bind((source_ip, 0))
+    s.connect((host, TELNET_PORT))
+    return s
+
+
+def probe_is_free(host: str) -> bool:
+    """Fresh connection returned a banner, not the busy reply (split-segment safe)."""
+    try:
+        s = _connect(host)
+    except OSError as exc:
+        log(f"probe connect failed: {exc}")
+        return False
+    try:
+        deadline = time.time() + 1.5
+        buf = b""
+        while time.time() < deadline and len(buf) < 4096:
+            s.settimeout(max(0.05, deadline - time.time()))
+            try:
+                chunk = s.recv(256)
+            except OSError:
+                break
+            if not chunk:
+                break
+            buf += chunk
+            if BUSY_MARKER in buf:
+                return False
+            if len(buf) >= FREE_CONFIRM_BYTES:
+                return True
+        return len(buf) > 0 and BUSY_MARKER not in buf
+    finally:
+        s.close()
+
+
+def measure_capacity(host: str, cap: int) -> int:
+    """Count how many concurrent sessions the listener will currently accept."""
+    conns = []
+    free = 0
+    for _ in range(cap + 1):
+        try:
+            s = _connect(host)
+            time.sleep(0.15)
+            data = s.recv(64)
+            if BUSY_MARKER in data:
+                s.close()
+            else:
+                conns.append(s)
+                free += 1
+        except OSError:
+            break
+    for s in conns:
+        s.close()
+    time.sleep(2.0)  # let the clean closes reap first
+    return free
+
+
+def run_cmd(args: list[str]) -> None:
+    subprocess.run(args, check=True, capture_output=True, text=True)
+
+
+def add_ip_alias(iface: str, victim_ip: str) -> None:
+    run_cmd(IP_CMD + ["addr", "add", f"{victim_ip}/24", "dev", iface])
+
+
+def del_ip_alias(iface: str, victim_ip: str) -> bool:
+    """Remove the throwaway victim IP; return True on success. Never raises."""
+    result = subprocess.run(
+        IP_CMD + ["addr", "del", f"{victim_ip}/24", "dev", iface],
+        check=False, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        log(f"ip addr del {victim_ip} failed: {(result.stderr or result.stdout).strip()}")
+    return result.returncode == 0
+
+
+def open_half_open_victims(host: str, victim_ip: str, count: int) -> list[socket.socket]:
+    victims = []
+    for i in range(count):
+        s = _connect(host, source_ip=victim_ip)
+        try:
+            s.settimeout(1.0)
+            s.recv(64)  # drain banner so the session is fully live
+        except OSError:
+            pass
+        victims.append(s)
+        log(f"  opened half-open victim {i + 1}/{count} from {victim_ip}")
+        time.sleep(0.2)
+    return victims
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Red/green E2E for the telnet half-open session leak "
+                    "(needs sudo on ip for the vanishing-peer alias).")
+    parser.add_argument("-H", "--host", default="u64",
+                        help="device hostname or IP (default u64)")
+    parser.add_argument("--iface", default="eth0",
+                        help="LAN interface for the throwaway victim IP")
+    parser.add_argument("--victim-ip", default="192.168.1.240",
+                        help="unused LAN IP to source the vanishing connections from")
+    parser.add_argument("--sessions", type=int, default=DEFAULT_MAX_SESSIONS,
+                        help="half-open sessions to leak (= TELNET_MAX_SESSIONS)")
+    parser.add_argument("--reap-timeout", type=float, default=75.0,
+                        help="seconds to wait for keepalive reaping before declaring RED")
+    parser.add_argument("--poll-interval", type=float, default=3.0,
+                        help="seconds between recovery polls")
+    args = parser.parse_args()
+
+    # Preflight: can we manage the alias? (needs sudo on ip)
+    check = subprocess.run(IP_CMD + ["addr", "show", "dev", args.iface],
+                           capture_output=True, text=True)
+    if check.returncode != 0:
+        log("ERROR: cannot run `sudo -n ip` - grant passwordless sudo for `ip` or "
+            f"run under sudo. ({(check.stderr or check.stdout).strip()})")
+        return 2
+
+    victims: list[socket.socket] = []
+    alias_added = False
+    try:
+        log(f"target telnet {args.host}:{TELNET_PORT}, victim source {args.victim_ip} on {args.iface}")
+
+        # Table must be fully free at baseline, else another client is using it.
+        free = measure_capacity(args.host, args.sessions)
+        log(f"baseline free session slots: {free} (expected {args.sessions})")
+        if free < args.sessions:
+            log("ERROR: listener not fully free at baseline - is another telnet client connected?")
+            return 3
+
+        # Fill every slot with a half-open victim from the throwaway IP.
+        add_ip_alias(args.iface, args.victim_ip)
+        alias_added = True
+        log(f"added victim IP alias {args.victim_ip}/24 on {args.iface}")
+        victims = open_half_open_victims(args.host, args.victim_ip, args.sessions)
+
+        time.sleep(1.0)
+        if probe_is_free(args.host):
+            log("ERROR: listener still free after filling every slot - could not saturate.")
+            return 4
+        log("listener saturated: fresh connections are refused (as expected).")
+
+        # Required: if this del fails the peers never vanish (fake RED) - abort.
+        if not del_ip_alias(args.iface, args.victim_ip):
+            log("ERROR: could not delete victim IP alias - peers would not truly vanish; aborting.")
+            return 5
+        alias_added = False
+        log(f"deleted victim IP {args.victim_ip}: {args.sessions} sessions are now half-open.")
+
+        # Require the FULL table back, not one slot (guards a partial reap).
+        deadline = time.time() + args.reap_timeout
+        start = time.time()
+        recovered_at = None
+        while time.time() < deadline:
+            free = measure_capacity(args.host, args.sessions)
+            if free >= args.sessions:
+                recovered_at = time.time() - start
+                break
+            log(f"  recovery poll: {free}/{args.sessions} slots free")
+            time.sleep(args.poll_interval)
+
+        if recovered_at is not None:
+            log(f"GREEN: all {args.sessions} leaked slots recovered after ~{recovered_at:.0f}s "
+                "(keepalive reaped the half-open sessions).")
+            return 0
+
+        log(f"RED: listener still wedged {args.reap_timeout:.0f}s after the peers vanished - "
+            "half-open sessions were never reaped (fix absent or ineffective).")
+        return 1
+
+    finally:
+        for s in victims:
+            try:
+                s.close()
+            except OSError:
+                pass
+        if alias_added:
+            del_ip_alias(args.iface, args.victim_ip)
+            log(f"cleanup: removed victim IP alias {args.victim_ip}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Overview

Fixes permanent Telnet listener degradation caused by abandoned TCP connections.

## Problem

The Telnet server supports up to four concurrent sessions.

Sessions are released normally when a client closes its connection or sends TCP `FIN` or `RST`. However, a client can disappear without completing the TCP shutdown handshake, for example when:

- a phone drops off Wi-Fi
- a laptop enters sleep mode
- an access point or route disappears
- an application or network failure completely abandons the connection

This leaves a **half-open TCP connection** on the Ultimate.

Without TCP keepalive, the server has no way to detect that the peer has vanished. The session continues occupying one of the four Telnet slots indefinitely.

After four such failures, every new Telnet connection is rejected with:

```text
Too many connections, try again later.
```

The Telnet listener remains unusable until the device is rebooted. REST and FTP continue working because they use separate listeners.

## Root cause

Each accepted Telnet connection runs in a `socket_gui_task`.

Its `run_remote()` loop exits only when `SocketStream::get_char()` or `transmit()` detects a closed or failed connection. Normally this happens when:

- `recv()` returns `0` after a TCP `FIN`
- `recv()` or `send()` reports a hard error after a TCP `RST` or another connection failure

For an abandoned connection, neither occurs.

The socket has a 200 ms receive timeout, but no idle or keepalive timeout. Consequently, `recv()` repeatedly returns `EAGAIN`, the task never exits, and the session permanently retains:

- one of the four Telnet session slots
- its session task
- one entry from the shared 16-entry netconn pool

## Fix

Enable lwIP TCP keepalive support and configure it on every accepted Telnet socket:

```text
SO_KEEPALIVE  = enabled
TCP_KEEPIDLE  = 20 seconds
TCP_KEEPINTVL = 5 seconds
TCP_KEEPCNT   = 3 probes
```

After approximately 35 seconds without a valid response:

1. lwIP declares the peer unreachable.
2. The socket reports an error.
3. `run_remote()` exits.
4. The task and network resources are released.
5. The Telnet session slot becomes available again.

A connected but idle client is unaffected because it continues acknowledging the keepalive probes.

## Scope and safety

### Telnet only

Keepalive is enabled only on sockets that explicitly opt in through `SO_KEEPALIVE`.

The only new caller is the Telnet accept path. The following remain unchanged:

- REST and HTTP
- FTP control and data connections
- raw DMA sockets
- UDP traffic

### No global keepalive activation

Changing `LWIP_TCP_KEEPALIVE` from `0` to `1` enables lwIP's per-socket keepalive timing options. It does not automatically enable keepalive on every TCP connection.

Individual sockets must still explicitly set `SO_KEEPALIVE`.

### Negligible resource cost

The change adds two `u32_t` fields to each `tcp_pcb`, approximately 240 bytes in total with the current PCB pool size.

It introduces:

- no additional task
- no additional timer
- no heap growth

Keepalive processing uses the existing 500 ms `tcp_slowtmr()` cycle. A dead connection generates only three small header-only probe packets.

### Existing leaked sessions

The fix prevents future half-open sessions from remaining allocated indefinitely.

Sessions already leaked before installing the updated firmware still require one reboot to clear.

### Ultimate II+L

The implementation is shared by the Ultimate 64 and Ultimate II+L firmware targets.

The small memory and CPU cost also helps the II+L by reclaiming dead sessions from the same four-session limit and shared netconn pool.

## Validation

| Check | Result |
| --- | --- |
| Host unit tests | `filemanager` 18, USB 23, API 11 + 23 passed |
| Firmware builds | Ultimate 64 Nios II and Ultimate II+L RISC-V builds passed |
| Ultimate 64 true half-open test | Before: listener remained wedged after 75 seconds. After: all four slots reaped in approximately 36 seconds |
| Ultimate II+L true half-open test | Tested on a unit plugged into a C64U. Before: listener remained wedged after 75 seconds. After: all four slots reaped in approximately 38 seconds |
| Ultimate II+L 20-minute soak | 23 consecutive half-open reap cycles, 0 failures, all four slots reaped every cycle |
| Independent reproductions | Standalone E2E and soak-test vanish lane both confirmed RED before and GREEN after |
| Telnet lifecycle stress | 632 successful interactions, 0 failures, 4 runners over 10 minutes |
| Whole-surface soak | 1 minute passed, 10 minutes passed, 20 minutes passed with 0 failures across 360 operations |
| Supporting `vivipi` work | `soak/u2-telnet-keepalive` pushed, with 4 new and 93 existing tests passing |

### True half-open reproduction

The test connections originate from a temporary secondary host IP address. That IP is then removed without closing the sockets.

The peer therefore:

- sends no `FIN`
- sends no `RST`
- stops responding to ARP
- cannot acknowledge the Ultimate's TCP keepalive probes

A normal `close()` is intentionally not used because it performs a normal TCP shutdown and does not reproduce the defect.

| Firmware | Result |
| --- | --- |
| Before the fix | The listener remained wedged 75 seconds after all four clients vanished. None of the four slots was released |
| After the fix | All four connections were detected and reaped in approximately 36 seconds, after which a new Telnet connection succeeded |

### Telnet lifecycle stress

The fixed firmware was exercised with:

- four concurrent runners
- connections aborted during active sessions
- continuous churn for 10 minutes

Results:

```text
632 successful Telnet interactions
0 Telnet failures
138 ms median latency
1.9 s p99 latency
```

Failures observed on unrelated surfaces during separate torture testing were caused by pre-existing FTP and HTTP connection limits. They were not Telnet failures and were not introduced by this change.

### Whole-surface soak

A host-side soak tool concurrently exercised:

- REST and HTTP
- FTP
- Telnet
- the raw DMA socket

The test was escalated through 1-minute, 10-minute, and 20-minute runs.

All runs completed with:

- zero transport failures
- zero unexpected exceptions
- zero blocked hosts
- valid probe ordering and lifecycle behaviour
- timing within the configured tolerances

### Ultimate II+L (plugged into a C64U)

The same true half-open test and a 20-minute soak were run against an Ultimate II+L plugged into a C64U.

| Firmware | Result |
| --- | --- |
| Before the fix | The listener stayed wedged for the full 75 seconds. None of the four slots was released |
| After the fix | All four connections were reaped in approximately 38 seconds, after which Telnet recovered to full capacity |

The soak ran 23 consecutive half-open reap cycles over 20 minutes with 0 failures, reaping all four slots each cycle, and the listener returned to full capacity at the end.

### Test-suite limitations

The available host environment did not contain the external libraries required to build the gtest- and libcheck-based suites.

Those suites do not cover the changed Telnet socket path. The bundled lwIP unit suite also uses its own test-specific `lwipopts.h` rather than the production configuration changed here.

## Files changed

- `software/network/socket_gui.cc`
  - Enables and configures TCP keepalive on each accepted Telnet socket.
  - Adds the required `lwip/sockets.h` include.

- `software/network/config/lwipopts.h`
  - Changes `LWIP_TCP_KEEPALIVE` from `0` to `1`.

- `tools/io/telnet/telnet_stale_session_test.py`
  - Adds a deterministic RED/GREEN end-to-end test using true half-open TCP connections.
