### PR TITLE
Fix reversed 6581/8580 selection for PDsid

### DIFF
--- a/software/u64/sid_device_pdsid.cc
+++ b/software/u64/sid_device_pdsid.cc
@@ -68,7 +68,7 @@ SidDevicePdSid::~SidDevicePdSid()
 int SidDevicePdSid::PdSidConfig:: S_cfg_pdsid_type(ConfigItem *it)
 {
     SidDevicePdSid *obj = (SidDevicePdSid *)it->store->get_hook_object();
-    obj->SetSidType(it->getValue());
+    obj->SetSidType(it->getValue() + 1); // menu enum is 0 = 6581, 1 = 8580; SetSidType takes 1 = 6581, 2 = 8580
     return 0;
 }
 


### PR DESCRIPTION
Fixes the reversed 6581/8580 selection reported in #755.

## The bug

`Emulation Mode` for PDsid is a `CFG_TYPE_ENUM` over `{ "6581", "8580" }`, so `it->getValue()` is **0 or 1**:

https://github.com/GideonZ/1541ultimate/blob/test-merge/software/u64/sid_device_pdsid.cc#L15-L19

The change hook passed that value straight into `SetSidType()`:

```c
obj->SetSidType(it->getValue());
```

But `SidDevice::SetSidType()` takes **1 = 6581, 2 = 8580**. That is the convention every other implementation follows — `sid_device_swinsid.cc`, `sid_device_armsid.cc` and `sid_device_fpgasid.cc` all open with the same line:

```c
type--; // receive 1 = 6581, 2 = 8580 => map to 0 and 1
```

and it is the same encoding `U64Config::MapSid()` passes down through `t_sid_definition::sidType` (`{ "None", "6581", "8580", "Either" }`).

So the hook is off by one, and the two options are swapped:

| Menu selection | `getValue()` | `SetSidType()` | `base[31]` | Device becomes |
|---|---|---|---|---|
| 6581 | 0 | 0 | `0x01` | **8580** |
| 8580 | 1 | 1 | `0x00` | **6581** |

## Why it also looked like the setting was not being saved

Reopening the menu calls `at_open_config()`, which reads the mode back from the device and displays it. So the menu was showing the chip the device had actually been switched to — the opposite of the one just selected. From the outside that is indistinguishable from the selection being discarded, which is how it was originally reported.

That is consistent with the reporter's own findings in #755: he independently arrived at the workaround "select 6581 to get 8580, and vice versa", and separately answered "no" to whether the selection survives leaving and reopening the menu. One bug, both symptoms.

## The fix

```c
obj->SetSidType(it->getValue() + 1);
```

`SetSidType()` and `at_open_config()` are already consistent with each other and with the register encoding (`0x00` = 6581, `0x01` = 8580) — `SetSidType(1)` writes `0x00`, and `at_open_config()` maps `base[31] & 1 == 0` back to enum index 0, `"6581"`. Only the call site disagreed, so only the call site is changed. `SetSidType()` semantics are untouched.

## Verification

`sid_device_pdsid.cc` is referenced by exactly two target makefiles — `target/u64/nios2/ultimate` and `target/u64ii/riscv/ultimate` — so those are the only two builds this can affect. Both were built from a clean tree and completed with exit status 0:

| Target | Toolchain | Result |
|---|---|---|
| `make u64` | Quartus Prime Lite 18.1.0.625, `nios2-elf-gcc 5.3.0` | exit 0 |
| `make u64ii` | `riscv32-unknown-elf-gcc 10.2.0`, ESP-IDF v5.3.1 | exit 0 |

Those are the CI toolchain versions, so the result should be directly comparable to yours.

I do **not** have PDsid hardware, so I have not confirmed this on a device. The reporter in #755 does, and has been very willing to test. Happy to have him verify before this is merged.

## Not addressed here

Two further problems from #755 are real but are separate from this one, and I would rather not fold them into this change:

1. **PDsid settings are absent from saved `.cfg` files.** `ConfigIO::S_write_to_file()` skips any store without a flash page, and `PdSidConfig` is constructed with `ConfigStore(NULL, ...)`. I checked the `.cfg` files the reporter attached to #755 — there is no `[SID Socket n: PDsid]` section in any of them. This guard is generic and also covers SidKick, ArmSid and the RTC stores, so changing it is a decision about intended behaviour rather than a bug fix.
2. **`PdSidConfig::effectuate()` is empty**, so even with the section present, loading a `.cfg` would not push the mode to the device.

I will raise both on #755 rather than guess at the intent here.

One thing noticed while tracing this, unrelated to #755 and not changed: `SidDeviceSidKick::SetSidType()` does not do the `type--` step the other implementations do, so the auto-mapping path in `U64Config::MapSid()` would select the wrong chip for a SidKick too. I have not tested that and it is a different code path — mentioning it in case it is useful.
