### PR TITLE
Remove duplicate liblwip.a rule from the lwip makefiles

### DIFF
--- a/target/libs/nios2/lwip/makefile
+++ b/target/libs/nios2/lwip/makefile
@@ -109,9 +109,4 @@ VPATH   += $(OUTPUT) $(RESULT)
 
 all: $(OUTPUT) $(RESULT) $(RESULT)/$(PRJ).a
 
-$(RESULT)/$(PRJ).a: $(LINK) $(OBJS_C)
-	@echo "Creating Archive $@"
-	$(AR) -rc $@ $(ALL_OBJS)
-
-
 include ../../../common/rules.mk

--- a/target/libs/riscv/lwip/makefile
+++ b/target/libs/riscv/lwip/makefile
@@ -110,9 +110,4 @@ VPATH   += $(OUTPUT) $(RESULT)
 
 all: $(OUTPUT) $(RESULT) $(RESULT)/$(PRJ).a
 
-$(RESULT)/$(PRJ).a: $(LINK) $(OBJS_C)
-	@echo "Creating Archive $@"
-	$(AR) -rc $@ $(ALL_OBJS)
-
-
 include ../../../common/rules.mk


### PR DESCRIPTION
## Overview

Every CI build emits ten `overriding recipe` warnings for `liblwip.a`, five per architecture. From run [30913782624](https://github.com/GideonZ/1541ultimate/actions/runs/30913782624) on `8efdffe6`:

```
3  makefile:114: warning: ignoring old recipe for target '/mnt/project/target/libs/riscv/lwip/result/liblwip.a'
3  ../../../common/rules.mk:45: warning: overriding recipe for target '/mnt/project/target/libs/riscv/lwip/result/liblwip.a'
2  makefile:113: warning: ignoring old recipe for target '/mnt/project/target/libs/nios2/lwip/result/liblwip.a'
2  ../../../common/rules.mk:45: warning: overriding recipe for target '/mnt/project/target/libs/nios2/lwip/result/liblwip.a'
```

## Bug

Both lwip makefiles define the archive rule and then include `common/rules.mk`, which defines the same target again:

```make
$(RESULT)/$(PRJ).a: $(LINK) $(OBJS_C)
	@echo "Creating Archive $@"
	$(AR) -rc $@ $(ALL_OBJS)

include ../../../common/rules.mk        # rules.mk:45 defines $(RESULT)/$(PRJ).a again
```

The include comes last, so make keeps `rules.mk`'s recipe and discards the local one.

## Fix

Delete the shadowed rule from both makefiles.

## Why this changes nothing

`rules.mk`'s recipe is already the one that executes. The two differ in quoting, and the CI log shows the quoted form running:

```
ar -rc "/mnt/project/target/libs/riscv/lwip/result/liblwip.a" ./output/sys_arch.o ...
```

`rules.mk:45` is `$(AR) -rc "$@" $(ALL_OBJS)`; the lwip makefiles' is unquoted. So the local recipe was already dead, and removing it cannot change what runs.

The only other difference is the `$(LINK)` prerequisite, which make merges even when it discards the recipe:

- **riscv** — `LINK` is empty (`makefile:102`), so the local rule expands to exactly `rules.mk`'s. Identical in every respect.
- **nios2** — `LINK = ./mb_app.lds` (`makefile:101`), a MicroBlaze linker script. It is not an input to `ar`, and the nios2 link step uses `-T'.../nios_appl_bsp/linker.x'` instead.

## Tests

**nios2**, building `target/libs/nios2/lwip` before and after:

```
BEFORE   warnings: 2   archive members md5: 35eea8fcb4fded7169e1cf997ab588d3
AFTER    warnings: 0   archive members md5: 35eea8fcb4fded7169e1cf997ab588d3
```

Same archive, same members.

**riscv**, at parse time via `make -n`, so no cross toolchain is needed:

```
BEFORE: 2 warnings
AFTER:  0 warnings
```

with the `ar -rc` rule still resolving afterwards.

Note that the wording differs by make version — 3.81 says `overriding commands`, 4.x says `overriding recipe` — so a grep for one phrasing will miss the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
