### PR TITLE
Debounce held USB keys when leaving the menu

### DIFF
--- a/software/api/tests/input_api_state_test.cpp
+++ b/software/api/tests/input_api_state_test.cpp
@@ -7,8 +7,29 @@
 
 #include <initializer_list>
 
+// Drives Keyboard_C64::wait_free(), which busy-waits through wait_ms(). Letting
+// the stub count calls and let go of the keys makes the wait deterministic.
+struct WaitFreeProbe {
+    int calls;
+    int release_usb_at;          // 0 = never
+    volatile uint8_t *row_register;
+    int release_row_at;          // 0 = never
+};
+
+static WaitFreeProbe wait_free_probe = { 0, 0, 0, 0 };
+
 extern "C" void wait_ms(int)
 {
+    wait_free_probe.calls++;
+    if (wait_free_probe.release_usb_at && (wait_free_probe.calls >= wait_free_probe.release_usb_at)) {
+        uint8_t release[USB_DATA_SIZE] = { 0 };
+        wait_free_probe.release_usb_at = 0;
+        system_usb_keyboard.process_data(release); // the user lets go of the USB key
+    }
+    if (wait_free_probe.release_row_at && (wait_free_probe.calls >= wait_free_probe.release_row_at)) {
+        wait_free_probe.release_row_at = 0;
+        *wait_free_probe.row_register = 0xFF;      // ... and of the C64 key
+    }
 }
 
 namespace {
@@ -368,6 +389,120 @@ TEST(KeyboardC64StateTest, MatrixLookupTranslatesUiKeyCodes)
     EXPECT_EQ(0x04, Keyboard_C64::matrixModifierFlag(ctrl->row, ctrl->col));
     EXPECT_EQ(0x00, Keyboard_C64::matrixModifierFlag(8, 0));
     EXPECT_EQ(0x00, Keyboard_C64::matrixToKeyCode(8, 0, 0));
+}
+
+// USB HID usage 0x29 (escape) maps to C64 matrix row 7, column 7: RUN/STOP.
+static const uint8_t USB_KEY_ESCAPE = 0x29;
+static const int MATRIX_RUNSTOP_ROW = 7;
+static const uint8_t MATRIX_RUNSTOP_BIT = 0x80;
+
+// Must outlive every test: the global keyboard keeps writing through this
+// pointer once setMatrix() has been handed it.
+static volatile uint8_t menu_exit_matrix[11] = { 0 };
+
+namespace {
+
+class AccessibleHost : public GenericHost
+{
+public:
+    bool exists(void) { return true; }
+    bool is_accessible(void) { return true; }
+};
+
+// system_usb_keyboard is global: never leave keys held for the next test.
+void release_usb_keys(void)
+{
+    uint8_t release[USB_DATA_SIZE] = { 0x00 };
+    system_usb_keyboard.process_data(release);
+}
+
+// The menu owns the keyboard and ESC is still held down: the state the firmware
+// is in at the moment the user leaves the menu.
+void arm_menu_with_escape_held(void)
+{
+    uint8_t escape[USB_DATA_SIZE] = { 0x00, 0x00, USB_KEY_ESCAPE, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+    release_usb_keys();
+    system_usb_keyboard.setMatrix(menu_exit_matrix);
+    system_usb_keyboard.enableMatrix(false);
+    system_usb_keyboard.process_data(escape);
+
+    wait_free_probe.calls = 0;
+    wait_free_probe.release_usb_at = 0;
+    wait_free_probe.row_register = 0;
+    wait_free_probe.release_row_at = 0;
+}
+
+} // namespace
+
+// Why the wait exists: the matrix mirrors the live USB report, so a key that is
+// still held when the menu gives the matrix back lands on the C64 right away.
+// ESC is RUN/STOP, and the SID player returns to the menu on RUN/STOP.
+TEST(KeyboardC64StateTest, HeldUsbEscapeIsRunStopOnTheC64Matrix)
+{
+    arm_menu_with_escape_held();
+    EXPECT_EQ(0x00, menu_exit_matrix[MATRIX_RUNSTOP_ROW]);
+
+    system_usb_keyboard.enableMatrix(true); // menu hands the matrix back
+    EXPECT_EQ(MATRIX_RUNSTOP_BIT, menu_exit_matrix[MATRIX_RUNSTOP_ROW]);
+
+    release_usb_keys();
+}
+
+TEST(KeyboardC64StateTest, MenuExitWaitsForHeldUsbKeyToBeReleased)
+{
+    Keyboard_C64 keyboard(NULL, NULL, NULL, NULL); // no host: only the USB wait runs
+
+    arm_menu_with_escape_held();
+    EXPECT_TRUE(system_usb_keyboard.anyKeyPressed());
+
+    wait_free_probe.release_usb_at = 5;
+    keyboard.wait_free();
+    EXPECT_EQ(5, wait_free_probe.calls); // it really waited the exit key out
+    EXPECT_FALSE(system_usb_keyboard.anyKeyPressed());
+
+    system_usb_keyboard.enableMatrix(true);
+    EXPECT_EQ(0x00, menu_exit_matrix[MATRIX_RUNSTOP_ROW]); // no phantom RUN/STOP
+
+    release_usb_keys();
+}
+
+// Neither keyboard may cut the other's wait short: the added USB wait must not
+// consume the budget the C64 matrix scan has always had.
+TEST(KeyboardC64StateTest, MenuExitWaitsForBothKeyboards)
+{
+    AccessibleHost host;
+    volatile uint8_t row_register = 0x7F; // a C64 key is down too
+    volatile uint8_t col_register = 0xFF;
+    Keyboard_C64 keyboard(&host, &row_register, &col_register, NULL);
+
+    arm_menu_with_escape_held();
+    wait_free_probe.row_register = &row_register;
+    wait_free_probe.release_usb_at = 5;
+    wait_free_probe.release_row_at = 9;
+
+    keyboard.wait_free();
+    EXPECT_EQ(9, wait_free_probe.calls); // waited past the USB release for the matrix
+    EXPECT_EQ(0xFF, col_register);       // rows deselected again
+
+    release_usb_keys();
+}
+
+TEST(KeyboardC64StateTest, MenuExitWaitIsBoundedWhenTheKeysAreNeverReleased)
+{
+    AccessibleHost host;
+    volatile uint8_t row_register = 0x7F;
+    volatile uint8_t col_register = 0xFF;
+    Keyboard_C64 keyboard(&host, &row_register, &col_register, NULL);
+
+    arm_menu_with_escape_held(); // both keys stay down forever
+
+    keyboard.wait_free();
+    // Worst case: each keyboard gets its own full budget, and no more.
+    EXPECT_EQ(2 * KEYBOARD_WAIT_FREE_TIMEOUT_MS, wait_free_probe.calls);
+    EXPECT_EQ(0xFF, col_register);
+
+    release_usb_keys();
 }
 
 TEST(RouteInputMenuTranslationTest, CollectsMenuKeysWithModifiers)

--- a/software/io/c64/keyboard.h
+++ b/software/io/c64/keyboard.h
@@ -1,6 +1,11 @@
 #ifndef KEYBOARD_H
 #define KEYBOARD_H
 
+// Upper bound for wait_free(): how long a menu exit waits for the key that
+// triggered it to be released, before giving up and continuing anyway.
+#define KEYBOARD_WAIT_FREE_TIMEOUT_MS 2000
+#define KEYBOARD_WAIT_FREE_POLL_MS      10
+
 class Keyboard
 {
 

--- a/software/io/c64/keyboard_c64.cc
+++ b/software/io/c64/keyboard_c64.cc
@@ -343,6 +343,18 @@ void Keyboard_C64 :: push_head(int c)
 
 void Keyboard_C64 :: wait_free(void)
 {
+    // getch() falls back to the USB keyboard, so the menu can be driven - and
+    // left - from there too. Those keys are kept out of the C64 matrix while the
+    // menu owns the keyboard, so the hardware scan below never sees them. Wait
+    // for the USB report as well, or the still-held exit key is handed straight
+    // to the running program the moment the menu gives the matrix back. ESC is
+    // RUN/STOP, which the SID player uses to return to the menu.
+    int usb_timeout = KEYBOARD_WAIT_FREE_TIMEOUT_MS;
+    while (system_usb_keyboard.anyKeyPressed() && usb_timeout) {
+        usb_timeout--;
+        wait_ms(1);
+    }
+
     if(!host) {
         return;
     }
@@ -356,7 +368,7 @@ void Keyboard_C64 :: wait_free(void)
 #endif
     *col_register = 0; // select all rows
 
-    int timeout = 2000;
+    int timeout = KEYBOARD_WAIT_FREE_TIMEOUT_MS;
     while ((*row_register != 0xFF) && (timeout)) {
         timeout--;
         wait_ms(1);

--- a/software/io/usb/keyboard_usb.cc
+++ b/software/io/usb/keyboard_usb.cc
@@ -41,6 +41,12 @@ uint8_t usb_matrix_lookup(const uint8_t *map, size_t map_size, uint8_t key)
 #if U64 && !RECOVERYAPP
 static const uint32_t REST_INPUT_TIMER_TICKS = (pdMS_TO_TICKS(20) > 0) ? pdMS_TO_TICKS(20) : 1;
 #endif
+#ifndef NO_FILE_ACCESS
+// vTaskDelay() counts ticks, not milliseconds: at configTICK_RATE_HZ = 200 a
+// tick is 5ms, so the conversion has to be explicit. Never round down to 0.
+static const uint32_t WAIT_FREE_POLL_TICKS =
+	(pdMS_TO_TICKS(KEYBOARD_WAIT_FREE_POLL_MS) > 0) ? pdMS_TO_TICKS(KEYBOARD_WAIT_FREE_POLL_MS) : 1;
+#endif
 static const uint8_t REST_TAP_GAP_TICKS = 2;
 static const uint8_t REST_TAP_CHORD_SETUP_TICKS = 1;
 static const uint8_t REST_TAP_CHORD_RELEASE_TICKS = 1;
@@ -623,23 +629,27 @@ void Keyboard_USB :: remove_injected_key(int c)
 	portEXIT_CRITICAL();
 }
 
+// True while the last USB report still holds any key or modifier down.
+bool Keyboard_USB :: anyKeyPressed(void) const
+{
+	for (int i=0; i < USB_DATA_SIZE; i++) {
+		if (last_data[i] != 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void Keyboard_USB :: wait_free(void)
 {
-	bool free;
-	do {
-		free = true;
-		for (int i=0; i < USB_DATA_SIZE; i++) {
-			if (last_data[i] != 0) {
-				free = false;
-				break;
-			}
-		}
+	int remaining_ms = KEYBOARD_WAIT_FREE_TIMEOUT_MS;
+
+	while (anyKeyPressed() && (remaining_ms > 0)) {
+		remaining_ms -= KEYBOARD_WAIT_FREE_POLL_MS;
 #ifndef NO_FILE_ACCESS
-		if (!free) {
-			vTaskDelay(10);
-		}
+		vTaskDelay(WAIT_FREE_POLL_TICKS);
 #endif
-	} while(!free);
+	}
 }
 
 void Keyboard_USB :: clear_buffer(void)

--- a/software/io/usb/keyboard_usb.h
+++ b/software/io/usb/keyboard_usb.h
@@ -96,6 +96,7 @@ public:
     bool has_injected_key(int c) const;
     void remove_injected_key(int c);
     void wait_free(void);
+    bool anyKeyPressed(void) const;
     void clear_buffer(void);
 
 	void restPress(uint8_t row, uint8_t col_bit);

--- a/software/io/usb/tests/usb_keyboard_queue_test.cpp
+++ b/software/io/usb/tests/usb_keyboard_queue_test.cpp
@@ -235,6 +235,36 @@ TEST(KeyboardUsbMatrixTest, ResetRestoreAndFreezeAreGatedAndNotStale)
 	EXPECT_EQ(0x00, matrix[10]);
 }
 
+TEST(KeyboardUsbMatrixTest, AnyKeyPressedTracksTheLiveReport)
+{
+	Keyboard_USB keyboard;
+	uint8_t press[USB_DATA_SIZE] = { 0x00, 0x00, USB_KEY_SPACE, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	uint8_t left_shift[USB_DATA_SIZE] = { 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	uint8_t release[USB_DATA_SIZE] = { 0x00 };
+
+	EXPECT_FALSE(keyboard.anyKeyPressed());
+
+	keyboard.process_data(press);
+	EXPECT_TRUE(keyboard.anyKeyPressed());
+	keyboard.process_data(release);
+	EXPECT_FALSE(keyboard.anyKeyPressed());
+
+	keyboard.process_data(left_shift); // modifier only still counts as held
+	EXPECT_TRUE(keyboard.anyKeyPressed());
+	keyboard.process_data(release);
+	EXPECT_FALSE(keyboard.anyKeyPressed());
+}
+
+TEST(KeyboardUsbMatrixTest, WaitFreeGivesUpOnAKeyThatIsNeverReleased)
+{
+	Keyboard_USB keyboard;
+	uint8_t press[USB_DATA_SIZE] = { 0x00, 0x00, USB_KEY_SPACE, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+	keyboard.process_data(press);
+	keyboard.wait_free(); // must return instead of spinning forever
+	EXPECT_TRUE(keyboard.anyKeyPressed());
+}
+
 TEST(KeyboardUsbQueueTest, RemoveInjectedKeyDropsPendingDirection)
 {
 	Keyboard_USB keyboard;

--- a/software/test/monitor/machine_monitor_bookmarks_test.cc
+++ b/software/test/monitor/machine_monitor_bookmarks_test.cc
@@ -53,6 +53,11 @@ void Keyboard_USB::wait_free(void)
 {
 }
 
+bool Keyboard_USB::anyKeyPressed(void) const
+{
+    return false;
+}
+
 void Keyboard_USB::clear_buffer(void)
 {
 }


### PR DESCRIPTION
## The bug

Play a SID tune, open the menu, then press ESC on a USB keyboard to leave the menu: the SID player reappears for a fraction of a second and the menu immediately re-opens. The only way out is to tap ESC so briefly that it is already released by the time the menu closes.

It does not happen with the C64's own RUN/STOP key, and not via the `machine:menu_button` REST endpoint. Normal menu navigation with the same USB keyboard, including leaving the menu to a plain BASIC screen, is also fine - so it looks specific to the menu -> SID player transition.

## Root cause

USB ESC decodes into two things at once:

* `KEY_ESCAPE` in the character queue, which the menu consumes and turns into `MENU_HIDE`
* C64 matrix row 7 / bit 7 = **RUN/STOP** (`keymap_usb2matrix[0x29] = 0x3F`, `keyboard_usb.cc`)

While the menu is open `enableMatrix(false)` keeps those bits off the C64, but `matrix_state` still tracks the live report. `ultimate.cc` calls `enableMatrix(true)` as soon as `run_once()` returns, so a key that is *still physically held* is asserted on the C64 immediately.

The SID player scans the matrix itself and treats RUN/STOP press-then-release as "go back to the Ultimate menu" (`software/6502/sidcrt/player/advanced/keyboard.asm`: `cmp #$7f` sets `runStopPressed`, and `gotoUltimateMenu` fires a UCI Freeze command once all keys are released). So it saw a fresh RUN/STOP and re-opened the menu. Other programs simply ignore RUN/STOP, which is why only the SID player shows the symptom.

The mechanism that is supposed to prevent this already exists: `wait_free()`, called from `TreeBrowser::poll()` whenever `handle_key()` returns a negative code. But there was an asymmetry:

* `Keyboard_C64::getch()` falls back to `system_usb_keyboard.getch()` - the menu can be driven from the USB keyboard
* `Keyboard_C64::wait_free()` only polled the **hardware** row register

So a held USB key was never waited out. The C64's own RUN/STOP debounced correctly, REST had no physical key to debounce, and USB ESC fell straight through.

## The fix

`Keyboard_C64::wait_free()` now also waits for the USB report to go idle, mirroring the fallback that `getch()` already has. The change is purely additive - a self-contained block prepended, with the original body untouched apart from replacing the `2000` literal with the shared `KEYBOARD_WAIT_FREE_TIMEOUT_MS` constant. Each keyboard keeps its own full budget, so the added wait cannot eat the matrix scan's.

Supporting changes in `Keyboard_USB`:

* new `anyKeyPressed()` - true while the last report still holds any key or modifier
* `wait_free()` refactored onto it and given the same bounded timeout (it was an unbounded spin loop; it has no live caller today, but the loop was a latent hang)
* the poll interval now converts ms to ticks explicitly via `pdMS_TO_TICKS`. `configTICK_RATE_HZ` is 200, so the old `vTaskDelay(10)` was a 50 ms poll, not 10 ms.

## Why this is safe

The hardware wait polls a register that updates on its own, but the new USB wait depends on the USB task clearing `last_data`. If the UI task could starve it, this would deadlock. Verified it cannot:

* `configUSE_PREEMPTION = 1`, `configUSE_TIME_SLICING = 1`
* the UI loop is `"U-II Main"` at `PRIO_MAIN = 0`; the USB tasks are `PRIO_POLL` / `PRIO_DRIVER = 1`

The higher-priority USB tasks preempt the busy-wait, so the release is always observed.

Other paths checked:

* **REST is unaffected.** `anyKeyPressed()` reads only `last_data`, written solely by `process_data()` from the USB HID task. REST keys go to `injected_buffer`, so REST-driven automation cannot stall.
* **No USB keyboard attached -> zero change.** `last_data` stays zero and the loop never iterates.
* **Disconnect with a key held** clears the report via `usb_hid_remove_keyboard_source()`, so there is no permanent stall.
* All seven `wait_free()` call sites (menu close, context menu, popups, edit boxes, machine monitor, SID editor) are one-shot screen transitions, never per-keystroke - arrow keys return 0 from `handle_key()` and never reach it. Every one of them already behaved this way for the C64 keyboard; the USB keyboard now matches.

Held longer than the 2 s timeout the key still gets through, which is the same bound the C64 keyboard has always had.

## Testing

**Host unit tests** - `software/api/tests` (that suite already links `keyboard_c64.cc` + `keyboard_usb.cc` and stubs `wait_ms`, so the busy-wait can be driven deterministically):

* `HeldUsbEscapeIsRunStopOnTheC64Matrix` - documents why the wait is needed
* `MenuExitWaitsForHeldUsbKeyToBeReleased` - the regression test: asserts the wait happened and no phantom RUN/STOP reaches the matrix
* `MenuExitWaitsForBothKeyboards` - fake `GenericHost` + fake row register; proves the added USB wait does not shorten the existing matrix scan
* `MenuExitWaitIsBoundedWhenTheKeysAreNeverReleased` - worst case is exactly `2 x KEYBOARD_WAIT_FREE_TIMEOUT_MS`

Plus `anyKeyPressed` / bounded-`wait_free` tests in `software/io/usb/tests/usb_keyboard_queue_test.cpp`.

Red/green proven: with only `keyboard_c64.cc` reverted, 2 of 27 fail; with the fix, 27/27 pass.

Full host suite green: 55 USB, 27 input-api-state, 18 filemanager, machine monitor + bookmarks.

**Hardware** - built and JTAG-deployed to an **Ultimate 64 Elite I**, tested with a wireless **Keychron** USB keyboard. Confirmed the SID player no longer bounces back into the menu: holding ESC now closes the menu on release and it stays closed.

`u64` and `u64ii` build clean. The `u2` target fails on a missing `rv700dd.chk` rule in my environment, which reproduces unmodified on the base commit and is unrelated to this change.
