### PR TITLE
Spike: Audio streaming over WiFi

### DIFF
--- a/software/api/route_streams.cc
+++ b/software/api/route_streams.cc
@@ -14,7 +14,20 @@ public:
 };
 static StreamNameToInt streamDict;
 
-API_CALL(PUT, streams, start, NULL, ARRAY ( { { "ip", P_REQUIRED } }))
+// Query parameters are strings; a flag is set by naming it, or by giving it a truthy value.
+static bool arg_is_true(const char *value)
+{
+    if (!value) {
+        return false;
+    }
+    if (!*value) {
+        return true;
+    }
+    return (strcasecmp(value, "true") == 0) || (strcasecmp(value, "1") == 0) ||
+           (strcasecmp(value, "yes") == 0) || (strcasecmp(value, "on") == 0);
+}
+
+API_CALL(PUT, streams, start, NULL, ARRAY ( { { "ip", P_REQUIRED }, { "wifi", P_OPTIONAL } }))
 {
     const char *streamName = args.get_path(0);
     SubsysCommand *sys_command;
@@ -38,7 +51,8 @@ API_CALL(PUT, streams, start, NULL, ARRAY ( { { "ip", P_REQUIRED } }))
     }
 
     sys_command = new SubsysCommand(NULL, -1, (int)dataStreamer, streamIndex, args["ip"], "");
-    sys_command->direct_call = DataStreamer :: S_startStream;
+    sys_command->direct_call = arg_is_true(args.get_or("wifi", NULL)) ? DataStreamer :: S_startStreamWireless
+                                                                     : DataStreamer :: S_startStream;
     SubsysResultCode_t retval = sys_command->execute();
     resp->error(SubsysCommand::error_string(retval.status));
     resp->json_response(SubsysCommand::http_response_map(retval.status));

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -44,6 +44,7 @@ DataStreamer :: DataStreamer()
     cfg->set_sort_order(SORT_ORDER_CFG_STREAMS);
 
     for (int i=0; i < 4; i++) {
+        streams[i].relay_socket = -1;
         timers[i] = xTimerCreate("StreamTimer", 100, pdFALSE, (void *)i, DataStreamer :: S_timer);
     }
 }
@@ -52,6 +53,21 @@ DataStreamer :: DataStreamer()
 DataStreamer :: ~DataStreamer()
 {
 
+}
+
+// The ARP probe leaves through whichever interface lwIP routes it to, which on a device with
+// two interfaces on one subnet is not necessarily the one the generator transmits from. Both
+// are on the same segment, so an entry learned by either of them holds the MAC we need.
+static bool peek_any_arp_table(uint32_t ip, uint8_t *mac)
+{
+    int n = NetworkInterface :: getNumberOfInterfaces();
+    for (int i = 0; i < n; i++) {
+        NetworkInterface *intf = NetworkInterface :: getInterface(i);
+        if (intf && intf->peekArpTable(ip, mac)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 DataStreamer *dataStreamer;
@@ -65,7 +81,13 @@ InitFunction datastreamer_init_func("Data Streamer", init, NULL, NULL, 70);
 SubsysResultCode_e DataStreamer :: S_startStream(SubsysCommand *cmd)
 {
     DataStreamer *str = (DataStreamer *)cmd->functionID;
-    return str->startStream(cmd);
+    return str->startStream(cmd, false);
+}
+
+SubsysResultCode_e DataStreamer :: S_startStreamWireless(SubsysCommand *cmd)
+{
+    DataStreamer *str = (DataStreamer *)cmd->functionID;
+    return str->startStream(cmd, true);
 }
 
 SubsysResultCode_e DataStreamer :: S_stopStream(SubsysCommand *cmd)
@@ -82,10 +104,11 @@ void DataStreamer :: S_timer(TimerHandle_t a)
         stream_config_t *stream = &(dataStreamer->streams[streamID]);
         stream->enable = 0;
         dataStreamer->calculate_udp_headers(streamID);
+        dataStreamer->stopRelay(streamID);
     }
 }
 
-SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
+SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd, bool wireless)
 {
     if(NetworkInterface :: getNumberOfInterfaces() < 1) {
         if (cmd->user_interface) cmd->user_interface->popup("No Network Interface", BUTTON_OK);
@@ -95,6 +118,17 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
 
     if (!intf) {
         return SSRET_NO_NETWORK; // shouldn't happen
+    }
+
+    // A wireless stream is relayed by the CPU, so we need a wireless interface that can carry it.
+    NetworkInterface *wlan = NULL;
+    if (wireless) {
+        wlan = getWirelessInterface();
+        if (!wlan) {
+            if (cmd->user_interface) cmd->user_interface->popup("No WiFi connection", BUTTON_OK);
+            else printf("No connected WiFi interface to stream over.\n");
+            return SSRET_NO_NETWORK;
+        }
     }
 
     int streamID = cmd->mode;
@@ -192,8 +226,34 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
         return SSRET_INVALID_PARAMETER;
     }
 
+    stopRelay(streamID);
+
+    if (wireless) {
+        // The generator cannot reach the wireless interface, so it is pointed at our own
+        // wireless address, and the relay task forwards the payload to the requested host.
+        union {
+            uint32_t ipaddr32[3];
+            uint8_t ipaddr[12];
+        } wireless_ip;
+        wlan->getIpAddr(wireless_ip.ipaddr);
+
+        stream->relay_ip = stream->dest_ip;
+        stream->relay_port = stream->dest_port;
+        stream->dest_ip = wireless_ip.ipaddr32[0];
+        stream->dest_port = STREAM_RELAY_PORT_BASE + streamID;
+        wlan->getMacAddr(stream->dest_mac);
+
+        SubsysResultCode_e relayResult = startRelay(streamID, wlan);
+        if (relayResult != SSRET_OK) {
+            if (cmd->user_interface) cmd->user_interface->popup("Cannot start WiFi relay.", BUTTON_OK);
+            return relayResult;
+        }
+    }
+
     // destination mac
-    if ((stream->dest_ip & 0x000000F8) == 0x000000E8) {
+    if (wireless) {
+        // already known: it is the MAC of our own wireless interface
+    } else if ((stream->dest_ip & 0x000000F8) == 0x000000E8) {
         printf("** User requested Multicast stream\n");
     } else if (stream->dest_ip == 0xFFFFFFFF) {
         printf("** User requested Broadcast stream\n");
@@ -202,7 +262,7 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
         for(int i=0;i<10;i++) {
             send_udp_packet(query_ip, stream->dest_port);
             vTaskDelay(20);
-            if (intf->peekArpTable(query_ip, stream->dest_mac)) {
+            if (intf->peekArpTable(query_ip, stream->dest_mac) || peek_any_arp_table(query_ip, stream->dest_mac)) {
                 ok = true;
                 break;
             }
@@ -216,6 +276,18 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
         }
     }
     stream->enable = 1;
+
+    if (wireless) {
+        printf("** Stream %d started over WiFi, relayed from %d.%d.%d.%d:%d to %d.%d.%d.%d:%d\n", streamID,
+                (stream->dest_ip >> 0) & 0xFF, (stream->dest_ip >> 8) & 0xFF,
+                (stream->dest_ip >> 16) & 0xFF, (stream->dest_ip >> 24) & 0xFF, stream->dest_port,
+                (stream->relay_ip >> 0) & 0xFF, (stream->relay_ip >> 8) & 0xFF,
+                (stream->relay_ip >> 16) & 0xFF, (stream->relay_ip >> 24) & 0xFF, stream->relay_port);
+    } else {
+        printf("** Stream %d started over Ethernet, to %d.%d.%d.%d:%d\n", streamID,
+                (stream->dest_ip >> 0) & 0xFF, (stream->dest_ip >> 8) & 0xFF,
+                (stream->dest_ip >> 16) & 0xFF, (stream->dest_ip >> 24) & 0xFF, stream->dest_port);
+    }
 
     // start stream!
     calculate_udp_headers(streamID);
@@ -243,9 +315,137 @@ SubsysResultCode_e DataStreamer :: stopStream(SubsysCommand *cmd)
         return SSRET_INVALID_PARAMETER;
     }
     stream_config_t *stream = &streams[streamID];
+    if (stream->enable) {
+        printf("** Stream %d stopped, it was running over %s\n", streamID, stream->relay ? "WiFi" : "Ethernet");
+    }
     stream->enable = 0;
     calculate_udp_headers(streamID);
+    stopRelay(streamID);
     return SSRET_OK;
+}
+
+NetworkInterface *DataStreamer :: getWirelessInterface(void)
+{
+    union {
+        uint32_t ipaddr32[3];
+        uint8_t ipaddr[12];
+    } ip;
+
+    int n = NetworkInterface :: getNumberOfInterfaces();
+    for (int i = 0; i < n; i++) {
+        NetworkInterface *intf = NetworkInterface :: getInterface(i);
+        if (!intf || !intf->is_wireless()) {
+            continue;
+        }
+        intf->getIpAddr(ip.ipaddr);
+        if (intf->is_link_up() && (ip.ipaddr32[0] != 0)) {
+            return intf;
+        }
+    }
+    return NULL;
+}
+
+SubsysResultCode_e DataStreamer :: startRelay(int streamID, NetworkInterface *intf)
+{
+    stream_config_t *stream = &streams[streamID];
+
+    union {
+        uint32_t ipaddr32[3];
+        uint8_t ipaddr[12];
+    } ip;
+    intf->getIpAddr(ip.ipaddr);
+
+    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0) {
+        printf("Cannot create relay socket for stream %d\n", streamID);
+        return SSRET_INTERNAL_ERROR;
+    }
+
+    // Bound to the wireless address, so that both the stream we receive and the packets we
+    // forward use that interface.
+    struct sockaddr_in local;
+    memset((char *)&local, 0, sizeof(local));
+    local.sin_family = AF_INET;
+    local.sin_addr.s_addr = ip.ipaddr32[0];
+    local.sin_port = htons(stream->dest_port);
+    if (bind(sockfd, (const struct sockaddr *)&local, sizeof(local)) < 0) {
+        printf("Cannot bind relay socket for stream %d to port %d\n", streamID, stream->dest_port);
+        lwip_close(sockfd);
+        return SSRET_INTERNAL_ERROR;
+    }
+
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 500000;
+    setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
+
+    stream->relay_socket = sockfd;
+    stream->relay_received = 0;
+    stream->relay_dropped = 0;
+    stream->relay = 1;
+
+    if (xTaskCreate(DataStreamer :: S_relayTask, "StreamRelay", configMINIMAL_STACK_SIZE, (void *)streamID,
+                    PRIO_NETSERVICE, &stream->relay_task) != pdPASS) {
+        printf("Cannot create relay task for stream %d\n", streamID);
+        stream->relay = 0;
+        stream->relay_task = NULL;
+        stream->relay_socket = -1;
+        lwip_close(sockfd);
+        return SSRET_INTERNAL_ERROR;
+    }
+    return SSRET_OK;
+}
+
+void DataStreamer :: stopRelay(int streamID)
+{
+    stream_config_t *stream = &streams[streamID];
+
+    stream->relay = 0;
+    // The task closes its own socket, so that it is never closed under a blocking recv(). It
+    // wakes up on its receive timeout, so this normally returns well within a second.
+    for (int i = 0; (i < 80) && stream->relay_task; i++) {
+        vTaskDelay(5);
+    }
+    if (stream->relay_task) {
+        printf("Relay task of stream %d did not stop.\n", streamID);
+    } else if (stream->relay_received) {
+        printf("Relay of stream %d forwarded %d packets, %d could not be sent.\n", streamID,
+                stream->relay_received, stream->relay_dropped);
+    }
+}
+
+void DataStreamer :: S_relayTask(void *context)
+{
+    dataStreamer->relayThread((int)context);
+}
+
+void DataStreamer :: relayThread(int streamID)
+{
+    stream_config_t *stream = &streams[streamID];
+    uint8_t *buffer = new uint8_t[1536];
+
+    struct sockaddr_in target;
+    memset((char *)&target, 0, sizeof(target));
+    target.sin_family = AF_INET;
+    target.sin_addr.s_addr = stream->relay_ip;
+    target.sin_port = htons(stream->relay_port);
+
+    while (stream->relay) {
+        int len = recv(stream->relay_socket, buffer, 1536, 0);
+        if (len <= 0) { // timeout, so that a stop request is picked up
+            continue;
+        }
+        stream->relay_received ++;
+        if (sendto(stream->relay_socket, buffer, len, 0, (const struct sockaddr *)&target, sizeof(target)) < 0) {
+            stream->relay_dropped ++;
+        }
+    }
+
+    delete[] buffer;
+    lwip_close(stream->relay_socket);
+    stream->relay_socket = -1;
+    stream->relay_task = NULL;
+    vTaskDelete(NULL);
 }
 
 void DataStreamer :: create_task_items()

--- a/software/io/network/data_streamer.h
+++ b/software/io/network/data_streamer.h
@@ -25,8 +25,21 @@ typedef struct {
     int      dest_port;
     uint8_t  dest_mac[6];
     uint8_t  enable;
+    uint8_t  relay;         // stream is received by the CPU and forwarded over a wireless interface
+    uint32_t relay_ip;      // final destination of a relayed stream
+    int      relay_port;
+    int      relay_socket;
+    uint32_t relay_received;
+    uint32_t relay_dropped;
+    TaskHandle_t relay_task;
 } stream_config_t;
 
+// The stream generators sit in the FPGA and can only transmit through the wired MAC. A stream
+// that has to leave over a wireless interface is therefore aimed at this device's own wireless
+// address, and forwarded to its final destination by the CPU.
+#define STREAM_RELAY_PORT_BASE 11100
+
+class NetworkInterface;
 
 class DataStreamer : public ObjectWithMenu
 {
@@ -48,8 +61,14 @@ class DataStreamer : public ObjectWithMenu
     TimerHandle_t timers[4];
 
     static void S_timer(TimerHandle_t a);
-    SubsysResultCode_e startStream(SubsysCommand *cmd);
+    static void S_relayTask(void *context);
+    SubsysResultCode_e startStream(SubsysCommand *cmd, bool wireless);
     SubsysResultCode_e stopStream(SubsysCommand *cmd);
+
+    static NetworkInterface *getWirelessInterface(void);
+    SubsysResultCode_e startRelay(int streamID, NetworkInterface *intf);
+    void stopRelay(int streamID);
+    void relayThread(int streamID);
 
     void calculate_udp_headers(int id);
     void send_udp_packet(uint32_t ip, uint16_t port);
@@ -58,6 +77,7 @@ public:
     virtual ~DataStreamer();
 
     static SubsysResultCode_e S_startStream(SubsysCommand *cmd);
+    static SubsysResultCode_e S_startStreamWireless(SubsysCommand *cmd);
     static SubsysResultCode_e S_stopStream(SubsysCommand *cmd);
 
     // from ObjectWithMenu

--- a/software/io/network/network_esp32.h
+++ b/software/io/network/network_esp32.h
@@ -35,6 +35,7 @@ public:
     virtual ~NetworkLWIP_WiFi();
 
     const char *identify() { return "WiFi"; }
+    bool is_wireless() { return true; }
     void attach_config();
 
     // User Interface

--- a/software/io/network/network_interface.h
+++ b/software/io/network/network_interface.h
@@ -112,6 +112,7 @@ public:
 
     virtual void attach_config();
     virtual const char *identify() { return "Wired Network"; }
+    virtual bool is_wireless() { return false; }
 
 	bool start();
     void stop();

--- a/tools/api/audio_stream_test.py
+++ b/tools/api/audio_stream_test.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""End-to-end test for U64 data streaming over Ethernet and over WiFi.
+
+Assumes the U64 is attached to both networks at once, and that this host can be
+reached from the device on the capture port.
+
+The "no WiFi available" rejection is not covered here: the WiFi interface cannot be
+taken down over REST. The "WiFi Enabled" setting is only read at startup (the disable
+branch of NetworkLWIP_WiFi::effectuate_settings() is deliberately commented out), and
+the "Disable" menu entry is a CFG_TYPE_FUNC item, which the config API ignores.
+"""
+import argparse
+import json
+import os
+import socket
+import struct
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from typing import Any, Dict, List, Optional, Tuple
+
+CHECK_COUNT = 0
+INFO_PATH = "/v1/info"
+# The payload shape and packet rate below are those of the audio stream, so this test is
+# tied to it; the video and debug streams carry different payloads.
+STREAM = "audio"
+DEFAULT_PORT = 11001
+# 48 kHz stereo, 192 frames per packet: a 2-byte little endian sequence number followed
+# by 192 * 2 channels * 2 bytes of LPCM.
+PAYLOAD_BYTES = 770
+PACKET_RATE = 250.0
+# The generator sends a two-byte probe to the destination before streaming starts, to open
+# the port on the receiving side. It is not part of the stream and carries no sequence number.
+PROBE_BYTES = 2
+RATE_TOLERANCE = 0.10
+MIN_CAPTURE_FRACTION = 0.90
+STREAM_SETTLE_SECONDS = 1.0
+
+TEST_CHOICES = ["ethernet", "wifi", "all"]
+DEFAULT_TESTS = ["ethernet", "wifi"]
+
+
+class Failure(RuntimeError):
+    pass
+
+
+@contextmanager
+def check(label: str):
+    global CHECK_COUNT
+    CHECK_COUNT += 1
+    print(f"[{CHECK_COUNT:02d}] {label} ... ", end="", flush=True)
+    try:
+        yield
+    except Exception:
+        print("FAIL", flush=True)
+        raise
+    print("OK", flush=True)
+
+
+def format_exception(exc: BaseException) -> str:
+    if isinstance(exc, urllib.error.URLError) and getattr(exc, "reason", None) is not None:
+        return f"{exc} ({exc.reason})"
+    return str(exc)
+
+
+def device_unavailable(exc: BaseException) -> bool:
+    return isinstance(exc, (ConnectionError, TimeoutError)) or (
+        isinstance(exc, urllib.error.URLError) and isinstance(getattr(exc, "reason", None), OSError)
+    )
+
+
+class RestStreamSession:
+    def __init__(self, host: str, password: Optional[str], timeout: float) -> None:
+        self.host = host
+        self.password = password
+        self.timeout = timeout
+
+    def url(self, path: str, params: Optional[Dict[str, Any]] = None) -> str:
+        query = ""
+        if params:
+            query = "?" + urllib.parse.urlencode(params)
+        return f"http://{self.host}{path}{query}"
+
+    def request(self, method: str, path: str, params: Optional[Dict[str, Any]] = None) -> Tuple[int, bytes]:
+        headers = {}
+        if self.password:
+            headers["X-Password"] = self.password
+        request = urllib.request.Request(self.url(path, params), headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return response.status, response.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read()
+        except (OSError, TimeoutError, urllib.error.URLError) as exc:
+            raise Failure(f"{method} {self.url(path, params)} failed: {format_exception(exc)}") from exc
+
+    def json_request(self, method: str, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        status, body = self.request(method, path, params)
+        try:
+            document = json.loads(body.decode("utf-8"))
+        except ValueError as exc:
+            raise Failure(f"{method} {path} returned non-JSON body: {body[:200]!r}") from exc
+        document["_status"] = status
+        return document
+
+    def info(self) -> Dict[str, Any]:
+        return self.json_request("GET", INFO_PATH)
+
+    def start_stream(self, stream: str, listen_ip: str, port: int, wifi: Optional[bool]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"ip": f"{listen_ip}:{port}"}
+        if wifi is not None:
+            params["wifi"] = "true" if wifi else "false"
+        return self.json_request("PUT", f"/v1/streams/{stream}:start", params)
+
+    def stop_stream(self, stream: str) -> Dict[str, Any]:
+        return self.json_request("PUT", f"/v1/streams/{stream}:stop")
+
+
+def errors_of(document: Dict[str, Any]) -> List[str]:
+    return [e for e in document.get("errors", []) if e]
+
+
+def expect_ok(document: Dict[str, Any], what: str) -> None:
+    errors = errors_of(document)
+    if errors:
+        raise Failure(f"{what} reported errors: {errors}")
+
+
+def local_ip_towards(host: str) -> str:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect((host, 9))
+        return probe.getsockname()[0]
+    except OSError as exc:
+        raise Failure(f"Cannot determine the local IP address towards {host}: {exc}") from exc
+    finally:
+        probe.close()
+
+
+class Capture:
+    """Sequence-number analysis of one captured stream."""
+
+    def __init__(self, packets: List[Tuple[float, str, bytes]]) -> None:
+        self.probes = [p for p in packets if len(p[2]) == PROBE_BYTES]
+        self.frames = [p for p in packets if len(p[2]) != PROBE_BYTES]
+        self.sources = sorted({p[1] for p in self.frames})
+        self.sizes = sorted({len(p[2]) for p in self.frames})
+
+        self.count = len(self.frames)
+        self.rate = 0.0
+        if self.count >= 2:
+            span = self.frames[-1][0] - self.frames[0][0]
+            if span > 0:
+                self.rate = (self.count - 1) / span
+
+        # 16-bit sequence numbers wrap; unwrap them into a monotonic range so that a
+        # reordered or duplicated packet is not mistaken for a gap.
+        absolute: List[int] = []
+        base = 0
+        previous: Optional[int] = None
+        for _, _, payload in self.frames:
+            seq = struct.unpack("<H", payload[0:2])[0]
+            if previous is not None and seq - previous < -32768:
+                base += 65536
+            if previous is not None and seq - previous > 32768:
+                base -= 65536
+            absolute.append(base + seq)
+            previous = seq
+
+        self.unique = len(set(absolute))
+        self.duplicates = len(absolute) - self.unique
+        self.reordered = sum(1 for i in range(1, len(absolute)) if absolute[i] < absolute[i - 1])
+        if absolute:
+            self.expected = max(absolute) - min(absolute) + 1
+            self.missing = self.expected - self.unique
+        else:
+            self.expected = 0
+            self.missing = 0
+
+    def describe(self) -> str:
+        return (
+            f"{self.count} packets from {','.join(self.sources) or '-'} "
+            f"({self.rate:.1f}/s, sizes={self.sizes}, expected={self.expected}, "
+            f"missing={self.missing}, duplicates={self.duplicates}, reordered={self.reordered})"
+        )
+
+
+def capture_stream(port: int, duration: float) -> List[Tuple[float, str, bytes]]:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4 * 1024 * 1024)
+    except OSError:
+        pass
+    try:
+        sock.bind(("", port))
+    except OSError as exc:
+        raise Failure(f"Cannot bind UDP port {port} to capture the stream: {exc}") from exc
+    sock.settimeout(0.5)
+
+    packets: List[Tuple[float, str, bytes]] = []
+    end = time.time() + duration
+    try:
+        while time.time() < end:
+            try:
+                payload, addr = sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            packets.append((time.time(), addr[0], payload))
+    finally:
+        sock.close()
+    return packets
+
+
+def assert_healthy(capture: Capture, duration: float, label: str) -> None:
+    if capture.count == 0:
+        raise Failure(f"{label}: no stream packets arrived on the capture port")
+    minimum = int(duration * PACKET_RATE * MIN_CAPTURE_FRACTION)
+    if capture.count < minimum:
+        raise Failure(f"{label}: only {capture.count} packets in {duration:.0f}s, expected at least {minimum}")
+    if capture.missing:
+        raise Failure(
+            f"{label}: {capture.missing} of {capture.expected} packets lost "
+            f"({100.0 * capture.missing / capture.expected:.3f}%)"
+        )
+    if len(capture.sources) != 1:
+        raise Failure(f"{label}: stream arrived from more than one address: {capture.sources}")
+    if capture.sizes != [PAYLOAD_BYTES]:
+        raise Failure(f"{label}: unexpected payload sizes {capture.sizes}, expected [{PAYLOAD_BYTES}]")
+    low = PACKET_RATE * (1.0 - RATE_TOLERANCE)
+    high = PACKET_RATE * (1.0 + RATE_TOLERANCE)
+    if not (low <= capture.rate <= high):
+        raise Failure(f"{label}: packet rate {capture.rate:.1f}/s outside {low:.0f}-{high:.0f}/s")
+
+
+def run_transport(
+    session: RestStreamSession,
+    stream: str,
+    listen_ip: str,
+    port: int,
+    duration: float,
+    wifi: Optional[bool],
+    label: str,
+) -> Capture:
+    with check(f"{label}: start {stream} stream to {listen_ip}:{port}"):
+        expect_ok(session.start_stream(stream, listen_ip, port, wifi), f"{label} start")
+
+    time.sleep(STREAM_SETTLE_SECONDS)
+    packets = capture_stream(port, duration)
+    capture = Capture(packets)
+
+    with check(f"{label}: stop {stream} stream"):
+        expect_ok(session.stop_stream(stream), f"{label} stop")
+
+    with check(f"{label}: {capture.describe()}"):
+        assert_healthy(capture, duration, label)
+
+    return capture
+
+
+def run_tests(
+    session: RestStreamSession,
+    stream: str,
+    listen_ip: str,
+    port: int,
+    duration: float,
+    selected: List[str],
+) -> None:
+    with check("REST interface is reachable"):
+        info = session.info()
+        expect_ok(info, "info")
+        if not info.get("product"):
+            raise Failure(f"Unexpected /v1/info response: {info}")
+
+    with check(f"no {stream} stream is running"):
+        session.stop_stream(stream)
+
+    ethernet: Optional[Capture] = None
+    wireless: Optional[Capture] = None
+
+    if "ethernet" in selected:
+        ethernet = run_transport(session, stream, listen_ip, port, duration, None, "ethernet")
+
+    if "wifi" in selected:
+        wireless = run_transport(session, stream, listen_ip, port, duration, True, "wifi")
+
+    if ethernet and wireless:
+        with check("wifi stream uses a different interface than the ethernet stream"):
+            if ethernet.sources == wireless.sources:
+                raise Failure(
+                    f"Both transports streamed from {ethernet.sources[0]}; "
+                    "the wifi stream did not leave over the wireless interface"
+                )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate U64 data streaming over Ethernet and over WiFi",
+        epilog="Requires the U64 to be connected to both networks, and this host to be reachable from it.",
+    )
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_AUDIO_HOST", "u64"))
+    parser.add_argument("-r", "--rest-host", default=os.environ.get("U64_AUDIO_REST_HOST"))
+    parser.add_argument(
+        "-p",
+        "--password",
+        default=os.environ.get("U64_AUDIO_PASSWORD", os.environ.get("C64U_PASSWORD")),
+    )
+    parser.add_argument("-t", "--timeout", type=float, default=float(os.environ.get("U64_AUDIO_TIMEOUT", "30.0")))
+    parser.add_argument(
+        "--test",
+        action="append",
+        choices=TEST_CHOICES,
+        help="run one transport; repeat for multiple selections (default: ethernet and wifi)",
+    )
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="capture port (default: %(default)s)")
+    parser.add_argument(
+        "-d",
+        "--duration",
+        type=float,
+        default=float(os.environ.get("U64_AUDIO_DURATION", "10.0")),
+        help="seconds to capture per transport (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--listen-ip",
+        default=os.environ.get("U64_AUDIO_LISTEN_IP"),
+        help="address the device should stream to (default: this host's address towards the device)",
+    )
+    args = parser.parse_args()
+
+    rest_host = args.rest_host or args.host
+    session = RestStreamSession(rest_host, args.password, args.timeout)
+
+    selected = args.test or DEFAULT_TESTS
+    if "all" in selected:
+        selected = DEFAULT_TESTS + [t for t in selected if t not in DEFAULT_TESTS and t != "all"]
+
+    try:
+        listen_ip = args.listen_ip or local_ip_towards(rest_host)
+        print(f"audio_stream_test: device {rest_host}, streaming to {listen_ip}:{args.port}")
+        run_tests(session, STREAM, listen_ip, args.port, args.duration, selected)
+    except Failure as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        if device_unavailable(exc):
+            print(f"Connection failure: {format_exception(exc)}", file=sys.stderr)
+        else:
+            print(f"REST failure: {format_exception(exc)}", file=sys.stderr)
+        return 1
+
+    print(f"audio_stream_test: OK ({CHECK_COUNT} checks)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Overview

I wanted to explore whether the existing audio stream might be sent over WiFi without changing the FPGA. 

Based on the firmware interfaces I could find, I have not yet found a practical way to do that.

I am opening this as a draft mainly to share the findings and check whether there is an existing FPGA-to-CPU path that I may have missed.

## Motivation

Streaming currently only supports Ethernet, not WiFi. One of the few workarounds is to use this setup: `U64 -(Ethernet)-> Router -(WiFi) -> Client`. This requires an Ethernet cable to a WiFI-enabled router. Not all users have such a device.

The U64 WiFi bandwidth is considerably too low for video stream, but would be sufficient for an audio-only stream.

Offering audio streaming over WiFi would allow more users to enjoy listening to SID songs wirelessly which is important for portable clients (smartphones, tablets, etc).

## What the spike does

`PUT /v1/streams/{stream}:start` accepts an optional `wifi` parameter:

```text
PUT /v1/streams/audio:start?ip=192.168.1.185:11001
PUT /v1/streams/audio:start?ip=192.168.1.185:11001&wifi=true
```

The default Ethernet behaviour is unchanged.

With `wifi=true`, the FPGA stream is redirected back to the U64, received by a relay task, and then forwarded over WiFi.

## Why this is not viable

From what I can see, the FPGA generates the stream packets directly on the Ethernet transmit path. The CPU neither produces nor receives their payloads.

The only software-only route I found was:

```text
FPGA -> Ethernet -> router/AP -> WiFi -> ESP32 -> CPU
     -> ESP32 -> WiFi -> destination
```

This route is clearly impractical:

* It still requires an Ethernet cable.
* Packets leave the device only to return to it.
* The payload crosses the ESP32 UART twice.
* It depends on Ethernet and WiFi being bridged by the external network.

The relay demonstrates that the REST and WiFi forwarding parts work, but it is not a reasonable implementation to build on.

## Main question

Is there already a mode in the FPGA stream generator that exposes generated packets to the CPU instead of sending them directly to the Ethernet MAC?

I could not find such a path in the code available here, but the relevant top-level FPGA implementation is not included, so I may have missed an existing capability.

Without a CPU-visible packet or audio-sample path, true WiFi-only streaming would appear to require an FPGA change.

## Separate issue found while testing

I also found that unicast streaming can fail when Ethernet and WiFi are active on the same subnet.

The UDP probe may be routed through WiFi, placing the ARP entry in the WiFi netif, while `startStream()` checks only the wired netif and reports `Network Host Resolve Error`.

The patch currently falls back to checking the other ARP tables. I am not certain that this belongs in this spike or that it is the best general solution, so it can be split out or removed.

Multicast and broadcast destinations are unaffected.

## Test

`tools/api/audio_stream_test.py` captures streams over both transports and checks for packet loss while tolerating duplicates and reordering.

```text
[05] ethernet: 2500 packets from 192.168.1.15 (249.9/s, sizes=[770],
     expected=2500, missing=0, duplicates=0, reordered=0) ... OK
[08] wifi:     2504 packets from 192.168.1.71 (250.2/s, sizes=[770],
     expected=2501, missing=0, duplicates=3, reordered=0) ... OK
[09] wifi stream uses a different interface than the ethernet stream ... OK
audio_stream_test: OK (9 checks)
```

No packet loss was observed during the test.

## Build status

* `u64`: built successfully
* `u64ii`: built successfully
* `u2`: compiles and links, but I could not run the updater step because it requires a prebuilt bitstream
