### PR TITLE
Fix readmem OOM hanging the device, and a 64 KB leak in machine:measure

### DIFF
--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -206,7 +206,7 @@ API_CALL(GET, machine, readmem, NULL, ARRAY( { {"address", P_REQUIRED}, {"length
     }
 
     int datalen = args.get_int("length", 256);
-    if ((datalen < 0) || (datalen > 65536)) {
+    if ((datalen < 1) || (datalen > 65536)) {
         resp->error("Invalid length");
         resp->json_response(HTTP_BAD_REQUEST);
         return;
@@ -218,20 +218,28 @@ API_CALL(GET, machine, readmem, NULL, ARRAY( { {"address", P_REQUIRED}, {"length
         return;
     }
 
-    uint8_t *buffer = new uint8_t[datalen];
+    // Use malloc (not new): operator new panics and spins forever on OOM, so a
+    // new[] result can never be NULL. malloc returns NULL, so this caller-sized
+    // request can fail cleanly with HTTP 500 instead of hanging the device.
+    uint8_t *buffer = (uint8_t *)malloc(datalen);
+    if (!buffer) {
+        resp->error("Out of memory");
+        resp->json_response(HTTP_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
     SubsysCommand *cmd = new SubsysCommand(NULL, SUBSYSID_C64, C64_DMA_RAW_READ, address, buffer, datalen);
     SubsysResultCode_t retval = cmd->execute();
     if (retval.status == SSRET_OK) {
         // output result in JSON format
         StreamRamFile *rf = resp->add_attachment();
         rf->write(buffer, datalen);
-        delete[] buffer;
         resp->binary_response();
     } else {
         resp->error(SubsysCommand::error_string(retval.status));
         resp->json_response(SubsysCommand::http_response_map(retval.status));
-        delete[] buffer;
     }
+    free(buffer);
 }
 
 API_CALL(GET, machine, menu_screen, NULL, ARRAY( {  }))
@@ -347,11 +355,20 @@ static void make_vcd(StreamRamFile *d, uint32_t *values, int count, const char *
 
 API_CALL(GET, machine, measure, NULL, ARRAY( {  }))
 {
-    uint8_t *buffer = new uint8_t[64*1024];
-
+    // Capability check before the allocation: it used to run after, and returned
+    // without freeing, leaking 64 KB per call. Bus measurement is off by default
+    // on U2 builds, so that early return is the common path, and the leak is what
+    // drives the heap towards the OOM the readmem path guards against.
     if (!(getFpgaCapabilities() & CAPAB_BUS_MEASURE)) {
         resp->error("The current FPGA build does not support timing measurement of the cartridge bus.");
         resp->json_response(HTTP_NOT_IMPLEMENTED);
+        return;
+    }
+
+    uint8_t *buffer = (uint8_t *)malloc(64*1024);
+    if (!buffer) {
+        resp->error("Out of memory");
+        resp->json_response(HTTP_INTERNAL_SERVER_ERROR);
         return;
     }
 
@@ -369,11 +386,10 @@ API_CALL(GET, machine, measure, NULL, ARRAY( {  }))
 #else
         make_vcd(rf, (uint32_t*)buffer, 64*256, "15 ns");
 #endif
-        delete[] buffer;
         resp->binary_response();
     } else {
         resp->error(SubsysCommand::error_string(retval.status));
         resp->json_response(SubsysCommand::http_response_map(retval.status));
-        delete[] buffer;
     }
+    free(buffer);
 }

--- a/tests/e2e/api/readmem_writemem_test.py
+++ b/tests/e2e/api/readmem_writemem_test.py
@@ -25,6 +25,7 @@ MENU_SCREEN_PATH = "/v1/machine:menu_screen"
 MENU_BUTTON_PATH = "/v1/machine:menu_button"
 READMEM_PATH = "/v1/machine:readmem"
 WRITEMEM_PATH = "/v1/machine:writemem"
+MEASURE_PATH = "/v1/machine:measure"
 RESET_PATH = "/v1/machine:reset"
 PAUSE_PATH = "/v1/machine:pause"
 RESUME_PATH = "/v1/machine:resume"
@@ -487,13 +488,81 @@ def run_reset(session: RestSession) -> None:
     wait_for_stable_zero_page(session, attempts=10, interval=1.0)
 
 
+# Every readmem request the firmware accepts allocates a caller-sized buffer, so
+# the parameter checks are the only thing standing between a hostile `length` and
+# the allocator. Rejection has to happen before the allocation, and the allocation
+# has to be able to fail: `operator new` PANICs and spins forever on OOM
+# (software/system/memory_wrap.cc), which takes the device down with no reset, so
+# the handler uses malloc and reports HTTP 500 instead.
+BAD_READ_REQUESTS = [
+    ({"address": "0000", "length": 0}, "zero length"),
+    ({"address": "0000", "length": -1}, "negative length"),
+    ({"address": "0000", "length": 65537}, "length one past the 64KB cap"),
+    ({"address": "0000", "length": 16 * 1024 * 1024}, "length far past the cap"),
+    ({"address": "0000", "length": "99999999999999999999"}, "length that overflows a long"),
+    ({"address": "ff00", "length": 65536}, "read running past $FFFF"),
+    ({"address": "10000", "length": 1}, "address above $FFFF"),
+    ({"address": "-1", "length": 1}, "negative address"),
+]
+# Repeats chosen so a 64KB-per-call leak is a few megabytes without making the
+# suite slow. This is a smoke check, not proof of a leak-free heap: nothing over
+# REST reports free heap, so the assertion is the observable one -- a max-size
+# read still succeeds afterwards.
+MEASURE_LEAK_REPEATS = 25
+# The suite's own live-noise probe already does eight full 64KB reads, so eight
+# here costs no more than something the run does anyway.
+MAX_READ_REPEATS = 8
+
+
+def run_bounds(session: RestSession) -> bool:
+    """Reject out-of-range readmem parameters, and survive the allocations we do accept.
+
+    Every accepted readmem allocates a caller-sized buffer, so these parameter
+    checks are the whole defence. A wrong verdict here means the firmware is
+    allocating on input it should have refused, which makes the rest of the run
+    meaningless -- so these raise rather than accumulate.
+    """
+    section("bounds: readmem rejects out-of-range parameters before allocating, "
+            "and max-size reads do not degrade the device")
+
+    for params, label in BAD_READ_REQUESTS:
+        with check(f"readmem rejects {label}"):
+            status, _, body = session.request("GET", READMEM_PATH, params=params)
+            if status != 400:
+                raise Failure(f"readmem({params}) returned HTTP {status}, expected 400: {body[:200]!r}")
+
+    # The success path allocates and frees the same 64KB every time. A regression
+    # that drops the free shows up here as a later iteration failing outright.
+    with check(f"{MAX_READ_REPEATS} back-to-back max-size reads ($0000, {MEM_SIZE} bytes) all succeed"):
+        for _ in range(MAX_READ_REPEATS):
+            session.readmem(0, MEM_SIZE)
+
+    # machine:measure allocated its 64KB buffer before checking whether the FPGA
+    # supports bus measurement, then returned 501 without freeing it. Bus timing
+    # measurement is off by default on U2 builds (commit 8155daec), so on those
+    # devices the leaking path is the only path this endpoint ever takes.
+    status, _, _ = session.request("GET", MEASURE_PATH)
+    if status == 501:
+        with check(f"{MEASURE_LEAK_REPEATS} unsupported machine:measure calls leave readmem working"):
+            for _ in range(MEASURE_LEAK_REPEATS):
+                session.request("GET", MEASURE_PATH)
+            session.readmem(0, MEM_SIZE)
+    elif status == 200:
+        detail("machine:measure is supported on this FPGA build; not repeating it, "
+               "a real bus measurement is intrusive and the leak was on the 501 path only")
+    else:
+        warn(f"machine:measure returned unexpected HTTP {status}; leak check not applicable")
+
+    return True
+
+
 FREEZE_ONLY_TESTS = ["selfcheck-freeze"]
 OVERLAY_DEPENDENT_TESTS = ["selfcheck-overlay", "screen-round-trip",
                            "overlay-to-freeze", "freeze-to-overlay"]
 
 
 def expand_tests(selected: Optional[List[str]]) -> List[str]:
-    all_tests = ["selfcheck-freeze", "selfcheck-overlay", "screen-round-trip",
+    all_tests = ["bounds", "selfcheck-freeze", "selfcheck-overlay", "screen-round-trip",
                  "overlay-to-freeze", "freeze-to-overlay"]
     if not selected:
         return all_tests
@@ -527,7 +596,7 @@ def main() -> int:
     parser.add_argument(
         "--test",
         action="append",
-        choices=("all", "selfcheck-freeze", "selfcheck-overlay", "screen-round-trip",
+        choices=("all", "bounds", "selfcheck-freeze", "selfcheck-overlay", "screen-round-trip",
                  "overlay-to-freeze", "freeze-to-overlay"),
     )
     parser.add_argument(
@@ -581,6 +650,11 @@ def main() -> int:
             tests = [t for t in tests if t not in OVERLAY_DEPENDENT_TESTS] or FREEZE_ONLY_TESTS
             if skipped_tests:
                 detail(f"skipping (requires Overlay-on-HDMI, unsupported here): {', '.join(skipped_tests)}")
+        # First, and before the live-noise probe spends eight full 64KB reads:
+        # if readmem mishandles its own parameters, everything after it is noise.
+        if "bounds" in tests:
+            results["bounds"] = run_bounds(session)
+
         noise_addrs: Set[int] = set()
         if interface_selectable:
             with check("switch to Overlay on HDMI to probe live background activity"):


### PR DESCRIPTION
Two allocation bugs on externally reachable REST endpoints, found while looking at what a REU read/write endpoint (#697) would need.

### `GET /v1/machine:readmem` can hang the device

The handler allocates a caller-sized buffer with `new uint8_t[datalen]`. On this target `operator new[]` never returns NULL on exhaustion — `get_mem()` prints `** PANIC **` and spins in an infinite loop:

```c
// software/system/memory_wrap.cc:36-40  (memory_rtos.cc:16-20 is identical)
if (!ret) {
    printf("** PANIC **: Error allocating %p..\n", __builtin_return_address(0));
    while(1)
        ;
}
```

So an allocation failure on this path hangs the firmware with no watchdog reset. `POST machine:writemem` was already hardened against exactly this (it uses `malloc` and returns 500); `readmem` was missed. This makes `readmem` match it.

**Behaviour change:** `readmem?length=0` now returns 400 instead of 200 with an empty body. This is required rather than cosmetic — `malloc_allocate` returns NULL for a zero-size request (`memory_wrap.cc:13`), so accepting `length=0` would turn a well-formed request into a spurious 500. A zero-length read has no use, and `PUT writemem` already refuses the same input.

### `GET /v1/machine:measure` leaks 64 KB per call

It allocated the buffer *before* checking whether the FPGA supports bus measurement, then returned 501 without freeing:

```c
uint8_t *buffer = new uint8_t[64*1024];

if (!(getFpgaCapabilities() & CAPAB_BUS_MEASURE)) {
    resp->error("The current FPGA build does not support timing measurement...");
    resp->json_response(HTTP_NOT_IMPLEMENTED);
    return;                     // buffer leaked
}
```

Bus timing measurement is off by default on U2 builds (8155daec), so on those devices that early return is the only path the endpoint ever takes, and every call leaks 64 KB — driving the heap toward the exhaustion the `readmem` change now survives. The capability check moves above the allocation, which removes the leak by construction rather than by adding a `delete`.

### Tests

Adds a `bounds` scenario to `tests/e2e/api/readmem_writemem_test.py`, wired into `--test` and picked up by `run-tests`:

- eight rejection cases that must all return 400 — zero, negative, 65537, 16 MB, a length that overflows a `long`, `$FF00`+65536 straddling `$FFFF`, address `$10000`, negative address
- a max-size read accepted, then eight back-to-back (a dropped `free` on the success path fails a later iteration)
- `machine:measure`: if it returns 501, 25 calls followed by a max-size read that must still succeed; skipped if the FPGA supports measurement, since a real bus measurement is intrusive and the leak was on the 501 path only

The OOM branch itself is not reachable on demand and nothing over REST reports free heap, so what the suite locks is the contract the fix depends on: rejection happens before allocation.

Compiles for both preprocessor paths — `target/u64ii/riscv/ultimate` (`U64=1`) and `target/u2plus_L/riscv/ultimate` (`U64=0`) with riscv GCC 11.3.0, and `target/u64/nios2/ultimate` with the CI-matched `nios2-elf-gcc 5.3.0`.

**Verified on hardware** (Ultimate 64 Elite, wired ethernet). The `bounds` scenario and the full suite were run against a firmware image built from this branch and flashed to the device; see the comment below for the before/after table and suite output.

### Relation to #697

**This does not implement REU access over REST.** #697 asks for REU read/write, and the discussion there settled on a `space=c64|reu` parameter on the existing `readmem`/`writemem` verbs. That extension makes this same allocation path caller-sized against a 16 MB address space, so it seemed worth fixing the allocation behaviour first and building on top of it afterwards.
