### PR TITLE
Fix operator precedence in the modem ATH handler

### DIFF
--- a/software/io/acia/modem.cc
+++ b/software/io/acia/modem.cc
@@ -624,7 +624,7 @@ int Modem :: ExecuteCommand(ModemCommand_t *cmd)
                 i++;
             busyMode = (temp > 0);
             keepConnection = false;
-            connectionStateChange = 1 + (busyMode) ? 2 : 0; // if busy mode is selected, return 3
+            connectionStateChange = busyMode ? 3 : 1; // if busy mode is selected, return 3
             break;
         case 'A': // answer
             if (keepConnection) {


### PR DESCRIPTION
Fixes https://github.com/GideonZ/1541ultimate/issues/590.

## Overview

`ATH1` drops the connection without ever sending the busy message. An incoming caller gets a silent disconnect instead of the configured busy file.

## Bug

`software/io/acia/modem.cc:627`:

```cpp
connectionStateChange = 1 + (busyMode) ? 2 : 0; // if busy mode is selected, return 3
```

The conditional operator has lower precedence than addition, so this parses as `(1 + busyMode) ? 2 : 0`. Both `1` and `2` are truthy, so the expression is **always 2** — the value 3 named in the comment is never produced.

That matters because the caller only relays the busy file on 3 (`modem.cc:322`):

```cpp
connChange = ExecuteCommand(&modemCommand);
if (connChange) {
    if (connChange == 3) { // ATH1
        RelayFileToSocket(cfg->get_string(CFG_MODEM_BUSYFILE), socket, "The modem you are connecting to is currently busy.\n");
    }
    break;
}
```

So that branch is unreachable today. The hangup itself still works — `keepConnection = false` handles it and any non-zero value breaks the loop — but the busy notification is lost.

## Fix

Write the intent directly:

```cpp
connectionStateChange = busyMode ? 3 : 1;
```

`busyMode` false gives 1, matching `ATZ`; true gives 3, which is what the comment and the caller expect.

## Tests

The precedence claim, demonstrated rather than asserted:

```cpp
for (int busyMode = 0; busyMode <= 1; busyMode++) {
    int old_expr = 1 + (busyMode) ? 2 : 0;
    int new_expr = busyMode ? 3 : 1;
    printf("busyMode=%d   old=%d   new=%d\n", busyMode, old_expr, new_expr);
}
```

```
busyMode=0   old=2   new=1
busyMode=1   old=2   new=3
```

No host test is included deliberately. `modem.cc` reaches FreeRTOS, the socket layer, the config store and the ACIA layer, so covering it on the host would mean a stub harness far larger than the change — which is the kind of churn you asked me to avoid. The behaviour is already covered on hardware by `tests/soak/network/modem_probe.py`, which inspects responses for `busy`.

Verified to compile: `make u64_no_esp` on a clean checkout of this branch, no new warnings in `modem.cc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
