### PR TITLE
Guard BYTE_ORDER against newlib's definition

### DIFF
--- a/software/portable/nios/endianness.h
+++ b/software/portable/nios/endianness.h
@@ -16,6 +16,11 @@ __inline uint16_t cpu_to_16le(uint16_t p)
 #define le16_to_cpu(x)  cpu_to_16le(x)
 #define le_to_cpu_32(x) cpu_to_32le(x)
 
+// newlib's <machine/endian.h> already defines BYTE_ORDER, and for nios2-elf it
+// resolves to little endian as well, so defining it unconditionally only
+// produced a redefinition warning in every translation unit that saw both.
+#ifndef BYTE_ORDER
 #define BYTE_ORDER LITTLE_ENDIAN
+#endif
 
 #endif /* ENDIANNESS_H */


### PR DESCRIPTION
## Overview

The U64 build emits 17 `"BYTE_ORDER" redefined` warnings. `software/portable/nios/endianness.h:19` defines `BYTE_ORDER` unconditionally, and newlib's `<machine/endian.h>:20` has already defined it in every translation unit that sees both.

## Fix

Guard the definition:

```c
#ifndef BYTE_ORDER
#define BYTE_ORDER LITTLE_ENDIAN
#endif
```

## Why this is safe

For `nios2-elf` the two definitions resolve to the same value, so taking whichever is already defined cannot change behaviour. Rather than argue that from the headers, here it is measured.

`-dM` shows how both sides resolve:

```
#define _LITTLE_ENDIAN 1234
#define _BYTE_ORDER    _LITTLE_ENDIAN     <- newlib, derived from __IEEE_LITTLE_ENDIAN
#define LITTLE_ENDIAN  _LITTLE_ENDIAN
#define BYTE_ORDER     LITTLE_ENDIAN      <- this header, unguarded
```

A translation unit that includes both headers and asserts the value:

```c
#include <stdint.h>
#include <machine/endian.h>
#include "endianness.h"
#if !defined(BYTE_ORDER)
#error BYTE_ORDER_UNDEFINED
#endif
#if BYTE_ORDER != 1234
#error BYTE_ORDER_NOT_1234
#endif
int ok = BYTE_ORDER;
```

```
WITHOUT guard: BYTE_ORDER == 1234 (compiles)
WITH guard:    BYTE_ORDER == 1234 (compiles)
object files identical: YES
```

The `#error` would fire on either side if the value moved. It doesn't, and the two object files are byte-identical.

Warning count on `make u64_no_esp`: **17 before, 0 after**.

## Scope

`software/portable/microblaze/endianness.h` has the same pattern but asserts `BIG_ENDIAN`, where a guard could genuinely change the value. That build needs Xilinx ISE, which I cannot run, so it is deliberately left alone.

## Note

While verifying this I found the firmware build is not reproducible — two `make u64_no_esp` runs from identical source produce different `ultimate.app` hashes:

```
959e1f1bd54a2bf8078390b7acb476fb
ba95800bc346aa33de1d3f4a535f615b
```

Not addressed here, but happy to open a separate issue if it is of interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
