### PR TITLE
Fix UCI wedge on LOAD_REU/SAVE_REU and SoftIEC reply framing

### DIFF
--- a/run-e2e-tests
+++ b/run-e2e-tests
@@ -46,6 +46,11 @@ SUITES=(
   "prg-load-path-trim|tests/e2e/api/prg_load_path_trim_test.sh|-H @HOST@ -p @PASS@"
   "temp-auto-cleanup|tests/e2e/filemanager/temp_auto_cleanup_test.sh|-H @HOST@ -p @PASS@"
   "printer|tests/e2e/io/printer/printer_test.py|-H @HOST@ -p @PASS@"
+  # Drives the UCI control and SoftIEC targets over $DF1B-$DF1F; reproduces #740.
+  # A #740 regression leaves the interface stuck in Command Busy for every target
+  # until the firmware restarts, so run it after the suites that drive the menu
+  # and the file system.
+  "uci-targets|tests/e2e/io/command_interface/uci_targets_test.py|-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"
   # Long telnet run; drives the machine-code monitor with its own long flags.
   "machine-code-monitor|tests/e2e/monitor/monitor_test.py|--host @HOST@ --password @PASS@ --timeout @TIMEOUT@|manual"
   # Needs passwordless "sudo -n ip" plus an --iface/--victim-ip for this LAN,

--- a/software/io/command_interface/command_intf.cc
+++ b/software/io/command_interface/command_intf.cc
@@ -214,7 +214,7 @@ void CommandInterface :: dump_registers(void)
     printf("CMD_IF_STATUS_END      %b\n", CMD_IF_STATUS_END    );
     printf("CMD_IF_STATUS_LENGTH   %b\n", CMD_IF_STATUS_LENGTH );
     printf("CMD_IF_RESPONSE_LEN_L  %b\n", CMD_IF_RESPONSE_LEN_L);
-    printf("CMD_IF_REPSONSE_LEN_H  %b\n", CMD_IF_RESPONSE_LEN_H);
+    printf("CMD_IF_RESPONSE_LEN_H  %b\n", CMD_IF_RESPONSE_LEN_H);
     printf("CMD_IF_COMMAND_LEN_L   %b\n", CMD_IF_COMMAND_LEN_L );
     printf("CMD_IF_COMMAND_LEN_H   %b\n", CMD_IF_COMMAND_LEN_H );
     printf("CMD_IF_IRQMASK         %b\n", CMD_IF_IRQMASK       );

--- a/software/io/command_interface/control_target.cc
+++ b/software/io/command_interface/control_target.cc
@@ -30,9 +30,8 @@ static Message c_status_reu_not_saved       = { 31, true, (uint8_t *)"86,REU OFF
 
 char *struprt(char *str)
 {
-    char *next = str;
-    while (*str != '\0')
-        *str = toupper((unsigned char)*str);
+    for (char *next = str; *next != '\0'; next++)
+        *next = toupper((unsigned char)*next);
     return str;
 }
 
@@ -299,6 +298,10 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
             *reply = &c_message_empty;
             if (command->length >= 5) {
                 *reply  = &data_message;
+                // LoadREU/SaveREU return without writing a status string when the REU is
+                // disabled, so clear it here; otherwise the reply length is taken from
+                // whatever the previous command left in this buffer.
+                data_message.message[4] = 0;
                 if (command->message[1] == CTRL_CMD_LOAD_REU) {
                     retVal = reu_preloader->LoadREU((char *)data_message.message + 4);
                 } else {

--- a/software/io/command_interface/softiec_target.cc
+++ b/software/io/command_interface/softiec_target.cc
@@ -23,7 +23,12 @@ static Message c_status_invalid_dir         = {  1, true, (uint8_t *)"\x09" };
 SoftIECTarget :: SoftIECTarget(int id)
 {
     command_targets[id] = this;
-    data_message.message = new uint8_t[512];
+    // cmd_get_fatname() fills this with strncpy(..., CMD_MAX_REPLY_LEN), and strncpy
+    // pads the destination all the way to n, so the buffer has to be that size.
+    data_message.message = new uint8_t[CMD_MAX_REPLY_LEN];
+    // No command in this target replies in more than one part; direct_message is
+    // the one that does, and it sets its own flag in prepare_data().
+    data_message.last_part = true;
     status_message.message = new uint8_t[80];
     input_channel = NULL;
     input_length = 0;

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,7 +20,7 @@ protocol used to drive it:
 | `api/` | `software/api/` | REST contracts for input, menu screen, memory, and PRG runners |
 | `filemanager/` | `software/filemanager/`, `software/userinterface/` | Browser actions, change notification, and managed `/Temp` lifecycle |
 | `filesystem/` | `software/filesystem/` | Filesystem implementations, including the remote FTP filesystem |
-| `io/` | `software/io/` | Device-facing I/O subsystems; nested by production package (`c64/`, `printer/`) |
+| `io/` | `software/io/` | Device-facing I/O subsystems; nested by production package (`c64/`, `command_interface/`, `printer/`) |
 | `monitor/` | `software/monitor/` | Machine-code monitor behavior over the normal Telnet UI |
 | `network/` | `software/network/` | Network service and connection lifecycle |
 

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -1,0 +1,940 @@
+#!/usr/bin/env python3
+# E2E: Verifies UCI transport state machine, command completion, and reply framing.
+
+"""End-to-end check of the Ultimate Command Interface over the cartridge registers.
+
+Regression guard for GideonZ/1541ultimate#740: CTRL_CMD_LOAD_REU ($08) and
+CTRL_CMD_SAVE_REU ($09) never returned, so the command interface stayed BUSY for
+every target until the machine was power-cycled.
+
+It also covers the transport state machine, the control target's rejection paths,
+and reply framing on the SoftIEC target, whose single-part replies were announced
+as "Data More" and left a client waiting for a block that is never sent.
+
+Every expected value here was taken from the firmware and confirmed against a
+real device. The manuals under doc/ ("Ultimate Command Interface - Register API",
+and the per-target summaries) describe the intended design and are useful
+background, but they have drifted from the implementation in places, so they are
+not used as the source of truth. Where the two differ, this suite follows the
+firmware and says so at the assertion.
+
+The registers live at $DF1B-$DF1F and are reached through REST
+machine:readmem / machine:writemem, which perform DMA cycles on the cartridge
+bus. No 6502 code is involved.
+
+  $DF1C  write: control (bit 0 PUSH_CMD, bit 1 DATA_ACC, bit 2 ABORT, bit 3 CLR_ERR)
+         read:  status  (bit 0 CMD_BUSY, bit 1 DATA_ACC, bit 2 ABORT_P, bit 3 ERROR,
+                         bits 4-5 state, bit 6 STAT_AV, bit 7 DATA_AV)
+  $DF1D  write: command byte queue;  read: identification ($C9, or $49 on IRQ)
+  $DF1E  read:  response data queue
+  $DF1F  read:  status data queue
+
+Command bytes go into $DF1D one REST call at a time on purpose: machine:writemem
+writes an ascending span, so a single multi-byte write would land on $DF1E onwards.
+Only $DF1C is polled for the same reason -- a span read starting there would pop
+the response and status queues.
+
+Supported on any Ultimate whose FPGA provides the command interface. The suite
+enables the "Command Interface" setting, changes REU settings, and restores all of
+them on exit.
+"""
+
+import argparse
+import ftplib
+import io
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from typing import Dict, List, Optional, Tuple
+
+CHECK_COUNT = 0
+
+READMEM_PATH = "/v1/machine:readmem"
+WRITEMEM_PATH = "/v1/machine:writemem"
+RESET_PATH = "/v1/machine:reset"
+
+CONFIG_CATEGORY = "C64 and Cartridge Settings"
+CFG_CMD_IF = "Command Interface"
+CFG_REU_ENABLE = "RAM Expansion Unit"
+CFG_REU_IMAGE = "REU Preload Image"
+CFG_REU_SIZE = "REU Size"
+CFG_REU_OFFSET = "REU Preload Offset"
+# Everything the suite writes, captured before the first change and put back at the end.
+OWNED_SETTINGS = (CFG_CMD_IF, CFG_REU_ENABLE, CFG_REU_IMAGE, CFG_REU_SIZE, CFG_REU_OFFSET)
+
+REG_CONTROL = 0xDF1C
+REG_COMMAND = 0xDF1D
+REG_RESPONSE = 0xDF1E
+REG_STATUS = 0xDF1F
+
+CTRL_PUSH_CMD = 0x01
+CTRL_DATA_ACC = 0x02
+CTRL_ABORT = 0x04
+CTRL_CLR_ERR = 0x08
+
+ST_ERROR = 0x08
+ST_STATE_MASK = 0x30
+ST_STATE_IDLE = 0x00
+ST_STATE_BUSY = 0x10
+ST_STATE_DATA_LAST = 0x20
+ST_STATE_DATA_MORE = 0x30
+ST_STAT_AV = 0x40
+ST_DATA_AV = 0x80
+STATE_NAMES = {ST_STATE_IDLE: "Idle", ST_STATE_BUSY: "Command Busy",
+               ST_STATE_DATA_LAST: "Data Last", ST_STATE_DATA_MORE: "Data More"}
+STATUS_FLAGS = ((0x01, "CMD_BUSY"), (0x02, "DATA_ACC"), (0x04, "ABORT_P"), (ST_ERROR, "ERROR"),
+                (ST_STAT_AV, "STAT_AV"), (ST_DATA_AV, "DATA_AV"))
+
+# Dispatch layer: the low nibble of the first command byte selects the target,
+# bit 7 asks for a command that sends no reply at all.
+TARGET_NO_REPLY = 0x80
+TARGET_CONTROL = 0x04
+TARGET_SOFTIEC = 0x05
+# 1 and 2 are Ultimate DOS, 3 network, 4 control, 5 SoftIEC, 6 HTTP. $0F is the
+# highest target the dispatcher can address and nothing registers there.
+TARGET_UNREGISTERED = 0x0F
+
+CTRL_CMD_IDENTIFY = 0x01
+CTRL_CMD_LOAD_REU = 0x08
+CTRL_CMD_SAVE_REU = 0x09
+CTRL_CMD_GET_HWINFO = 0x28
+SOFTIEC_CMD_IDENTIFY = 0x01
+SOFTIEC_CMD_LOAD_SU = 0x10
+SOFTIEC_CMD_GET_FATNAME = 0x22
+# No target implements $7F, so it reaches the unknown-command path.
+CMD_UNIMPLEMENTED = 0x7F
+
+STATUS_OK = b"00,OK"
+STATUS_UNKNOWN_COMMAND = b"21,UNKNOWN COMMAND"
+STATUS_INVALID_PARAMS = b"81,INVALID PARAMS"
+STATUS_REU_DISABLED = b"84,REU NOT ENABLED"
+STATUS_REU_CANNOT_OPEN = b"85,REU FILE CANNOT BE OPENED"
+STATUS_REU_NOT_SAVED = b"86,REU OFFSET > SIZE. NOT SAVED"
+# The SoftIEC target answers with a single status byte, not with text.
+SOFTIEC_OK = b"\x00"
+SOFTIEC_FILE_NOT_FOUND = b"\x01"
+SOFTIEC_UNKNOWN_COMMAND = b"\x04"
+SOFTIEC_NOT_LOADED = b"\x05"
+
+# Any filename bytes will do for the REU commands: the handler takes the image path
+# from the "REU Preload Image" setting, not from the command. They are here only to
+# push the command past the five-byte minimum length that selects the REU code path.
+REU_FILENAME = b"REU.IMG"
+# A path that must not exist, so LoadREU fails to open it and writes a status
+# string into the reply buffer. That string is what the uppercase conversion in
+# control_target.cc used to loop on forever. Absence is asserted, not assumed:
+# if the file were there, a correct device would load it and report success.
+ABSENT_IMAGE = "/Temp/uci_e2e_absent.reu"
+# The smallest REU with a preload offset at its end. SaveREU rejects that before it
+# touches storage, so SAVE_REU can be exercised on a path that writes a status
+# string without renaming or writing any file.
+OVERSIZE_OFFSET_SIZE = "128 KB"
+OVERSIZE_OFFSET = "128 KB"
+# Issue #740 reproduced the hang with an image present as well as absent. The
+# reporter used a 16384-byte file, so this uses the same size. It is uploaded over
+# FTP for the run and deleted afterwards.
+PRESENT_IMAGE = "/Temp/uci_e2e_present.reu"
+PRESENT_IMAGE_BYTES = 16384
+# 128 KB REU with no preload offset, so a load of the file above transfers all of it
+# and the expected byte count does not depend on the device's configured REU size.
+MATRIX_REU_SIZE = "128 KB"
+MATRIX_REU_OFFSET = "0 KB"
+# The issue sends the filename at offset 2, and once at offset 4 behind two zero
+# bytes, to rule out a framing mistake. Neither reaches the handler, which takes the
+# path from the setting, but both have to complete.
+FILENAME_OFFSETS = (2, 4)
+# "#" selects the buffer stream, which GET_FATNAME answers with a fixed string
+# without resolving a partition or touching the file system. A plain file name
+# would be answered from the current SoftIEC partition, and would report an
+# invalid directory on a device whose partition is not set up.
+FATNAME_CHANNEL = 0x02
+FATNAME_BUFFER_STREAM = b"#"
+FATNAME_BUFFER_REPLY = b"/buffer"
+# LOAD_SU opens a file for reading. A name that does not exist makes it report
+# "file not found" without creating or changing anything. cmd_load_su() reads the
+# secondary address, verify flag, load address and end address from bytes 2 to 7
+# and starts the name at byte 8, so all six have to be present before the name.
+LOAD_SU_MISSING = bytes(6) + b"NOSUCHFILE"
+
+BUSY_TIMEOUT_SECONDS = 15.0
+BUSY_POLL_SECONDS = 0.05
+ABORT_TIMEOUT_SECONDS = 5.0
+RELEASE_TIMEOUT_SECONDS = 5.0
+# How often a request that can be repeated safely is retried when the device's
+# connection pool is momentarily full, and how long to wait in between.
+CONNECT_ATTEMPTS = 3
+CONNECT_RETRY_SECONDS = 2.0
+NO_REPLY_TIMEOUT_SECONDS = 5.0
+MAX_QUEUE_BYTES = 1024
+RESET_SETTLE_SECONDS = 3.0
+
+TESTS = [
+    "transport",
+    "control-target",
+    "issue-740-matrix",
+    "save-reu-offset-past-end",
+    "load-reu-disabled",
+    "save-reu-disabled",
+    "softiec-single-part-reply",
+    "interface-usable-after",
+]
+
+
+class Failure(RuntimeError):
+    pass
+
+
+class Wedged(Failure):
+    """The command interface never left Command Busy: issue #740's failure mode."""
+
+
+@contextmanager
+def check(label: str):
+    global CHECK_COUNT
+    CHECK_COUNT += 1
+    print(f"[{CHECK_COUNT:02d}] {label} ... ", end="", flush=True)
+    try:
+        yield
+    except Exception:
+        print("FAIL", flush=True)
+        raise
+    print("OK", flush=True)
+
+
+def format_exception(exc: BaseException) -> str:
+    if isinstance(exc, urllib.error.URLError) and getattr(exc, "reason", None) is not None:
+        return f"{exc} ({exc.reason})"
+    return str(exc)
+
+
+def describe_status(status: int) -> str:
+    flags = [name for bit, name in STATUS_FLAGS if status & bit]
+    state = STATE_NAMES[status & ST_STATE_MASK]
+    return f"${status:02X} ({state}{', ' + '|'.join(flags) if flags else ''})"
+
+
+def as_int32(reply: bytes) -> int:
+    return int.from_bytes(reply[:4], "little", signed=True)
+
+
+class RestSession:
+    def __init__(self, host: str, password: Optional[str], timeout: float) -> None:
+        self.host = host
+        self.password = password
+        self.timeout = timeout
+
+    def request(self, method: str, path: str, params: Optional[Dict[str, object]] = None,
+                repeatable: bool = False) -> Tuple[int, bytes]:
+        url = f"http://{self.host}{path}"
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        headers = {"X-Password": self.password} if self.password else {}
+        request = urllib.request.Request(url, headers=headers, method=method)
+        attempts = CONNECT_ATTEMPTS if repeatable else 1
+        for attempt in range(1, attempts + 1):
+            try:
+                with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                    return response.status, response.read()
+            except urllib.error.HTTPError as exc:
+                # An HTTP status is an answer, not a transport failure, so it is never
+                # retried. HTTPError also holds the connection open until it is
+                # collected, and this suite opens one per register access, so close it
+                # here rather than later.
+                with exc:
+                    return exc.code, exc.read()
+            except (OSError, TimeoutError, urllib.error.URLError) as exc:
+                # The device serves about four HTTP connections at a time and reaps a
+                # stuck one after roughly 15 seconds, so a request can be refused or
+                # time out while the pool is momentarily full. That is a property of
+                # the device, not a firmware failure, and it shows up here because this
+                # suite opens a connection per register access. Only requests that can
+                # be repeated without changing device state are retried; a write to the
+                # command queue or a read that pops a response FIFO is not, because a
+                # timeout does not say whether the first one landed.
+                if attempt == attempts:
+                    raise Failure(
+                        f"{method} {url} failed after {attempt} attempt(s): {format_exception(exc)}"
+                    ) from exc
+                print(f"\n  retrying {method} {url}: {format_exception(exc)}", flush=True)
+                time.sleep(CONNECT_RETRY_SECONDS)
+        raise Failure(f"{method} {url} failed")  # not reachable, keeps the type checker happy
+
+    def peek(self, address: int, repeatable: bool = False) -> int:
+        status, body = self.request(
+            "GET", READMEM_PATH, params={"address": f"{address:04x}", "length": 1}, repeatable=repeatable
+        )
+        if status != 200 or len(body) != 1:
+            raise Failure(f"readmem(${address:04X}) failed with HTTP {status}: {body[:200]!r}")
+        return body[0]
+
+    def poke(self, address: int, value: int) -> None:
+        status, body = self.request(
+            "PUT", WRITEMEM_PATH, params={"address": f"{address:04x}", "data": f"{value:02x}"}
+        )
+        if status != 200:
+            raise Failure(f"writemem(${address:04X}, ${value:02X}) failed with HTTP {status}: {body[:200]!r}")
+
+    def get_config(self, category: str) -> Dict[str, object]:
+        status, body = self.request("GET", f"/v1/configs/{urllib.parse.quote(category)}", repeatable=True)
+        if status != 200:
+            raise Failure(f"GET config {category!r} failed with HTTP {status}: {body[:200]!r}")
+        return json.loads(body.decode("utf-8"))[category]
+
+    def set_config(self, category: str, item: str, value: str) -> None:
+        path = f"/v1/configs/{urllib.parse.quote(category)}/{urllib.parse.quote(item)}"
+        status, body = self.request("PUT", path, params={"value": value})
+        if status != 200:
+            raise Failure(f"PUT config {category!r}/{item!r}={value!r} failed with HTTP {status}: {body[:200]!r}")
+
+    def file_info(self, path: str) -> Optional[Dict[str, object]]:
+        quoted = urllib.parse.quote(path.lstrip("/"))
+        status, body = self.request("GET", f"/v1/files/{quoted}:info", repeatable=True)
+        if status == 404:
+            return None
+        if status != 200:
+            raise Failure(f"files:info for {path!r} returned HTTP {status}: {body[:200]!r}")
+        return json.loads(body.decode("utf-8"))["files"]
+
+    def file_exists(self, path: str) -> bool:
+        return self.file_info(path) is not None
+
+    def file_size(self, path: str) -> int:
+        info = self.file_info(path)
+        if info is None:
+            raise Failure(f"{path} does not exist on the device")
+        return int(info["size"])
+
+    def reset(self) -> None:
+        status, body = self.request("PUT", RESET_PATH)
+        if status != 200:
+            raise Failure(f"reset failed with HTTP {status}: {body[:200]!r}")
+
+
+class FtpFixture:
+    """Files this suite puts on the device, over FTP because REST cannot delete."""
+
+    def __init__(self, host: str, password: Optional[str], timeout: float) -> None:
+        self.host = host
+        self.password = password or ""
+        self.timeout = timeout
+        self.created: List[str] = []
+
+    def _open(self) -> ftplib.FTP:
+        ftp = ftplib.FTP()
+        ftp.connect(self.host, 21, timeout=self.timeout)
+        # Any user name is accepted; the password is the device's network password.
+        ftp.login("user", self.password)
+        return ftp
+
+    def _close(self, ftp: ftplib.FTP) -> None:
+        try:
+            ftp.quit()
+        except Exception:
+            ftp.close()
+
+    def upload(self, path: str, data: bytes) -> None:
+        ftp = self._open()
+        try:
+            ftp.storbinary(f"STOR {path}", io.BytesIO(data))
+            self.created.append(path)
+        except Exception as exc:
+            raise Failure(f"FTP upload of {path!r} failed: {exc}") from exc
+        finally:
+            self._close(ftp)
+
+    def cleanup(self) -> bool:
+        """Delete what this suite created. Returns False if anything is left."""
+        if not self.created:
+            return True
+        ok = True
+        ftp = None
+        try:
+            ftp = self._open()
+            for path in list(self.created):
+                try:
+                    ftp.delete(path)
+                    self.created.remove(path)
+                except Exception as exc:
+                    print(f"uci_targets_test: could not delete {path}: {exc}", file=sys.stderr)
+                    ok = False
+        except Exception as exc:
+            print(f"uci_targets_test: FTP cleanup failed: {exc}", file=sys.stderr)
+            return False
+        finally:
+            if ftp is not None:
+                self._close(ftp)
+        return ok
+
+
+class Uci:
+    """The $DF1C-$DF1F transport, one REST DMA cycle per register access."""
+
+    def __init__(self, session: RestSession, busy_timeout: float) -> None:
+        self.session = session
+        self.busy_timeout = busy_timeout
+
+    def status(self) -> int:
+        # Reading $DF1C has no side effect, unlike the response and status FIFOs.
+        return self.session.peek(REG_CONTROL, repeatable=True)
+
+    def control(self, bits: int) -> None:
+        self.session.poke(REG_CONTROL, bits)
+
+    def state(self) -> int:
+        return self.status() & ST_STATE_MASK
+
+    def release(self) -> bool:
+        """Accept any pending data and clear a stale error, until the state is Idle.
+
+        Accepting data from "Data More" returns to Command Busy while the target
+        prepares the next block, so this has to keep trying rather than assume one
+        write is enough.
+        """
+        deadline = time.time() + RELEASE_TIMEOUT_SECONDS
+        while True:
+            self.control(CTRL_DATA_ACC)
+            self.control(CTRL_CLR_ERR)
+            if self.state() == ST_STATE_IDLE:
+                return True
+            if time.time() > deadline:
+                return False
+            time.sleep(BUSY_POLL_SECONDS)
+
+    def abort_to_idle(self) -> bool:
+        """Ask the Ultimate to abandon the exchange, the documented way back to Idle."""
+        self.control(CTRL_ABORT)
+        if not self.wait_for_state(ST_STATE_IDLE, ABORT_TIMEOUT_SECONDS):
+            return False
+        self.control(CTRL_CLR_ERR)
+        return True
+
+    def wait_for_state(self, wanted: int, timeout: float) -> bool:
+        deadline = time.time() + timeout
+        while True:
+            if self.state() == wanted:
+                return True
+            if time.time() > deadline:
+                return False
+            time.sleep(BUSY_POLL_SECONDS)
+
+    def require_idle(self, when: str) -> None:
+        status = self.status()
+        if (status & ST_STATE_MASK) != ST_STATE_IDLE:
+            raise Failure(f"command interface is not idle {when}: {describe_status(status)}")
+        if status & ST_ERROR:
+            raise Failure(f"command interface reports a command error {when}: {describe_status(status)}")
+
+    def push(self, command: bytes) -> None:
+        """Queue the command bytes and hand them to the Ultimate."""
+        for byte in command:
+            self.session.poke(REG_COMMAND, byte)
+        self.control(CTRL_PUSH_CMD)
+
+    def wait_for_reply(self, command: bytes) -> int:
+        started = time.time()
+        while True:
+            status = self.status()
+            if (status & ST_STATE_MASK) in (ST_STATE_DATA_LAST, ST_STATE_DATA_MORE):
+                return status
+            if time.time() - started > self.busy_timeout:
+                raise Wedged(
+                    f"command {command.hex(' ') or '<empty>'} never left Command Busy after "
+                    f"{self.busy_timeout:.0f}s: {describe_status(status)}. The command "
+                    f"interface is now wedged for every target (issue #740) and only a "
+                    f"firmware restart or power cycle releases it."
+                )
+            time.sleep(BUSY_POLL_SECONDS)
+
+    def drain(self) -> Tuple[bytes, bytes]:
+        return (bytes(self._drain(ST_DATA_AV, REG_RESPONSE, "response")),
+                bytes(self._drain(ST_STAT_AV, REG_STATUS, "status")))
+
+    def _drain(self, available_bit: int, register: int, what: str) -> bytearray:
+        out = bytearray()
+        while self.status() & available_bit:
+            out.append(self.session.peek(register))
+            if len(out) > MAX_QUEUE_BYTES:
+                raise Failure(f"{what} queue did not drain within {MAX_QUEUE_BYTES} bytes: {bytes(out)[:80]!r}")
+        return out
+
+    def transact(self, command: bytes) -> Tuple[bytes, bytes]:
+        """Push one command and return (response data, status text).
+
+        Every command this suite sends is answered in one part, so the reply has to
+        arrive in the Data Last state. A single-part reply announced as Data More
+        makes a client that follows the protocol accept the data and then wait for a
+        block that never comes.
+        """
+        self.release()
+        self.require_idle("before pushing a command")
+        started = time.time()
+        self.push(command)
+        status = self.wait_for_reply(command)
+        elapsed = time.time() - started
+
+        if (status & ST_STATE_MASK) != ST_STATE_DATA_LAST:
+            raise Failure(
+                f"command {command.hex(' ')} replied in state {describe_status(status)}; "
+                f"this reply is sent in one part, so the state has to be Data Last"
+            )
+
+        data, text = self.drain()
+        self.control(CTRL_DATA_ACC)
+        self.require_idle("after accepting the reply")
+        print(f"  {command.hex(' ') or '<empty>'} -> {elapsed:.2f}s, data {data!r}, status {text!r}")
+        return data, text
+
+
+def expect(uci: Uci, label: str, command: bytes, status: bytes,
+           reply: Optional[bytes] = None, reply_prefix: Optional[bytes] = None) -> bytes:
+    """Run one command and check the documented status and reply."""
+    with check(label):
+        got_reply, got_status = uci.transact(command)
+        if got_status != status:
+            raise Failure(f"{label}: expected status {status!r}, got {got_status!r}")
+        if reply is not None and got_reply != reply:
+            raise Failure(f"{label}: expected reply {reply!r}, got {got_reply!r}")
+        if reply_prefix is not None and not got_reply.startswith(reply_prefix):
+            raise Failure(f"{label}: expected a reply starting with {reply_prefix!r}, got {got_reply!r}")
+        return got_reply
+
+
+def expect_uppercase(message: str, scenario: str) -> None:
+    """The whole reply text must be uppercased, not just its first character.
+
+    The conversion in control_target.cc used to re-read the same byte forever
+    instead of advancing, so it never got past character one.
+    """
+    lowercase = [c for c in message if c.islower()]
+    if lowercase:
+        raise Failure(
+            f"{scenario}: reply text was not fully uppercased, "
+            f"{len(lowercase)} lowercase character(s) in {message!r}"
+        )
+
+
+def run_transport(uci: Uci) -> bool:
+    """The transport state machine of the Register API, independent of any target."""
+    scenario = "transport"
+
+    # run_task() handles a zero-length command itself: it answers with an empty data
+    # block instead of handing anything to a target.
+    expect(uci, f"{scenario}: an empty command returns an empty reply", b"", b"", reply=b"")
+
+    # Nothing registers on target $0F, so the dispatcher's placeholder answers.
+    expect(uci, f"{scenario}: unregistered target answers IDENTIFY",
+           bytes([TARGET_UNREGISTERED, CTRL_CMD_IDENTIFY]), STATUS_OK, reply=b"NO TARGET")
+    expect(uci, f"{scenario}: unregistered target rejects anything else",
+           bytes([TARGET_UNREGISTERED, CMD_UNIMPLEMENTED]), STATUS_UNKNOWN_COMMAND, reply=b"")
+
+    with check(f"{scenario}: a no-reply command returns straight to Idle"):
+        uci.release()
+        uci.require_idle("before pushing a no-reply command")
+        uci.push(bytes([TARGET_CONTROL | TARGET_NO_REPLY, CTRL_CMD_IDENTIFY]))
+        if not uci.wait_for_state(ST_STATE_IDLE, NO_REPLY_TIMEOUT_SECONDS):
+            raise Failure(
+                f"{scenario}: expected Idle within {NO_REPLY_TIMEOUT_SECONDS:.0f}s of a "
+                f"no-reply command, got {describe_status(uci.status())}"
+            )
+        status = uci.status()
+        if status & (ST_DATA_AV | ST_STAT_AV | ST_ERROR):
+            raise Failure(
+                f"{scenario}: a no-reply command left data, status or an error behind: "
+                f"{describe_status(status)}"
+            )
+
+    with check(f"{scenario}: pushing while a reply is pending sets and clears ERROR"):
+        uci.release()
+        uci.push(bytes([TARGET_CONTROL, CTRL_CMD_IDENTIFY]))
+        uci.wait_for_reply(b"\x04\x01")
+        # Strobe PUSH_CMD on its own. Queueing command bytes first would leave them
+        # in the command queue when the push is rejected, and the interface only
+        # resets the data and status queues, not that one.
+        uci.control(CTRL_PUSH_CMD)
+        status = uci.status()
+        if not (status & ST_ERROR):
+            raise Failure(
+                f"{scenario}: pushing a command while the interface was not idle should set "
+                f"ERROR, got {describe_status(status)}"
+            )
+        uci.control(CTRL_CLR_ERR)
+        status = uci.status()
+        if status & ST_ERROR:
+            raise Failure(f"{scenario}: CLR_ERR did not clear the error: {describe_status(status)}")
+        # The reply that was already there has to survive the rejected push.
+        data, text = uci.drain()
+        uci.control(CTRL_DATA_ACC)
+        if not data.startswith(b"CONTROL TARGET") or text != STATUS_OK:
+            raise Failure(f"{scenario}: the pending reply was damaged: data {data!r}, status {text!r}")
+        uci.require_idle("after recovering from a state error")
+
+    with check(f"{scenario}: the next command is not prefixed by leftover bytes"):
+        # If anything were left in the command queue, this GET_HWINFO would be read
+        # as the IDENTIFY in front of it and would answer with the target name.
+        reply, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_HWINFO, 0x00]))
+        if text != STATUS_OK:
+            raise Failure(f"{scenario}: expected status {STATUS_OK!r}, got {text!r}")
+        if not reply or reply.startswith(b"CONTROL TARGET"):
+            raise Failure(
+                f"{scenario}: GET_HWINFO answered {reply!r}, which is the reply to the "
+                f"preceding IDENTIFY; the command queue still held it"
+            )
+
+    with check(f"{scenario}: ABORT releases a pending reply back to Idle"):
+        uci.release()
+        uci.push(bytes([TARGET_CONTROL, CTRL_CMD_IDENTIFY]))
+        uci.wait_for_reply(b"\x04\x01")
+        if not uci.abort_to_idle():
+            raise Failure(
+                f"{scenario}: the interface did not return to Idle within "
+                f"{ABORT_TIMEOUT_SECONDS:.0f}s of an abort: {describe_status(uci.status())}"
+            )
+
+    return True
+
+
+def run_control_target(uci: Uci) -> bool:
+    """Control target identification and the commands it has to reject."""
+    scenario = "control-target"
+    expect(uci, f"{scenario}: IDENTIFY answers with the target name",
+           bytes([TARGET_CONTROL, CTRL_CMD_IDENTIFY]), STATUS_OK, reply_prefix=b"CONTROL TARGET")
+    expect(uci, f"{scenario}: an unimplemented command is reported as unknown",
+           bytes([TARGET_CONTROL, CMD_UNIMPLEMENTED]), STATUS_UNKNOWN_COMMAND, reply=b"")
+    # Both REU commands share one handler that needs at least five command bytes.
+    expect(uci, f"{scenario}: LOAD_REU without a filename is rejected, not run",
+           bytes([TARGET_CONTROL, CTRL_CMD_LOAD_REU]), STATUS_INVALID_PARAMS, reply=b"")
+    expect(uci, f"{scenario}: SAVE_REU without a filename is rejected, not run",
+           bytes([TARGET_CONTROL, CTRL_CMD_SAVE_REU]), STATUS_INVALID_PARAMS, reply=b"")
+    expect(uci, f"{scenario}: GET_HWINFO rejects a device number it does not have",
+           bytes([TARGET_CONTROL, CTRL_CMD_GET_HWINFO, 0x02]), STATUS_INVALID_PARAMS, reply=b"")
+    return True
+
+
+def prime_reply_buffer(uci: Uci) -> None:
+    """Leave a non-empty string in the control target's reply buffer.
+
+    CTRL_CMD_GET_HWINFO writes the product name there. The REU commands reuse the
+    same buffer, and the handler does not write a status string of its own when the
+    REU is disabled, so this is what makes the "no status written" path observable
+    rather than dependent on whatever the heap happened to contain.
+    """
+    reply, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_HWINFO, 0x00]))
+    if text != STATUS_OK:
+        raise Failure(f"prime reply buffer: expected status {STATUS_OK!r}, got {text!r}")
+    if len(reply) < 5 or reply[4] == 0:
+        raise Failure(
+            f"prime reply buffer: GET_HWINFO returned {reply!r}, which leaves no text at "
+            f"offset 4; the following REU checks would not be meaningful"
+        )
+
+
+def load_reu_command(filename_offset: int) -> bytes:
+    """The LOAD_REU command as issue #740 sends it, with the name at offset 2 or 4."""
+    padding = bytes(filename_offset - 2)
+    return bytes([TARGET_CONTROL, CTRL_CMD_LOAD_REU]) + padding + REU_FILENAME
+
+
+def run_issue_740_matrix(session: RestSession, ftp: "FtpFixture", uci: Uci) -> bool:
+    """Walk the four conditions issue #740 reported, and check each one completes.
+
+    The report lists REU enabled and disabled, image present and absent, and the
+    filename at offset 2 and at offset 4. All four hung identically. Each row here
+    sends the same command the report sends and requires the interface to leave
+    Command Busy, return the status that row should produce, and go back to Idle on
+    a single DATA_ACC, with no abort and no clear-error needed.
+    """
+    scenario = "issue-740-matrix"
+
+    with check(f"{scenario}: confirm {ABSENT_IMAGE} does not exist"):
+        if session.file_exists(ABSENT_IMAGE):
+            raise Failure(
+                f"{scenario} needs {ABSENT_IMAGE} to be absent so the load fails to open it, "
+                f"but the file exists on this device. Delete it and re-run."
+            )
+    with check(f"{scenario}: put a {PRESENT_IMAGE_BYTES}-byte image at {PRESENT_IMAGE}"):
+        ftp.upload(PRESENT_IMAGE, bytes(PRESENT_IMAGE_BYTES))
+        actual = session.file_size(PRESENT_IMAGE)
+        if actual != PRESENT_IMAGE_BYTES:
+            raise Failure(f"{scenario}: uploaded image is {actual} bytes, expected {PRESENT_IMAGE_BYTES}")
+        session.set_config(CONFIG_CATEGORY, CFG_REU_SIZE, MATRIX_REU_SIZE)
+        session.set_config(CONFIG_CATEGORY, CFG_REU_OFFSET, MATRIX_REU_OFFSET)
+
+    # (REU setting, image path, expected status, expected transferred count, text prefix)
+    rows = [
+        ("Enabled", ABSENT_IMAGE, STATUS_REU_CANNOT_OPEN, -1, "REU LOAD: FAILED TO OPEN "),
+        ("Disabled", ABSENT_IMAGE, STATUS_REU_DISABLED, -2, None),
+        ("Enabled", PRESENT_IMAGE, STATUS_OK, PRESENT_IMAGE_BYTES, "REU LOAD: LOADED "),
+    ]
+    for reu, image, want_status, want_count, want_prefix in rows:
+        for offset in FILENAME_OFFSETS:
+            label = f"REU {reu}, image {'present' if image == PRESENT_IMAGE else 'absent'}, name at offset {offset}"
+            with check(f"{scenario}: {label}"):
+                session.set_config(CONFIG_CATEGORY, CFG_REU_ENABLE, reu)
+                session.set_config(CONFIG_CATEGORY, CFG_REU_IMAGE, image)
+                command = load_reu_command(offset)
+                # transact() fails with the wedge message if the interface stays in
+                # Command Busy, and requires Idle after a single DATA_ACC.
+                reply, text = uci.transact(command)
+                if text != want_status:
+                    raise Failure(f"{scenario} [{label}]: expected status {want_status!r}, got {text!r}")
+                if as_int32(reply) != want_count:
+                    raise Failure(
+                        f"{scenario} [{label}]: expected {want_count} bytes transferred, "
+                        f"got {as_int32(reply)} from {reply!r}"
+                    )
+                message = reply[4:].decode("latin-1")
+                if want_prefix is None:
+                    # The handler writes no status string when the REU is disabled.
+                    if reply[4:]:
+                        raise Failure(
+                            f"{scenario} [{label}]: expected a 4-byte reply, got {len(reply)} bytes "
+                            f"{reply!r} (stale text from the previous command)"
+                        )
+                else:
+                    if not message.startswith(want_prefix):
+                        raise Failure(f"{scenario} [{label}]: unexpected reply text {message!r}")
+                    if image.upper() not in message:
+                        raise Failure(
+                            f"{scenario} [{label}]: reply text does not name {image.upper()!r}: {message!r}"
+                        )
+                    expect_uppercase(message, f"{scenario} [{label}]")
+    return True
+
+
+def run_save_reu_offset_past_end(session: RestSession, uci: Uci) -> bool:
+    """Exercise SAVE_REU on a path that writes its own status string.
+
+    A save with the preload offset at the end of the REU is rejected before any
+    rename, delete or write happens, so this covers the same uppercase conversion
+    for SAVE_REU without producing a multi-megabyte file on the device.
+    """
+    scenario = "save-reu-offset-past-end"
+    with check(f"{scenario}: put the preload offset at the end of a 128 KB REU"):
+        session.set_config(CONFIG_CATEGORY, CFG_REU_ENABLE, "Enabled")
+        session.set_config(CONFIG_CATEGORY, CFG_REU_SIZE, OVERSIZE_OFFSET_SIZE)
+        session.set_config(CONFIG_CATEGORY, CFG_REU_OFFSET, OVERSIZE_OFFSET)
+    with check(f"{scenario}: SAVE_REU reports the offset and saves nothing"):
+        reply, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_SAVE_REU]) + REU_FILENAME)
+        if text != STATUS_REU_NOT_SAVED:
+            raise Failure(f"{scenario}: expected status {STATUS_REU_NOT_SAVED!r}, got {text!r}")
+        if as_int32(reply) != -3:
+            raise Failure(f"{scenario}: expected -3 transferred, got {as_int32(reply)} from {reply!r}")
+        message = reply[4:].decode("latin-1")
+        if not message.startswith("REU SAVE: OFFSET "):
+            raise Failure(f"{scenario}: unexpected reply text {message!r}")
+        expect_uppercase(message, scenario)
+    return True
+
+
+def run_reu_disabled(session: RestSession, uci: Uci, command: int, scenario: str) -> bool:
+    """Run LOAD_REU or SAVE_REU with the REU switched off.
+
+    SAVE_REU is only exercised here and in save-reu-offset-past-end, and never
+    against an REU that would really be written, because a real save renames the
+    existing image and writes the full REU size to storage.
+    """
+    with check(f"{scenario}: disable the REU"):
+        session.set_config(CONFIG_CATEGORY, CFG_REU_ENABLE, "Disabled")
+    with check(f"{scenario}: leave text in the reply buffer from a previous command"):
+        prime_reply_buffer(uci)
+    with check(f"{scenario}: command reports the REU is disabled and replies with 4 bytes"):
+        reply, text = uci.transact(bytes([TARGET_CONTROL, command]) + REU_FILENAME)
+        if text != STATUS_REU_DISABLED:
+            raise Failure(f"{scenario}: expected status {STATUS_REU_DISABLED!r}, got {text!r}")
+        # The handler writes no status string on this path, so the reply is the
+        # 4-byte transferred count and nothing else. Trailing bytes here mean the
+        # previous command's text was measured as this command's reply.
+        if len(reply) != 4:
+            raise Failure(
+                f"{scenario}: expected a 4-byte reply, got {len(reply)} bytes {reply!r} "
+                f"(stale text from the previous command)"
+            )
+        if as_int32(reply) != -2:
+            raise Failure(f"{scenario}: expected -2 transferred, got {as_int32(reply)} from {reply!r}")
+    return True
+
+
+def run_softiec_single_part_reply(uci: Uci) -> bool:
+    """The SoftIEC target sends every reply in one part, so it must say Data Last.
+
+    Both commands used here are read-only: LOAD_SU on a name that does not exist
+    reports "file not found" and GET_FATNAME only asks what a name maps to. They
+    cover the empty and the non-empty reply through the same reply buffer.
+    """
+    scenario = "softiec-single-part-reply"
+    with check(f"{scenario}: SoftIEC target answers IDENTIFY"):
+        reply, text = uci.transact(bytes([TARGET_SOFTIEC, SOFTIEC_CMD_IDENTIFY]))
+        if text == SOFTIEC_NOT_LOADED:
+            raise Failure("the SoftIEC drive is not enabled on this device, so this check cannot run")
+        if text != STATUS_OK:
+            raise Failure(f"{scenario}: expected status {STATUS_OK!r}, got {text!r}")
+        if not reply.startswith(b"SOFTWARE IEC TARGET"):
+            raise Failure(f"{scenario}: unexpected identification {reply!r}")
+    expect(uci, f"{scenario}: LOAD_SU on a missing file completes in one part",
+           bytes([TARGET_SOFTIEC, SOFTIEC_CMD_LOAD_SU]) + LOAD_SU_MISSING,
+           SOFTIEC_FILE_NOT_FOUND, reply=b"")
+    expect(uci, f"{scenario}: GET_FATNAME reply completes in one part",
+           bytes([TARGET_SOFTIEC, SOFTIEC_CMD_GET_FATNAME, FATNAME_CHANNEL]) + FATNAME_BUFFER_STREAM,
+           SOFTIEC_OK, reply=FATNAME_BUFFER_REPLY)
+    expect(uci, f"{scenario}: an unimplemented SoftIEC command is reported as unknown",
+           bytes([TARGET_SOFTIEC, CMD_UNIMPLEMENTED]), SOFTIEC_UNKNOWN_COMMAND, reply=b"")
+    return True
+
+
+def run_interface_usable_after(uci: Uci) -> bool:
+    expect(uci, "interface-usable-after: the control target still answers IDENTIFY",
+           bytes([TARGET_CONTROL, CTRL_CMD_IDENTIFY]), STATUS_OK, reply_prefix=b"CONTROL TARGET")
+    return True
+
+
+def release_interface(uci: Uci) -> bool:
+    """Leave the command interface idle and error-free, whatever the scenarios did.
+
+    Accepting the data is tried first because it is the ordinary way to finish an
+    exchange; an abort is the documented fallback that forces the state machine back
+    to Idle when a reply cannot be drained.
+    """
+    try:
+        if not uci.release():
+            uci.abort_to_idle()
+        status = uci.status()
+        if (status & ST_STATE_MASK) != ST_STATE_IDLE or (status & ST_ERROR):
+            print(f"uci_targets_test: command interface left in {describe_status(status)}, "
+                  f"wanted Idle with no error", file=sys.stderr)
+            return False
+        return True
+    except Exception as exc:
+        print(f"uci_targets_test: could not release the command interface: {exc}", file=sys.stderr)
+        return False
+
+
+def restore_settings(session: RestSession, original: Dict[str, str], keep_config: bool) -> bool:
+    """Put every setting the suite wrote back, and prove it took effect."""
+    if not original or keep_config:
+        return True
+    try:
+        for item, value in original.items():
+            session.set_config(CONFIG_CATEGORY, item, value)
+        current = session.get_config(CONFIG_CATEGORY)
+        wrong = {k: str(current.get(k)) for k, v in original.items() if str(current.get(k)) != v}
+        if wrong:
+            print(f"uci_targets_test: settings not restored, still {wrong}, wanted {original}",
+                  file=sys.stderr)
+            return False
+        print(f"restored {CONFIG_CATEGORY}: {original}")
+        return True
+    except Exception as exc:
+        print(f"uci_targets_test: cleanup failed: {exc}", file=sys.stderr)
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify the UCI transport state machine, that CTRL_CMD_LOAD_REU / "
+                    "CTRL_CMD_SAVE_REU complete and leave the interface usable (issue #740), "
+                    "and that SoftIEC replies are framed as single-part."
+    )
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", os.environ.get("C64U_PASSWORD")))
+    parser.add_argument("-t", "--timeout", type=float, default=float(os.environ.get("U64_TIMEOUT", "30.0")))
+    parser.add_argument("-b", "--busy-timeout", type=float, default=BUSY_TIMEOUT_SECONDS,
+                        help="How long a single command may stay in Command Busy before it counts as wedged.")
+    parser.add_argument("--test", action="append", choices=["all"] + TESTS)
+    parser.add_argument("--no-reset", action="store_true",
+                        help="Skip resetting the C64 before the test (use an already-stable machine).")
+    parser.add_argument("--keep-config", action="store_true",
+                        help="Don't restore the original Command Interface and REU settings on exit.")
+    args = parser.parse_args()
+
+    selected = TESTS if not args.test or "all" in args.test else [t for t in TESTS if t in args.test]
+    session = RestSession(args.host, args.password, args.timeout)
+    ftp = FtpFixture(args.host, args.password, args.timeout)
+    uci = Uci(session, args.busy_timeout)
+
+    original: Dict[str, str] = {}
+    results: Dict[str, bool] = {}
+    cleanup_ok = True
+    # $DF1C only belongs to the command interface once the setting is on; before
+    # that the address is the REU's, so the suite must not write to it.
+    interface_enabled = False
+
+    def run(name: str, fn, *fn_args) -> None:
+        if name not in selected:
+            return
+        results[name] = False  # so an aborted scenario reports FAIL, not "not reached"
+        results[name] = fn(*fn_args)
+
+    try:
+        if not args.no_reset:
+            with check("reset the C64 so the command interface starts idle"):
+                session.reset()
+                time.sleep(RESET_SETTLE_SECONDS)
+
+        with check(f"read {CONFIG_CATEGORY!r}"):
+            config = session.get_config(CONFIG_CATEGORY)
+            missing = [k for k in OWNED_SETTINGS if k not in config]
+            if missing:
+                raise Failure(f"this device has no {', '.join(missing)} setting; it cannot run this suite")
+            original = {k: str(config[k]) for k in OWNED_SETTINGS}
+            print(f"  current: {original}")
+
+        with check("enable the Command Interface registers at $DF1B-$DF1F"):
+            session.set_config(CONFIG_CATEGORY, CFG_CMD_IF, "Enabled")
+            interface_enabled = True
+            uci.release()
+            uci.require_idle("after enabling the command interface")
+            identification = session.peek(REG_COMMAND)
+            if identification not in (0xC9, 0x49):
+                raise Failure(
+                    f"$DF1D read back ${identification:02X}, expected the command interface "
+                    f"identification $C9 (or $49 while an interrupt is pending)"
+                )
+
+        run("transport", run_transport, uci)
+        run("control-target", run_control_target, uci)
+        run("issue-740-matrix", run_issue_740_matrix, session, ftp, uci)
+        run("save-reu-offset-past-end", run_save_reu_offset_past_end, session, uci)
+        run("load-reu-disabled", run_reu_disabled, session, uci, CTRL_CMD_LOAD_REU, "load-reu-disabled")
+        run("save-reu-disabled", run_reu_disabled, session, uci, CTRL_CMD_SAVE_REU, "save-reu-disabled")
+        run("softiec-single-part-reply", run_softiec_single_part_reply, uci)
+        run("interface-usable-after", run_interface_usable_after, uci)
+
+    except Failure as exc:
+        print(f"uci_targets_test: {exc}", file=sys.stderr)
+    finally:
+        # A failed scenario can leave the interface holding a reply, so hand the
+        # data back before the settings go home. Both steps have to succeed, and
+        # both run even if the first one fails.
+        released = release_interface(uci) if interface_enabled else True
+        restored = restore_settings(session, original, args.keep_config)
+        removed = ftp.cleanup()
+        cleanup_ok = released and restored and removed
+
+    print("\n=== SUMMARY ===")
+    all_ok = cleanup_ok
+    for name in selected:
+        outcome = results.get(name)
+        state = "PASS" if outcome else ("FAIL" if outcome is False else "NOT REACHED")
+        if outcome is not True:
+            all_ok = False
+        print(f"  {name}: {state}")
+    print(f"  cleanup: {'OK' if cleanup_ok else 'FAILED'}")
+
+    if all_ok:
+        print(f"uci_targets_test: OK ({CHECK_COUNT} checks)")
+        return 0
+    print("uci_targets_test: FAIL", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        print(f"uci_targets_test: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
Fixes https://github.com/GideonZ/1541ultimate/issues/740.

While investigating the bug reported in that issue, I also reviewed the rest of `software/io/command_interface` for the same class of problem and found three additional defects. This PR fixes all four.

Three fixes were demonstrated failing and then passing on an Ultimate 64 Elite by reverting exactly one change at a time. The fourth fixes a SoftIEC heap buffer overrun. That defect cannot be made observably red on hardware, for the reasons explained in section 4, but is included anyway to ensure code correctness and to prevent future issues.

The firmware change is 13 added and 5 removed lines across three files, including comments. Everything else is test coverage.

## 1. `CTRL_CMD_LOAD_REU` and `CTRL_CMD_SAVE_REU` never return (#740)

### Cause

`struprt()` in `control_target.cc` never advanced its pointer:

```c
char *next = str;
while (*str != '\0')
    *str = toupper((unsigned char)*str);   // str is never incremented
````

`LoadREU()` and `SaveREU()` write a status string into the reply buffer, after which `parse_command()` uppercases that string in place. Because the loop repeatedly reads the same byte, it never terminates for any non-empty string.

`CommandInterface::run_task()` calls the target handler inline, so the failure wedges the entire UCI server task rather than only the current command:

* `HANDSHAKE_ACCEPT_COMMAND` is never written.
* `CMD_NEW_COMMAND` is never cleared.
* The task never reaches the code that services an abort.

This explains both parts of the report: `$DF1C` remains at `$11`, and ControlAbort, ControlClearError, and ControlDataAccept cannot release it because they are handled by the same loop that is spinning.

The issue report narrowed the defect to the correct seven lines. Its register traces and four-condition table made the problem quick to confirm.

The report interpreted `data_message.message + 4` as a filename, which is understandable from `control_target.cc` alone but is not what the argument represents. `REUPreloader::LoadREU(char *status)` receives an output buffer for status text and reads the image path from the "REU Preload Image" setting. Passing the reply buffer at offset 4 is therefore deliberate: the reply contains a 4-byte little-endian transferred count followed by status text. The parameter name is only visible in `reu_preloader.h`, so the call site otherwise looks like a filename is being passed.

The report is correct that the documented `<FILENAME>` argument never reaches the handler. That is a genuine but separate gap and is not changed here.

### Fix

Advance the pointer in `struprt()`.

### Verification against the issue reproduction

The `issue-740-matrix` scenario exercises the same four conditions listed in the report. It sends the same command through the same registers and requires every case to leave Command Busy and return to Idle.

**Red**, with only the `struprt` fix reverted:

```text
[06] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... FAIL
     command 04 08 52 45 55 2e 49 4d 47 never left Command Busy after 15s:
     $11 (Command Busy, CMD_BUSY)
     command interface left in $15 (Command Busy, CMD_BUSY|ABORT_P), wanted Idle
```

These are the same values recorded in the issue: `$11` while polling, then `$15` after the client gives up and requests an abort. The suite teardown attempts DATA_ACC, CLR_ERR, and ABORT. None releases Busy, reproducing the issue's recovery table. The run stops at that point because the interface is wedged for every target.

**Green**, with all six commands completing in under 0.2 seconds each:

```text
[06] REU Enabled,  image absent,  name at offset 2  -> b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST"  85,REU FILE CANNOT BE OPENED
[07] REU Enabled,  image absent,  name at offset 4  -> same
[08] REU Disabled, image absent,  name at offset 2  -> b'\xfe\xff\xff\xff'  84,REU NOT ENABLED
[09] REU Disabled, image absent,  name at offset 4  -> same
[10] REU Enabled,  image present, name at offset 2  -> b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU'  00,OK
[11] REU Enabled,  image present, name at offset 4  -> same
```

Rows 10 and 11 also verify the command's intended behaviour: a 16384-byte image produces a reported transfer count of exactly 16384 bytes. This is the first successful REU load exercised by the suite.

### Why a freshly restarted device may not reproduce the hang

With the REU disabled immediately after a firmware restart, `LoadREU()` returns before writing a status string. The reply buffer then contains fresh heap memory whose first byte happens to be zero, so the broken uppercase loop exits immediately.

The device used for the issue report had already run other commands, leaving text in the buffer. That exposes defect 2 below. The `load-reu-disabled` scenario reproduces it deterministically by dirtying the buffer first.

### Fixture differences from the issue report

The transport is identical to the issue reproduction:

* Command bytes are written to `$DF1D`, one `machine:writemem` call at a time.
* The command is pushed with `$DF1C = $01`.
* Only `$DF1C` is polled, for the reasons given in the report.
* No 6502 code is involved on either side.

The differences are limited to the fixture:

|                | Issue #740                                                                           | This suite                                                            | Reason                                                                                                                                                                                          |
| -------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Image file     | Present in the working directory                                                     | A 16384-byte file uploaded to `/Temp` over FTP and deleted afterwards | The run must not depend on existing device contents and must leave nothing behind. FTP is used because the REST API can create disk images but cannot delete a file.                            |
| REU size       | 16 MB                                                                                | 128 KB, preload offset 0                                              | The transferred count then depends only on file size, allowing an exact assertion of 16384. The code path is unchanged; the size only changes how many bytes `LoadREU()` requests.              |
| Recovery probe | ControlAbort, ControlClearError, and ControlDataAccept tried manually after the hang | No separate test step                                                 | After the fix, the command completes and one DATA_ACC returns the interface to Idle. On a red run, teardown still tries all three and reports the interface stuck at `$15`, matching the issue. |
| Status names   | Busy, NewCommandSet, AbortSet                                                        | Command Busy, CMD_BUSY, ABORT_P                                       | These are the same bits, named as in the register API document.                                                                                                                                 |

The report also exercised DOS, ECHO, and control IDENTIFY to show that only LOAD_REU failed. Equivalent coverage comes from the `transport` and `control-target` groups, which test IDENTIFY, an unregistered target, an unimplemented command, and rejection paths. The `interface-usable-after` group repeats IDENTIFY after the REU commands have completed.

## 2. The REU reply length comes from the previous command

### Cause

When the REU is disabled, `LoadREU()` and `SaveREU()` return `-2` without writing a status string. `parse_command()` nevertheless called `strlen()` on that buffer and used the result as the reply length.

As a result, both the reply length and any trailing reply content came from whichever command had most recently used the same buffer.

### Fix

Clear the first byte of the status area before calling the handler. A handler that writes no status text now produces a 4-byte reply containing only the little-endian return value.

### Verification

**Red**, with the `struprt` fix present and only the buffer clear removed:

```text
[21] 04 28 00                    data b'Ultimate 64 Elite'
[22] 04 08 52 45 55 2e 49 4d 47  data b'\xfe\xff\xff\xffMATE 64 ELITE'
     FAIL: expected a 4-byte reply, got 17 bytes (stale text from the previous command)
```

`MATE 64 ELITE` is the product name from offset 4, uppercased by the same conversion. If the leftover text is longer, the reported reply length grows with it.

**Green**: `04 08 ...` and `04 09 ...` both return exactly `b'\xfe\xff\xff\xff'`, which is `-2` in little-endian form.

## 3. SoftIEC replies are announced as Data More

### Cause

`SoftIECTarget::data_message.last_part` was never assigned in `softiec_target.cc`. The object has static storage, so the flag initially remained `false`, causing `copy_result()` to write `HANDSHAKE_VALIDATE_MORE`.

Every single-part SoftIEC reply, including LOAD_SU, was therefore announced as Data More.

A client following the register API accepts the data and waits for another block. The next call reaches `get_more_data()` without an input channel and returns `03`, meaning not in data mode. The interface recovers, but the client consumes one spurious status byte for every affected command.

The separate `direct_message` object is the path that genuinely streams. `prepare_data()` assigns its flag for each block. Only `data_message` lacked an initial value, and nothing in the file later sets it to `false`.

### Fix

Set `data_message.last_part` to `true` in the constructor.

### Verification

**Red**, with the first two fixes present and only this assignment removed:

```text
[27] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... FAIL
     command 05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 replied in state
     $70 (Data More, STAT_AV); this reply is sent in one part, so the state has to
     be Data Last
```

**Green**: the same command returns status `01` in state `$60`, Data Last. GET_FATNAME returns `b'/buffer'`, also in Data Last.

## 4. The SoftIEC reply buffer is smaller than the bound used by its writes

### Cause

`cmd_get_fatname()` fills the reply buffer in two places using:

```c
strncpy((char *)data_message.message, work.c_str(), CMD_MAX_REPLY_LEN);   // n = 896
```

The constructor allocated only 512 bytes:

```c
data_message.message = new uint8_t[512];
```

`strncpy()` does not stop after the source terminator. It pads the destination with zeroes up to `n`. Every GET_FATNAME call therefore writes 896 bytes into a 512-byte heap block, overrunning it by 384 bytes regardless of whether the resolved path is long or short.

### Fix

Allocate `CMD_MAX_REPLY_LEN` bytes, matching the bound already passed by both `strncpy()` calls. `HttpTarget` already sizes its reply buffer this way.

This restores the invariant directly: the buffer size equals the maximum length used by every write to it.

### Why there is no red run

The other three defects have failing runs recorded above. This one does not, because the overrun is silent rather than because it was not checked.

`strncpy()` copies the correct path first and then writes zero padding past the allocation. The reply read by the client is therefore still correct. Nothing changes observably on the C64 side or through REST. The corruption affects whatever heap allocation follows this block and may only surface later as an apparently unrelated failure.

I also checked whether `data_message.length = work.length()` could expose the problem as an over-long reply. It cannot: `ConstructPath()` bounds the result well below the buffer size. On hardware, an 880-character request produced a 53-byte reply:

```text
name  880 -> cmd 883B, reply 53B, status b'\x00'
   head b'/Temp/AAAAAAAAAAAAAAAAAAAAAAAA' ... tail b'AAAAAAAAAAAA.???'
```

The length assignment is therefore unchanged. Only the allocation is corrected.

Verification for this fix consists of:

* A successful firmware build.
* Rechecking the affected reply paths on hardware.
* Confirming that the full suite still passes.

```text
05 22 02 54 45 53 54          data b'/Temp/TEST.???'            status b'\x00'  Data Last, back to Idle
05 22 02 4c 4f 4e 47 ...      data b'/Temp/LONGISHNAMEHERE.???'  status b'\x00'  Data Last, back to Idle
05 22 02 23                   data b'/buffer'                    status b'\x00'  Data Last, back to Idle
05 23 02 54 45 53 54          data b'\x00\x02TEST'               status b'\x00'  Data Last, back to Idle
```

The first two commands exercise the `strncpy()` path changed here. The `#` case in the suite uses a `sprintf()` path and does not cover it, which is why the affected paths were also run separately.

## 5. Misspelled register name in the register dump

`dump_registers()` printed `CMD_IF_REPSONSE_LEN_H` while reading `CMD_IF_RESPONSE_LEN_H`.

The correction changes one word and has no behavioural effect, but it ensures that anyone searching the source for the register name shown in the log can find it.

## Test suite

`tests/e2e/io/command_interface/uci_targets_test.py` is registered as `uci-targets`. It performs 36 checks in 8 groups and takes about 33 seconds.

| Group                                    | Coverage                                                                                                                                                                                                                                          |
| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `transport`                              | Empty command; unregistered target `$0F`; the no-reply bit; ERROR set by pushing while a reply is pending and cleared by CLR_ERR; verification that the rejected push leaves nothing in the command queue; ABORT returning the interface to Idle. |
| `control-target`                         | IDENTIFY; an unimplemented command; both REU commands below the five-byte minimum; GET_HWINFO with a device number the product does not have.                                                                                                     |
| `issue-740-matrix`                       | Defect 1 across the four conditions from the issue, using both filename offsets.                                                                                                                                                                  |
| `save-reu-offset-past-end`               | Defect 1 on the SAVE path, using the branch that reports the offset before accessing storage.                                                                                                                                                     |
| `load-reu-disabled`, `save-reu-disabled` | Defect 2, requiring a 4-byte reply after deliberately dirtying the buffer.                                                                                                                                                                        |
| `softiec-single-part-reply`              | Defect 3 for LOAD_SU and GET_FATNAME.                                                                                                                                                                                                             |
| `interface-usable-after`                 | Confirms that the interface still serves other targets after the REU commands.                                                                                                                                                                    |

### Test design notes

* Apart from the 16384-byte image described above, every scenario is read-only with respect to device storage. LOAD_REU targets a path whose absence is verified through `files:info` rather than assumed. SAVE_REU is used only on the two paths that return before any rename or write, so the suite never creates a multi-megabyte image. GET_FATNAME targets the `#` buffer stream, which is resolved without accessing a partition, making the result independent of the device's SoftIEC setup.

* The ERROR check strobes PUSH_CMD directly instead of queueing bytes first. The FPGA advances the command pointer on every write to `$DF1D`, even when it rejects the push, while only the data and status queues are reset. Queueing bytes before the rejected push would therefore leave them in front of the next command. A subsequent GET_HWINFO verifies that nothing was left behind.

* The suite records the five settings it changes, restores them, reads them back for confirmation, deletes the uploaded file, and returns the interface to Idle. If accepting the data is insufficient, teardown escalates to ABORT. Any failure in cleanup or restoration fails the run.

* The suite opens one connection for each register access, roughly 900 connections per run. This can briefly encounter a full HTTP connection pool. Hardware measurements show that about four connections are served concurrently and that a stuck connection is reaped after roughly 15 seconds.

  Requests that can be repeated without changing device state, namely reads of `$DF1C` plus configuration and file queries, are retried up to three times at two-second intervals, with each retry logged. Writes to the command queue and reads that pop `$DF1E` or `$DF1F` are never retried because a timeout does not reveal whether the first request took effect. This behaviour surfaced once as a single `readmem` timeout at the end of a complete eleven-suite sweep.

* Expected values were derived from the firmware and confirmed on hardware. The manuals under `doc/` were used as background, but they have drifted from the implementation in places and are therefore not treated as authoritative.

## Verification

All hardware runs used an Ultimate 64 Elite with FPGA 122, core 1.4B, and firmware built from this branch. Each build was deployed over JTAG.

For each observable defect, the red run was produced by reverting exactly one change, rebuilding, deploying, and running the same suite. The corresponding green run restored that change and repeated the process.

```text
red 1  (struprt reverted)        issue-740-matrix FAIL at $11, teardown stuck at $15
red 2  (buffer clear reverted)   load-reu-disabled FAIL
red 3  (last_part reverted)      softiec-single-part-reply FAIL
green  (all three)               uci_targets_test: OK (36 checks)

section 4 (reply buffer size)    no red possible; see "Why there is no red run";
                                 affected reply paths rechecked on hardware,
                                 suite still 36/36
```

The complete automatic sweep through `run-e2e-tests` passes on the final build.

## Found but not fixed here

The review of `software/io/command_interface` found two additional issues. Neither can currently be demonstrated failing on hardware, so neither is changed in this PR. They are documented here so that the findings and the decision to defer them are explicit.

The SoftIEC buffer overrun originally belonged in this list, but is now fixed in section 4. It is the deliberate exception to the "no red, no change" rule because leaving it would permit heap corruption rather than merely produce an incorrect reply.

### 1. `HttpTarget::cmd_exchange()` does not set `data_message.last_part` on the object path

This is the same defect as section 3 in a different target, but it is masked in normal use. `cmd_header_create()`, which a client must call before an exchange, leaves the flag set to `true`.

Reaching the faulty state requires a client to abandon a raw exchange part way through and then begin an object exchange. I could not turn that sequence into a reliable test, so the code is unchanged. The eventual fix would be one line.

### 2. `CommandInterface::copy_result()` does not bound the reply length

`data->length` and `status->length` are passed directly to `memcpy()` operations targeting fixed-size FPGA queues.

Defect 2 was one path to an unbounded length. With that fixed, and with `ConstructPath()` measured to keep the SoftIEC reply well below its buffer, I found no remaining reachable trigger. Adding a bound here would therefore be hardening rather than a demonstrated bug fix, and there is no failing case to justify including it in this PR.

It remains worth considering separately because this shared choke point could contain any future target that reports a length larger than the data it can safely provide.
