### PR TITLE
Add missing type mapping to SidDeviceSidKick::SetSidType

### DIFF
--- a/software/u64/sid_device_sidkick.cc
+++ b/software/u64/sid_device_sidkick.cc
@@ -61,6 +61,8 @@ void SidDeviceSidKick :: SetSidType(int type)
     base[0x1e] = 0x00; // choose profile to update
 //     base[0x1d] = 0xFC; // update and afterwards leave config mode
 
+    type--; // receive 1 = 6581, 2 = 8580 => map to 0 and 1
+
     // Set sid#2 to none for now
     if (type) { // 8580
         base[0x1d] = SID_TYPE_8580_BOOST;


### PR DESCRIPTION
Noticed while tracing #755. This is a latent bug — it changes nothing today — but it needs fixing before a related gap can be closed, so I would rather put it in on its own than bundle it later.

## The bug

`SidDevice::SetSidType()` receives **1 = 6581, 2 = 8580**. The other three implementations all begin by mapping that down:

```c
type--; // receive 1 = 6581, 2 = 8580 => map to 0 and 1
```

`sid_device_swinsid.cc:41`, `sid_device_armsid.cc:324`, `sid_device_fpgasid.cc:103`. `U64Config::GetSidType()` returns the same 1/2 encoding, and `MapSid()` passes it down through `t_sid_definition::sidType`.

`SidDeviceSidKick::SetSidType()` does not do this, and then tests the raw value for truth:

```c
if (type) { // 8580
    base[0x1d] = SID_TYPE_8580_BOOST;
} else {
    base[0x1d] = SID_TYPE_6581;
}
```

Both valid arguments are non-zero, so **every call selects `SID_TYPE_8580_BOOST` and `SID_TYPE_6581` is unreachable** — asking for a 6581 gets you an 8580 with digiboost.

## Why nothing is broken today

`SidDeviceSidKick::SetSidType()` is currently never called:

- `U64Config::GetSidType()` has no case for `SID_TYPE_SIDKICK (10)` or `SID_TYPE_SIDKICK_PICO (11)`, so both fall through to `default: return 0` — the socket is reported as empty.
- `MapSid()` only calls `SetSidType()` on sockets it has classified as `3` ("either type").
- The SidKick config menu hook writes the profile register directly rather than going through `SetSidType()`.

So this is dead code with a bug in it.

## Why fix it now

That `GetSidType()` gap looks worth closing separately — a detected SidKick or PDsid currently reports as "no SID present" to the SID player's auto-mapper, which I suspect is behind the reporter of #755 having to set SID Player Behavior manually to get any sound from his PDsids.

But closing it un-gates this function. If `SID_TYPE_SIDKICK` starts being reported as "either type", `MapSid()` will begin calling `SetSidType()` on SidKick sockets, and every tune asking for a 6581 would get an 8580. Fixing that gap while this is still wrong would introduce a real regression, so this wants to go in first.

I have deliberately not touched the `GetSidType()` gap here — whether PDsid and SidKick should be auto-mapped at all is a behaviour decision (it would let SID tunes override the chip type chosen in the menu, as already happens for FpgaSID and ArmSid), and that is yours to make, not mine to smuggle into a one-line fix.

## Scope

One line, matching the other three devices verbatim. `SID_TYPE_8580_BOOST` is kept for the 8580 case exactly as before — only the mapping is added.

## Verification

`sid_device_sidkick.cc` is referenced by two target makefiles, `target/u64/nios2/ultimate` and `target/u64ii/riscv/ultimate`. Both built from a clean tree with the CI toolchains and completed with exit status 0:

| Target | Toolchain | Result |
|---|---|---|
| `make u64` | Quartus Prime Lite 18.1.0.625, `nios2-elf-gcc 5.3.0` | exit 0 |
| `make u64ii` | `riscv32-unknown-elf-gcc 10.2.0`, ESP-IDF v5.3.1 | exit 0 |

I do not have a SidKick, so this is not confirmed on hardware. Given the function is unreachable at present, the runtime risk of merging it is nil; the value is that the trap is gone before anyone closes the `GetSidType()` gap.
