### PR TITLE
Remove unused cart ROM declarations that break the RISC-V builds

### DIFF
--- a/software/io/c64/c64_crt.cc
+++ b/software/io/c64/c64_crt.cc
@@ -16,9 +16,6 @@ extern uint8_t _eapi_65_start[768];
 #define CRTCHP_LOAD    0x0C
 #define CRTCHP_SIZE    0x0E
 
-extern uint8_t __cart_rom_start;
-extern uint8_t __cart_rom_limit;
-
 const struct C64_CRT::t_cart C64_CRT::c_recognized_c64_carts[] = {
     {  0, 0xFF, CART_NORMAL,    "Normal cartridge" },
     {  1, 0xFF, CART_ACTION,    "Action Replay" }, // max 4 banks of 8K


### PR DESCRIPTION
## Overview

Every RISC-V target fails to compile on `test-merge`:

```
software/io/c64/c64_crt.cc:19:16: error: conflicting declaration 'uint8_t __cart_rom_start'
software/io/c64/c64.h:420:24: note: previous declaration as 'uint8_t __cart_rom_start [1048576]'
make: *** [c64_crt.o] Error 1
```

Reproduced on a clean checkout of `e2264deb` with the xPack RISC-V GCC 11.3.0 pinned in `docker/Dockerfile`.

## Bug

`c64_crt.cc:19-20` declares two symbols at file scope:

```cpp
extern uint8_t __cart_rom_start;
extern uint8_t __cart_rom_limit;
```

Neither is referenced anywhere in the file — those two lines are the only occurrences of either name. The one place that needs the cartridge ROM size calls the accessor instead (`c64_crt.cc:666`):

```cpp
work->initialize(mem, C64::get_cartridge_max_rom());
```

But the scalar declaration of `__cart_rom_start` conflicts with `c64.h:420`, which declares it as an array inside `get_cartridge_rom_addr()`:

```cpp
extern uint8_t __cart_rom_start[1024*1024];
```

`__cart_rom_limit` is scalar in both places and does not conflict; it is removed only because it is equally unused.

These came in with `eaa7751b` (large cartridge support) and are not on `master`.

## Fix

Delete both declarations.

## Tests

**Before**, clean `test-merge`:

```
$ make -C target/u64ii/riscv/ultimate
c64_crt.cc:19:16: error: conflicting declaration 'uint8_t __cart_rom_start'
make: *** [c64_crt.o] Error 1     (exit 2)
```

**After**, both affected targets:

```
target/u64ii/riscv/ultimate     exit 0, 0 errors
target/u2plus_L/riscv/ultimate  exit 0, 0 errors
```

**No behavioural change.** On nios2 the file compiles both ways, so the object files can be compared directly. Same-source rebuilds were first confirmed byte-identical, so the comparison is meaningful:

```
code disassembly identical:   YES
sections differing:           .debug_info only, 0x7f85 -> 0x7f6d
```

The emitted code is byte identical. The only difference is 24 bytes of DWARF — the records describing the two removed declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
