### PR TITLE
Add E2E test for the SID-mirroring freeze wedge

### DIFF
--- a/run-e2e-tests
+++ b/run-e2e-tests
@@ -16,6 +16,7 @@ TIMEOUT="30.0"
 SELECTED=()
 LIST_ONLY=false
 STOP_ON_FAIL=false
+RUN_MANUAL=false
 
 C_BLUE='\033[1;34m'
 C_GREEN='\033[1;32m'
@@ -23,7 +24,11 @@ C_RED='\033[1;31m'
 C_YEL='\033[1;33m'
 C_NC='\033[0m'
 
-# name|relative path|space separated arguments (@HOST@/@PASS@/@TIMEOUT@ are substituted)
+# name|relative path|space separated arguments (@HOST@/@PASS@/@TIMEOUT@ are
+# substituted)|mode, where mode is "auto" (the default when the field is
+# absent) or "manual". Manual suites need an operator decision -- extra
+# privileges, a long wall-clock wait, or a device setting they change -- so
+# they only run when named with -s or when -a is given.
 SUITES=(
   "readmem-writemem|tools/api/readmem_writemem_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"
   "menu-screen|tools/api/menu_screen_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"
@@ -34,7 +39,18 @@ SUITES=(
   "prg-load-path-trim|tools/io/prg-load-path-trim-test.sh|-H @HOST@ -p @PASS@"
   "temp-auto-cleanup|tools/io/temp-auto-cleanup/temp-auto-cleanup-test.sh|-H @HOST@ -p @PASS@"
   "printer|tools/io/printer/printer_test.py|-H @HOST@ -p @PASS@"
+  # Reproduces #733: with the SID decoder fix, "mirroring off" is the
+  # regression guard. Without it, the same scenario stalls the whole Nios
+  # and needs a JTAG recovery -- do not fold into the auto sweep until the
+  # decoder ack no longer depends on it being firmware.
+  "freeze-menu|tools/io/c64/freeze_menu_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all|manual"
 )
+
+suite_mode() {
+    local mode
+    mode="$(echo "$1" | cut -d'|' -f4)"
+    echo "${mode:-auto}"
+}
 
 show_help() {
     cat << EOF
@@ -51,12 +67,14 @@ Options:
   -H, --host <host>         Device host name or IP (default: \$U64_HOST or u64).
   -p, --password <pass>     REST and FTP password (default: \$U64_PASS, empty).
   -t, --timeout <seconds>   Per-request REST timeout (default: $TIMEOUT).
-  -s, --suite <name>        Run only this suite. Repeatable.
+  -s, --suite <name>        Run only this suite. Repeatable. Also selects
+                            manual suites.
+  -a, --all                 Also run the manual suites.
   -l, --list                List the suite names and exit.
   -x, --stop-on-fail        Stop at the first failing suite.
 
 Suites:
-$(for entry in "${SUITES[@]}"; do printf '  %-24s %s\n' "${entry%%|*}" "$(echo "$entry" | cut -d'|' -f2)"; done)
+$(for entry in "${SUITES[@]}"; do printf '  %-26s %-58s %s\n' "${entry%%|*}" "$(echo "$entry" | cut -d'|' -f2)" "$(suite_mode "$entry")"; done)
 
 Notes:
   The device must be idle: these suites open the menu, reset the machine and
@@ -82,6 +100,7 @@ while [[ $# -gt 0 ]]; do
         -p|--password) [[ $# -ge 2 ]] || die "$1 needs a value"; PASSWORD="$2"; shift 2 ;;
         -t|--timeout) [[ $# -ge 2 ]] || die "$1 needs a value"; TIMEOUT="$2"; shift 2 ;;
         -s|--suite) [[ $# -ge 2 ]] || die "$1 needs a value"; SELECTED+=("$2"); shift 2 ;;
+        -a|--all) RUN_MANUAL=true; shift ;;
         -l|--list) LIST_ONLY=true; shift ;;
         -x|--stop-on-fail) STOP_ON_FAIL=true; shift ;;
         -*) die "Unknown option: $1" ;;
@@ -91,14 +110,17 @@ done
 
 if [[ "$LIST_ONLY" == true ]]; then
     for entry in "${SUITES[@]}"; do
-        printf '%-24s %s\n' "${entry%%|*}" "$(echo "$entry" | cut -d'|' -f2)"
+        printf '%-26s %-58s %s\n' "${entry%%|*}" "$(echo "$entry" | cut -d'|' -f2)" "$(suite_mode "$entry")"
     done
     exit 0
 fi
 
 selected_wanted() {
-    local name=$1
-    [[ ${#SELECTED[@]} -eq 0 ]] && return 0
+    local name=$1 mode=$2
+    if [[ ${#SELECTED[@]} -eq 0 ]]; then
+        [[ "$mode" == "auto" || "$RUN_MANUAL" == true ]]
+        return
+    fi
     local want
     for want in "${SELECTED[@]}"; do
         [[ "$want" == "$name" ]] && return 0
@@ -127,9 +149,9 @@ START_ALL=$SECONDS
 for entry in "${SUITES[@]}"; do
     name="${entry%%|*}"
     path="$(echo "$entry" | cut -d'|' -f2)"
-    raw_args="$(echo "$entry" | cut -d'|' -f3-)"
+    raw_args="$(echo "$entry" | cut -d'|' -f3)"
 
-    selected_wanted "$name" || continue
+    selected_wanted "$name" "$(suite_mode "$entry")" || continue
 
     full_path="$ROOT/$path"
     if [[ ! -f "$full_path" ]]; then

--- a/tools/io/c64/freeze_menu_test.py
+++ b/tools/io/c64/freeze_menu_test.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Validate the freezer menu against SID mappings without auto address mirroring.
+
+With "Interface Type" set to "Freeze" the firmware stops the C64 and pokes the SID volume
+registers before it draws the menu. Those registers used to be hard coded to
+$D418/$D438/$D518, which are only decoded while "Auto Address Mirroring" widens every SID
+decode to the full $D400-$D7FF range. With mirroring disabled the writes addressed nothing
+at all, which stalled the C64 bus and left the device on a black screen that only a forced
+power off could clear. See GideonZ/1541ultimate#733.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from typing import Dict, Optional, Tuple
+
+
+CHECK_COUNT = 0
+MENU_SCREEN_PATH = "/v1/machine:menu_screen"
+MENU_BUTTON_PATH = "/v1/machine:menu_button"
+READMEM_PATH = "/v1/machine:readmem"
+CONFIGS_PATH = "/v1/configs"
+UI_STORE = "User Interface Settings"
+UI_ITEM = "Interface Type"
+SID_STORE = "SID Addressing"
+SID_ITEM = "Auto Address Mirroring"
+FREEZE = "Freeze"
+ENABLED = "Enabled"
+DISABLED = "Disabled"
+# The KERNAL interrupt bumps the low byte of the jiffy clock 50 or 60 times a second, so it
+# only moves while the 6510 runs. That distinguishes a properly resumed C64 from one that
+# was left stopped in Ultimax mode, which is what the reported "garbled characters" are.
+JIFFY_ADDRESS = 0x00A2
+JIFFY_SAMPLE_SECONDS = 0.5
+JIFFY_SETTLE_SECONDS = 5.0
+MENU_TOGGLE_SETTLE_SECONDS = 0.25
+MENU_TOGGLE_TIMEOUT_SECONDS = 5.0
+SCREEN_WIDTH = 40
+SCREEN_HEIGHT = 25
+SCREEN_CELLS = SCREEN_WIDTH * SCREEN_HEIGHT
+SCREEN_BYTES = SCREEN_CELLS * 2
+WEDGE_HINT = (
+    "the device stopped answering REST requests. This is the wedge from issue #733; "
+    "hold the menu button for 5 seconds or redeploy over JTAG to recover"
+)
+
+
+class Failure(RuntimeError):
+    pass
+
+
+@contextmanager
+def check(label: str):
+    global CHECK_COUNT
+    CHECK_COUNT += 1
+    print(f"[{CHECK_COUNT:02d}] {label} ... ", end="", flush=True)
+    try:
+        yield
+    except Exception:
+        print("FAIL", flush=True)
+        raise
+    print("OK", flush=True)
+
+
+def format_exception(exc: BaseException) -> str:
+    if isinstance(exc, urllib.error.URLError) and getattr(exc, "reason", None) is not None:
+        return f"{exc} ({exc.reason})"
+    return str(exc)
+
+
+def header_value(headers: Dict[str, str], name: str) -> str:
+    wanted = name.lower()
+    for key, value in headers.items():
+        if key.lower() == wanted:
+            return value
+    return ""
+
+
+def parse_json(label: str, body: bytes) -> Dict[str, object]:
+    try:
+        data = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise Failure(f"{label}: response body is not valid JSON: {body[:160]!r}") from exc
+    if not isinstance(data, dict):
+        raise Failure(f"{label}: expected JSON object, got {data!r}")
+    return data
+
+
+class RestSession:
+    def __init__(self, host: str, password: Optional[str], timeout: float) -> None:
+        self.host = host
+        self.password = password
+        self.timeout = timeout
+
+    def url(self, path: str, params: Optional[Dict[str, object]] = None) -> str:
+        query = ""
+        if params:
+            query = "?" + urllib.parse.urlencode(params)
+        return f"http://{self.host}{path}{query}"
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, object]] = None,
+    ) -> Tuple[int, Dict[str, str], bytes]:
+        headers: Dict[str, str] = {}
+        if self.password:
+            headers["X-Password"] = self.password
+
+        request = urllib.request.Request(self.url(path, params), headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return response.status, dict(response.headers.items()), response.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, dict(exc.headers.items()), exc.read()
+        except (OSError, TimeoutError, urllib.error.URLError) as exc:
+            raise Failure(f"{method} {self.url(path, params)} failed: {format_exception(exc)}") from exc
+
+    def responds(self) -> bool:
+        try:
+            status, _, _ = self.request("GET", "/v1/version")
+        except Failure:
+            return False
+        return status == 200
+
+    def config_path(self, store: str, item: str) -> str:
+        return f"{CONFIGS_PATH}/{urllib.parse.quote(store)}/{urllib.parse.quote(item)}"
+
+    def get_config(self, store: str, item: str) -> str:
+        status, _, body = self.request("GET", self.config_path(store, item))
+        if status != 200:
+            raise Failure(f"reading '{item}' failed with HTTP {status}: {body[:160]!r}")
+        data = parse_json(f"config {item}", body)
+        # The reply nests the setting under its category and name.
+        entry = data.get(store, {})
+        if isinstance(entry, dict):
+            entry = entry.get(item, {})
+        current = entry.get("current") if isinstance(entry, dict) else None
+        if not isinstance(current, str):
+            raise Failure(f"config '{item}' has no string 'current': {data!r}")
+        return current
+
+    def set_config(self, store: str, item: str, value: str) -> None:
+        status, _, body = self.request("PUT", self.config_path(store, item), params={"value": value})
+        if status != 200:
+            raise Failure(f"setting '{item}' to '{value}' failed with HTTP {status}: {body[:160]!r}")
+
+    def menu_button(self) -> None:
+        status, _, body = self.request("PUT", MENU_BUTTON_PATH)
+        if status != 200:
+            raise Failure(f"menu_button failed with HTTP {status}: {body[:160]!r}")
+        time.sleep(MENU_TOGGLE_SETTLE_SECONDS)
+
+    def menu_is_open(self) -> bool:
+        status, headers, body = self.request("GET", MENU_SCREEN_PATH)
+        if status == 404:
+            return False
+        if status != 200:
+            raise Failure(f"menu_screen failed with HTTP {status}: {body[:160]!r}")
+        content_type = header_value(headers, "Content-Type")
+        if "application/octet-stream" not in content_type:
+            raise Failure(f"expected application/octet-stream from menu_screen, got {content_type!r}")
+        if len(body) != SCREEN_BYTES:
+            raise Failure(f"expected {SCREEN_BYTES} bytes from menu_screen, got {len(body)}")
+        return True
+
+    def wait_menu_state(self, want_open: bool) -> bool:
+        deadline = time.monotonic() + MENU_TOGGLE_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if self.menu_is_open() == want_open:
+                return True
+            time.sleep(MENU_TOGGLE_SETTLE_SECONDS)
+        return False
+
+    def read_jiffy(self) -> int:
+        status, _, body = self.request(
+            "GET", READMEM_PATH, params={"address": f"{JIFFY_ADDRESS:04X}", "length": 1}
+        )
+        if status != 200:
+            raise Failure(f"readmem failed with HTTP {status}: {body[:160]!r}")
+        if len(body) != 1:
+            raise Failure(f"expected 1 byte from readmem, got {len(body)}")
+        return body[0]
+
+    def jiffy_advances(self) -> bool:
+        first = self.read_jiffy()
+        time.sleep(JIFFY_SAMPLE_SECONDS)
+        return self.read_jiffy() != first
+
+
+def require_alive(session: RestSession, label: str) -> None:
+    if not session.responds():
+        raise Failure(f"{label}: {WEDGE_HINT}")
+
+
+def wedge_aware(session: RestSession, label: str, action) -> None:
+    """Run 'action', and report a dead device as the known wedge rather than a raw error."""
+    try:
+        action()
+    except Failure as exc:
+        if not session.responds():
+            raise Failure(f"{label}: {WEDGE_HINT}") from exc
+        raise
+
+
+def require_machine_running(session: RestSession, label: str) -> None:
+    with check(label):
+        deadline = time.monotonic() + JIFFY_SETTLE_SECONDS
+        while time.monotonic() < deadline:
+            if session.jiffy_advances():
+                return
+        raise Failure(
+            f"{label}: the jiffy clock at ${JIFFY_ADDRESS:04X} is not advancing, so the C64 "
+            "is not running. It must be resumed after the menu closes, and it must be at a "
+            "prompt with KERNAL interrupts enabled before the test starts"
+        )
+
+
+def require_machine_frozen(session: RestSession, label: str) -> None:
+    with check(label):
+        if session.jiffy_advances():
+            raise Failure(
+                f"{label}: the jiffy clock at ${JIFFY_ADDRESS:04X} keeps advancing, so the menu "
+                f"did not freeze the C64. Check that '{UI_ITEM}' really is '{FREEZE}'"
+            )
+
+
+def toggle_menu(session: RestSession, label: str, want_open: bool) -> None:
+    def action() -> None:
+        session.menu_button()
+        if not session.wait_menu_state(want_open=want_open):
+            raise Failure(f"menu did not {'open' if want_open else 'close'}")
+
+    with check(label):
+        wedge_aware(session, label, action)
+
+
+def open_menu(session: RestSession) -> None:
+    toggle_menu(session, "open the menu", want_open=True)
+    require_machine_frozen(session, "C64 frozen while the menu is open")
+
+
+def close_menu(session: RestSession) -> None:
+    toggle_menu(session, "close the menu", want_open=False)
+    require_machine_running(session, "C64 resumed after the menu closed")
+
+
+def prepare(session: RestSession, mirroring: str) -> None:
+    with check(f"select '{FREEZE}' interface with mirroring {mirroring.lower()}"):
+        session.set_config(UI_STORE, UI_ITEM, FREEZE)
+        session.set_config(SID_STORE, SID_ITEM, mirroring)
+    require_alive(session, "applying the SID mapping")
+    require_machine_running(session, "C64 running before the menu is opened")
+
+
+def run_menu_cycle(session: RestSession, mirroring: str) -> None:
+    print(f"-- menu cycle with {SID_ITEM} {mirroring}")
+    prepare(session, mirroring)
+    open_menu(session)
+    close_menu(session)
+
+
+def run_toggle_while_open(session: RestSession) -> None:
+    print(f"-- {SID_ITEM} switched off while the menu is open")
+    prepare(session, ENABLED)
+    open_menu(session)
+    with check(f"set {SID_ITEM} to {DISABLED} while the menu is open"):
+        wedge_aware(
+            session,
+            "applying the new SID mapping",
+            lambda: session.set_config(SID_STORE, SID_ITEM, DISABLED),
+        )
+    close_menu(session)
+
+
+def expand_tests(selected) -> set:
+    names = {"mirroring-off", "toggle-open", "mirroring-on"}
+    if not selected or "all" in selected:
+        return names
+    return {name for name in selected if name in names}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the freezer menu against SID mappings without auto address mirroring."
+    )
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_INPUT_HOST", "u64"))
+    parser.add_argument("-r", "--rest-host", default=os.environ.get("U64_INPUT_REST_HOST"))
+    parser.add_argument(
+        "-p",
+        "--password",
+        default=os.environ.get("U64_INPUT_PASSWORD", os.environ.get("C64U_PASSWORD")),
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("U64_INPUT_TIMEOUT", "5.0")),
+    )
+    parser.add_argument(
+        "--test",
+        action="append",
+        choices=("all", "mirroring-off", "toggle-open", "mirroring-on"),
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        metavar="COUNT",
+        help="Number of times to run the selected checks (default: 1).",
+    )
+    args = parser.parse_args()
+
+    if args.repeat < 1:
+        parser.error("--repeat must be at least 1")
+
+    session = RestSession(args.rest_host or args.host, args.password, args.timeout)
+    tests = expand_tests(args.test)
+
+    if not session.responds():
+        raise Failure(f"{session.host} is not answering REST requests")
+
+    initial_interface = session.get_config(UI_STORE, UI_ITEM)
+    initial_mirroring = session.get_config(SID_STORE, SID_ITEM)
+    print(f"-- captured '{UI_ITEM}'={initial_interface}, '{SID_ITEM}'={initial_mirroring}")
+
+    try:
+        for iteration in range(args.repeat):
+            if args.repeat > 1:
+                print(f"-- pass {iteration + 1} of {args.repeat}")
+            if "mirroring-off" in tests:
+                run_menu_cycle(session, DISABLED)
+            if "toggle-open" in tests:
+                run_toggle_while_open(session)
+            if "mirroring-on" in tests:
+                run_menu_cycle(session, ENABLED)
+    finally:
+        # Never leave the device on a changed mapping or with the menu open.
+        if session.responds():
+            if session.menu_is_open():
+                session.menu_button()
+            session.set_config(SID_STORE, SID_ITEM, initial_mirroring)
+            session.set_config(UI_STORE, UI_ITEM, initial_interface)
+        else:
+            print("-- device is not responding; configuration left as-is", file=sys.stderr)
+
+    print(f"freeze_menu_test: OK ({CHECK_COUNT} checks)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        print(f"freeze_menu_test: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

Test-only extraction from #734 to test fix of SID-mirroring freeze wedge.

## Context

As discussed, the firmware workaround from #734 will not be merged. It can address only DMA-based accesses, including the freezer, `machine:readmem`/`writemem`, and the monitor. It cannot solve the general case because a real 6510 `POKE` or `PEEK` to the same unclaimed address stalls the C64 core in exactly the same way, with no firmware involved in that path.

The correct fix belongs in the address decoder of the FPGA core, maintained in the separate `ult64` repository. The `$D400-$D7FF` region must acknowledge accesses based on the address range rather than on a successful decoder hit. An unclaimed SID address should therefore return open bus instead of leaving the bus stalled.

This PR preserves only the regression coverage from #734 so that it is not lost. It contains `tools/io/c64/freeze_menu_test.py`, unchanged from that branch, and makes no firmware changes.

## Wiring

The suite is registered in `run-e2e-tests` as `freeze-menu` in **manual** mode.

Until the FPGA decoder fix is available, the "mirroring off" scenario reproduces the actual failure: the DMA access stalls and recovery requires JTAG. It therefore must not be included in a normal `run-e2e-tests` sweep.

The suite can be run explicitly with `-s freeze-menu` or as part of `-a`. Once the FPGA core fix has shipped, it can be changed to `auto` and retained as a permanent regression guard.

## Testing

The following checks pass:

* `bash -n run-e2e-tests`
* `python3 -m py_compile`

Also verified that the suite:

* appears as `manual` in `--list`
* is excluded from a bare `run-e2e-tests` invocation
* can be selected with `-s freeze-menu`

The test was not run against real hardware for this PR. The purpose of `manual` mode is specifically to prevent automated test sweeps from triggering the wedge scenario before the FPGA decoder fix is available.
