### PR TITLE
Link pattern.cc into the input API validation test

### DIFF
--- a/software/api/tests/Makefile
+++ b/software/api/tests/Makefile
@@ -5,7 +5,7 @@ STATE_TEST_FLAGS := $(CXXFLAGS) -DNO_FILE_ACCESS -I../../io/c64 -I../../io/usb -
 all: input-api input-api-state
 
 input-api:
-	$(CXX) $(CXXFLAGS) input_api_validation_test.cpp ../json.cc ../../components/mystring.cc ../../system/small_printf.cc ../../io/usb/tests/host_test_main.cpp -lpthread -o inputApiValidationTest && ./inputApiValidationTest
+	$(CXX) $(CXXFLAGS) input_api_validation_test.cpp ../json.cc ../../components/mystring.cc ../../components/pattern.cc ../../system/small_printf.cc ../../io/usb/tests/host_test_main.cpp -lpthread -o inputApiValidationTest && ./inputApiValidationTest
 
 input-api-state:
 	$(CXX) $(STATE_TEST_FLAGS) input_api_state_test.cpp ../../io/usb/keyboard_usb.cc ../../io/c64/joystick_output.cc ../../io/c64/keyboard_c64.cc ../../io/usb/tests/host_test_main.cpp -lpthread -o inputApiStateTest && ./inputApiStateTest


### PR DESCRIPTION
## Overview

`software/api/tests` does not build on `test-merge`. `make -C software/api/tests` fails at the link step:

```
undefined reference to `url_encode(char const*, mstring&)'
collect2: error: ld returned 1 exit status
make: *** [Makefile:8: input-api] Error 1
```

## Bug

`input_api_validation_test.cpp` links `../json.cc`, which calls `url_encode()`. That function lives in `software/components/pattern.cc`, and that source is not on the link line — `mystring.cc` is there, `pattern.cc` is not.

## Fix

Add `../../components/pattern.cc` to the `input-api` link line. One line, no test or production code touched.

## Tests

Reproduced and verified in `gcc:11`, matching the CI toolchain.

Before, on a clean `test-merge` checkout:

```
undefined reference to `url_encode(char const*, mstring&)'
make: *** [Makefile:8: input-api] Error 1
```

After:

```
$ make -C software/api/tests
11 test(s) passed
27 test(s) passed
```

Both suites in the directory pass; `input-api-state` was already fine and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
