### PR TITLE
Fix unbounded boot-cart name copy

### DIFF
--- a/run-e2e-tests
+++ b/run-e2e-tests
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# run-e2e-tests — run every hardware end-to-end test against one Ultimate device.
+#
+# Each suite drives the real firmware over REST/FTP/Telnet, so a device has to
+# be reachable and idle. Suites run sequentially; the exit status is non-zero if
+# any of them fails.
+
+set -uo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+HOST="${U64_HOST:-u64}"
+PASSWORD="${U64_PASS:-}"
+TIMEOUT="30.0"
+SELECTED=()
+LIST_ONLY=false
+STOP_ON_FAIL=false
+
+C_BLUE='\033[1;34m'
+C_GREEN='\033[1;32m'
+C_RED='\033[1;31m'
+C_YEL='\033[1;33m'
+C_NC='\033[0m'
+
+# name|relative path|space separated arguments (@HOST@/@PASS@/@TIMEOUT@ are substituted)
+SUITES=(
+  "readmem-writemem|tools/api/readmem_writemem_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"
+  "menu-screen|tools/api/menu_screen_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"
+  "input|tools/api/input_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@"
+  "prg-context-menu|tools/io/filemanager/prg_context_menu_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@"
+  "browser-long-filename|tools/io/filemanager/browser_long_filename_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@"
+  "ftp-client|tools/io/filemanager/ftp_client_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@"
+  "prg-load-path-trim|tools/io/prg-load-path-trim-test.sh|-H @HOST@ -p @PASS@"
+  "temp-auto-cleanup|tools/io/temp-auto-cleanup/temp-auto-cleanup-test.sh|-H @HOST@ -p @PASS@"
+  "printer|tools/io/printer/printer_test.py|-H @HOST@ -p @PASS@"
+)
+
+show_help() {
+    cat << EOF
+Usage: $SCRIPT_NAME [OPTIONS] [HOST]
+
+Run every hardware end-to-end test suite sequentially against one Ultimate
+device and print a pass/fail summary.
+
+Arguments:
+  HOST                      Device host name or IP. May also be given with -H.
+
+Options:
+  -h, --help                Show this help message and exit.
+  -H, --host <host>         Device host name or IP (default: \$U64_HOST or u64).
+  -p, --password <pass>     REST and FTP password (default: \$U64_PASS, empty).
+  -t, --timeout <seconds>   Per-request REST timeout (default: $TIMEOUT).
+  -s, --suite <name>        Run only this suite. Repeatable.
+  -l, --list                List the suite names and exit.
+  -x, --stop-on-fail        Stop at the first failing suite.
+
+Suites:
+$(for entry in "${SUITES[@]}"; do printf '  %-24s %s\n' "${entry%%|*}" "$(echo "$entry" | cut -d'|' -f2)"; done)
+
+Notes:
+  The device must be idle: these suites open the menu, reset the machine and
+  mount disks. Some of them change device settings and restore them on exit.
+
+Examples:
+  $SCRIPT_NAME u64
+  $SCRIPT_NAME -H 192.168.0.64 -p secret
+  $SCRIPT_NAME -H u64 -s prg-context-menu -s menu-screen
+  $SCRIPT_NAME --list
+EOF
+}
+
+die() {
+    echo -e "${C_RED}ERROR: $*${C_NC}" >&2
+    exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help) show_help; exit 0 ;;
+        -H|--host) [[ $# -ge 2 ]] || die "$1 needs a value"; HOST="$2"; shift 2 ;;
+        -p|--password) [[ $# -ge 2 ]] || die "$1 needs a value"; PASSWORD="$2"; shift 2 ;;
+        -t|--timeout) [[ $# -ge 2 ]] || die "$1 needs a value"; TIMEOUT="$2"; shift 2 ;;
+        -s|--suite) [[ $# -ge 2 ]] || die "$1 needs a value"; SELECTED+=("$2"); shift 2 ;;
+        -l|--list) LIST_ONLY=true; shift ;;
+        -x|--stop-on-fail) STOP_ON_FAIL=true; shift ;;
+        -*) die "Unknown option: $1" ;;
+        *) HOST="$1"; shift ;;
+    esac
+done
+
+if [[ "$LIST_ONLY" == true ]]; then
+    for entry in "${SUITES[@]}"; do
+        printf '%-24s %s\n' "${entry%%|*}" "$(echo "$entry" | cut -d'|' -f2)"
+    done
+    exit 0
+fi
+
+selected_wanted() {
+    local name=$1
+    [[ ${#SELECTED[@]} -eq 0 ]] && return 0
+    local want
+    for want in "${SELECTED[@]}"; do
+        [[ "$want" == "$name" ]] && return 0
+    done
+    return 1
+}
+
+for want in "${SELECTED[@]-}"; do
+    [[ -z "$want" ]] && continue
+    found=false
+    for entry in "${SUITES[@]}"; do
+        [[ "${entry%%|*}" == "$want" ]] && found=true
+    done
+    [[ "$found" == true ]] || die "Unknown suite: $want (use --list)"
+done
+
+echo -e "${C_YEL}Ultimate end-to-end test run${C_NC}"
+echo -e "Host:    ${HOST}"
+echo -e "Timeout: ${TIMEOUT}s"
+
+PASSED=()
+FAILED=()
+SKIPPED=()
+START_ALL=$SECONDS
+
+for entry in "${SUITES[@]}"; do
+    name="${entry%%|*}"
+    path="$(echo "$entry" | cut -d'|' -f2)"
+    raw_args="$(echo "$entry" | cut -d'|' -f3-)"
+
+    selected_wanted "$name" || continue
+
+    full_path="$ROOT/$path"
+    if [[ ! -f "$full_path" ]]; then
+        echo -e "\n${C_YEL}SKIP: $name (missing $path)${C_NC}"
+        SKIPPED+=("$name")
+        continue
+    fi
+
+    args=()
+    for token in $raw_args; do
+        token="${token//@HOST@/$HOST}"
+        token="${token//@TIMEOUT@/$TIMEOUT}"
+        if [[ "$token" == "@PASS@" ]]; then
+            args+=("$PASSWORD")
+        else
+            args+=("$token")
+        fi
+    done
+
+    if [[ "$full_path" == *.py ]]; then
+        cmd=(python3 "$full_path" "${args[@]}")
+    else
+        cmd=(bash "$full_path" "${args[@]}")
+    fi
+
+    echo -e "\n${C_BLUE}SUITE: $name${C_NC}\n$(printf '%.s-' {1..60})"
+    start=$SECONDS
+    if "${cmd[@]}"; then
+        echo -e "${C_GREEN}PASS: $name ($((SECONDS - start))s)${C_NC}"
+        PASSED+=("$name")
+    else
+        echo -e "${C_RED}FAIL: $name ($((SECONDS - start))s)${C_NC}"
+        FAILED+=("$name")
+        if [[ "$STOP_ON_FAIL" == true ]]; then
+            break
+        fi
+    fi
+done
+
+echo -e "\n${C_YEL}Summary after $((SECONDS - START_ALL))s${C_NC}\n$(printf '%.s-' {1..60})"
+for name in "${PASSED[@]-}"; do [[ -n "$name" ]] && echo -e "  ${C_GREEN}PASS${C_NC}  $name"; done
+for name in "${SKIPPED[@]-}"; do [[ -n "$name" ]] && echo -e "  ${C_YEL}SKIP${C_NC}  $name"; done
+for name in "${FAILED[@]-}"; do [[ -n "$name" ]] && echo -e "  ${C_RED}FAIL${C_NC}  $name"; done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    exit 1
+fi
+echo -e "\n${C_GREEN}SUCCESS: all selected suites passed.${C_NC}"

--- a/software/io/c64/c64_subsys.cc
+++ b/software/io/c64/c64_subsys.cc
@@ -42,20 +42,23 @@ static bool contains_path_separator(const char *name)
     return false;
 }
 
-static void format_bootcrt_display_name(const char *name, char *display_name)
+// Returns either the name itself, or a trimmed copy in the caller's buffer.
+// Plain names are passed on untouched: CbmFileName cuts them to 16 PETSCII
+// characters itself, and needs the extension that trimming here would remove.
+static const char *format_bootcrt_display_name(const char *name, char *trimmed)
 {
     const int kDisplayChars = 16;
     const int kTrimmedTailChars = 13;
     int length = strlen(name);
 
     if ((length <= kDisplayChars) || !contains_path_separator(name)) {
-        strcpy(display_name, name);
-        return;
+        return name;
     }
 
-    memcpy(display_name, "...", 3);
-    memcpy(display_name + 3, name + length - kTrimmedTailChars, kTrimmedTailChars);
-    display_name[kDisplayChars] = 0;
+    memcpy(trimmed, "...", 3);
+    memcpy(trimmed + 3, name + length - kTrimmedTailChars, kTrimmedTailChars);
+    trimmed[kDisplayChars] = 0;
+    return trimmed;
 }
 
 cart_def boot_cart; // static => initialized with all zeros.
@@ -601,8 +604,8 @@ int C64_Subsys :: dma_load(File *f, const uint8_t *buffer, const int bufferSize,
 
     C64_POKE(C64_BOOTCRT_DOSYNC, (c64->cfg->get_value(CFG_C64_DO_SYNC) == 1) ? 1 : 0);
 
-    char display_name[17];
-    format_bootcrt_display_name(name, display_name);
+    char trimmed_name[17];
+    const char *display_name = format_bootcrt_display_name(name, trimmed_name);
 
     CbmFileName cbm;
     cbm.init(display_name);

--- a/tools/io/filemanager/prg_context_menu_test.py
+++ b/tools/io/filemanager/prg_context_menu_test.py
@@ -1,0 +1,1182 @@
+#!/usr/bin/env python3
+"""Validate every PRG context-menu action in the real U64 browser.
+
+The fixture is a tiny BASIC+ML program that stores a known signature at
+$C000 and prints a line through CHROUT. It is seeded into `/Temp` three
+times: as a plain FAT file, under a name far longer than the boot cart can
+display, and as the only file inside a D64 image, so the same program can be
+launched from both sides of the disk boundary.
+
+For each of those two locations the test reads what the context menu offers
+and then drives every single entry, failing if the browser grows an action
+that nothing here covers. Everything is driven with `machine:input` key
+injection and verified from outside the browser - C64 memory and screen for
+the loaders, FTP and the raw D64 directory for the file operations:
+
+  Run          the program executed -> signature present and output on screen
+  Load         the program is in RAM -> load image present, signature absent
+  DMA          the program is in RAM afterwards and RUN starts it
+  Mount & Run  D64 on drive A, program executed
+  Real Run     D64 on drive A, real 1541 LOAD (no FILE NOT FOUND), executed
+  View         a viewer opens over the browser and closes again
+  Hex View     the hex dump shows the fixture's own bytes
+  Copy to...   the copy lands in the picked directory, original untouched
+  Move to...   the file lands in the picked directory and leaves its origin
+  Rename       the new name replaces the old one
+  Delete       the file is gone
+"""
+
+import argparse
+import ftplib
+import io
+import json
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "api"))
+
+from menu_screen_test import Failure, MenuScreenInfo, RestSession, check
+
+
+FTP_USER = "user"
+FTP_DEFAULT_PASSWORD = "password"
+
+TEMP_PATH = "/Temp/"
+ROOT_PATH = "/"
+FIXTURE_PREFIX = "prgmenu"
+# 16 characters: the longest name a CBM directory entry can hold. Together with
+# the ".prg" the browser appends this is the longest name the boot-cart loader
+# ever sees, which is exactly the case that used to overflow its name buffer.
+CBM_FILE_NAME = "DMATESTPROGRAM01"
+DISK_NAME = "DMATEST"
+LONG_NAME_LENGTH = 100
+
+SIGNATURE_ADDRESS = 0xC000
+SIGNATURE = b"U64PRGOK"
+LOAD_ADDRESS = 0x0801
+MESSAGE = "U64 PRG TEST OK"
+
+MENU_SETTLE_SECONDS = 0.15
+MENU_OPEN_SETTLE_SECONDS = 0.35
+ACTION_SETTLE_SECONDS = 1.0
+RUN_TIMEOUT_SECONDS = 12.0
+REAL_RUN_TIMEOUT_SECONDS = 40.0
+BOOT_TIMEOUT_SECONDS = 15.0
+POPUP_SETTLE_SECONDS = 0.6
+SCREEN_TIMEOUT_SECONDS = 6.0
+EDIT_FIELD_CLEAR_TAPS = 64
+
+HEX_VIEW_FIRST_LINE = "0000 01 08 0B 08"
+# Pin the interface so a run does not depend on how the device happens to be
+# configured, and on whether a monitor is plugged in.
+INTERFACE_TYPE_PATH = "/v1/configs/User%20Interface%20Settings/Interface%20Type"
+REQUIRED_INTERFACE_TYPE = "Freeze"
+
+PICKER_TITLE = "Select Path"
+PICKER_SELECT_ENTRY = "<< Select Current Dir >>"
+EDITOR_KEYS = {".": "period"}
+
+# Offered entries this test knowingly does not drive, with the reason why.
+UNEXERCISED_ACTIONS = {
+    "Run with App": "only offered when /Flash/apps/<ext>.prg is installed",
+}
+
+# 10 SYS 2064 ; the machine code stores SIGNATURE at $C000 and prints MESSAGE.
+PRG_BYTES = bytes(
+    [
+        0x01, 0x08,                    # load address $0801
+        0x0B, 0x08,                    # link to $080B
+        0x0A, 0x00,                    # line 10
+        0x9E,                          # SYS token
+        0x32, 0x30, 0x36, 0x34,        # "2064"
+        0x00,                          # end of line
+        0x00, 0x00,                    # end of program
+        0x00, 0x00, 0x00,              # filler up to $0810
+        0xA2, 0x07,                    # ldx #$07
+        0xBD, 0x29, 0x08,              # lda signature,x
+        0x9D, 0x00, 0xC0,              # sta $C000,x
+        0xCA,                          # dex
+        0x10, 0xF7,                    # bpl -9
+        0xA2, 0x00,                    # ldx #$00
+        0xBD, 0x31, 0x08,              # lda message,x
+        0xF0, 0x06,                    # beq done
+        0x20, 0xD2, 0xFF,              # jsr $ffd2
+        0xE8,                          # inx
+        0xD0, 0xF5,                    # bne -11
+        0x60,                          # rts
+    ]
+) + SIGNATURE + MESSAGE.encode("ascii") + bytes([0x0D, 0x00])
+
+SECTORS_PER_TRACK = [21] * 17 + [19] * 7 + [18] * 6 + [17] * 5
+D64_SIZE = 174848
+D64_DIR_TRACK = 18
+D64_FILE_TRACK = 17
+D64_FILE_SECTOR = 0
+
+
+def sector_offset(track: int, sector: int) -> int:
+    return (sum(SECTORS_PER_TRACK[: track - 1]) + sector) * 256
+
+
+def cbm_padded(name: str, length: int = 16) -> bytes:
+    return name.upper().encode("ascii")[:length].ljust(length, b"\xa0")
+
+
+def build_d64(disk_name: str, file_name: str, payload: bytes) -> bytes:
+    """A 35-track image holding exactly one single-sector PRG."""
+    if len(payload) > 254:
+        raise Failure("fixture payload must fit in a single D64 sector")
+    image = bytearray(D64_SIZE)
+
+    bam = sector_offset(D64_DIR_TRACK, 0)
+    image[bam + 0x00] = D64_DIR_TRACK
+    image[bam + 0x01] = 0x01
+    image[bam + 0x02] = 0x41  # DOS version 'A'
+    for track in range(1, 36):
+        entry = bam + 0x04 + (track - 1) * 4
+        free = SECTORS_PER_TRACK[track - 1]
+        bits = (1 << free) - 1
+        image[entry] = free
+        image[entry + 1] = bits & 0xFF
+        image[entry + 2] = (bits >> 8) & 0xFF
+        image[entry + 3] = (bits >> 16) & 0xFF
+    image[bam + 0x90 : bam + 0xA0] = cbm_padded(disk_name)
+    image[bam + 0xA0 : bam + 0xA2] = b"\xa0\xa0"
+    image[bam + 0xA2 : bam + 0xA4] = b"64"
+    image[bam + 0xA4] = 0xA0
+    image[bam + 0xA5 : bam + 0xA7] = b"2A"
+    image[bam + 0xA7 : bam + 0xAB] = b"\xa0" * 4
+
+    def allocate(track: int, sector: int) -> None:
+        entry = bam + 0x04 + (track - 1) * 4
+        image[entry] -= 1
+        image[entry + 1 + (sector >> 3)] &= ~(1 << (sector & 7)) & 0xFF
+
+    allocate(D64_DIR_TRACK, 0)
+    allocate(D64_DIR_TRACK, 1)
+    allocate(D64_FILE_TRACK, D64_FILE_SECTOR)
+
+    directory = sector_offset(D64_DIR_TRACK, 1)
+    image[directory + 0x00] = 0x00
+    image[directory + 0x01] = 0xFF
+    image[directory + 0x02] = 0x82  # closed PRG
+    image[directory + 0x03] = D64_FILE_TRACK
+    image[directory + 0x04] = D64_FILE_SECTOR
+    image[directory + 0x05 : directory + 0x15] = cbm_padded(file_name)
+    image[directory + 0x1E] = 0x01  # one block
+    image[directory + 0x1F] = 0x00
+
+    data = sector_offset(D64_FILE_TRACK, D64_FILE_SECTOR)
+    image[data + 0x00] = 0x00
+    image[data + 0x01] = len(payload) + 1
+    image[data + 0x02 : data + 0x02 + len(payload)] = payload
+
+    return bytes(image)
+
+
+def screencode_to_ascii(code: int) -> str:
+    value = code & 0x7F
+    if value < 0x20:
+        return chr(value + 0x40)
+    if value < 0x40:
+        return chr(value)
+    return "."
+
+
+class Machine:
+    """C64-side observation and the browser navigation built on top of it."""
+
+    def __init__(self, session: RestSession) -> None:
+        self.session = session
+
+    # ---- REST helpers ---------------------------------------------------
+    def readmem(self, address: int, length: int) -> bytes:
+        status, _, body = self.session.request(
+            "GET", "/v1/machine:readmem",
+            params={"address": f"{address:04X}", "length": length})
+        if status != 200:
+            raise Failure(f"readmem ${address:04X} failed with HTTP {status}")
+        return body
+
+    def writemem(self, address: int, data: bytes) -> None:
+        status, _, body = self.session.request(
+            "PUT", "/v1/machine:writemem",
+            params={"address": f"{address:04X}", "data": data.hex()})
+        if status != 200:
+            raise Failure(f"writemem ${address:04X} failed with HTTP {status}: {body[:120]!r}")
+
+    def reset(self) -> None:
+        status, _, _ = self.session.request("PUT", "/v1/machine:reset")
+        if status != 200:
+            raise Failure(f"machine:reset failed with HTTP {status}")
+        # Wait for the BASIC cold start to finish. Freezing before it has run
+        # its NEW leaves the boot sequence to wipe the program area and the
+        # BASIC pointers the moment the machine is released again.
+        deadline = time.monotonic() + BOOT_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if self.readmem(0x002B, 2) == b"\x01\x08" and "READY." in self.c64_screen():
+                time.sleep(0.3)
+                return
+            time.sleep(0.25)
+        raise Failure(f"C64 did not reach the BASIC prompt:\n{self.c64_screen()}")
+
+    def drive_a(self) -> Dict[str, object]:
+        status, _, body = self.session.request("GET", "/v1/drives")
+        if status != 200:
+            raise Failure(f"drives query failed with HTTP {status}")
+        for entry in json.loads(body.decode("utf-8")).get("drives", []):
+            if "a" in entry:
+                return entry["a"]
+        raise Failure("drive A missing from the drives listing")
+
+    def remove_drive_a(self) -> None:
+        self.session.request("PUT", "/v1/drives/a:remove")
+
+    def get_interface_type(self) -> str:
+        status, _, body = self.session.request("GET", INTERFACE_TYPE_PATH)
+        if status != 200:
+            raise Failure(f"reading the interface type failed with HTTP {status}")
+        setting = json.loads(body.decode("utf-8"))["User Interface Settings"]["Interface Type"]
+        return setting["current"]
+
+    def set_interface_type(self, value: str) -> None:
+        status, _, body = self.session.request(
+            "PUT", INTERFACE_TYPE_PATH, params={"value": value})
+        if status != 200:
+            raise Failure(f"setting the interface type to {value!r} failed: {body[:120]!r}")
+
+    # ---- C64 observation ------------------------------------------------
+    def signature(self) -> bytes:
+        return self.readmem(SIGNATURE_ADDRESS, len(SIGNATURE))
+
+    def clear_signature(self) -> None:
+        self.writemem(SIGNATURE_ADDRESS, bytes(len(SIGNATURE)))
+
+    def clear_load_area(self) -> None:
+        self.writemem(LOAD_ADDRESS, bytes(len(PRG_BYTES) - 2))
+
+    def load_image(self) -> bytes:
+        return self.readmem(LOAD_ADDRESS, len(PRG_BYTES) - 2)
+
+    def c64_screen(self) -> str:
+        data = self.readmem(0x0400, 1000)
+        return "\n".join(
+            "".join(screencode_to_ascii(b) for b in data[row * 40 : (row + 1) * 40])
+            for row in range(25)
+        )
+
+    def visible_text(self) -> str:
+        """Whatever the user is looking at: the menu when open, else the C64."""
+        body = self.session.try_get_menu_screen()
+        if body is not None:
+            return MenuScreenInfo(body).text
+        return self.c64_screen()
+
+    def wait_for_signature(self, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.signature() == SIGNATURE:
+                return
+            time.sleep(0.25)
+        raise Failure(
+            f"program never ran (no {SIGNATURE!r} at ${SIGNATURE_ADDRESS:04X}); "
+            f"screen was:\n{self.visible_text()}")
+
+    def wait_for_load_image(self, timeout: float) -> None:
+        expected = PRG_BYTES[2:]
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.load_image() == expected:
+                return
+            time.sleep(0.25)
+        raise Failure(
+            f"program was never placed at ${LOAD_ADDRESS:04X}; "
+            f"screen was:\n{self.visible_text()}")
+
+    # ---- Menu navigation ------------------------------------------------
+    def tap(self, inputs: List[str], settle: float = MENU_SETTLE_SECONDS) -> None:
+        # The device serves a small number of HTTP connections, so a single
+        # request can time out under load. Retry once: losing a keystroke here
+        # would be reported as a firmware failure.
+        try:
+            self.session.tap_keyboard(inputs)
+        except Failure:
+            time.sleep(1.0)
+            self.session.tap_keyboard(inputs)
+        time.sleep(settle)
+
+    def type_basic_line(self, text: str) -> None:
+        """Type a direct-mode line, making sure every character really landed.
+
+        REST key injection goes through the C64 keyboard matrix, so a tap can
+        be missed if the KERNAL scan does not see it. Check the echo before
+        pressing RETURN rather than sending BASIC a truncated command.
+        """
+        for attempt in range(5):
+            # The menu disables the C64 keyboard matrix while it is up and only
+            # re-enables it after the browser task has fully unwound, so give
+            # the machine its keyboard back before typing.
+            try:
+                self.session.release_all_input()
+            except Failure:
+                pass
+            time.sleep(0.5)
+            for character in text:
+                self.tap([character.lower()], 0.20)
+            time.sleep(0.2)
+            if any(row.strip() == text for row in self.c64_screen().splitlines()):
+                self.tap(["return"], 0.40)
+                return
+            # Wipe whatever did land and try again.
+            for _ in range(len(text) + 2):
+                self.tap(["inst_del"], 0.06)
+        raise Failure(f"could not type {text!r} on the C64:\n{self.c64_screen()}")
+
+    def rows(self) -> List[str]:
+        return MenuScreenInfo(self.session.get_menu_screen()).rows
+
+    def current_path(self) -> str:
+        return self.rows()[24].split()[0]
+
+    def selected(self) -> str:
+        return MenuScreenInfo(self.session.get_menu_screen()).selected_text
+
+    def open_menu(self) -> None:
+        if not self.session.menu_screen_unavailable():
+            return
+        self.session.open_menu()
+        time.sleep(MENU_OPEN_SETTLE_SECONDS)
+
+    def close_menu(self) -> None:
+        for _ in range(20):
+            if self.session.menu_screen_unavailable():
+                return
+            # RUN/STOP backs out of browsers and editors but does nothing to a
+            # popup: those only listen for their button keys.
+            rows = [row.strip() for row in self.rows()]
+            if "Yes  No" in rows:
+                self.tap(["n"], POPUP_SETTLE_SECONDS)
+            elif "Ok" in rows:
+                self.tap(["o"], POPUP_SETTLE_SECONDS)
+            else:
+                self.tap(["run_stop"], MENU_OPEN_SETTLE_SECONDS)
+        raise Failure("could not close the menu; screen was:\n" + "\n".join(self.rows()))
+
+    def go_to_root(self) -> None:
+        for _ in range(12):
+            if self.current_path() == ROOT_PATH:
+                return
+            self.tap(["left_shift", "cursor_left_right"], MENU_OPEN_SETTLE_SECONDS)
+        raise Failure(f"could not return to {ROOT_PATH!r}, now at {self.current_path()!r}")
+
+    def go_to_top(self, count: int = 24) -> None:
+        for _ in range(count):
+            self.tap(["left_shift", "cursor_up_down"], 0.03)
+
+    def select_entry(self, prefix: str, max_steps: int = 30) -> None:
+        self.go_to_top()
+        for _ in range(max_steps):
+            if self.selected().startswith(prefix):
+                return
+            self.tap(["cursor_up_down"])
+        raise Failure(f"could not select an entry starting with {prefix!r}")
+
+    def enter(self) -> None:
+        self.tap(["cursor_left_right"], MENU_OPEN_SETTLE_SECONDS)
+
+    def open_temp(self) -> None:
+        # Always start from a closed menu: a half-finished action can leave a
+        # nested screen (a path picker, an editor) on the UI stack, and that
+        # looks enough like the browser to silently swallow the whole test.
+        self.close_menu()
+        self.open_menu()
+        self.go_to_root()
+        self.select_entry("Temp")
+        self.enter()
+        if self.current_path() != TEMP_PATH:
+            raise Failure(f"expected {TEMP_PATH!r}, got {self.current_path()!r}")
+
+    def context_menu_items(self, before: List[str]) -> List[Tuple[int, str]]:
+        """Map the context-menu overlay to (screen row, label) pairs."""
+        after = self.rows()
+        items = []
+        for index, (old, new) in enumerate(zip(before, after)):
+            if old == new:
+                continue
+            label = new[len(os.path.commonprefix([old, new])) :].strip()
+            if label:
+                items.append((index, label))
+        if not items:
+            raise Failure(f"no context menu appeared; screen was:\n" + "\n".join(after))
+        return items
+
+    def invoke_context_action(self, label: str) -> None:
+        before = self.rows()
+        self.tap(["return"], MENU_OPEN_SETTLE_SECONDS)
+        items = self.context_menu_items(before)
+        labels = [text for _, text in items]
+        if label not in labels:
+            raise Failure(f"context menu has no {label!r}; it offers {labels}")
+        for _ in range(labels.index(label)):
+            self.tap(["cursor_up_down"])
+        self.tap(["return"], ACTION_SETTLE_SECONDS)
+
+    def context_labels(self) -> List[str]:
+        """Open the context menu of the selected entry and close it again."""
+        before = self.rows()
+        self.tap(["return"], MENU_OPEN_SETTLE_SECONDS)
+        labels = [text for _, text in self.context_menu_items(before)]
+        self.tap(["run_stop"], MENU_OPEN_SETTLE_SECONDS)
+        return labels
+
+    # ---- Nested screens the actions open --------------------------------
+    def wait_for_text(self, text: str, timeout: float = SCREEN_TIMEOUT_SECONDS) -> str:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            screen = "\n".join(self.rows())
+            if text in screen:
+                return screen
+            time.sleep(0.15)
+        raise Failure(f"{text!r} never appeared; screen was:\n" + "\n".join(self.rows()))
+
+    def press_popup_button(self, key: str, settle: float = POPUP_SETTLE_SECONDS) -> None:
+        """Popups are keyed: o=Ok, y=Yes, n=No, a=All, c=Cancel."""
+        self.tap([key], settle)
+
+    def leave_nested_screen(self) -> None:
+        """RUN/STOP backs out of the editors and of the path picker."""
+        self.tap(["run_stop"], MENU_OPEN_SETTLE_SECONDS)
+
+    def replace_edit_field(self, text: str) -> None:
+        for _ in range(EDIT_FIELD_CLEAR_TAPS):
+            self.tap(["inst_del"], 0.03)
+        for character in text:
+            key = EDITOR_KEYS.get(character)
+            if key is None and (character.isalnum()):
+                key = character.lower()
+            if key is None:
+                raise Failure(f"cannot type {character!r} through the REST keyboard")
+            self.tap([key], 0.08)
+        self.tap(["return"], POPUP_SETTLE_SECONDS)
+
+    def pick_directory(self, directory: str) -> None:
+        """Drive the 'Select Path' browser onto `directory` and pick it."""
+        self.wait_for_text(PICKER_TITLE)
+        parts = [part for part in directory.strip("/").split("/") if part]
+        for part in parts:
+            self.select_entry(part)
+            self.enter()
+        if self.current_path().rstrip("/") != directory.rstrip("/"):
+            raise Failure(
+                f"path picker is at {self.current_path()!r}, expected {directory!r}")
+        self.select_entry(PICKER_SELECT_ENTRY)
+        self.tap(["return"], ACTION_SETTLE_SECONDS)
+
+
+def ftp_connect(host: str, password: str) -> ftplib.FTP:
+    ftp = ftplib.FTP(host, timeout=30)
+    ftp.login(FTP_USER, password or FTP_DEFAULT_PASSWORD)
+    return ftp
+
+
+def default_fixture_token() -> str:
+    # The browser caches a disk image's directory per path, so every run needs
+    # its own image name to be sure it reads the freshly uploaded fixture.
+    return f"{int(time.time()) % 100000:05d}"
+
+
+def parse_d64_directory(image: bytes) -> List[str]:
+    """Names of the live files in a D64, read straight from the image."""
+    names = []
+    track, sector = D64_DIR_TRACK, 1
+    seen = set()
+    while track and (track, sector) not in seen:
+        seen.add((track, sector))
+        base = sector_offset(track, sector)
+        for entry in range(8):
+            # 32 byte slots; the first two bytes of slot 0 are the sector link,
+            # so the type/track/sector/name fields start at slot + 2.
+            slot = base + entry * 32
+            if image[slot + 2] == 0x00:  # deleted / unused slot
+                continue
+            raw = image[slot + 5 : slot + 21]
+            names.append(bytes(b & 0x7F for b in raw).decode("ascii", "replace").rstrip(" "))
+        track, sector = image[base], image[base + 1]
+    return names
+
+
+class Fixtures:
+    def __init__(self, token: str) -> None:
+        self.token = token
+        self.prg = f"{FIXTURE_PREFIX}{token}.prg"
+        self.d64 = f"{FIXTURE_PREFIX}{token}.d64"
+        self.target_dir = f"{FIXTURE_PREFIX}{token}tgt"
+        self.disk_serial = 0
+        # A name far beyond the 16 characters the boot cart can display. The
+        # loader has to shorten it for the C64 without overrunning its own
+        # buffer, so this is the fixture that catches that overrun.
+        stem = f"{FIXTURE_PREFIX}{token}_long_"
+        self.long_prg = stem + "0123456789" * ((LONG_NAME_LENGTH - len(stem)) // 10) + ".prg"
+        self.long_prefix = stem
+
+    def seed(self, host: str, password: str) -> None:
+        """All fixtures live side by side in /Temp: plain PRGs and a D64."""
+        payload = {
+            self.prg: PRG_BYTES,
+            self.long_prg: PRG_BYTES,
+            self.d64: build_d64(DISK_NAME, CBM_FILE_NAME, PRG_BYTES),
+        }
+        ftp = ftp_connect(host, password)
+        try:
+            try:
+                ftp.mkd(f"{TEMP_PATH}{self.target_dir}")
+            except ftplib.error_perm:
+                pass
+            for name, blob in payload.items():
+                self._store(ftp, name, blob)
+            # Overlong names come back through a shortened FTP alias, so match
+            # on the leading run that survives instead of the whole name.
+            listing = ftp.nlst(TEMP_PATH)
+            for name in payload:
+                stem = name[:20]
+                if not any(entry.startswith(stem) for entry in listing):
+                    raise Failure(f"fixture {name} was not stored in {TEMP_PATH}: {listing}")
+        finally:
+            ftp.quit()
+
+    @staticmethod
+    def _store(ftp: ftplib.FTP, name: str, blob: bytes) -> None:
+        try:
+            ftp.delete(f"{TEMP_PATH}{name}")
+        except ftplib.error_perm:
+            pass
+        ftp.storbinary(f"STOR {TEMP_PATH}{name}", io.BytesIO(blob))
+
+    def reseed_prg(self, host: str, password: str) -> None:
+        ftp = ftp_connect(host, password)
+        try:
+            self._store(ftp, self.prg, PRG_BYTES)
+        finally:
+            ftp.quit()
+
+    def new_disk(self, host: str, password: str) -> None:
+        """A fresh image name: the browser caches a disk directory per path."""
+        self.disk_serial += 1
+        self.d64 = f"{FIXTURE_PREFIX}{self.token}d{self.disk_serial}.d64"
+        ftp = ftp_connect(host, password)
+        try:
+            self._store(ftp, self.d64, build_d64(DISK_NAME, CBM_FILE_NAME, PRG_BYTES))
+        finally:
+            ftp.quit()
+
+    def temp_listing(self, host: str, password: str, directory: str = "") -> List[str]:
+        ftp = ftp_connect(host, password)
+        try:
+            return ftp.nlst(f"{TEMP_PATH}{directory}")
+        finally:
+            ftp.quit()
+
+    def disk_listing(self, host: str, password: str) -> List[str]:
+        """Read the fixture image back over FTP and decode its directory."""
+        ftp = ftp_connect(host, password)
+        try:
+            buffer = io.BytesIO()
+            ftp.retrbinary(f"RETR {TEMP_PATH}{self.d64}", buffer.write)
+        finally:
+            ftp.quit()
+        return parse_d64_directory(buffer.getvalue())
+
+    def remove(self, host: str, password: str) -> None:
+        try:
+            ftp = ftp_connect(host, password)
+        except Exception:
+            return
+        try:
+            for directory in (f"{self.target_dir}/", ""):
+                try:
+                    entries = ftp.nlst(f"{TEMP_PATH}{directory}")
+                except Exception:
+                    continue
+                for name in entries:
+                    if not name.startswith(FIXTURE_PREFIX) and directory == "":
+                        continue
+                    try:
+                        ftp.delete(f"{TEMP_PATH}{directory}{name}")
+                    except ftplib.error_perm:
+                        pass
+            try:
+                ftp.rmd(f"{TEMP_PATH}{self.target_dir}")
+            except ftplib.error_perm:
+                pass
+        except Exception:
+            pass
+        finally:
+            try:
+                ftp.quit()
+            except Exception:
+                pass
+
+
+def remove_leftovers_via_browser(machine: Machine, host: str, password: str) -> None:
+    """Delete fixtures FTP cannot reach.
+
+    An overlong name is only listed through a shortened FTP alias and DELE on
+    that alias fails, so the long-named fixture has to go out the same way it
+    came in view: through the browser, which resolves the real name.
+    """
+    ftp = ftp_connect(host, password)
+    try:
+        remaining = [n for n in ftp.nlst(TEMP_PATH) if n.startswith(FIXTURE_PREFIX)]
+    finally:
+        ftp.quit()
+    if not remaining:
+        return
+
+    machine.open_temp()
+    for _ in range(len(remaining)):
+        try:
+            machine.select_entry(FIXTURE_PREFIX)
+        except Failure:
+            break
+        machine.invoke_context_action("Delete")
+        machine.wait_for_text("Are you sure?")
+        machine.press_popup_button("y")
+    machine.close_menu()
+
+
+def prepare(machine: Machine, mounted: bool = False) -> None:
+    machine.close_menu()
+    machine.reset()
+    if not mounted:
+        machine.remove_drive_a()
+    machine.clear_signature()
+    machine.clear_load_area()
+    if machine.signature() == SIGNATURE:
+        raise Failure("could not clear the signature before the action")
+
+
+def open_plain_prg(machine: Machine, fixtures: Fixtures) -> None:
+    machine.open_temp()
+    machine.select_entry(fixtures.prg)
+
+
+def open_long_name_prg(machine: Machine, fixtures: Fixtures) -> None:
+    machine.open_temp()
+    machine.select_entry(fixtures.long_prefix)
+
+
+def open_disk_prg(machine: Machine, fixtures: Fixtures) -> None:
+    machine.open_temp()
+    machine.select_entry(fixtures.d64)
+    machine.enter()
+    expected = f"{TEMP_PATH}{fixtures.d64}/"
+    if machine.current_path() != expected:
+        raise Failure(f"expected to be inside {expected!r}, got {machine.current_path()!r}")
+    machine.select_entry(CBM_FILE_NAME)
+
+
+def assert_no_load_error(machine: Machine) -> None:
+    screen = machine.c64_screen()
+    for error in ("FILE NOT FOUND", "DEVICE NOT PRESENT"):
+        if error in screen:
+            raise Failure(f"drive reported {error}:\n{screen}")
+
+
+def assert_signature_absent(machine: Machine) -> None:
+    if machine.signature() == SIGNATURE:
+        raise Failure("the program ran even though the action should only load it")
+
+
+def run_action_run(machine: Machine, fixtures: Fixtures, open_entry) -> None:
+    prepare(machine)
+    open_entry(machine, fixtures)
+    machine.invoke_context_action("Run")
+    machine.wait_for_signature(RUN_TIMEOUT_SECONDS)
+    if MESSAGE not in machine.c64_screen():
+        raise Failure(f"program output missing from the screen:\n{machine.c64_screen()}")
+
+
+def run_action_load(machine: Machine, fixtures: Fixtures, open_entry) -> None:
+    prepare(machine)
+    open_entry(machine, fixtures)
+    machine.invoke_context_action("Load")
+    machine.wait_for_load_image(RUN_TIMEOUT_SECONDS)
+    assert_signature_absent(machine)
+
+
+def run_action_dma(machine: Machine, fixtures: Fixtures, open_entry) -> None:
+    prepare(machine)
+    open_entry(machine, fixtures)
+    machine.invoke_context_action("DMA")
+    # A DMA-only load hands the machine back and leaves the menu, by design.
+    machine.close_menu()
+    machine.wait_for_load_image(RUN_TIMEOUT_SECONDS)
+    assert_signature_absent(machine)
+    machine.type_basic_line("RUN")
+    machine.wait_for_signature(RUN_TIMEOUT_SECONDS)
+    if MESSAGE not in machine.c64_screen():
+        raise Failure(f"DMA-loaded program did not run:\n{machine.c64_screen()}")
+
+
+def run_action_mount_and_run(machine: Machine, fixtures: Fixtures) -> None:
+    prepare(machine)
+    open_disk_prg(machine, fixtures)
+    machine.invoke_context_action("Mount & Run")
+    machine.wait_for_signature(RUN_TIMEOUT_SECONDS)
+    assert_disk_mounted(machine, fixtures, "Mount & Run")
+
+
+def run_action_real_run(machine: Machine, fixtures: Fixtures) -> None:
+    prepare(machine)
+    open_disk_prg(machine, fixtures)
+    machine.invoke_context_action("Real Run")
+    assert_disk_mounted(machine, fixtures, "Real Run")
+    deadline = time.monotonic() + REAL_RUN_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        assert_no_load_error(machine)
+        if machine.signature() == SIGNATURE:
+            return
+        time.sleep(0.5)
+    raise Failure(f"real 1541 load/run never completed:\n{machine.c64_screen()}")
+
+
+def assert_disk_mounted(machine: Machine, fixtures: Fixtures, action: str) -> None:
+    drive_a = machine.drive_a()
+    mounted = f"{drive_a.get('image_path', '')}{drive_a.get('image_file', '')}"
+    if fixtures.d64 not in mounted:
+        raise Failure(f"{action} did not mount the D64 on drive A: {drive_a!r}")
+
+
+class PlainLocation:
+    """The PRG as an ordinary file in /Temp."""
+
+    label = "a plain PRG"
+
+    def open(self, machine: Machine, fixtures: Fixtures) -> None:
+        open_plain_prg(machine, fixtures)
+
+    def entry_name(self, fixtures: Fixtures) -> str:
+        return fixtures.prg
+
+    def renamed_to(self, fixtures: Fixtures) -> str:
+        return f"{FIXTURE_PREFIX}{fixtures.token}ren.prg"
+
+    def listing(self, host: str, password: str, fixtures: Fixtures) -> List[str]:
+        return fixtures.temp_listing(host, password)
+
+    def refresh(self, host: str, password: str, fixtures: Fixtures) -> None:
+        fixtures.reseed_prg(host, password)
+
+    def forbidden_actions(self) -> Tuple[str, ...]:
+        return ("Mount & Run", "Real Run")
+
+
+class DiskLocation:
+    """The same PRG as the only file inside a D64 image."""
+
+    label = "a PRG inside a D64"
+
+    def open(self, machine: Machine, fixtures: Fixtures) -> None:
+        open_disk_prg(machine, fixtures)
+
+    def entry_name(self, fixtures: Fixtures) -> str:
+        return CBM_FILE_NAME
+
+    def renamed_to(self, fixtures: Fixtures) -> str:
+        return "RENAMEDPRG"
+
+    def listing(self, host: str, password: str, fixtures: Fixtures) -> List[str]:
+        return fixtures.disk_listing(host, password)
+
+    def refresh(self, host: str, password: str, fixtures: Fixtures) -> None:
+        fixtures.new_disk(host, password)
+
+    def forbidden_actions(self) -> Tuple[str, ...]:
+        return ()
+
+
+def assert_present(names: List[str], wanted: str, what: str) -> None:
+    if not any(name.startswith(wanted) for name in names):
+        raise Failure(f"{what}: {wanted!r} is missing from {names}")
+
+
+def assert_absent(names: List[str], wanted: str, what: str) -> None:
+    if any(name.startswith(wanted) for name in names):
+        raise Failure(f"{what}: {wanted!r} is still present in {names}")
+
+
+def action_view(machine: Machine, fixtures: Fixtures, location, host: str, password: str) -> None:
+    location.open(machine, fixtures)
+    listing = machine.rows()
+    machine.invoke_context_action("View")
+    if machine.rows() == listing:
+        raise Failure("View did not open anything over the browser")
+    machine.leave_nested_screen()
+    machine.select_entry(location.entry_name(fixtures))
+
+
+def action_hex_view(machine: Machine, fixtures: Fixtures, location, host: str, password: str) -> None:
+    location.open(machine, fixtures)
+    machine.invoke_context_action("Hex View")
+    screen = machine.wait_for_text(HEX_VIEW_FIRST_LINE)
+    if "U64PRG" not in screen:
+        raise Failure(f"hex view is not showing the fixture:\n{screen}")
+    machine.leave_nested_screen()
+    machine.select_entry(location.entry_name(fixtures))
+
+
+def action_copy_to(machine: Machine, fixtures: Fixtures, location, host: str, password: str) -> None:
+    clear_target_dir(host, password, fixtures)
+    location.open(machine, fixtures)
+    machine.invoke_context_action("Copy to...")
+    machine.pick_directory(f"{TEMP_PATH}{fixtures.target_dir}")
+    machine.wait_for_text("Copy complete.")
+    machine.press_popup_button("o")
+
+    copied = fixtures.temp_listing(host, password, f"{fixtures.target_dir}/")
+    if len(copied) != 1:
+        raise Failure(f"expected exactly one copy in the target directory, got {copied}")
+    if fetch_temp_file(host, password, f"{fixtures.target_dir}/{copied[0]}")[:len(PRG_BYTES)] != PRG_BYTES:
+        raise Failure(f"the copy {copied[0]!r} does not hold the fixture bytes")
+    assert_present(location.listing(host, password, fixtures),
+                   location.entry_name(fixtures), "Copy to... removed the original")
+
+
+def action_move_to(machine: Machine, fixtures: Fixtures, location, host: str, password: str) -> None:
+    clear_target_dir(host, password, fixtures)
+    location.refresh(host, password, fixtures)
+    location.open(machine, fixtures)
+    machine.invoke_context_action("Move to...")
+    machine.pick_directory(f"{TEMP_PATH}{fixtures.target_dir}")
+    machine.wait_for_text("Move complete.")
+    machine.press_popup_button("o")
+
+    moved = fixtures.temp_listing(host, password, f"{fixtures.target_dir}/")
+    if len(moved) != 1:
+        raise Failure(f"expected exactly one moved file in the target directory, got {moved}")
+    assert_absent(location.listing(host, password, fixtures),
+                  location.entry_name(fixtures), "Move to... left the original behind")
+
+
+def action_rename(machine: Machine, fixtures: Fixtures, location, host: str, password: str) -> None:
+    location.refresh(host, password, fixtures)
+    location.open(machine, fixtures)
+    original = location.entry_name(fixtures)
+    renamed = location.renamed_to(fixtures)
+    machine.invoke_context_action("Rename")
+    machine.wait_for_text("Give a new name..")
+    machine.replace_edit_field(renamed)
+
+    names = location.listing(host, password, fixtures)
+    assert_present(names, renamed, "Rename did not create the new name")
+    assert_absent(names, original, "Rename left the old name behind")
+
+
+def action_delete(machine: Machine, fixtures: Fixtures, location, host: str, password: str) -> None:
+    location.refresh(host, password, fixtures)
+    location.open(machine, fixtures)
+    original = location.entry_name(fixtures)
+    machine.invoke_context_action("Delete")
+    machine.wait_for_text("Are you sure?")
+    machine.press_popup_button("y")
+
+    assert_absent(location.listing(host, password, fixtures), original, "Delete did not remove the file")
+
+
+# --- The scenarios issue #729 reports, checked the way a user would see them ---
+
+def scenario_dma_runnable(machine: Machine, fixtures: Fixtures, location, host, password) -> str:
+    """DMA has to leave a program in RAM that the user can actually RUN."""
+    prepare(machine)
+    location.open(machine, fixtures)
+    machine.invoke_context_action("DMA")
+    machine.close_menu()
+    in_ram = machine.load_image() == PRG_BYTES[2:]
+    machine.type_basic_line("RUN")
+    ran = False
+    deadline = time.monotonic() + RUN_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if machine.signature() == SIGNATURE:
+            ran = True
+            break
+        time.sleep(0.25)
+    problems = []
+    if not in_ram:
+        problems.append("program not in RAM")
+    if not ran:
+        pointers = machine.readmem(0x002B, 4).hex(" ")
+        problems.append(f"RUN did not start it (TXTTAB/VARTAB {pointers})")
+    return ", ".join(problems)
+
+
+def scenario_real_run(machine: Machine, fixtures: Fixtures, location, host, password) -> str:
+    """Real Run has to complete a real 1541 load, with no drive error."""
+    prepare(machine)
+    open_disk_prg(machine, fixtures)
+    machine.invoke_context_action("Real Run")
+    deadline = time.monotonic() + REAL_RUN_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        screen = machine.c64_screen()
+        for error in ("FILE NOT FOUND", "DEVICE NOT PRESENT"):
+            if error in screen:
+                return f"drive reported {error}"
+        if machine.signature() == SIGNATURE:
+            return ""
+        time.sleep(0.5)
+    return "load/run never completed"
+
+
+def scenario_long_name_run(machine: Machine, fixtures: Fixtures, location, host, password) -> str:
+    """Run a PRG whose name is far longer than the boot cart can display.
+
+    On firmware without the name-buffer fix this does not merely misbehave: it
+    takes the whole device down, so the check has to survive the machine going
+    away rather than raise on the first refused connection.
+    """
+    prepare(machine)
+    machine.open_temp()
+    machine.select_entry(fixtures.long_prefix)
+    machine.invoke_context_action("Run")
+    deadline = time.monotonic() + RUN_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            if machine.signature() == SIGNATURE:
+                return ""
+        except Failure as exc:
+            return f"device stopped responding ({exc})"
+        time.sleep(0.25)
+    return "program never ran"
+
+
+SCENARIOS = [
+    ("long-name", "Run a PRG with a 101 character name", scenario_long_name_run, PlainLocation),
+    ("dma-plain", "DMA a plain PRG", scenario_dma_runnable, PlainLocation),
+    ("dma-disk", "DMA a PRG inside a D64", scenario_dma_runnable, DiskLocation),
+    ("real-run", "Real Run a PRG inside a D64", scenario_real_run, DiskLocation),
+]
+
+
+def run_repeat_mode(machine: Machine, fixtures: Fixtures, host: str, password: str,
+                    repeat: int, selected: List[str]) -> int:
+    """Hammer selected scenarios so an intermittent defect cannot look like a pass."""
+    chosen = [entry for entry in SCENARIOS if not selected or entry[0] in selected]
+    tally = {label: [] for _, label, _, _ in chosen}
+    for iteration in range(1, repeat + 1):
+        for _, label, scenario, location_type in chosen:
+            location = location_type()
+            location.refresh(host, password, fixtures)
+            try:
+                problem = scenario(machine, fixtures, location, host, password)
+            except Failure as exc:
+                problem = str(exc)
+            tally[label].append(problem)
+            state = "ok  " if not problem else "FAIL"
+            print(f"  [{iteration:02d}/{repeat}] {state} {label}"
+                  + (f" -> {problem}" if problem else ""), flush=True)
+
+    print("\n=== repeat summary ===")
+    failed_total = 0
+    for label, results in tally.items():
+        bad = [r for r in results if r]
+        failed_total += len(bad)
+        reasons = sorted(set(bad))
+        print(f"  {label}: {len(results) - len(bad)}/{len(results)} ok"
+              + (f"  failures: {reasons}" if reasons else ""))
+    return 1 if failed_total else 0
+
+
+def fetch_temp_file(host: str, password: str, relative: str) -> bytes:
+    ftp = ftp_connect(host, password)
+    try:
+        buffer = io.BytesIO()
+        ftp.retrbinary(f"RETR {TEMP_PATH}{relative}", buffer.write)
+        return buffer.getvalue()
+    finally:
+        ftp.quit()
+
+
+def clear_target_dir(host: str, password: str, fixtures: Fixtures) -> None:
+    ftp = ftp_connect(host, password)
+    try:
+        for name in ftp.nlst(f"{TEMP_PATH}{fixtures.target_dir}/"):
+            try:
+                ftp.delete(f"{TEMP_PATH}{fixtures.target_dir}/{name}")
+            except ftplib.error_perm:
+                pass
+    finally:
+        ftp.quit()
+
+
+# Every action the browser offers for a PRG, in the order the test drives them:
+# the destructive ones come last so the earlier checks run against a pristine
+# fixture. The load/run entries are handled separately because they also need a
+# freshly reset C64.
+FILE_ACTIONS = [
+    ("View", action_view),
+    ("Hex View", action_hex_view),
+    ("Copy to...", action_copy_to),
+    ("Rename", action_rename),
+    ("Move to...", action_move_to),
+    ("Delete", action_delete),
+]
+
+
+def load_actions(machine: Machine, fixtures: Fixtures, location):
+    """The load/run entries, bound to one location."""
+    actions = [
+        ("Run", lambda: run_action_run(machine, fixtures, location.open)),
+        ("Load", lambda: run_action_load(machine, fixtures, location.open)),
+        ("DMA", lambda: run_action_dma(machine, fixtures, location.open)),
+    ]
+    if isinstance(location, DiskLocation):
+        actions.append(("Mount & Run", lambda: run_action_mount_and_run(machine, fixtures)))
+        actions.append(("Real Run", lambda: run_action_real_run(machine, fixtures)))
+    return actions
+
+
+def offered_actions(machine: Machine, fixtures: Fixtures, location) -> List[str]:
+    location.open(machine, fixtures)
+    return machine.context_labels()
+
+
+def run_context_menu_inventory(machine: Machine, fixtures: Fixtures, location, offered: List[str]) -> None:
+    for label in location.forbidden_actions():
+        if label in offered:
+            raise Failure(f"{location.label} should not offer {label!r}: {offered}")
+    handled = {label for label, _ in FILE_ACTIONS}
+    handled.update(label for label, _ in load_actions(machine, fixtures, location))
+    handled.update(UNEXERCISED_ACTIONS)
+    missing = [label for label in offered if label not in handled]
+    if missing:
+        raise Failure(
+            f"{location.label} offers actions this test never drives: {missing}. "
+            "Add a handler for each, or list it in UNEXERCISED_ACTIONS with a reason.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Drive and verify every PRG context-menu action on real firmware.")
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_INPUT_HOST", "u64"))
+    parser.add_argument(
+        "-p", "--password",
+        default=os.environ.get("U64_INPUT_PASSWORD", os.environ.get("C64U_PASSWORD", "")))
+    parser.add_argument(
+        "-t", "--timeout", type=float,
+        default=float(os.environ.get("U64_INPUT_TIMEOUT", "15.0")))
+    parser.add_argument(
+        "--keep-fixtures", action="store_true",
+        help="Leave the seeded /Temp fixtures in place for manual inspection.")
+    parser.add_argument(
+        "--repeat", type=int, default=0, metavar="N",
+        help="Instead of the full matrix, repeat the load/run scenarios N times.")
+    parser.add_argument(
+        "--scenario", action="append", metavar="NAME",
+        choices=[name for name, _, _, _ in SCENARIOS],
+        help="Limit --repeat to this scenario. Repeatable. "
+             "One of: " + ", ".join(name for name, _, _, _ in SCENARIOS))
+    parser.add_argument(
+        "--fixture-token", default=default_fixture_token(),
+        help="Suffix that makes this run's /Temp fixture names unique.")
+    args = parser.parse_args()
+
+    session = RestSession(args.host, args.password or None, args.timeout)
+    machine = Machine(session)
+    fixtures = Fixtures(args.fixture_token)
+    original_interface_type = None
+
+    locations = [PlainLocation(), DiskLocation()]
+
+    failures: List[Tuple[str, str]] = []
+    total = 0
+
+    # Every action is independent, so keep going after a failure: one run then
+    # reports the whole context-menu matrix instead of stopping at the first hole.
+    def run_case(label, action) -> None:
+        nonlocal total
+        total += 1
+        try:
+            with check(label):
+                action()
+        except Failure as exc:
+            failures.append((label, str(exc)))
+
+    try:
+        with check(f"select the {REQUIRED_INTERFACE_TYPE} interface"):
+            original_interface_type = machine.get_interface_type()
+            if original_interface_type != REQUIRED_INTERFACE_TYPE:
+                machine.set_interface_type(REQUIRED_INTERFACE_TYPE)
+                machine.close_menu()
+
+        with check(f"seed /Temp with {fixtures.prg}, {fixtures.d64} and a long-named PRG"):
+            fixtures.seed(args.host, args.password)
+
+        if args.repeat > 0:
+            names = args.scenario or [name for name, _, _, _ in SCENARIOS]
+            print(f"\nRepeating {', '.join(names)} {args.repeat} times")
+            return run_repeat_mode(machine, fixtures, args.host, args.password,
+                                   args.repeat, args.scenario or [])
+
+        for location in locations:
+            with check(f"read the context menu of {location.label}"):
+                offered = offered_actions(machine, fixtures, location)
+            print(f"     offers: {', '.join(offered)}")
+
+            run_case(f"{location.label}: every offered action is covered",
+                     lambda loc=location, off=offered: run_context_menu_inventory(
+                         machine, fixtures, loc, off))
+
+            for label, action in load_actions(machine, fixtures, location):
+                if label in offered:
+                    run_case(f"{label} on {location.label}", action)
+            for label, handler in FILE_ACTIONS:
+                if label in offered:
+                    run_case(
+                        f"{label} on {location.label}",
+                        lambda h=handler, loc=location: h(
+                            machine, fixtures, loc, args.host, args.password))
+
+        # Last on purpose: on firmware without the boot-cart name fix this one
+        # takes the whole device down, which would mask every earlier result.
+        run_case("Run a PRG whose name is far longer than the boot-cart display",
+                 lambda: run_action_run(machine, fixtures, open_long_name_prg))
+
+        if failures:
+            print(f"\nprg_context_menu_test: {len(failures)} of {total} actions FAILED")
+            for label, message in failures:
+                print(f"  - {label}: {message}")
+            return 1
+
+        print(f"prg_context_menu_test: OK ({total} actions)")
+        return 0
+    finally:
+        try:
+            machine.close_menu()
+        except Exception:
+            pass
+        try:
+            machine.remove_drive_a()
+        except Exception:
+            pass
+        if not args.keep_fixtures:
+            fixtures.remove(args.host, args.password)
+            try:
+                remove_leftovers_via_browser(machine, args.host, args.password)
+            except Exception:
+                pass
+        if original_interface_type and original_interface_type != REQUIRED_INTERFACE_TYPE:
+            try:
+                machine.set_interface_type(original_interface_type)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        print(f"prg_context_menu_test: FAIL: {exc}")
+        raise SystemExit(1)


### PR DESCRIPTION
## Overview

Removes an unbounded string copy in the boot-cart loader that can crash the app. 

In order to increase E2E test coverage and as part of investigating (#729), this PR also adds an end-to-end test that drives **every** action the context menu offers for a PRG and verifies each one from outside the browser, plus a top-level script that runs all hardware end-to-end suites against one device.

## Issue

`format_bootcrt_display_name()` shortens long paths to `...` plus the last 13 characters before the boot cart displays them. The pass-through branch copied the name into a 17 byte stack buffer with no bound:

```cpp
char display_name[17];
...
strcpy(display_name, name);   // name can be a full FAT long file name
```

Any PRG whose file name is longer than 16 characters and has no path separator - an ordinary long file name - overruns that buffer inside `dma_load()`.

On an Ultimate 64 Elite, selecting **Run** on a PRG with a 101 character name **kills the firmware outright**: no REST, no FTP, no ping, recoverable only by a power cycle or a JTAG download. It is a regression introduced after `v3.14d` and present in `v3.15`.

## Fix

The helper now returns the caller's name unchanged for the pass-through case, and only writes into the caller's buffer for the trimmed case. The trimming itself is untouched.

Passing the name on untouched is also what `CbmFileName` wants: it cuts to 16 PETSCII characters itself, and it needs the file extension that pre-trimming would remove.

## Context

Same class of bug as #718 (*Fix long browser filenames*), which tightened `generate_fat_name()` and grew the FAT name buffer in `FileSystem::walk_path()` from 64 to 132 bytes: a fixed-size name buffer meeting a long file name. This is the same pattern one layer further on, where the browser hands that name to the boot-cart loader. The new end-to-end test also follows the one added there, `tools/io/filemanager/browser_long_filename_test.py`.

## Evidence

On an Ultimate 64 Elite I, same test both sides, only the firmware swapped. The deployed ELF was checked for the fix before each run so a stale image cannot be mistaken for a result.

**The bug, 10 attempts per side.** Every failing attempt takes the device down, so each attempt gets a fresh JTAG deploy first:

```
prg_context_menu_test.py -H u64 --repeat 1 --scenario long-name

before:  [01/1] FAIL Run a PRG with a 101 character name -> device stopped responding
         === PRE-FIX: 0 ok, 10 failed out of 10

after:   [01/1] ok   Run a PRG with a 101 character name
         === FIXED: 10 ok, 0 failed out of 10
```

Fully deterministic in both directions.

**Nothing else moved.** The full context-menu matrix on the fixed build:

```
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
prg_context_menu_test: OK (23 actions)
```

## On #729

Neither of the two symptoms in that report survived investigation as a bug of its own:

* **DMA** behaves identically before and after this change: the program lands in RAM, BASIC's pointers are set, and `RUN` starts it - 10/10 on both firmwares. Leaving the Ultimate menu afterwards is the intended behaviour.
* **Real Run** never failed for me. 10 consecutive runs on each firmware, plus 17 CBM name shapes on the RAM disk against both firmwares (spaces, `/`, `.PRG`, `+`, `*`, brackets, 16 character names, 8 and 16 shifted letters, 16 PETSCII graphics characters, mixed) and 6 shapes from a folder on a USB stick. All of them loaded and ran.

The overrun above is the only change on that code path between `v3.14d` and `v3.15`, and how much damage it does depends on the stack layout of the build, so it stays a plausible cause on another unit - but I am not claiming it proven. @GameTimeWarp, if Real Run still fails for you on a build with this fix, the disk image that does it is what I need.

## The new test: `tools/io/filemanager/prg_context_menu_test.py`

Follows the existing `tools/io/**/..._test.py` conventions: self-contained, `RestSession` + `check()`/`Failure` from `menu_screen_test`, `-H/-p/-t` with environment fallbacks.

It uploads a small BASIC + machine-code program to `/Temp` three times - as a plain file, under a 101 character name, and as the only file in a D64 - then reads what the context menu offers for a PRG in each location and drives all of it. A new menu entry that no check covers fails the run.

Nothing is taken on the browser's word: `machine:readmem` for the signature the program writes at `$C000`, the load image at `$0801` and the text screen; FTP for the plain file; and the D64 pulled back over FTP and its directory decoded for the disk entry.

| Action | Checked |
| --- | --- |
| `Run` (plain, in-D64, long name) | signature written and the program's output on screen |
| `Load`, `DMA` (plain, in-D64) | program in RAM, and for DMA that `RUN` then starts it |
| `Mount & Run`, `Real Run` | D64 on drive A, no drive error, program ran |
| `View`, `Hex View` | viewer opens over the browser, hex dump shows the fixture's bytes |
| `Copy to...`, `Move to...` | file lands in the picked directory, origin left alone or emptied |
| `Rename`, `Delete` | the directory entry really changed |

`--repeat N [--scenario NAME]` re-runs the load/run scenarios N times, which is how the numbers above were produced. The test pins the **Freeze** interface for the run and restores the previous setting, so a result does not depend on how the device happened to be configured.

`./run-e2e-tests [-H host] [-p password]` runs all hardware suites sequentially and prints a summary; `-l` lists them, `-s` picks one, `-x` stops at the first failure.

## Tested hardware

- Ultimate 64 Elite I, firmware built from this branch and deployed over JTAG

`u64` and `u64ii` build clean. The local `u2` software-only build fails on a missing FPGA bitstream checksum (`rv700dd.chk`); that failure is identical on an unmodified tree here, since this machine has no Xilinx ISE.
