### PR TITLE
Report failure when COPY_HOME_PATH cannot enter the home directory

### DIFF
--- a/software/filemanager/dos.cc
+++ b/software/filemanager/dos.cc
@@ -420,6 +420,11 @@ void Dos::parse_command(Message *command, Message **reply, Message **status) {
                 strlen(destination) + 1);
         command->length = 2 + strlen(destination) + 1;
         cd(command, reply, status);
+        if (*status != &c_status_ok) {
+            // The home directory could not be entered. Report that, rather than
+            // falling through and overwriting the status with "00,OK".
+            break;
+        }
         // fallthrough
 
     case DOS_CMD_GET_PATH:

--- a/software/filemanager/tests/Makefile
+++ b/software/filemanager/tests/Makefile
@@ -2,11 +2,32 @@ CXX ?= g++
 CXXFLAGS := -std=c++14 -g -I. -I.. -I../../components -I../../filesystem -I../../infra -I../../system -I../../userinterface -I../../io/usb/tests
 OUTPUT_DIR := output
 TEMP_AUTO_CLEANUP_TEST := $(OUTPUT_DIR)/tempAutoCleanupTest
+DOS_COMMAND_TEST := $(OUTPUT_DIR)/dosCommandTest
 
-.PHONY: all temp-auto-cleanup
+SOURCES := ../../io/usb/tests/host_test_main.cpp ../filemanager.cc ../path.cc \
+           ../../filesystem/file_system.cc ../../filesystem/filesystem_root.cc \
+           ../../filesystem/directory.cc ../../filesystem/partition.cc \
+           ../../components/pattern.cc ../../components/mystring.cc
 
-all: temp-auto-cleanup
+# dos.cc reaches into the drive, user interface, RTOS and network layers, none
+# of which build on the host. The stubs in ../../test/hoststubs replace exactly
+# those headers and must therefore be searched before the real ones.
+DOS_CXXFLAGS := -std=c++14 -g -I../../test/hoststubs -I. -I.. -I../../components \
+                -I../../filesystem -I../../infra -I../../system -I../../portable/riscv \
+                -I../../io/command_interface -I../../io/flash -I../../io/rtc \
+                -I../../io/stream -I../../userinterface \
+                -I../../httpd/c-version/lib -I../../io/usb/tests
+DOS_SOURCES := ../dos.cc ../../test/hoststubs/command_intf_globals.cc \
+               ../../test/hoststubs/firmware_globals.cc
+
+.PHONY: all temp-auto-cleanup dos-command
+
+all: temp-auto-cleanup dos-command
 
 temp-auto-cleanup:
 	mkdir -p $(OUTPUT_DIR)
-	$(CXX) $(CXXFLAGS) temp_auto_cleanup_test.cpp ../../io/usb/tests/host_test_main.cpp ../filemanager.cc ../path.cc ../../filesystem/file_system.cc ../../filesystem/filesystem_root.cc ../../filesystem/directory.cc ../../filesystem/partition.cc ../../components/pattern.cc ../../components/mystring.cc -lpthread -o $(TEMP_AUTO_CLEANUP_TEST) && $(TEMP_AUTO_CLEANUP_TEST)
+	$(CXX) $(CXXFLAGS) temp_auto_cleanup_test.cpp $(SOURCES) -lpthread -o $(TEMP_AUTO_CLEANUP_TEST) && $(TEMP_AUTO_CLEANUP_TEST)
+
+dos-command:
+	mkdir -p $(OUTPUT_DIR)
+	$(CXX) $(DOS_CXXFLAGS) dos_command_test.cpp $(SOURCES) $(DOS_SOURCES) -lpthread -o $(DOS_COMMAND_TEST) && $(DOS_COMMAND_TEST)

--- a/software/filemanager/tests/dos_command_test.cpp
+++ b/software/filemanager/tests/dos_command_test.cpp
@@ -1,0 +1,88 @@
+#include "../../io/usb/tests/host_test/host_test.h"
+
+#include "../dos.h"
+#include "home_directory.h"
+
+#include <string>
+
+namespace {
+
+// The DOS command targets register themselves into command_targets[] when the
+// dos1/dos2 globals in dos.cc are constructed.
+CommandTarget *dos_target()
+{
+    return command_targets[1];
+}
+
+std::string message_text(Message *message)
+{
+    if (!message || !message->message) {
+        return std::string();
+    }
+    return std::string((const char *)message->message, message->length);
+}
+
+// Issues a single-byte DOS command and reports the status message text. The
+// root filesystem is enough here: "/" always resolves and a name below it
+// never does, which is the whole distinction COPY_HOME_PATH gets wrong.
+std::string run_command(uint8_t command_id)
+{
+    uint8_t buffer[64];
+    Message command = { 2, true, buffer };
+    buffer[0] = 1;            // target id
+    buffer[1] = command_id;
+
+    Message *reply = 0;
+    Message *status = 0;
+    dos_target()->parse_command(&command, &reply, &status);
+    return message_text(status);
+}
+
+const char *STATUS_OK = "00,OK";
+
+class HomeDirectoryGuard
+{
+public:
+    HomeDirectoryGuard(const char *path) { HomeDirectory::setHomeDirectory(path); }
+    ~HomeDirectoryGuard() { HomeDirectory::setHomeDirectory("/"); }
+};
+
+} // namespace
+
+TEST(DosCopyHomePathTest, ReportsOkWhenHomeDirectoryResolves)
+{
+    HomeDirectoryGuard home("/");
+
+    EXPECT_EQ(run_command(DOS_CMD_COPY_HOME_PATH), std::string(STATUS_OK));
+}
+
+TEST(DosCopyHomePathTest, ReportsFailureWhenHomeDirectoryIsMissing)
+{
+    HomeDirectoryGuard home("/does_not_exist");
+
+    EXPECT_NE(run_command(DOS_CMD_COPY_HOME_PATH), std::string(STATUS_OK));
+}
+
+// DOS_CMD_CHANGE_DIR already reports failure correctly; COPY_HOME_PATH must
+// behave the same way, since it is documented as the equivalent operation.
+// This is the assertion that actually pins the bug: before the fix the two
+// disagreed, because COPY_HOME_PATH fell through and overwrote the status.
+TEST(DosCopyHomePathTest, MatchesChangeDirFailureStatus)
+{
+    const char *missing = "/does_not_exist";
+    HomeDirectoryGuard home(missing);
+    const std::string home_status = run_command(DOS_CMD_COPY_HOME_PATH);
+
+    uint8_t buffer[64];
+    Message command = { 0, true, buffer };
+    buffer[0] = 1;
+    buffer[1] = DOS_CMD_CHANGE_DIR;
+    strcpy((char *)buffer + 2, missing);
+    command.length = 2 + strlen(missing);
+
+    Message *reply = 0;
+    Message *status = 0;
+    dos_target()->parse_command(&command, &reply, &status);
+
+    EXPECT_EQ(home_status, message_text(status));
+}

--- a/software/test/hoststubs/FreeRTOS.h
+++ b/software/test/hoststubs/FreeRTOS.h
@@ -1,0 +1,6 @@
+#ifndef TEST_HOSTSTUBS_FreeRTOS_H
+#define TEST_HOSTSTUBS_FreeRTOS_H
+
+// Host-test stub: the target RTOS port is not available on the host.
+
+#endif

--- a/software/test/hoststubs/c1541.h
+++ b/software/test/hoststubs/c1541.h
@@ -1,0 +1,70 @@
+#ifndef TEST_STUBS_C1541_H
+#define TEST_STUBS_C1541_H
+
+// Host-test stub for software/drive/c1541.h.
+//
+// The real header makes C1541 a Browsable and a SubSystem, which drags in the
+// entire user interface and lwIP network stack (browsable_root.h ->
+// assembly_search.h -> ...). The command-interface tests only need to ask a
+// drive for its IEC address, power state and subsystem id, so this stub
+// provides exactly that, with setters so a test can arrange drive state.
+
+#include "integer.h"
+#include "subsys.h"
+
+// Command ids, kept identical to software/drive/c1541.h.
+#define MENU_1541_RESET     0x1501
+#define MENU_1541_REMOVE    0x1502
+#define MENU_1541_SAVED64   0x1503
+#define MENU_1541_SAVEG64   0x1504
+#define MENU_1541_BLANK     0x1505
+#define MENU_1541_TURNON    0x1506
+#define MENU_1541_TURNOFF   0x1507
+#define FLOPPY_LOAD_DOS     0x1508
+#define MENU_1541_UNLINK    0x1513
+#define MENU_1541_SWAP      0x1514
+#define MENU_1541_SET_MODE  0x1515
+
+#define MENU_1541_READ_ONLY    0x8000
+#define MENU_1541_UNLINKED     0x4000
+#define MENU_1541_NO_FLAGS     0x1FFF
+
+#define MENU_1541_MOUNT_D64    0x1520 // +1 for .d71, +2 for .d81
+#define MENU_1541_MOUNT_D64_RO (MENU_1541_MOUNT_D64 | MENU_1541_READ_ONLY)
+#define MENU_1541_MOUNT_D64_UL (MENU_1541_MOUNT_D64 | MENU_1541_UNLINKED)
+
+#define MENU_1541_MOUNT_G64    0x1530
+#define MENU_1541_MOUNT_G64_RO (MENU_1541_MOUNT_G64 | MENU_1541_READ_ONLY)
+#define MENU_1541_MOUNT_G64_UL (MENU_1541_MOUNT_G64 | MENU_1541_UNLINKED)
+
+class C1541 : public SubSystem
+{
+    int  iec_address;
+    bool drive_power;
+public:
+    C1541(int id = SUBSYSID_DRIVE_A, int iec_address = 8)
+        : SubSystem(id), iec_address(iec_address), drive_power(true) { }
+    virtual ~C1541() { }
+
+    const char *identify(void) { return "Stub 1541"; }
+
+    int  get_effective_iec_address(void) { return iec_address; }
+    void set_effective_iec_address(int address) { iec_address = address; }
+
+    bool get_drive_power(void) { return drive_power; }
+    void set_drive_power(bool on) { drive_power = on; }
+
+    // Tests set this to steer C1541::get_last_mounted_drive().
+    static C1541 *&last_mounted_drive()
+    {
+        static C1541 *drive = 0;
+        return drive;
+    }
+
+    static C1541 *get_last_mounted_drive(void) { return last_mounted_drive(); }
+};
+
+extern C1541 *c1541_A;
+extern C1541 *c1541_B;
+
+#endif // TEST_STUBS_C1541_H

--- a/software/test/hoststubs/c64.h
+++ b/software/test/hoststubs/c64.h
@@ -1,0 +1,27 @@
+/*
+ * Host stub for software/io/c64/c64.h.
+ *
+ * The real header cannot be compiled for a 64-bit host: get_cartridge_max_rom()
+ * casts pointers to uint32_t, which is a hard error off the 32-bit target.
+ *
+ * dos.cc only reaches C64 for the two MP3 ramdrive queries below, neither of
+ * which is on any path this test exercises, so stubbing the header collapses
+ * the whole dependency without changing what is under test.
+ */
+#ifndef HOSTSTUB_C64_H
+#define HOSTSTUB_C64_H
+
+#include <stdint.h>
+
+#define REU_MEMORY_BASE 0x1000000
+#define DRVTYPE_MP3_DNP 31
+
+// Defined in firmware_globals.cc, which reports both ram drives as absent.
+class C64
+{
+public:
+    static int isMP3RamDrive(int dev);
+    static int getSizeOfMP3NativeRamdrive(int dev);
+};
+
+#endif

--- a/software/test/hoststubs/command_intf_globals.cc
+++ b/software/test/hoststubs/command_intf_globals.cc
@@ -1,0 +1,15 @@
+// Host-test definitions for the globals that command_intf.h declares.
+//
+// The real definitions live in command_intf.cc, which talks to the memory
+// mapped command interface hardware. Host tests only need the registry that
+// CommandTarget subclasses register themselves into, and the shared reply and
+// status messages that command handlers hand back.
+
+#include "command_intf.h"
+
+CommandTarget *command_targets[64] = { 0 };
+
+Message c_message_empty         = {  0, true, (uint8_t *)"" };
+Message c_message_no_target     = { 20, true, (uint8_t *)"99,NO SUCH TARGET   " };
+Message c_status_ok             = {  5, true, (uint8_t *)"00,OK" };
+Message c_status_unknown_command = { 22, true, (uint8_t *)"99,UNKNOWN COMMAND    " };

--- a/software/test/hoststubs/firmware_globals.cc
+++ b/software/test/hoststubs/firmware_globals.cc
@@ -1,0 +1,96 @@
+// Host-test doubles for the firmware globals that dos.cc links against.
+//
+// These live in translation units that talk to hardware (rtc.cc, c64.cc,
+// c1541.cc, subsys.cc, itu.c) and cannot be built on the host. Only the symbols
+// the command interface actually reaches are provided here, with deterministic
+// behaviour so tests can rely on them.
+
+#include "rtc.h"
+#include "c64.h"
+#include "c1541.h"
+#include "subsys.h"
+#include "itu.h"
+
+// --- Drives ---------------------------------------------------------------
+// No drives are attached by default. Tests that need one assign these.
+C1541 *c1541_A = 0;
+C1541 *c1541_B = 0;
+
+// --- Real time clock ------------------------------------------------------
+// A fixed, valid timestamp: 2026-08-02 12:34:56. The year is stored as an
+// offset from 1980, matching the firmware convention.
+Rtc rtc;
+
+Rtc::Rtc() : capable(true), cfg(0)
+{
+    for (int i = 0; i < 16; i++) {
+        rtc_regs[i] = 0;
+    }
+}
+
+Rtc::~Rtc()
+{
+}
+
+int Rtc::get_correction(void)
+{
+    return 0;
+}
+
+void Rtc::get_time(int &y, int &M, int &D, int &wd, int &h, int &m, int &s)
+{
+    y = 46; // 1980 + 46 = 2026
+    M = 8;
+    D = 2;
+    wd = 0;
+    h = 12;
+    m = 34;
+    s = 56;
+}
+
+void Rtc::set_time(int y, int M, int D, int wd, int h, int m, int s)
+{
+    (void)y; (void)M; (void)D; (void)wd; (void)h; (void)m; (void)s;
+}
+
+void Rtc::set_time_in_chip(int corr, int y, int M, int D, int wd, int h, int m, int s)
+{
+    (void)corr; (void)y; (void)M; (void)D; (void)wd; (void)h; (void)m; (void)s;
+}
+
+// --- C64 ------------------------------------------------------------------
+// The MP3 ram drives are a U64 feature and are reported as absent.
+int C64::isMP3RamDrive(int dev)
+{
+    (void)dev;
+    return 0;
+}
+
+int C64::getSizeOfMP3NativeRamdrive(int dev)
+{
+    (void)dev;
+    return 0;
+}
+
+// --- Subsystem dispatch ---------------------------------------------------
+// Commands are recorded rather than executed, so tests can assert on what the
+// command interface asked the rest of the firmware to do.
+IndexedList<SubsysCommand *>& executed_subsys_commands()
+{
+    static IndexedList<SubsysCommand *> commands(8, 0);
+    return commands;
+}
+
+SubsysResultCode_t SubsysCommand::execute(void)
+{
+    executed_subsys_commands().append(this);
+    SubsysResultCode_t result;
+    result.status = SSRET_OK;
+    return result;
+}
+
+// --- FPGA -----------------------------------------------------------------
+uint32_t getFpgaCapabilities(void)
+{
+    return 0xFFFFFFFF; // report every capability as present
+}

--- a/software/test/hoststubs/home_directory.h
+++ b/software/test/hoststubs/home_directory.h
@@ -1,0 +1,40 @@
+#ifndef TEST_HOSTSTUBS_HOME_DIRECTORY_H
+#define TEST_HOSTSTUBS_HOME_DIRECTORY_H
+
+// Host-test stub for software/userinterface/home_directory.h.
+//
+// The real class owns a polling task, a TreeBrowser and the config store. Only
+// the configured path matters to the command interface, so this stub keeps it
+// in a plain string that tests can set directly.
+
+#include <string.h>
+
+class HomeDirectory
+{
+public:
+    static const char *getHomeDirectory(void)
+    {
+        return storage();
+    }
+
+    static void setHomeDirectory(const char *path)
+    {
+        if (!path) {
+            storage()[0] = 0;
+            return;
+        }
+        strncpy(storage(), path, max_length - 1);
+        storage()[max_length - 1] = 0;
+    }
+
+private:
+    static const int max_length = 256;
+
+    static char *storage()
+    {
+        static char path[max_length] = "/";
+        return path;
+    }
+};
+
+#endif // TEST_HOSTSTUBS_HOME_DIRECTORY_H

--- a/software/test/hoststubs/queue.h
+++ b/software/test/hoststubs/queue.h
@@ -1,0 +1,12 @@
+#ifndef TEST_HOSTSTUBS_QUEUE_H
+#define TEST_HOSTSTUBS_QUEUE_H
+
+// Host-test stub for the FreeRTOS queue API. The command-interface tests drive
+// executeCommand() directly rather than posting to a queue, so only the type
+// needs to exist.
+
+#include "FreeRTOS.h"
+
+typedef void * QueueHandle_t;
+
+#endif // TEST_HOSTSTUBS_QUEUE_H

--- a/software/test/hoststubs/semphr.h
+++ b/software/test/hoststubs/semphr.h
@@ -1,0 +1,52 @@
+#ifndef TEST_HOSTSTUBS_SEMPHR_H
+#define TEST_HOSTSTUBS_SEMPHR_H
+
+// Host-test stub for the FreeRTOS semaphore API.
+//
+// Host tests are single threaded, so the mutexes that guard the firmware's
+// shared state have nothing to protect. Take/Give are no-ops that always
+// succeed, which keeps the locking call sites in the firmware unchanged.
+
+#include "FreeRTOS.h"
+
+typedef void * SemaphoreHandle_t;
+
+#ifndef pdTRUE
+#define pdTRUE  1
+#define pdFALSE 0
+#endif
+
+#ifndef portMAX_DELAY
+#define portMAX_DELAY 0xFFFFFFFFUL
+#endif
+
+static inline SemaphoreHandle_t xSemaphoreCreateMutex(void)
+{
+    static int mutex;
+    return &mutex;
+}
+
+static inline SemaphoreHandle_t xSemaphoreCreateBinary(void)
+{
+    return xSemaphoreCreateMutex();
+}
+
+static inline int xSemaphoreTake(SemaphoreHandle_t handle, unsigned long ticks)
+{
+    (void)handle;
+    (void)ticks;
+    return pdTRUE;
+}
+
+static inline int xSemaphoreGive(SemaphoreHandle_t handle)
+{
+    (void)handle;
+    return pdTRUE;
+}
+
+static inline void vSemaphoreDelete(SemaphoreHandle_t handle)
+{
+    (void)handle;
+}
+
+#endif // TEST_HOSTSTUBS_SEMPHR_H

--- a/software/test/hoststubs/task.h
+++ b/software/test/hoststubs/task.h
@@ -1,0 +1,13 @@
+#ifndef TEST_HOSTSTUBS_TASK_H
+#define TEST_HOSTSTUBS_TASK_H
+
+// Host-test stub for the FreeRTOS task API. Host tests are single threaded and
+// drive the code under test directly, so no task ever gets created.
+
+#include "FreeRTOS.h"
+
+typedef void * TaskHandle_t;
+
+static inline void vTaskDelay(unsigned long ticks) { (void)ticks; }
+
+#endif // TEST_HOSTSTUBS_TASK_H

--- a/software/test/hoststubs/userinterface.h
+++ b/software/test/hoststubs/userinterface.h
@@ -1,0 +1,82 @@
+#ifndef USERINTERFACE_H
+#define USERINTERFACE_H
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+// Values must match software/userinterface/userinterface.h.
+#define MENU_NOP     0  // Stay in current window
+#define MENU_CLOSE  -1  // Window operation is complete and can be closed
+#define MENU_HIDE   -2  // The selected action requests the menu to hide.
+#define MENU_EXIT   -3  // The selected action requests the menu to exit and be destroyed.
+
+typedef int MenuAction_t;
+
+#define BUTTON_OK     0x01
+#define BUTTON_YES    0x02
+#define BUTTON_NO     0x04
+#define BUTTON_ALL    0x08
+#define BUTTON_CANCEL 0x10
+
+class UserInterface
+{
+    int  popup(const char *msg, uint32_t flags, int count, const char **names, const char *keys)
+    {
+        // Automated tests must never block on stdin, so the answer is scripted
+        // instead of read. It defaults to the first button that is enabled.
+        (void)msg;
+        (void)names;
+        (void)keys;
+        if (scripted_answer()) {
+            return scripted_answer();
+        }
+        for (int i = 0; i < count; i++) {
+            if (flags & (1 << i)) {
+                return (1 << i);
+            }
+        }
+        return 0;
+    }
+
+public:
+    // Tests set this to force a specific popup answer (a BUTTON_* value).
+    static int& scripted_answer()
+    {
+        static int answer = 0;
+        return answer;
+    }
+
+    UserInterface(const char *title)
+    {
+        printf("Welcome to the User Interface '%s'. This is a dummy!\n", title);
+    };
+    virtual ~UserInterface() { }
+
+    int  popup(const char *msg, uint8_t flags)
+    { // blocking 
+        const char *c_button_names[] = { " Ok ", " Yes ", " No ", " All ", " Cancel " };
+        const char c_button_keys[] = { 'o', 'y', 'n', 'a', 'c' };
+        return popup(msg, flags, 5, c_button_names, c_button_keys);
+    }
+
+    int  popup(const char *msg, int count, const char **names, const char *keys)
+    { // blocking, custom
+        return popup(msg, (1 << count)-1, count, names, keys);
+    }
+
+    int  string_box(const char *msg, char *buffer, int maxlen)
+    {
+        (void)msg;
+        if (buffer && (maxlen > 0)) {
+            buffer[0] = 0;
+        }
+        return 0;
+    }
+
+    void show_progress(const char *msg, int steps) {} // not blocking
+    void update_progress(const char *msg, int steps) {} // not blocking
+    void hide_progress(void) {} // not blocking (of course)
+};
+
+#endif


### PR DESCRIPTION
Fixes https://github.com/GideonZ/1541ultimate/issues/725.

## Overview

`DOS_CMD_COPY_HOME_PATH` ($17) reports `00,OK` even when it did not change directory. A client asking to jump to an unreachable home directory is told the command succeeded, and is handed the current path instead of the one it asked for.

Split out of #743 so each change stands on its own.

## Bug

The `$17` case calls `cd()`, which sets the status correctly, and then falls through into `DOS_CMD_GET_PATH`:

```c
case DOS_CMD_COPY_HOME_PATH:
    ...
    cd(command, reply, status);
    // fallthrough

case DOS_CMD_GET_PATH:
    ...
    *status = &c_status_ok;
```

`DOS_CMD_GET_PATH` overwrites the status unconditionally, so the failure from `cd()` is discarded.

## Fix

Break out of the case when `cd()` failed, so the real status reaches the caller. The success path is unchanged.

The failure status is now identical to what `DOS_CMD_CHANGE_DIR` already returns for the same directory — the command this one is documented to mirror.

## Tests

### Host unit / regression tests

`make -C software/filemanager/tests dos-command`

```
3 test(s) passed
```

Added to `software/filemanager/tests/dos_command_test.cpp`:

- `ReportsOkWhenHomeDirectoryResolves` — control; the success path must stay green
- `ReportsFailureWhenHomeDirectoryIsMissing`
- `MatchesChangeDirFailureStatus` — pins `COPY_HOME_PATH` to the status `DOS_CMD_CHANGE_DIR` already returns

Confirmed red before the fix. Reverting only the `break` in `dos.cc` gives:

```
2 test(s) failed
```

The root filesystem is enough to tell the two cases apart — `/` always resolves and a name below it never does — so the tests need no fixture filesystem.

`software/test/hoststubs/` makes `dos.cc` host-buildable. `dos.h` → `c1541.h` → `browsable_root.h` drags in the whole UI and the lwIP stack; stubbing at `c1541.h` collapses that subtree in one move. Only headers that genuinely cannot build on a host are replaced — everything else is the real firmware source.

One of those stubs is worth flagging: **`c64.h` cannot be compiled for a 64-bit host.** `get_cartridge_max_rom()` casts pointers to `uint32_t`, which is a hard error off the 32-bit target:

```
c64.h:426:17: error: cast from 'uint8_t*' to 'uint32_t' loses precision [-fpermissive]
```

`dos.cc` only uses `isMP3RamDrive()` and `getSizeOfMP3NativeRamdrive()` from it, neither on any path these tests reach, so the stub declares just those. Happy to change the casts to `uintptr_t` in a separate PR instead if you would rather the real header stayed host-compilable — on the 32-bit target that generates identical code.

### Real hardware / e2e verification

Not yet. Per `tests/README.md` this behaviour belongs beside its component as a host test, which is what the above is; an `e2e/io/command_interface/` case driving the same command over the wire would be complementary rather than a replacement. I have a JTAG programmer arriving and will follow up with one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
