### PR TITLE
Drop machine-code monitor and FTP client from U2 (original) build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,14 @@ jobs:
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u64ii_no_esp && mv update.ue2 update_${{ env.GIT_VERSION }}.ue2 && mv update.cfw update_${{ env.GIT_VERSION }}.cfw"
 
+      - name: Report Firmware Application Space
+        if: always()
+        run: |
+          docker run --rm -e GITHUB_ACTIONS -e GITHUB_STEP_SUMMARY \
+          -v /opt/build-tools:/mnt/build-tools:ro \
+          -v $GITHUB_STEP_SUMMARY:$GITHUB_STEP_SUMMARY:rw \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make app_space"
+
       - name: Upload User Artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,14 @@
 name: Build
 
-on:
-  push:
-    branches: [master, test-merge]
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:
+    # A same-repo branch's push already builds via the push event above; only run the
+    # pull_request event when the PR head is a fork, whose pushes never reach this repo
+    # and so would otherwise never build at all. This is what avoids building the same
+    # commit twice, without restricting which branches build on push.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: self-hosted
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u64ii_no_esp && mv update.ue2 update_${{ env.GIT_VERSION }}.ue2 && mv update.cfw update_${{ env.GIT_VERSION }}.cfw"
 
-      - name: Report Firmware Application Space
+      - name: Check Firmware Application Space
         if: always()
         run: |
           docker run --rm -e GITHUB_ACTIONS -e GITHUB_STEP_SUMMARY \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master, test-merge]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,54 +83,54 @@ jobs:
       - if: steps.cache-u2.outputs.cache-hit != 'true'
         name: Build U2 including FPGAs
         run: |
-          docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
+          docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2_rv && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
 
       - if: steps.cache-u2.outputs.cache-hit == 'true'
         name: Build U2 using cached FPGAs
         run: |
-          docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
+          docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2_rv_swonly && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
 
       - if: steps.cache-u2p.outputs.cache-hit != 'true'
         name: Build U2+ including FPGAs
         run: |
-          docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
+          docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2plus && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
 
       - if: steps.cache-u2p.outputs.cache-hit == 'true'
         name: Build U2+ using cached FPGAs
         run: |
-          docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
+          docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2plus_swonly && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
 
       - if: steps.cache-u2pl.outputs.cache-hit != 'true'
         name: Build U2+L including FPGA
         run: |
-          docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
+          docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2pl_no_esp && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
 
       - if: steps.cache-u2pl.outputs.cache-hit == 'true'
         name: Build U2+L using cached FPGAs
         run: |
-          docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
+          docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2pl_swonly && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
 
       - name: Build U64 Software
         run: |
-          docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
+          docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u64_no_esp && mv update.u64 update_${{ env.GIT_VERSION }}.u64"
 
       - name: Build U64-II Software
         run: |
-          docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
+          docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u64ii_no_esp && mv update.ue2 update_${{ env.GIT_VERSION }}.ue2 && mv update.cfw update_${{ env.GIT_VERSION }}.cfw"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 
 all: esp32 u2_rv u2plus u2pl u64 u64ii
 
+APP_SPACE_CHECK = python3 tools/app_space.py
+
+.PHONY: app_space_test
+
+app_space_test:
+	@python3 tools/test_app_space.py
+
 esp32: esp32_raw_u64 esp32_raw_c3 esp32_u64ctrl
 
 esp32_clean: esp32_raw_u64_clean esp32_raw_c3_clean esp32_u64ctrl_clean
@@ -64,21 +71,23 @@ fpga_depends::
 esp_depends::
 	@cd software && python3 esp_depends.py >esp_depends.txt
 
-u2_rv:
+u2_rv: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/u2/riscv/boot1
 	@$(MAKE) -C target/u2/riscv/boot2
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
+	@$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/fpga/rv700dd
 	@$(MAKE) -C target/fpga/rv700au
 	@$(MAKE) -C target/u2/riscv/updater
 	@cp target/u2/riscv/updater/result/update.u2r ./update.u2r
 
-u2_rv_swonly:
+u2_rv_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
+	@$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2/riscv/updater
 	@cp target/u2/riscv/updater/result/update.u2r ./update.u2r
 
@@ -125,7 +134,7 @@ niosboot:
 	@$(MAKE) -C software/nios_solo_bsp
 	@$(MAKE) -C software/nios_appl_bsp
 
-u2plus:
+u2plus: app_space_test
 	@touch software/nios_solo_bsp/Makefile
 	@touch software/nios_solo_bsp/public.mk
 	@touch software/nios_appl_bsp/Makefile
@@ -139,6 +148,7 @@ u2plus:
 	@$(MAKE) -C target/fpga/u2plus_recovery
 	@$(MAKE) -C target/fpga/u2plus_run
 	@$(MAKE) -C target/u2plus/nios/ultimate
+	@$(APP_SPACE_CHECK) u2plus target/u2plus/nios/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus/nios/recovery
 	@$(MAKE) -C target/u2plus/nios/updater
 	@cp target/u2plus/nios/updater/result/update.app ./update.u2p
@@ -212,7 +222,7 @@ mb_clean:
 	@rm -rf `find target/u2/microblaze/mb* -name result`
 	@rm -rf `find target/u2/microblaze/mb* -name output`
 
-u2plus_swonly:
+u2plus_swonly: app_space_test
 	@touch software/nios_solo_bsp/Makefile
 	@touch software/nios_solo_bsp/public.mk
 	@touch software/nios_appl_bsp/Makefile
@@ -222,6 +232,7 @@ u2plus_swonly:
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u2plus/nios/ultimate
+	@$(APP_SPACE_CHECK) u2plus target/u2plus/nios/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus/nios/recovery
 	@$(MAKE) -C target/u2plus/nios/updater
 	@cp target/u2plus/nios/updater/result/update.app ./update.u2p
@@ -251,7 +262,7 @@ nios_bsps:
 	@$(MAKE) -C software/nios_solo_bsp
 	@$(MAKE) -C software/nios_appl_bsp
 
-u64: esp32_raw_u64
+u64: app_space_test esp32_raw_u64
 	@touch software/nios_solo_bsp/Makefile
 	@touch software/nios_solo_bsp/public.mk
 	@touch software/nios_appl_bsp/Makefile
@@ -261,10 +272,11 @@ u64: esp32_raw_u64
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u64/nios2/ultimate
+	@$(APP_SPACE_CHECK) u64 target/u64/nios2/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u64/nios2/updater
 	@cp target/u64/nios2/updater/result/update.app ./update.u64
 
-u64_no_esp::
+u64_no_esp:: app_space_test
 	@touch software/nios_solo_bsp/Makefile
 	@touch software/nios_solo_bsp/public.mk
 	@touch software/nios_appl_bsp/Makefile
@@ -274,6 +286,7 @@ u64_no_esp::
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u64/nios2/ultimate
+	@$(APP_SPACE_CHECK) u64 target/u64/nios2/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u64/nios2/updater
 	@cp target/u64/nios2/updater/result/update.app ./update.u64
 
@@ -281,11 +294,12 @@ u64_clean:
 	@$(MAKE) -C target/u64/nios2/ultimate clean
 	@$(MAKE) -C target/u64/nios2/updater clean
 
-u64ii: esp32_u64ctrl
+u64ii: app_space_test esp32_u64ctrl
 	@mkdir -p u64ii
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u64ii/riscv/ultimate
+	@$(APP_SPACE_CHECK) u64ii target/u64ii/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u64ii/riscv/factorytest
 	@$(MAKE) -C target/u64ii/riscv/update
 	@cp target/u64ii/riscv/ultimate/result/ultimate.app u64ii
@@ -296,11 +310,12 @@ u64ii: esp32_u64ctrl
 	@cp target/u64ii/riscv/update/result/update.app ./update.ue2
 	@cp target/u64ii/riscv/update/result/update.cfw ./update.cfw
 
-u64ii_no_esp::
+u64ii_no_esp:: app_space_test
 	@mkdir -p u64ii
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u64ii/riscv/ultimate
+	@$(APP_SPACE_CHECK) u64ii target/u64ii/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u64ii/riscv/factorytest
 	@$(MAKE) -C target/u64ii/riscv/update
 	@cp target/u64ii/riscv/ultimate/result/ultimate.app u64ii
@@ -311,27 +326,30 @@ u64ii_no_esp::
 	@cp target/u64ii/riscv/update/result/update.app ./update.ue2
 	@cp target/u64ii/riscv/update/result/update.cfw ./update.cfw
 
-u2pl: esp32_raw_c3
+u2pl: app_space_test esp32_raw_c3
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2plus_L/rvlite/bootloader
 	@$(MAKE) -C target/fpga/u2plus_ecp5
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
+	@$(APP_SPACE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l
 
-u2pl_no_esp::
+u2pl_no_esp:: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2plus_L/rvlite/bootloader
 	@$(MAKE) -C target/fpga/u2plus_ecp5
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
+	@$(APP_SPACE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l
 
-u2pl_swonly:
+u2pl_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
+	@$(APP_SPACE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 
+APP_SPACE = python3 tools/app_space.py
+
+.PHONY: all app_space app_space_test
+
 all: esp32 u2_rv u2plus u2pl u64 u64ii
+	@$(APP_SPACE) report
 
-FIRMWARE_SIZE_CHECK = python3 tools/app_space.py
-
-.PHONY: app_space_test
+app_space:
+	@$(APP_SPACE) report
 
 app_space_test:
 	@python3 tools/test_app_space.py
@@ -77,7 +81,7 @@ u2_rv: app_space_test
 	@$(MAKE) -C target/u2/riscv/boot2
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin
+	@$(APP_SPACE) check u2
 	@$(MAKE) -C target/fpga/rv700dd
 	@$(MAKE) -C target/fpga/rv700au
 	@$(MAKE) -C target/u2/riscv/updater
@@ -87,7 +91,7 @@ u2_rv_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin
+	@$(APP_SPACE) check u2
 	@$(MAKE) -C target/u2/riscv/updater
 	@cp target/u2/riscv/updater/result/update.u2r ./update.u2r
 
@@ -148,7 +152,7 @@ u2plus: app_space_test
 	@$(MAKE) -C target/fpga/u2plus_recovery
 	@$(MAKE) -C target/fpga/u2plus_run
 	@$(MAKE) -C target/u2plus/nios/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u2plus target/u2plus/nios/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u2plus
 	@$(MAKE) -C target/u2plus/nios/recovery
 	@$(MAKE) -C target/u2plus/nios/updater
 	@cp target/u2plus/nios/updater/result/update.app ./update.u2p
@@ -232,7 +236,7 @@ u2plus_swonly: app_space_test
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u2plus/nios/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u2plus target/u2plus/nios/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u2plus
 	@$(MAKE) -C target/u2plus/nios/recovery
 	@$(MAKE) -C target/u2plus/nios/updater
 	@cp target/u2plus/nios/updater/result/update.app ./update.u2p
@@ -272,7 +276,7 @@ u64: app_space_test esp32_raw_u64
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u64/nios2/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u64 target/u64/nios2/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u64
 	@$(MAKE) -C target/u64/nios2/updater
 	@cp target/u64/nios2/updater/result/update.app ./update.u64
 
@@ -286,7 +290,7 @@ u64_no_esp:: app_space_test
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u64/nios2/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u64 target/u64/nios2/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u64
 	@$(MAKE) -C target/u64/nios2/updater
 	@cp target/u64/nios2/updater/result/update.app ./update.u64
 
@@ -299,8 +303,8 @@ u64ii: app_space_test esp32_u64ctrl
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u64ii/riscv/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u64e2_50t target/u64ii/riscv/ultimate/result/ultimate.app
-	@$(FIRMWARE_SIZE_CHECK) u64e2_100t target/u64ii/riscv/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u64e2_50t
+	@$(APP_SPACE) check u64e2_100t
 	@$(MAKE) -C target/u64ii/riscv/factorytest
 	@$(MAKE) -C target/u64ii/riscv/update
 	@cp target/u64ii/riscv/ultimate/result/ultimate.app u64ii
@@ -316,8 +320,8 @@ u64ii_no_esp:: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u64ii/riscv/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u64e2_50t target/u64ii/riscv/ultimate/result/ultimate.app
-	@$(FIRMWARE_SIZE_CHECK) u64e2_100t target/u64ii/riscv/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u64e2_50t
+	@$(APP_SPACE) check u64e2_100t
 	@$(MAKE) -C target/u64ii/riscv/factorytest
 	@$(MAKE) -C target/u64ii/riscv/update
 	@cp target/u64ii/riscv/ultimate/result/ultimate.app u64ii
@@ -334,7 +338,7 @@ u2pl: app_space_test esp32_raw_c3
 	@$(MAKE) -C target/u2plus_L/rvlite/bootloader
 	@$(MAKE) -C target/fpga/u2plus_ecp5
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u2pl
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l
 
@@ -344,7 +348,7 @@ u2pl_no_esp:: app_space_test
 	@$(MAKE) -C target/u2plus_L/rvlite/bootloader
 	@$(MAKE) -C target/fpga/u2plus_ecp5
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u2pl
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l
 
@@ -352,6 +356,6 @@ u2pl_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(FIRMWARE_SIZE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
+	@$(APP_SPACE) check u2pl
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 all: esp32 u2_rv u2plus u2pl u64 u64ii
 
-APP_SPACE_CHECK = python3 tools/app_space.py --warning-only
+FIRMWARE_SIZE_CHECK = python3 tools/app_space.py
 
 .PHONY: app_space_test
 
@@ -77,7 +77,7 @@ u2_rv: app_space_test
 	@$(MAKE) -C target/u2/riscv/boot2
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
-	@$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin
+	@$(FIRMWARE_SIZE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin
 	@$(MAKE) -C target/fpga/rv700dd
 	@$(MAKE) -C target/fpga/rv700au
 	@$(MAKE) -C target/u2/riscv/updater
@@ -87,7 +87,7 @@ u2_rv_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
-	@$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin
+	@$(FIRMWARE_SIZE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin
 	@$(MAKE) -C target/u2/riscv/updater
 	@cp target/u2/riscv/updater/result/update.u2r ./update.u2r
 
@@ -148,7 +148,7 @@ u2plus: app_space_test
 	@$(MAKE) -C target/fpga/u2plus_recovery
 	@$(MAKE) -C target/fpga/u2plus_run
 	@$(MAKE) -C target/u2plus/nios/ultimate
-	@$(APP_SPACE_CHECK) u2plus target/u2plus/nios/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u2plus target/u2plus/nios/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus/nios/recovery
 	@$(MAKE) -C target/u2plus/nios/updater
 	@cp target/u2plus/nios/updater/result/update.app ./update.u2p
@@ -232,7 +232,7 @@ u2plus_swonly: app_space_test
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u2plus/nios/ultimate
-	@$(APP_SPACE_CHECK) u2plus target/u2plus/nios/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u2plus target/u2plus/nios/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus/nios/recovery
 	@$(MAKE) -C target/u2plus/nios/updater
 	@cp target/u2plus/nios/updater/result/update.app ./update.u2p
@@ -272,7 +272,7 @@ u64: app_space_test esp32_raw_u64
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u64/nios2/ultimate
-	@$(APP_SPACE_CHECK) u64 target/u64/nios2/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u64 target/u64/nios2/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u64/nios2/updater
 	@cp target/u64/nios2/updater/result/update.app ./update.u64
 
@@ -286,7 +286,7 @@ u64_no_esp:: app_space_test
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u64/nios2/ultimate
-	@$(APP_SPACE_CHECK) u64 target/u64/nios2/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u64 target/u64/nios2/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u64/nios2/updater
 	@cp target/u64/nios2/updater/result/update.app ./update.u64
 
@@ -299,7 +299,8 @@ u64ii: app_space_test esp32_u64ctrl
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u64ii/riscv/ultimate
-	@$(APP_SPACE_CHECK) u64ii target/u64ii/riscv/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u64e2_50t target/u64ii/riscv/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u64e2_100t target/u64ii/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u64ii/riscv/factorytest
 	@$(MAKE) -C target/u64ii/riscv/update
 	@cp target/u64ii/riscv/ultimate/result/ultimate.app u64ii
@@ -315,7 +316,8 @@ u64ii_no_esp:: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u64ii/riscv/ultimate
-	@$(APP_SPACE_CHECK) u64ii target/u64ii/riscv/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u64e2_50t target/u64ii/riscv/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u64e2_100t target/u64ii/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u64ii/riscv/factorytest
 	@$(MAKE) -C target/u64ii/riscv/update
 	@cp target/u64ii/riscv/ultimate/result/ultimate.app u64ii
@@ -332,7 +334,7 @@ u2pl: app_space_test esp32_raw_c3
 	@$(MAKE) -C target/u2plus_L/rvlite/bootloader
 	@$(MAKE) -C target/fpga/u2plus_ecp5
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(APP_SPACE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l
 
@@ -342,7 +344,7 @@ u2pl_no_esp:: app_space_test
 	@$(MAKE) -C target/u2plus_L/rvlite/bootloader
 	@$(MAKE) -C target/fpga/u2plus_ecp5
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(APP_SPACE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l
 
@@ -350,6 +352,6 @@ u2pl_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(APP_SPACE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
+	@$(FIRMWARE_SIZE_CHECK) u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 all: esp32 u2_rv u2plus u2pl u64 u64ii
 
-APP_SPACE_CHECK = python3 tools/app_space.py
+APP_SPACE_CHECK = python3 tools/app_space.py --warning-only
 
 .PHONY: app_space_test
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ u2_rv: app_space_test
 	@$(MAKE) -C target/u2/riscv/boot2
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
-	@$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.app
+	@$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin
 	@$(MAKE) -C target/fpga/rv700dd
 	@$(MAKE) -C target/fpga/rv700au
 	@$(MAKE) -C target/u2/riscv/updater
@@ -87,7 +87,7 @@ u2_rv_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
-	@$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.app
+	@$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin
 	@$(MAKE) -C target/u2/riscv/updater
 	@cp target/u2/riscv/updater/result/update.u2r ./update.u2r
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ u2_rv: app_space_test
 	@$(MAKE) -C target/u2/riscv/boot2
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
-	@$(APP_SPACE) check u2
+	@$(APP_SPACE) measure u2
 	@$(MAKE) -C target/fpga/rv700dd
 	@$(MAKE) -C target/fpga/rv700au
 	@$(MAKE) -C target/u2/riscv/updater
@@ -91,7 +91,7 @@ u2_rv_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2/riscv/ultimate
-	@$(APP_SPACE) check u2
+	@$(APP_SPACE) measure u2
 	@$(MAKE) -C target/u2/riscv/updater
 	@cp target/u2/riscv/updater/result/update.u2r ./update.u2r
 
@@ -152,7 +152,7 @@ u2plus: app_space_test
 	@$(MAKE) -C target/fpga/u2plus_recovery
 	@$(MAKE) -C target/fpga/u2plus_run
 	@$(MAKE) -C target/u2plus/nios/ultimate
-	@$(APP_SPACE) check u2plus
+	@$(APP_SPACE) measure u2plus
 	@$(MAKE) -C target/u2plus/nios/recovery
 	@$(MAKE) -C target/u2plus/nios/updater
 	@cp target/u2plus/nios/updater/result/update.app ./update.u2p
@@ -236,7 +236,7 @@ u2plus_swonly: app_space_test
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u2plus/nios/ultimate
-	@$(APP_SPACE) check u2plus
+	@$(APP_SPACE) measure u2plus
 	@$(MAKE) -C target/u2plus/nios/recovery
 	@$(MAKE) -C target/u2plus/nios/updater
 	@cp target/u2plus/nios/updater/result/update.app ./update.u2p
@@ -276,7 +276,7 @@ u64: app_space_test esp32_raw_u64
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u64/nios2/ultimate
-	@$(APP_SPACE) check u64
+	@$(APP_SPACE) measure u64
 	@$(MAKE) -C target/u64/nios2/updater
 	@cp target/u64/nios2/updater/result/update.app ./update.u64
 
@@ -290,7 +290,7 @@ u64_no_esp:: app_space_test
 	@$(MAKE) -C software/nios_appl_bsp
 	@$(MAKE) -C target/libs/nios2/lwip
 	@$(MAKE) -C target/u64/nios2/ultimate
-	@$(APP_SPACE) check u64
+	@$(APP_SPACE) measure u64
 	@$(MAKE) -C target/u64/nios2/updater
 	@cp target/u64/nios2/updater/result/update.app ./update.u64
 
@@ -303,8 +303,8 @@ u64ii: app_space_test esp32_u64ctrl
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u64ii/riscv/ultimate
-	@$(APP_SPACE) check u64e2_50t
-	@$(APP_SPACE) check u64e2_100t
+	@$(APP_SPACE) measure u64e2_50t
+	@$(APP_SPACE) measure u64e2_100t
 	@$(MAKE) -C target/u64ii/riscv/factorytest
 	@$(MAKE) -C target/u64ii/riscv/update
 	@cp target/u64ii/riscv/ultimate/result/ultimate.app u64ii
@@ -320,8 +320,8 @@ u64ii_no_esp:: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u64ii/riscv/ultimate
-	@$(APP_SPACE) check u64e2_50t
-	@$(APP_SPACE) check u64e2_100t
+	@$(APP_SPACE) measure u64e2_50t
+	@$(APP_SPACE) measure u64e2_100t
 	@$(MAKE) -C target/u64ii/riscv/factorytest
 	@$(MAKE) -C target/u64ii/riscv/update
 	@cp target/u64ii/riscv/ultimate/result/ultimate.app u64ii
@@ -338,7 +338,7 @@ u2pl: app_space_test esp32_raw_c3
 	@$(MAKE) -C target/u2plus_L/rvlite/bootloader
 	@$(MAKE) -C target/fpga/u2plus_ecp5
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(APP_SPACE) check u2pl
+	@$(APP_SPACE) measure u2pl
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l
 
@@ -348,7 +348,7 @@ u2pl_no_esp:: app_space_test
 	@$(MAKE) -C target/u2plus_L/rvlite/bootloader
 	@$(MAKE) -C target/fpga/u2plus_ecp5
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(APP_SPACE) check u2pl
+	@$(APP_SPACE) measure u2pl
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l
 
@@ -356,6 +356,6 @@ u2pl_swonly: app_space_test
 	@$(MAKE) -C tools
 	@$(MAKE) -C target/libs/riscv/lwip
 	@$(MAKE) -C target/u2plus_L/riscv/ultimate
-	@$(APP_SPACE) check u2pl
+	@$(APP_SPACE) measure u2pl
 	@$(MAKE) -C target/u2plus_L/riscv/updater
 	@cp target/u2plus_L/riscv/updater/result/update.app ./update.u2l

--- a/target/u2/riscv/ultimate/Makefile
+++ b/target/u2/riscv/ultimate/Makefile
@@ -89,7 +89,6 @@ SRCS_CC	 =	small_printf.cc \
 			sdcard_manager.cc \
 			size_str.cc \
 			userinterface.cc \
-			run_machine_monitor.cc \
 			ui_elements.cc \
 			form.cc \
 			user_file_interaction.cc \
@@ -100,13 +99,6 @@ SRCS_CC	 =	small_printf.cc \
 			config_menu.cc \
 			context_menu.cc \
 			task_menu.cc \
-			monitor_init.cc \
-			monitor_file_io.cc \
-			monitor_bookmarks.cc \
-			machine_monitor.cc \
-			disassembler_6502.cc \
-			assembler_6502.cc \
-			u2_memory_backend.cc \
 			audio_select.cc \
 			filetype_d64.cc \
 			filetype_g64.cc \
@@ -166,9 +158,7 @@ SRCS_CC	 =	small_printf.cc \
 			http_target.cc \
 			assembly_search.cc \
 			assembly.cc \
-			ftp_client.cc \
 			filesystem_a64.cc \
-			filesystem_ftp.cc \
 			sntp_time.cc \
 			$(PRJ).cc
 

--- a/tools/app_space.py
+++ b/tools/app_space.py
@@ -77,6 +77,16 @@ class ApplicationSpaceReport:
             )
         )
 
+    def warning_message(self):
+        return (
+            "%s is below the application-space warning threshold "
+            "(%d%% is %.1f KiB)." % (
+                TARGET_NAMES[self.target],
+                WARNING_PERCENT,
+                self.warning_bytes / 1024,
+            )
+        )
+
 
 def check_application_space(target, application_bytes):
     return ApplicationSpaceReport(
@@ -96,15 +106,7 @@ def main(argv):
     report = check_application_space(args.target, args.application.stat().st_size)
     print(report.message())
     if report.is_below_warning_threshold:
-        print(
-            "ERROR: %s is below the %d%% application-space warning threshold "
-            "(%.1f KiB remaining)." % (
-                TARGET_NAMES[args.target],
-                WARNING_PERCENT,
-                report.warning_bytes / 1024,
-            ),
-            file=sys.stderr,
-        )
+        print("ERROR: " + report.warning_message(), file=sys.stderr)
         return 1
     return 0
 

--- a/tools/app_space.py
+++ b/tools/app_space.py
@@ -1,49 +1,59 @@
 #!/usr/bin/env python3
 """Report and enforce the application space budget of the final firmware images.
 
-    app_space.py check <variant>   gate one freshly built image (used by the Makefile)
-    app_space.py report            table across every firmware (used by CI and `make all`)
+    app_space.py measure <variant>  print one image's row as it is built (never fails on size)
+    app_space.py report             table across every firmware; the single size gate
+
+Measuring never stops a build, so every firmware in a run gets built and measured even
+when an earlier one is over its limit. `report` runs last and fails the build there.
 """
 
 import argparse
 import os
 import pathlib
+import re
 import sys
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
-# The limits are the FLASH_ID_APPL partition sizes in software/io/flash/*_flash.cc.
-# tools/test_app_space.py checks that these two definitions stay in sync.
+# The limits are not restated here. They are read from the FLASH_ID_APPL entry of the
+# flash partition tables below, which are what the firmware itself uses at runtime.
+# A table that appears in more than one of these files must fit the smallest of them.
+FLASH_TABLE_SOURCES = (
+    "software/io/flash/w25q_flash.cc",
+    "software/io/flash/at45_flash.cc",
+)
+
 FIRMWARE_VARIANTS = {
     "u2": {
         "name": "U2",
-        "limit_bytes": 0xC6000,
+        "partition": "flash_addresses",
         "artifact": "target/u2/riscv/ultimate/result/ultimate.bin",
     },
     "u2plus": {
         "name": "U2+",
-        "limit_bytes": 0x140000,
+        "partition": "flash_addresses_u2p",
         "artifact": "target/u2plus/nios/ultimate/result/ultimate.app",
     },
     "u2pl": {
         "name": "U2+L",
-        "limit_bytes": 0x160000,
+        "partition": "flash_addresses_u2pl",
         "artifact": "target/u2plus_L/riscv/ultimate/result/ultimate.app",
     },
     "u64": {
         "name": "U64",
-        "limit_bytes": 0x170000,
+        "partition": "flash_addresses_u64",
         "artifact": "target/u64/nios2/ultimate/result/ultimate.app",
     },
     "u64e2_50t": {
         "name": "U64E2_50T",
-        "limit_bytes": 0x1E0000,
+        "partition": "flash_addresses_u64ii_50t",
         "artifact": "target/u64ii/riscv/ultimate/result/ultimate.app",
     },
     "u64e2_100t": {
         "name": "U64E2_100T",
-        "limit_bytes": 0x1C0000,
+        "partition": "flash_addresses_u64ii_100t",
         "artifact": "target/u64ii/riscv/ultimate/result/ultimate.app",
     },
 }
@@ -76,6 +86,59 @@ ROW_WIDTH = sum(width for _, width, _ in COLUMNS) + len(GAP) * (len(COLUMNS) - 1
 ANSI_RESET = "\033[0m"
 ANSI_BOLD = "\033[1m"
 ANSI_COLORS = {PASS: "\033[32m", WARNING: "\033[33m", FAIL: "\033[31m", MISSING: "\033[90m"}
+
+
+class LimitError(Exception):
+    """The application space limits could not be read from the flash partition tables."""
+
+
+def read_partition_limits(source):
+    """Map each t_flash_address table in one C++ source to its FLASH_ID_APPL size."""
+    limits = {}
+    for table, body in re.findall(
+        r"t_flash_address\s+(\w+)\[\]\s*=\s*\{(.*?)\};", source, re.DOTALL
+    ):
+        entry = re.search(r"FLASH_ID_APPL\s*,([^\n]*)", body)
+        if entry:
+            fields = re.findall(r"0x[0-9A-Fa-f]+", entry.group(1))
+            if fields:
+                limits[table] = int(fields[-1], 16)  # size is the last field
+    return limits
+
+
+def load_limits(root=None):
+    """Read every variant's limit out of the flash partition tables."""
+    root = REPO_ROOT if root is None else root
+    partitions = {}
+    for name in FLASH_TABLE_SOURCES:
+        path = root / name
+        try:
+            source = path.read_text()
+        except OSError as error:
+            raise LimitError("cannot read the flash partition table %s: %s" % (path, error))
+        for table, size in read_partition_limits(source).items():
+            # One table can describe several flash devices; the app must fit the smallest.
+            partitions[table] = min(size, partitions.get(table, size))
+
+    limits = {}
+    for variant, details in FIRMWARE_VARIANTS.items():
+        if details["partition"] not in partitions:
+            raise LimitError(
+                "no FLASH_ID_APPL entry for %s (table %s) in %s"
+                % (details["name"], details["partition"], ", ".join(FLASH_TABLE_SOURCES))
+            )
+        limits[variant] = partitions[details["partition"]]
+    return limits
+
+
+_LIMITS = None
+
+
+def firmware_limits():
+    global _LIMITS
+    if _LIMITS is None:
+        _LIMITS = load_limits()
+    return _LIMITS
 
 
 def label(status):
@@ -146,10 +209,9 @@ class FirmwareSizeReport:
 
 
 def read_report(variant):
-    details = FIRMWARE_VARIANTS[variant]
-    artifact = REPO_ROOT / details["artifact"]
+    artifact = REPO_ROOT / FIRMWARE_VARIANTS[variant]["artifact"]
     actual_bytes = artifact.stat().st_size if artifact.is_file() else None
-    return FirmwareSizeReport(variant, actual_bytes, details["limit_bytes"])
+    return FirmwareSizeReport(variant, actual_bytes, firmware_limits()[variant])
 
 
 def _supports_unicode(stream):
@@ -284,8 +346,13 @@ def announce(level, message):
         print("::%s::%s" % (level, message))
 
 
-def run_check(variant):
-    """Gate a single freshly built image. Prints one row; annotations come from `report`."""
+def run_measure(variant):
+    """Print one freshly built image's row.
+
+    Deliberately does not fail on size: the build continues so that every remaining
+    firmware is still built and measured. `report` is the gate. A missing artifact is
+    a build fault rather than a size fault, so that alone stops the build here.
+    """
     report = read_report(variant)
     if report.status == MISSING:
         print("ERROR: " + report.missing_message(), file=sys.stderr)
@@ -296,14 +363,18 @@ def run_check(variant):
     print(renderer.row(report))
     sys.stdout.flush()  # keep the row ahead of the diagnostics on stderr
     if report.status == FAIL:
-        print("ERROR: " + report.failure_message(), file=sys.stderr)
+        print(
+            "OVER LIMIT: %s The build fails at the final application space report."
+            % report.failure_message(),
+            file=sys.stderr,
+        )
     elif report.status == WARNING:
         print("WARNING: " + report.warning_message(), file=sys.stderr)
-    return report.exit_status
+    return 0
 
 
 def run_report():
-    """Central signal: one table over every firmware, plus CI annotations and job summary."""
+    """The size gate: one table over every firmware, plus CI annotations and job summary."""
     reports = [read_report(variant) for variant in FIRMWARE_VARIANTS]
     print(Renderer().table(reports))
     sys.stdout.flush()  # keep the table ahead of the diagnostics on stderr
@@ -323,14 +394,18 @@ def main(argv):
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     commands = parser.add_subparsers(dest="command", required=True)
-    check = commands.add_parser("check", help="gate one freshly built firmware image")
-    check.add_argument("variant", choices=sorted(FIRMWARE_VARIANTS))
-    commands.add_parser("report", help="tabulate the application space of every firmware")
+    measure = commands.add_parser("measure", help="print one freshly built image's row")
+    measure.add_argument("variant", choices=sorted(FIRMWARE_VARIANTS))
+    commands.add_parser("report", help="tabulate every firmware and gate the build on size")
     args = parser.parse_args(argv)
 
-    if args.command == "check":
-        return run_check(args.variant)
-    return run_report()
+    try:
+        if args.command == "measure":
+            return run_measure(args.variant)
+        return run_report()
+    except LimitError as error:
+        print("ERROR: " + str(error), file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/tools/app_space.py
+++ b/tools/app_space.py
@@ -1,121 +1,109 @@
 #!/usr/bin/env python3
-"""Report firmware application-partition headroom during builds."""
+"""Validate final firmware images against their application-size limits."""
 
 import argparse
+import os
 import pathlib
-import re
 import sys
 
 
-FLASH_LAYOUT = pathlib.Path(__file__).parents[1] / "software/io/flash/w25q_flash.cc"
-TARGET_TABLES = {
-    "u2": ("flash_addresses",),
-    "u2plus": ("flash_addresses_u2p",),
-    "u2pl": ("flash_addresses_u2pl",),
-    "u64": ("flash_addresses_u64",),
-    "u64ii": ("flash_addresses_u64ii_50t", "flash_addresses_u64ii_100t"),
+FIRMWARE_VARIANTS = {
+    "u2": {"name": "U2", "limit_bytes": 0xC6000},
+    "u2plus": {"name": "U2+", "limit_bytes": 0x140000},
+    "u2pl": {"name": "U2+L", "limit_bytes": 0x160000},
+    "u64": {"name": "U64", "limit_bytes": 0x170000},
+    "u64e2_50t": {"name": "U64E2_50T", "limit_bytes": 0x1E0000},
+    "u64e2_100t": {"name": "U64E2_100T", "limit_bytes": 0x1C0000},
 }
-TARGET_NAMES = {
-    "u2": "U2",
-    "u2plus": "U2+",
-    "u2pl": "U2+L",
-    "u64": "U64",
-    "u64ii": "U64-II",
-}
-WARNING_PERCENT = 5
 
 
-def table_application_limit(source, table_name):
-    table = re.search(
-        r"static const t_flash_address " + re.escape(table_name) +
-        r"\[\] = \{(.*?)\};",
-        source,
-        re.DOTALL,
-    )
-    if table is None:
-        raise ValueError("could not find flash layout table " + table_name)
-
-    application = re.search(
-        r"\{\s*FLASH_ID_APPL\s*,\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*"
-        r"(0x[0-9A-Fa-f]+|[0-9]+)\s*\}",
-        table.group(1),
-    )
-    if application is None:
-        raise ValueError("could not find application partition in " + table_name)
-    return int(application.group(1), 0)
-
-
-def application_limit_bytes(target):
+def firmware_limit_bytes(variant):
     try:
-        table_names = TARGET_TABLES[target]
+        return FIRMWARE_VARIANTS[variant]["limit_bytes"]
     except KeyError as error:
-        raise ValueError("unknown target " + target) from error
-
-    source = FLASH_LAYOUT.read_text()
-    return min(table_application_limit(source, name) for name in table_names)
+        raise ValueError("unknown firmware variant " + variant) from error
 
 
-class ApplicationSpaceReport:
-    def __init__(self, target, application_bytes, limit_bytes):
-        self.target = target
-        self.application_bytes = application_bytes
+class FirmwareSizeReport:
+    def __init__(self, variant, actual_bytes, limit_bytes):
+        self.variant = variant
+        self.actual_bytes = actual_bytes
         self.limit_bytes = limit_bytes
-        self.remaining_bytes = limit_bytes - application_bytes
-        self.warning_bytes = limit_bytes * WARNING_PERCENT // 100
+        self.remaining_bytes = limit_bytes - actual_bytes
 
     @property
-    def is_below_warning_threshold(self):
-        return self.remaining_bytes < self.warning_bytes
+    def status(self):
+        if self.remaining_bytes < 0:
+            return "FAIL"
+        if self.remaining_bytes * 100 < self.limit_bytes:
+            return "WARNING"
+        return "PASS"
+
+    @property
+    def exit_status(self):
+        return 1 if self.status == "FAIL" else 0
+
+    def percentage(self):
+        basis_points = abs(self.remaining_bytes) * 10000 // self.limit_bytes
+        whole, fraction = divmod(basis_points, 100)
+        sign = "-" if self.remaining_bytes < 0 else ""
+        return "%s%d.%02d%%" % (sign, whole, fraction)
 
     def message(self):
         return (
-            "%s application: %.1f KiB remaining of %.1f KiB (%.1f%% free)" % (
-                TARGET_NAMES[self.target],
-                self.remaining_bytes / 1024,
-                self.limit_bytes / 1024,
-                self.remaining_bytes * 100 / self.limit_bytes,
+            "variant=%s, actual=0x%X (%d bytes), limit=0x%X (%d bytes), "
+            "remaining=%d bytes, percentage=%s, status=%s" % (
+                FIRMWARE_VARIANTS[self.variant]["name"],
+                self.actual_bytes,
+                self.actual_bytes,
+                self.limit_bytes,
+                self.limit_bytes,
+                self.remaining_bytes,
+                self.percentage(),
+                self.status,
             )
         )
 
     def warning_message(self):
         return (
-            "%s is below the application-space warning threshold "
-            "(%d%% is %.1f KiB)." % (
-                TARGET_NAMES[self.target],
-                WARNING_PERCENT,
-                self.warning_bytes / 1024,
+            "%s has less than 1%% of its firmware limit remaining." % (
+                FIRMWARE_VARIANTS[self.variant]["name"],
             )
         )
 
 
-def check_application_space(target, application_bytes):
-    return ApplicationSpaceReport(
-        target, application_bytes, application_limit_bytes(target)
+def check_firmware_size(variant, actual_bytes):
+    return FirmwareSizeReport(
+        variant, actual_bytes, firmware_limit_bytes(variant)
     )
 
 
 def main(argv):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--warning-only",
-        action="store_true",
-        help="report threshold breaches without failing the build",
-    )
-    parser.add_argument("target", choices=sorted(TARGET_TABLES))
-    parser.add_argument("application", type=pathlib.Path)
+    parser.add_argument("variant", choices=sorted(FIRMWARE_VARIANTS))
+    parser.add_argument("artifact", type=pathlib.Path)
     args = parser.parse_args(argv)
 
-    if not args.application.is_file():
-        parser.error("application image not found: " + str(args.application))
+    if not args.artifact.is_file():
+        print(
+            "ERROR: expected firmware artifact for %s was not produced: %s" % (
+                FIRMWARE_VARIANTS[args.variant]["name"],
+                args.artifact,
+            ),
+            file=sys.stderr,
+        )
+        return 2
 
-    report = check_application_space(args.target, args.application.stat().st_size)
+    report = check_firmware_size(args.variant, args.artifact.stat().st_size)
     print(report.message())
-    if report.is_below_warning_threshold:
-        prefix = "WARNING" if args.warning_only else "ERROR"
-        print(prefix + ": " + report.warning_message(), file=sys.stderr)
-        if not args.warning_only:
-            return 1
-    return 0
+    if report.status == "WARNING":
+        warning = report.warning_message()
+        print("WARNING: " + warning, file=sys.stderr)
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            print("::warning::" + warning)
+    elif report.status == "FAIL":
+        print("ERROR: firmware exceeds its limit.", file=sys.stderr)
+    return report.exit_status
 
 
 if __name__ == "__main__":

--- a/tools/app_space.py
+++ b/tools/app_space.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Report firmware application-partition headroom during builds."""
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+FLASH_LAYOUT = pathlib.Path(__file__).parents[1] / "software/io/flash/w25q_flash.cc"
+TARGET_TABLES = {
+    "u2": ("flash_addresses",),
+    "u2plus": ("flash_addresses_u2p",),
+    "u2pl": ("flash_addresses_u2pl",),
+    "u64": ("flash_addresses_u64",),
+    "u64ii": ("flash_addresses_u64ii_50t", "flash_addresses_u64ii_100t"),
+}
+TARGET_NAMES = {
+    "u2": "U2",
+    "u2plus": "U2+",
+    "u2pl": "U2+L",
+    "u64": "U64",
+    "u64ii": "U64-II",
+}
+WARNING_PERCENT = 5
+
+
+def table_application_limit(source, table_name):
+    table = re.search(
+        r"static const t_flash_address " + re.escape(table_name) +
+        r"\[\] = \{(.*?)\};",
+        source,
+        re.DOTALL,
+    )
+    if table is None:
+        raise ValueError("could not find flash layout table " + table_name)
+
+    application = re.search(
+        r"\{\s*FLASH_ID_APPL\s*,\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*"
+        r"(0x[0-9A-Fa-f]+|[0-9]+)\s*\}",
+        table.group(1),
+    )
+    if application is None:
+        raise ValueError("could not find application partition in " + table_name)
+    return int(application.group(1), 0)
+
+
+def application_limit_bytes(target):
+    try:
+        table_names = TARGET_TABLES[target]
+    except KeyError as error:
+        raise ValueError("unknown target " + target) from error
+
+    source = FLASH_LAYOUT.read_text()
+    return min(table_application_limit(source, name) for name in table_names)
+
+
+class ApplicationSpaceReport:
+    def __init__(self, target, application_bytes, limit_bytes):
+        self.target = target
+        self.application_bytes = application_bytes
+        self.limit_bytes = limit_bytes
+        self.remaining_bytes = limit_bytes - application_bytes
+        self.warning_bytes = limit_bytes * WARNING_PERCENT // 100
+
+    @property
+    def is_below_warning_threshold(self):
+        return self.remaining_bytes < self.warning_bytes
+
+    def message(self):
+        return (
+            "%s application: %.1f KiB remaining of %.1f KiB (%.1f%% free)" % (
+                TARGET_NAMES[self.target],
+                self.remaining_bytes / 1024,
+                self.limit_bytes / 1024,
+                self.remaining_bytes * 100 / self.limit_bytes,
+            )
+        )
+
+
+def check_application_space(target, application_bytes):
+    return ApplicationSpaceReport(
+        target, application_bytes, application_limit_bytes(target)
+    )
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target", choices=sorted(TARGET_TABLES))
+    parser.add_argument("application", type=pathlib.Path)
+    args = parser.parse_args(argv)
+
+    if not args.application.is_file():
+        parser.error("application image not found: " + str(args.application))
+
+    report = check_application_space(args.target, args.application.stat().st_size)
+    print(report.message())
+    if report.is_below_warning_threshold:
+        print(
+            "ERROR: %s is below the %d%% application-space warning threshold "
+            "(%.1f KiB remaining)." % (
+                TARGET_NAMES[args.target],
+                WARNING_PERCENT,
+                report.warning_bytes / 1024,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/app_space.py
+++ b/tools/app_space.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Validate final firmware images against their application-size limits."""
+"""Report and enforce the application space budget of the final firmware images.
+
+    app_space.py check <variant>   gate one freshly built image (used by the Makefile)
+    app_space.py report            table across every firmware (used by CI and `make all`)
+"""
 
 import argparse
 import os
@@ -7,103 +11,326 @@ import pathlib
 import sys
 
 
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# The limits are the FLASH_ID_APPL partition sizes in software/io/flash/*_flash.cc.
+# tools/test_app_space.py checks that these two definitions stay in sync.
 FIRMWARE_VARIANTS = {
-    "u2": {"name": "U2", "limit_bytes": 0xC6000},
-    "u2plus": {"name": "U2+", "limit_bytes": 0x140000},
-    "u2pl": {"name": "U2+L", "limit_bytes": 0x160000},
-    "u64": {"name": "U64", "limit_bytes": 0x170000},
-    "u64e2_50t": {"name": "U64E2_50T", "limit_bytes": 0x1E0000},
-    "u64e2_100t": {"name": "U64E2_100T", "limit_bytes": 0x1C0000},
+    "u2": {
+        "name": "U2",
+        "limit_bytes": 0xC6000,
+        "artifact": "target/u2/riscv/ultimate/result/ultimate.bin",
+    },
+    "u2plus": {
+        "name": "U2+",
+        "limit_bytes": 0x140000,
+        "artifact": "target/u2plus/nios/ultimate/result/ultimate.app",
+    },
+    "u2pl": {
+        "name": "U2+L",
+        "limit_bytes": 0x160000,
+        "artifact": "target/u2plus_L/riscv/ultimate/result/ultimate.app",
+    },
+    "u64": {
+        "name": "U64",
+        "limit_bytes": 0x170000,
+        "artifact": "target/u64/nios2/ultimate/result/ultimate.app",
+    },
+    "u64e2_50t": {
+        "name": "U64E2_50T",
+        "limit_bytes": 0x1E0000,
+        "artifact": "target/u64ii/riscv/ultimate/result/ultimate.app",
+    },
+    "u64e2_100t": {
+        "name": "U64E2_100T",
+        "limit_bytes": 0x1C0000,
+        "artifact": "target/u64ii/riscv/ultimate/result/ultimate.app",
+    },
 }
 
+WARNING_THRESHOLD_PERCENT = 1
 
-def firmware_limit_bytes(variant):
-    try:
-        return FIRMWARE_VARIANTS[variant]["limit_bytes"]
-    except KeyError as error:
-        raise ValueError("unknown firmware variant " + variant) from error
+PASS = "PASS"
+WARNING = "WARNING"
+FAIL = "FAIL"
+MISSING = "MISSING"
+
+STATUS_LABELS = {MISSING: "n/a"}
+MARKDOWN_ICONS = {PASS: "✅", WARNING: "⚠️", FAIL: "❌", MISSING: "⬜"}
+
+TITLE = "Firmware application space (limit = FLASH_ID_APPL partition size)"
+BAR_WIDTH = 20
+INDENT = "  "
+GAP = "  "
+COLUMNS = (
+    ("Firmware", 11, "<"),
+    ("Limit", 11, ">"),
+    ("Size", 11, ">"),
+    ("Free", 11, ">"),
+    ("Free %", 8, ">"),
+    ("Usage", BAR_WIDTH, "<"),
+    ("Status", 7, "<"),
+)
+ROW_WIDTH = sum(width for _, width, _ in COLUMNS) + len(GAP) * (len(COLUMNS) - 1)
+
+ANSI_RESET = "\033[0m"
+ANSI_BOLD = "\033[1m"
+ANSI_COLORS = {PASS: "\033[32m", WARNING: "\033[33m", FAIL: "\033[31m", MISSING: "\033[90m"}
+
+
+def label(status):
+    return STATUS_LABELS.get(status, status)
+
+
+def format_kib(size_bytes):
+    return "%.1f KiB" % (size_bytes / 1024.0)
 
 
 class FirmwareSizeReport:
+    """Application space accounting for a single firmware image."""
+
     def __init__(self, variant, actual_bytes, limit_bytes):
         self.variant = variant
         self.actual_bytes = actual_bytes
         self.limit_bytes = limit_bytes
-        self.remaining_bytes = limit_bytes - actual_bytes
+        self.remaining_bytes = (
+            None if actual_bytes is None else limit_bytes - actual_bytes
+        )
+
+    @property
+    def name(self):
+        return FIRMWARE_VARIANTS[self.variant]["name"]
+
+    @property
+    def artifact(self):
+        return REPO_ROOT / FIRMWARE_VARIANTS[self.variant]["artifact"]
 
     @property
     def status(self):
+        if self.actual_bytes is None:
+            return MISSING
         if self.remaining_bytes < 0:
-            return "FAIL"
-        if self.remaining_bytes * 100 < self.limit_bytes:
-            return "WARNING"
-        return "PASS"
+            return FAIL
+        if self.remaining_bytes * 100 < self.limit_bytes * WARNING_THRESHOLD_PERCENT:
+            return WARNING
+        return PASS
 
     @property
     def exit_status(self):
-        return 1 if self.status == "FAIL" else 0
+        return 1 if self.status == FAIL else 0
 
-    def percentage(self):
-        basis_points = abs(self.remaining_bytes) * 10000 // self.limit_bytes
-        whole, fraction = divmod(basis_points, 100)
-        sign = "-" if self.remaining_bytes < 0 else ""
-        return "%s%d.%02d%%" % (sign, whole, fraction)
+    def free_percent(self):
+        return 100.0 * self.remaining_bytes / self.limit_bytes
 
-    def message(self):
-        return (
-            "variant=%s, actual=0x%X (%d bytes), limit=0x%X (%d bytes), "
-            "remaining=%d bytes, percentage=%s, status=%s" % (
-                FIRMWARE_VARIANTS[self.variant]["name"],
-                self.actual_bytes,
-                self.actual_bytes,
-                self.limit_bytes,
-                self.limit_bytes,
-                self.remaining_bytes,
-                self.percentage(),
-                self.status,
-            )
+    def failure_message(self):
+        return "%s is %d bytes over its application space limit (%d of %d bytes)." % (
+            self.name,
+            -self.remaining_bytes,
+            self.actual_bytes,
+            self.limit_bytes,
         )
 
     def warning_message(self):
-        return (
-            "%s has less than 1%% of its firmware limit remaining." % (
-                FIRMWARE_VARIANTS[self.variant]["name"],
-            )
+        return "%s has %d bytes (%.2f%%) of application space left, under the %d%% warning threshold." % (
+            self.name,
+            self.remaining_bytes,
+            self.free_percent(),
+            WARNING_THRESHOLD_PERCENT,
+        )
+
+    def missing_message(self):
+        return "expected firmware artifact for %s was not produced: %s" % (
+            self.name,
+            self.artifact,
         )
 
 
-def check_firmware_size(variant, actual_bytes):
-    return FirmwareSizeReport(
-        variant, actual_bytes, firmware_limit_bytes(variant)
-    )
+def read_report(variant):
+    details = FIRMWARE_VARIANTS[variant]
+    artifact = REPO_ROOT / details["artifact"]
+    actual_bytes = artifact.stat().st_size if artifact.is_file() else None
+    return FirmwareSizeReport(variant, actual_bytes, details["limit_bytes"])
+
+
+def _supports_unicode(stream):
+    try:
+        "─█░".encode(getattr(stream, "encoding", None) or "ascii")
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
+
+
+def _supports_color(stream):
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("FORCE_COLOR"):
+        return True
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+class Renderer:
+    """Renders reports as aligned, optionally coloured terminal rows."""
+
+    def __init__(self, stream=None):
+        stream = sys.stdout if stream is None else stream
+        self.unicode = _supports_unicode(stream)
+        self.color = _supports_color(stream)
+
+    def _pad(self, text, width, align):
+        return text.ljust(width) if align == "<" else text.rjust(width)
+
+    def _paint(self, text, status, bold=False):
+        if not self.color:
+            return text
+        return "%s%s%s%s" % (
+            ANSI_BOLD if bold else "",
+            ANSI_COLORS[status],
+            text,
+            ANSI_RESET,
+        )
+
+    def _bar(self, report):
+        if report.status == MISSING:
+            return "not built".ljust(BAR_WIDTH)
+        used = report.actual_bytes / float(report.limit_bytes)
+        filled = BAR_WIDTH if used >= 1.0 else int(used * BAR_WIDTH)
+        if filled == 0 and report.actual_bytes:
+            filled = 1
+        full, empty = ("█", "░") if self.unicode else ("#", ".")
+        return full * filled + empty * (BAR_WIDTH - filled)
+
+    def header(self):
+        cells = [self._pad(name, width, align) for name, width, align in COLUMNS]
+        return INDENT + GAP.join(cells)
+
+    def rule(self):
+        return INDENT + ("─" if self.unicode else "-") * ROW_WIDTH
+
+    def row(self, report):
+        if report.status == MISSING:
+            size = free = percent = "-"
+        else:
+            size = format_kib(report.actual_bytes)
+            free = format_kib(report.remaining_bytes)
+            percent = "%.1f %%" % report.free_percent()
+        values = (report.name, format_kib(report.limit_bytes), size, free, percent)
+        cells = [
+            self._pad(value, width, align)
+            for value, (_, width, align) in zip(values, COLUMNS)
+        ]
+        cells.append(self._paint(self._bar(report), report.status))
+        status = label(report.status).ljust(COLUMNS[-1][1])
+        cells.append(self._paint(status, report.status, bold=True))
+        return INDENT + GAP.join(cells)
+
+    def totals(self, reports):
+        parts = []
+        for status in (FAIL, WARNING, PASS, MISSING):
+            count = sum(1 for report in reports if report.status == status)
+            if count:
+                parts.append(self._paint("%s %d" % (label(status), count), status, bold=True))
+        return INDENT + GAP.join(parts)
+
+    def table(self, reports):
+        lines = [TITLE, "", self.header(), self.rule()]
+        lines.extend(self.row(report) for report in reports)
+        lines.extend([self.rule(), self.totals(reports)])
+        return "\n".join(lines)
+
+
+def markdown_table(reports):
+    lines = [
+        "### " + TITLE,
+        "",
+        "| Firmware | Limit | Size | Free | Free % | Status |",
+        "| --- | ---: | ---: | ---: | ---: | :--- |",
+    ]
+    for report in reports:
+        if report.status == MISSING:
+            size, free, percent = "-", "-", "-"
+        else:
+            size = format_kib(report.actual_bytes)
+            free = format_kib(report.remaining_bytes)
+            percent = "%.1f %%" % report.free_percent()
+        lines.append(
+            "| %s | %s | %s | %s | %s | %s %s |"
+            % (
+                report.name,
+                format_kib(report.limit_bytes),
+                size,
+                free,
+                percent,
+                MARKDOWN_ICONS[report.status],
+                label(report.status),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_job_summary(text):
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    try:
+        with open(path, "a", encoding="utf-8") as summary:
+            summary.write(text)
+    except OSError as error:
+        print("WARNING: could not write the CI job summary: %s" % error, file=sys.stderr)
+
+
+def announce(level, message):
+    print(("ERROR: " if level == "error" else "WARNING: ") + message, file=sys.stderr)
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print("::%s::%s" % (level, message))
+
+
+def run_check(variant):
+    """Gate a single freshly built image. Prints one row; annotations come from `report`."""
+    report = read_report(variant)
+    if report.status == MISSING:
+        print("ERROR: " + report.missing_message(), file=sys.stderr)
+        return 2
+
+    renderer = Renderer()
+    print(renderer.header())
+    print(renderer.row(report))
+    sys.stdout.flush()  # keep the row ahead of the diagnostics on stderr
+    if report.status == FAIL:
+        print("ERROR: " + report.failure_message(), file=sys.stderr)
+    elif report.status == WARNING:
+        print("WARNING: " + report.warning_message(), file=sys.stderr)
+    return report.exit_status
+
+
+def run_report():
+    """Central signal: one table over every firmware, plus CI annotations and job summary."""
+    reports = [read_report(variant) for variant in FIRMWARE_VARIANTS]
+    print(Renderer().table(reports))
+    sys.stdout.flush()  # keep the table ahead of the diagnostics on stderr
+    write_job_summary(markdown_table(reports))
+
+    for report in reports:
+        if report.status == FAIL:
+            announce("error", report.failure_message())
+    for report in reports:
+        if report.status == WARNING:
+            announce("warning", report.warning_message())
+    return max(report.exit_status for report in reports)
 
 
 def main(argv):
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("variant", choices=sorted(FIRMWARE_VARIANTS))
-    parser.add_argument("artifact", type=pathlib.Path)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    check = commands.add_parser("check", help="gate one freshly built firmware image")
+    check.add_argument("variant", choices=sorted(FIRMWARE_VARIANTS))
+    commands.add_parser("report", help="tabulate the application space of every firmware")
     args = parser.parse_args(argv)
 
-    if not args.artifact.is_file():
-        print(
-            "ERROR: expected firmware artifact for %s was not produced: %s" % (
-                FIRMWARE_VARIANTS[args.variant]["name"],
-                args.artifact,
-            ),
-            file=sys.stderr,
-        )
-        return 2
-
-    report = check_firmware_size(args.variant, args.artifact.stat().st_size)
-    print(report.message())
-    if report.status == "WARNING":
-        warning = report.warning_message()
-        print("WARNING: " + warning, file=sys.stderr)
-        if os.environ.get("GITHUB_ACTIONS") == "true":
-            print("::warning::" + warning)
-    elif report.status == "FAIL":
-        print("ERROR: firmware exceeds its limit.", file=sys.stderr)
-    return report.exit_status
+    if args.command == "check":
+        return run_check(args.variant)
+    return run_report()
 
 
 if __name__ == "__main__":

--- a/tools/app_space.py
+++ b/tools/app_space.py
@@ -96,6 +96,11 @@ def check_application_space(target, application_bytes):
 
 def main(argv):
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--warning-only",
+        action="store_true",
+        help="report threshold breaches without failing the build",
+    )
     parser.add_argument("target", choices=sorted(TARGET_TABLES))
     parser.add_argument("application", type=pathlib.Path)
     args = parser.parse_args(argv)
@@ -106,8 +111,10 @@ def main(argv):
     report = check_application_space(args.target, args.application.stat().st_size)
     print(report.message())
     if report.is_below_warning_threshold:
-        print("ERROR: " + report.warning_message(), file=sys.stderr)
-        return 1
+        prefix = "WARNING" if args.warning_only else "ERROR"
+        print(prefix + ": " + report.warning_message(), file=sys.stderr)
+        if not args.warning_only:
+            return 1
     return 0
 
 

--- a/tools/test_app_space.py
+++ b/tools/test_app_space.py
@@ -51,6 +51,11 @@ class AppSpaceTest(unittest.TestCase):
             .is_below_warning_threshold
         )
 
+    def test_warning_identifies_the_threshold_as_such(self):
+        report = app_space.check_application_space("u2", 0xC6000)
+
+        self.assertIn("5% is 39.6 KiB", report.warning_message())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_app_space.py
+++ b/tools/test_app_space.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Regression tests for the firmware application-space build guard."""
+"""Regression tests for the final-firmware size build guard."""
 
+import contextlib
+import io
 import pathlib
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 
@@ -11,55 +15,106 @@ import app_space
 
 
 class AppSpaceTest(unittest.TestCase):
-    def test_uses_application_partition_limits(self):
-        self.assertEqual(app_space.application_limit_bytes("u2"), 0xC6000)
-        self.assertEqual(app_space.application_limit_bytes("u2plus"), 0x140000)
-        self.assertEqual(app_space.application_limit_bytes("u2pl"), 0x160000)
-        self.assertEqual(app_space.application_limit_bytes("u64"), 0x170000)
-        self.assertEqual(app_space.application_limit_bytes("u64ii"), 0x1C0000)
+    def test_uses_supplied_firmware_limits(self):
+        self.assertEqual(
+            {
+                variant: details["limit_bytes"]
+                for variant, details in app_space.FIRMWARE_VARIANTS.items()
+            },
+            {
+                "u2": 0xC6000,
+                "u2plus": 0x140000,
+                "u2pl": 0x160000,
+                "u64": 0x170000,
+                "u64e2_50t": 0x1E0000,
+                "u64e2_100t": 0x1C0000,
+            },
+        )
 
-    def test_u2_guard_checks_the_flashed_binary(self):
+    def test_build_checks_all_final_firmware_artifacts(self):
         makefile = pathlib.Path(__file__).parents[1] / "Makefile"
         source = makefile.read_text()
 
-        self.assertIn(
-            "$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin",
-            source,
-        )
-        self.assertNotIn(
-            "$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.app",
-            source,
-        )
+        for check in (
+            "u2 target/u2/riscv/ultimate/result/ultimate.bin",
+            "u2plus target/u2plus/nios/ultimate/result/ultimate.app",
+            "u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app",
+            "u64 target/u64/nios2/ultimate/result/ultimate.app",
+            "u64e2_50t target/u64ii/riscv/ultimate/result/ultimate.app",
+            "u64e2_100t target/u64ii/riscv/ultimate/result/ultimate.app",
+        ):
+            self.assertIn("$(FIRMWARE_SIZE_CHECK) " + check, source)
 
-    def test_build_checks_are_warning_only_until_limits_are_confirmed(self):
-        makefile = pathlib.Path(__file__).parents[1] / "Makefile"
+    def test_github_actions_forwards_warning_context_to_builds(self):
+        workflow = pathlib.Path(__file__).parents[1] / ".github/workflows/build.yml"
 
-        self.assertIn("APP_SPACE_CHECK = python3 tools/app_space.py --warning-only", makefile.read_text())
+        self.assertIn("docker run --rm -e GITHUB_ACTIONS", workflow.read_text())
 
-    def test_reports_remaining_space_in_kib(self):
-        report = app_space.check_application_space("u64", 0x170000 - 100 * 1024)
+    def test_comfortably_below_limit_passes(self):
+        report = app_space.FirmwareSizeReport("u2", 100, 1000)
 
-        self.assertEqual(report.remaining_bytes, 100 * 1024)
-        self.assertIn("100.0 KiB remaining", report.message())
-        self.assertFalse(report.is_below_warning_threshold)
+        self.assertEqual(report.remaining_bytes, 900)
+        self.assertEqual(report.status, "PASS")
+        self.assertEqual(report.exit_status, 0)
+        self.assertIn("variant=U2", report.message())
+        self.assertIn("actual=0x64", report.message())
+        self.assertIn("limit=0x3E8", report.message())
+        self.assertIn("remaining=900 bytes", report.message())
+        self.assertIn("percentage=90.00%", report.message())
+        self.assertIn("status=PASS", report.message())
 
-    def test_fails_only_below_five_percent_remaining(self):
-        limit = app_space.application_limit_bytes("u2plus")
-        threshold = limit * 5 // 100
+    def test_exactly_one_percent_remaining_passes_without_warning(self):
+        report = app_space.FirmwareSizeReport("u2", 99, 100)
 
-        self.assertFalse(
-            app_space.check_application_space("u2plus", limit - threshold)
-            .is_below_warning_threshold
-        )
-        self.assertTrue(
-            app_space.check_application_space("u2plus", limit - threshold + 1)
-            .is_below_warning_threshold
-        )
+        self.assertEqual(report.status, "PASS")
+        self.assertEqual(report.exit_status, 0)
 
-    def test_warning_identifies_the_threshold_as_such(self):
-        report = app_space.check_application_space("u2", 0xC6000)
+    def test_less_than_one_percent_remaining_warns(self):
+        report = app_space.FirmwareSizeReport("u2", 1000, 1009)
 
-        self.assertIn("5% is 39.6 KiB", report.warning_message())
+        self.assertEqual(report.status, "WARNING")
+        self.assertEqual(report.exit_status, 0)
+
+    def test_exactly_at_limit_warns(self):
+        report = app_space.FirmwareSizeReport("u2", 1000, 1000)
+
+        self.assertEqual(report.status, "WARNING")
+        self.assertEqual(report.exit_status, 0)
+
+    def test_one_byte_over_limit_fails(self):
+        report = app_space.FirmwareSizeReport("u2", 1001, 1000)
+
+        self.assertEqual(report.status, "FAIL")
+        self.assertEqual(report.exit_status, 1)
+
+    def test_missing_artifact_fails_clearly(self):
+        missing = pathlib.Path("does-not-exist")
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            exit_status = app_space.main(["u2", str(missing)])
+
+        self.assertEqual(exit_status, 2)
+        self.assertIn("expected firmware artifact for U2 was not produced", stderr.getvalue())
+
+    def test_main_returns_report_exit_status(self):
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = pathlib.Path(directory) / "firmware.bin"
+            artifact.write_bytes(b"x" * (0xC6000 + 1))
+
+            self.assertEqual(app_space.main(["u2", str(artifact)]), 1)
+
+    def test_github_actions_emits_a_native_warning(self):
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = pathlib.Path(directory) / "firmware.bin"
+            artifact.write_bytes(b"x" * 0xC6000)
+            stdout = io.StringIO()
+
+            with mock.patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}):
+                with contextlib.redirect_stdout(stdout):
+                    self.assertEqual(app_space.main(["u2", str(artifact)]), 0)
+
+        self.assertIn("::warning::U2 has less than 1%", stdout.getvalue())
 
 
 if __name__ == "__main__":

--- a/tools/test_app_space.py
+++ b/tools/test_app_space.py
@@ -224,28 +224,23 @@ class RenderTest(unittest.TestCase):
 
 
 class CommandTest(unittest.TestCase):
-    @contextlib.contextmanager
-    def artifact_at(self, variant, artifact):
-        variants = dict(app_space.FIRMWARE_VARIANTS)
-        variants[variant] = dict(variants[variant], artifact=str(artifact))
-        with mock.patch.object(app_space, "FIRMWARE_VARIANTS", variants):
-            yield
+    def setUp(self):
+        # Every variant points at a path that cannot exist, so no test can be swayed by
+        # which firmware images happen to be built in the checkout it runs in.
+        self.variants = {
+            variant: dict(details, artifact="/does/not/exist/" + variant)
+            for variant, details in app_space.FIRMWARE_VARIANTS.items()
+        }
+        patcher = mock.patch.object(app_space, "FIRMWARE_VARIANTS", self.variants)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     @contextlib.contextmanager
     def artifact_of_size(self, variant, size_bytes):
         with tempfile.TemporaryDirectory() as directory:
             artifact = pathlib.Path(directory) / "ultimate.app"
             artifact.write_bytes(b"x" * size_bytes)
-            with self.artifact_at(variant, artifact):
-                yield
-
-    @contextlib.contextmanager
-    def no_artifacts(self):
-        variants = {
-            variant: dict(details, artifact="/does/not/exist/" + variant)
-            for variant, details in app_space.FIRMWARE_VARIANTS.items()
-        }
-        with mock.patch.object(app_space, "FIRMWARE_VARIANTS", variants):
+            self.variants[variant] = dict(self.variants[variant], artifact=str(artifact))
             yield
 
     def run_main(self, argv):
@@ -273,8 +268,7 @@ class CommandTest(unittest.TestCase):
         self.assertIn("fails at the final application space report", stderr)
 
     def test_measure_stops_the_build_when_the_artifact_was_not_produced(self):
-        with self.artifact_at("u2", "/does/not/exist/ultimate.bin"):
-            status, _, stderr = self.run_main(["measure", "u2"])
+        status, _, stderr = self.run_main(["measure", "u2"])
 
         self.assertEqual(status, 2)
         self.assertIn("expected firmware artifact for U2 was not produced", stderr)
@@ -290,8 +284,7 @@ class CommandTest(unittest.TestCase):
         self.assertNotIn("::warning::", stdout)
 
     def test_report_tabulates_every_variant_even_when_none_are_built(self):
-        with self.no_artifacts():
-            status, stdout, _ = self.run_main(["report"])
+        status, stdout, _ = self.run_main(["report"])
 
         self.assertEqual(status, 0)
         for details in app_space.FIRMWARE_VARIANTS.values():
@@ -319,9 +312,8 @@ class CommandTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             summary = pathlib.Path(directory) / "summary.md"
             summary.write_text("earlier step\n")
-            with self.no_artifacts():
-                with mock.patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": str(summary)}):
-                    self.run_main(["report"])
+            with mock.patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": str(summary)}):
+                self.run_main(["report"])
 
             written = summary.read_text()
 
@@ -329,11 +321,10 @@ class CommandTest(unittest.TestCase):
         self.assertIn("| Firmware | Limit | Size | Free | Free % | Status |", written)
 
     def test_report_survives_an_unwritable_job_summary(self):
-        with self.no_artifacts():
-            with mock.patch.dict(
-                "os.environ", {"GITHUB_STEP_SUMMARY": "/does/not/exist/summary.md"}
-            ):
-                status, _, stderr = self.run_main(["report"])
+        with mock.patch.dict(
+            "os.environ", {"GITHUB_STEP_SUMMARY": "/does/not/exist/summary.md"}
+        ):
+            status, _, stderr = self.run_main(["report"])
 
         self.assertEqual(status, 0)
         self.assertIn("could not write the CI job summary", stderr)

--- a/tools/test_app_space.py
+++ b/tools/test_app_space.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Regression tests for the final-firmware size build guard."""
+"""Regression tests for the firmware application space guard."""
 
 import contextlib
 import io
 import pathlib
+import re
 import sys
 import tempfile
 import unittest
@@ -14,107 +15,304 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent))
 import app_space
 
 
-class AppSpaceTest(unittest.TestCase):
-    def test_uses_supplied_firmware_limits(self):
-        self.assertEqual(
-            {
-                variant: details["limit_bytes"]
-                for variant, details in app_space.FIRMWARE_VARIANTS.items()
-            },
-            {
-                "u2": 0xC6000,
-                "u2plus": 0x140000,
-                "u2pl": 0x160000,
-                "u64": 0x170000,
-                "u64e2_50t": 0x1E0000,
-                "u64e2_100t": 0x1C0000,
-            },
-        )
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
-    def test_build_checks_all_final_firmware_artifacts(self):
-        makefile = pathlib.Path(__file__).parents[1] / "Makefile"
-        source = makefile.read_text()
+# Variant -> the flash partition table in software/io/flash/w25q_flash.cc it is budgeted from.
+FLASH_TABLES = {
+    "u2": "flash_addresses",
+    "u2plus": "flash_addresses_u2p",
+    "u2pl": "flash_addresses_u2pl",
+    "u64": "flash_addresses_u64",
+    "u64e2_50t": "flash_addresses_u64ii_50t",
+    "u64e2_100t": "flash_addresses_u64ii_100t",
+}
 
-        for check in (
-            "u2 target/u2/riscv/ultimate/result/ultimate.bin",
-            "u2plus target/u2plus/nios/ultimate/result/ultimate.app",
-            "u2pl target/u2plus_L/riscv/ultimate/result/ultimate.app",
-            "u64 target/u64/nios2/ultimate/result/ultimate.app",
-            "u64e2_50t target/u64ii/riscv/ultimate/result/ultimate.app",
-            "u64e2_100t target/u64ii/riscv/ultimate/result/ultimate.app",
-        ):
-            self.assertIn("$(FIRMWARE_SIZE_CHECK) " + check, source)
 
-    def test_github_actions_forwards_warning_context_to_builds(self):
-        workflow = pathlib.Path(__file__).parents[1] / ".github/workflows/build.yml"
+def application_sizes_from_flash_tables():
+    source = (REPO_ROOT / "software/io/flash/w25q_flash.cc").read_text()
+    sizes = {}
+    for table, body in re.findall(
+        r"t_flash_address (\w+)\[\] = \{(.*?)\};", source, re.DOTALL
+    ):
+        entry = re.search(r"FLASH_ID_APPL,([^\n]*)", body)
+        if entry:
+            # The partition size is the last field of the entry.
+            sizes[table] = int(re.findall(r"0x[0-9A-Fa-f]+", entry.group(1))[-1], 16)
+    return sizes
 
-        self.assertIn("docker run --rm -e GITHUB_ACTIONS", workflow.read_text())
 
+def report_for(actual_bytes, limit_bytes=1000, variant="u2"):
+    return app_space.FirmwareSizeReport(variant, actual_bytes, limit_bytes)
+
+
+class LimitTest(unittest.TestCase):
+    def test_limits_match_the_flash_partition_tables(self):
+        sizes = application_sizes_from_flash_tables()
+
+        self.assertEqual(len(sizes), 6)
+        for variant, table in FLASH_TABLES.items():
+            self.assertEqual(
+                app_space.FIRMWARE_VARIANTS[variant]["limit_bytes"],
+                sizes[table],
+                "%s limit differs from %s in w25q_flash.cc" % (variant, table),
+            )
+
+    def test_artifact_paths_are_repo_relative_and_plausible(self):
+        for variant, details in app_space.FIRMWARE_VARIANTS.items():
+            artifact = pathlib.Path(details["artifact"])
+
+            self.assertFalse(artifact.is_absolute(), variant)
+            self.assertEqual(artifact.parent.name, "result", variant)
+            self.assertTrue(
+                (REPO_ROOT / artifact.parent.parent).is_dir(),
+                "%s build directory is missing: %s" % (variant, artifact),
+            )
+
+
+class StatusTest(unittest.TestCase):
     def test_comfortably_below_limit_passes(self):
-        report = app_space.FirmwareSizeReport("u2", 100, 1000)
+        report = report_for(100)
 
         self.assertEqual(report.remaining_bytes, 900)
-        self.assertEqual(report.status, "PASS")
+        self.assertEqual(report.status, app_space.PASS)
         self.assertEqual(report.exit_status, 0)
-        self.assertIn("variant=U2", report.message())
-        self.assertIn("actual=0x64", report.message())
-        self.assertIn("limit=0x3E8", report.message())
-        self.assertIn("remaining=900 bytes", report.message())
-        self.assertIn("percentage=90.00%", report.message())
-        self.assertIn("status=PASS", report.message())
+        self.assertAlmostEqual(report.free_percent(), 90.0)
 
     def test_exactly_one_percent_remaining_passes_without_warning(self):
-        report = app_space.FirmwareSizeReport("u2", 99, 100)
+        report = report_for(99, limit_bytes=100)
 
-        self.assertEqual(report.status, "PASS")
+        self.assertEqual(report.status, app_space.PASS)
         self.assertEqual(report.exit_status, 0)
 
     def test_less_than_one_percent_remaining_warns(self):
-        report = app_space.FirmwareSizeReport("u2", 1000, 1009)
+        report = report_for(1000, limit_bytes=1009)
 
-        self.assertEqual(report.status, "WARNING")
+        self.assertEqual(report.status, app_space.WARNING)
         self.assertEqual(report.exit_status, 0)
+        self.assertIn("9 bytes (0.89%) of application space left", report.warning_message())
 
     def test_exactly_at_limit_warns(self):
-        report = app_space.FirmwareSizeReport("u2", 1000, 1000)
+        report = report_for(1000)
 
-        self.assertEqual(report.status, "WARNING")
+        self.assertEqual(report.status, app_space.WARNING)
         self.assertEqual(report.exit_status, 0)
 
     def test_one_byte_over_limit_fails(self):
-        report = app_space.FirmwareSizeReport("u2", 1001, 1000)
+        report = report_for(1001)
 
-        self.assertEqual(report.status, "FAIL")
+        self.assertEqual(report.status, app_space.FAIL)
         self.assertEqual(report.exit_status, 1)
+        self.assertIn("U2 is 1 bytes over", report.failure_message())
 
-    def test_missing_artifact_fails_clearly(self):
-        missing = pathlib.Path("does-not-exist")
-        stderr = io.StringIO()
+    def test_unbuilt_artifact_is_reported_without_failing(self):
+        report = report_for(None)
 
-        with contextlib.redirect_stderr(stderr):
-            exit_status = app_space.main(["u2", str(missing)])
+        self.assertEqual(report.status, app_space.MISSING)
+        self.assertEqual(report.exit_status, 0)
 
-        self.assertEqual(exit_status, 2)
-        self.assertIn("expected firmware artifact for U2 was not produced", stderr.getvalue())
 
-    def test_main_returns_report_exit_status(self):
+class RenderTest(unittest.TestCase):
+    def plain_renderer(self):
+        renderer = app_space.Renderer(io.StringIO())
+        renderer.color = False
+        renderer.unicode = False
+        return renderer
+
+    def test_row_columns_line_up_with_the_header(self):
+        renderer = self.plain_renderer()
+
+        for report in (report_for(250), report_for(1001), report_for(None)):
+            self.assertEqual(
+                len(renderer.row(report)), len(renderer.header()), report.status
+            )
+
+    def test_row_reports_limit_size_free_and_percentage(self):
+        row = self.plain_renderer().row(report_for(250, limit_bytes=1024))
+
+        self.assertIn("1.0 KiB", row)
+        self.assertIn("0.2 KiB", row)
+        self.assertIn("0.8 KiB", row)
+        self.assertIn("75.6 %", row)
+        self.assertIn("PASS", row)
+
+    def test_usage_bar_fills_in_proportion_and_saturates_when_over(self):
+        renderer = self.plain_renderer()
+
+        self.assertEqual(renderer._bar(report_for(500)), "#" * 10 + "." * 10)
+        self.assertEqual(renderer._bar(report_for(1001)), "#" * 20)
+        self.assertEqual(renderer._bar(report_for(1)), "#" + "." * 19)
+        self.assertEqual(renderer._bar(report_for(None)), "not built".ljust(20))
+
+    def test_unbuilt_row_shows_dashes_rather_than_numbers(self):
+        row = self.plain_renderer().row(report_for(None))
+
+        self.assertIn("n/a", row)
+        self.assertIn("not built", row)
+        self.assertNotIn("0.0 KiB", row)
+
+    def test_table_lists_every_variant_once(self):
+        reports = [report_for(250, variant=variant) for variant in app_space.FIRMWARE_VARIANTS]
+        table = self.plain_renderer().table(reports)
+
+        for details in app_space.FIRMWARE_VARIANTS.values():
+            self.assertEqual(table.count(details["name"] + " "), 1, details["name"])
+
+    def test_totals_line_counts_each_status(self):
+        totals = self.plain_renderer().totals(
+            [report_for(250), report_for(1000), report_for(1001), report_for(None)]
+        )
+
+        self.assertEqual(totals.split(), ["FAIL", "1", "WARNING", "1", "PASS", "1", "n/a", "1"])
+
+    def test_colours_are_emitted_on_github_actions_but_not_in_plain_pipes(self):
+        with mock.patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}, clear=True):
+            self.assertTrue(app_space.Renderer(io.StringIO()).color)
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(app_space.Renderer(io.StringIO()).color)
+        with mock.patch.dict("os.environ", {"GITHUB_ACTIONS": "true", "NO_COLOR": "1"}, clear=True):
+            self.assertFalse(app_space.Renderer(io.StringIO()).color)
+
+    def test_ascii_is_used_when_the_stream_cannot_encode_box_drawing(self):
+        ascii_stream = io.TextIOWrapper(io.BytesIO(), encoding="ascii")
+        utf8_stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+
+        self.assertFalse(app_space.Renderer(ascii_stream).unicode)
+        self.assertTrue(app_space.Renderer(utf8_stream).unicode)
+
+    def test_markdown_table_is_one_row_per_variant_with_a_status_icon(self):
+        markdown = app_space.markdown_table([report_for(250), report_for(1001), report_for(None)])
+
+        self.assertEqual(markdown.count("\n|"), 5)
+        self.assertIn("✅ PASS", markdown)
+        self.assertIn("❌ FAIL", markdown)
+        self.assertIn("⬜ n/a", markdown)
+
+
+class CommandTest(unittest.TestCase):
+    @contextlib.contextmanager
+    def artifact_of_size(self, variant, size_bytes):
         with tempfile.TemporaryDirectory() as directory:
-            artifact = pathlib.Path(directory) / "firmware.bin"
-            artifact.write_bytes(b"x" * (0xC6000 + 1))
+            artifact = pathlib.Path(directory) / "ultimate.app"
+            artifact.write_bytes(b"x" * size_bytes)
+            variants = dict(app_space.FIRMWARE_VARIANTS)
+            variants[variant] = dict(variants[variant], artifact=artifact.name)
+            with mock.patch.object(app_space, "FIRMWARE_VARIANTS", variants):
+                with mock.patch.object(app_space, "REPO_ROOT", pathlib.Path(directory)):
+                    yield
 
-            self.assertEqual(app_space.main(["u2", str(artifact)]), 1)
+    def run_main(self, argv):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            with contextlib.redirect_stderr(stderr):
+                status = app_space.main(argv)
+        return status, stdout.getvalue(), stderr.getvalue()
 
-    def test_github_actions_emits_a_native_warning(self):
-        with tempfile.TemporaryDirectory() as directory:
-            artifact = pathlib.Path(directory) / "firmware.bin"
-            artifact.write_bytes(b"x" * 0xC6000)
-            stdout = io.StringIO()
+    def test_check_prints_a_header_and_one_row(self):
+        with self.artifact_of_size("u64", 1024):
+            status, stdout, _ = self.run_main(["check", "u64"])
 
+        self.assertEqual(status, 0)
+        self.assertEqual(len(stdout.strip().splitlines()), 2)
+        self.assertIn("Firmware", stdout)
+        self.assertIn("U64", stdout)
+
+    def test_check_fails_the_build_when_over_the_limit(self):
+        with self.artifact_of_size("u2", 0xC6000 + 1):
+            status, _, stderr = self.run_main(["check", "u2"])
+
+        self.assertEqual(status, 1)
+        self.assertIn("U2 is 1 bytes over its application space limit", stderr)
+
+    def test_check_fails_when_the_artifact_was_not_produced(self):
+        status, _, stderr = self.run_main(["check", "u2"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("expected firmware artifact for U2 was not produced", stderr)
+
+    def test_check_does_not_duplicate_the_github_annotations(self):
+        with self.artifact_of_size("u2", 0xC6000):
             with mock.patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}):
-                with contextlib.redirect_stdout(stdout):
-                    self.assertEqual(app_space.main(["u2", str(artifact)]), 0)
+                status, stdout, stderr = self.run_main(["check", "u2"])
 
-        self.assertIn("::warning::U2 has less than 1%", stdout.getvalue())
+        self.assertEqual(status, 0)
+        self.assertIn("WARNING: U2 has", stderr)
+        self.assertNotIn("::warning::", stdout)
+
+    def test_report_tabulates_every_variant_even_when_none_are_built(self):
+        status, stdout, _ = self.run_main(["report"])
+
+        self.assertEqual(status, 0)
+        for details in app_space.FIRMWARE_VARIANTS.values():
+            self.assertIn(details["name"], stdout)
+        self.assertIn("not built", stdout)
+
+    def test_report_fails_and_annotates_when_any_firmware_is_over(self):
+        with self.artifact_of_size("u64", 0x170000 + 4096):
+            with mock.patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}):
+                status, stdout, stderr = self.run_main(["report"])
+
+        self.assertEqual(status, 1)
+        self.assertIn("::error::U64 is 4096 bytes over", stdout)
+        self.assertIn("ERROR: U64 is 4096 bytes over", stderr)
+
+    def test_report_annotates_the_near_limit_warning(self):
+        with self.artifact_of_size("u64", 0x170000):
+            with mock.patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}):
+                status, stdout, _ = self.run_main(["report"])
+
+        self.assertEqual(status, 0)
+        self.assertIn("::warning::U64 has 0 bytes", stdout)
+
+    def test_report_appends_a_markdown_job_summary_for_github(self):
+        with tempfile.TemporaryDirectory() as directory:
+            summary = pathlib.Path(directory) / "summary.md"
+            summary.write_text("earlier step\n")
+            with mock.patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": str(summary)}):
+                self.run_main(["report"])
+
+            written = summary.read_text()
+
+        self.assertTrue(written.startswith("earlier step\n"))
+        self.assertIn("| Firmware | Limit | Size | Free | Free % | Status |", written)
+
+    def test_report_survives_an_unwritable_job_summary(self):
+        with mock.patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": "/does/not/exist/summary.md"}):
+            status, _, stderr = self.run_main(["report"])
+
+        self.assertEqual(status, 0)
+        self.assertIn("could not write the CI job summary", stderr)
+
+
+class BuildIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.makefile = (REPO_ROOT / "Makefile").read_text()
+        self.workflow = (REPO_ROOT / ".github/workflows/build.yml").read_text()
+
+    def test_every_firmware_target_gates_its_own_image(self):
+        for variant in app_space.FIRMWARE_VARIANTS:
+            self.assertIn("$(APP_SPACE) check " + variant + "\n", self.makefile)
+
+    def test_artifact_paths_are_not_duplicated_into_the_makefile(self):
+        invocations = re.findall(r"\$\(APP_SPACE\)[^\n]*", self.makefile)
+
+        self.assertTrue(invocations)
+        for invocation in invocations:
+            self.assertRegex(invocation, r"^\$\(APP_SPACE\) (report|check \w+)$")
+
+    def test_a_local_full_build_ends_with_the_report(self):
+        recipe = self.makefile.split("all: esp32", 1)[1].splitlines()[1]
+
+        self.assertEqual(recipe.strip(), "@$(APP_SPACE) report")
+
+    def test_ci_runs_the_report_as_a_dedicated_final_step(self):
+        step = self.workflow.split("- name: Report Firmware Application Space", 1)[1]
+        step = step.split("- name:", 1)[0]
+
+        self.assertIn("if: always()", step)
+        self.assertIn("make app_space", step)
+        self.assertIn("-e GITHUB_ACTIONS", step)
+        self.assertIn("-e GITHUB_STEP_SUMMARY", step)
+        self.assertIn("-v $GITHUB_STEP_SUMMARY:$GITHUB_STEP_SUMMARY:rw", step)
 
 
 if __name__ == "__main__":

--- a/tools/test_app_space.py
+++ b/tools/test_app_space.py
@@ -17,45 +17,80 @@ import app_space
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
-# Variant -> the flash partition table in software/io/flash/w25q_flash.cc it is budgeted from.
-FLASH_TABLES = {
-    "u2": "flash_addresses",
-    "u2plus": "flash_addresses_u2p",
-    "u2pl": "flash_addresses_u2pl",
-    "u64": "flash_addresses_u64",
-    "u64e2_50t": "flash_addresses_u64ii_50t",
-    "u64e2_100t": "flash_addresses_u64ii_100t",
-}
-
-
-def application_sizes_from_flash_tables():
-    source = (REPO_ROOT / "software/io/flash/w25q_flash.cc").read_text()
-    sizes = {}
-    for table, body in re.findall(
-        r"t_flash_address (\w+)\[\] = \{(.*?)\};", source, re.DOTALL
-    ):
-        entry = re.search(r"FLASH_ID_APPL,([^\n]*)", body)
-        if entry:
-            # The partition size is the last field of the entry.
-            sizes[table] = int(re.findall(r"0x[0-9A-Fa-f]+", entry.group(1))[-1], 16)
-    return sizes
-
 
 def report_for(actual_bytes, limit_bytes=1000, variant="u2"):
     return app_space.FirmwareSizeReport(variant, actual_bytes, limit_bytes)
 
 
 class LimitTest(unittest.TestCase):
-    def test_limits_match_the_flash_partition_tables(self):
-        sizes = application_sizes_from_flash_tables()
+    def test_limits_read_from_the_flash_tables_are_the_partition_sizes(self):
+        # Pins the parse against the real sources. A change here means a partition
+        # moved, which has to be a deliberate decision rather than a silent one.
+        self.assertEqual(
+            app_space.load_limits(),
+            {
+                "u2": 0xC6000,
+                "u2plus": 0x140000,
+                "u2pl": 0x160000,
+                "u64": 0x170000,
+                "u64e2_50t": 0x1E0000,
+                "u64e2_100t": 0x1C0000,
+            },
+        )
 
-        self.assertEqual(len(sizes), 6)
-        for variant, table in FLASH_TABLES.items():
-            self.assertEqual(
-                app_space.FIRMWARE_VARIANTS[variant]["limit_bytes"],
-                sizes[table],
-                "%s limit differs from %s in w25q_flash.cc" % (variant, table),
-            )
+    def test_no_limit_is_written_down_outside_the_flash_tables(self):
+        for source in ("tools/app_space.py", "Makefile", ".github/workflows/build.yml"):
+            text = (REPO_ROOT / source).read_text()
+
+            for limit in app_space.load_limits().values():
+                self.assertNotIn("0x%X" % limit, text, source)
+                self.assertNotIn(str(limit), text, source)
+
+    def test_size_is_taken_from_the_last_field_of_the_appl_entry(self):
+        limits = app_space.read_partition_limits("""
+            static const t_flash_address flash_addresses[] = {
+                { FLASH_ID_BOOTFPGA,   0x01, 0x000000, 0x000000, 0x53CA0 },
+                { FLASH_ID_APPL,       0x01, 0x062000, 0x062000, 0xC6000 }, // max 792K
+                { FLASH_ID_CONFIG,     0x00, 0x1F0000, 0x1F0000, 0x10000 } };
+            static const t_flash_address other[] = {
+                { FLASH_ID_BOOTFPGA,   0x00, 0x000000, 0x000000, 0x0C0000 } };
+        """)
+
+        self.assertEqual(limits, {"flash_addresses": 0xC6000})
+
+    def test_a_table_shared_by_two_devices_uses_the_smaller_partition(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "software/io/flash").mkdir(parents=True)
+            entry = "{ FLASH_ID_APPL, 0x01, 0x062000, 0x062000, %s }"
+            for name, size in zip(app_space.FLASH_TABLE_SOURCES, ("0xC6000", "0xB0000")):
+                (root / name).write_text(
+                    "\n".join(
+                        "static const t_flash_address %s[] = { %s };"
+                        % (details["partition"], entry % size)
+                        for details in app_space.FIRMWARE_VARIANTS.values()
+                    )
+                )
+
+            self.assertEqual(app_space.load_limits(root)["u2"], 0xB0000)
+
+    def test_a_missing_partition_table_is_reported_clearly(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "software/io/flash").mkdir(parents=True)
+            for name in app_space.FLASH_TABLE_SOURCES:
+                (root / name).write_text("static const t_flash_address other[] = { };")
+
+            with self.assertRaises(app_space.LimitError) as raised:
+                app_space.load_limits(root)
+
+        self.assertIn("no FLASH_ID_APPL entry for U2", str(raised.exception))
+
+    def test_an_unreadable_source_is_reported_clearly(self):
+        with self.assertRaises(app_space.LimitError) as raised:
+            app_space.load_limits(pathlib.Path("/does/not/exist"))
+
+        self.assertIn("cannot read the flash partition table", str(raised.exception))
 
     def test_artifact_paths_are_repo_relative_and_plausible(self):
         for variant, details in app_space.FIRMWARE_VARIANTS.items():
@@ -190,15 +225,28 @@ class RenderTest(unittest.TestCase):
 
 class CommandTest(unittest.TestCase):
     @contextlib.contextmanager
+    def artifact_at(self, variant, artifact):
+        variants = dict(app_space.FIRMWARE_VARIANTS)
+        variants[variant] = dict(variants[variant], artifact=str(artifact))
+        with mock.patch.object(app_space, "FIRMWARE_VARIANTS", variants):
+            yield
+
+    @contextlib.contextmanager
     def artifact_of_size(self, variant, size_bytes):
         with tempfile.TemporaryDirectory() as directory:
             artifact = pathlib.Path(directory) / "ultimate.app"
             artifact.write_bytes(b"x" * size_bytes)
-            variants = dict(app_space.FIRMWARE_VARIANTS)
-            variants[variant] = dict(variants[variant], artifact=artifact.name)
-            with mock.patch.object(app_space, "FIRMWARE_VARIANTS", variants):
-                with mock.patch.object(app_space, "REPO_ROOT", pathlib.Path(directory)):
-                    yield
+            with self.artifact_at(variant, artifact):
+                yield
+
+    @contextlib.contextmanager
+    def no_artifacts(self):
+        variants = {
+            variant: dict(details, artifact="/does/not/exist/" + variant)
+            for variant, details in app_space.FIRMWARE_VARIANTS.items()
+        }
+        with mock.patch.object(app_space, "FIRMWARE_VARIANTS", variants):
+            yield
 
     def run_main(self, argv):
         stdout, stderr = io.StringIO(), io.StringIO()
@@ -207,39 +255,43 @@ class CommandTest(unittest.TestCase):
                 status = app_space.main(argv)
         return status, stdout.getvalue(), stderr.getvalue()
 
-    def test_check_prints_a_header_and_one_row(self):
+    def test_measure_prints_a_header_and_one_row(self):
         with self.artifact_of_size("u64", 1024):
-            status, stdout, _ = self.run_main(["check", "u64"])
+            status, stdout, _ = self.run_main(["measure", "u64"])
 
         self.assertEqual(status, 0)
         self.assertEqual(len(stdout.strip().splitlines()), 2)
         self.assertIn("Firmware", stdout)
         self.assertIn("U64", stdout)
 
-    def test_check_fails_the_build_when_over_the_limit(self):
+    def test_measure_does_not_stop_a_build_that_is_over_the_limit(self):
         with self.artifact_of_size("u2", 0xC6000 + 1):
-            status, _, stderr = self.run_main(["check", "u2"])
+            status, _, stderr = self.run_main(["measure", "u2"])
 
-        self.assertEqual(status, 1)
-        self.assertIn("U2 is 1 bytes over its application space limit", stderr)
+        self.assertEqual(status, 0)
+        self.assertIn("OVER LIMIT: U2 is 1 bytes over its application space limit", stderr)
+        self.assertIn("fails at the final application space report", stderr)
 
-    def test_check_fails_when_the_artifact_was_not_produced(self):
-        status, _, stderr = self.run_main(["check", "u2"])
+    def test_measure_stops_the_build_when_the_artifact_was_not_produced(self):
+        with self.artifact_at("u2", "/does/not/exist/ultimate.bin"):
+            status, _, stderr = self.run_main(["measure", "u2"])
 
         self.assertEqual(status, 2)
         self.assertIn("expected firmware artifact for U2 was not produced", stderr)
 
-    def test_check_does_not_duplicate_the_github_annotations(self):
-        with self.artifact_of_size("u2", 0xC6000):
+    def test_measure_does_not_duplicate_the_github_annotations(self):
+        with self.artifact_of_size("u2", 0xC6000 + 1):
             with mock.patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}):
-                status, stdout, stderr = self.run_main(["check", "u2"])
+                status, stdout, stderr = self.run_main(["measure", "u2"])
 
         self.assertEqual(status, 0)
-        self.assertIn("WARNING: U2 has", stderr)
+        self.assertIn("OVER LIMIT: U2 is", stderr)
+        self.assertNotIn("::error::", stdout)
         self.assertNotIn("::warning::", stdout)
 
     def test_report_tabulates_every_variant_even_when_none_are_built(self):
-        status, stdout, _ = self.run_main(["report"])
+        with self.no_artifacts():
+            status, stdout, _ = self.run_main(["report"])
 
         self.assertEqual(status, 0)
         for details in app_space.FIRMWARE_VARIANTS.values():
@@ -267,8 +319,9 @@ class CommandTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             summary = pathlib.Path(directory) / "summary.md"
             summary.write_text("earlier step\n")
-            with mock.patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": str(summary)}):
-                self.run_main(["report"])
+            with self.no_artifacts():
+                with mock.patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": str(summary)}):
+                    self.run_main(["report"])
 
             written = summary.read_text()
 
@@ -276,8 +329,11 @@ class CommandTest(unittest.TestCase):
         self.assertIn("| Firmware | Limit | Size | Free | Free % | Status |", written)
 
     def test_report_survives_an_unwritable_job_summary(self):
-        with mock.patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": "/does/not/exist/summary.md"}):
-            status, _, stderr = self.run_main(["report"])
+        with self.no_artifacts():
+            with mock.patch.dict(
+                "os.environ", {"GITHUB_STEP_SUMMARY": "/does/not/exist/summary.md"}
+            ):
+                status, _, stderr = self.run_main(["report"])
 
         self.assertEqual(status, 0)
         self.assertIn("could not write the CI job summary", stderr)
@@ -288,16 +344,19 @@ class BuildIntegrationTest(unittest.TestCase):
         self.makefile = (REPO_ROOT / "Makefile").read_text()
         self.workflow = (REPO_ROOT / ".github/workflows/build.yml").read_text()
 
-    def test_every_firmware_target_gates_its_own_image(self):
+    def test_every_firmware_target_measures_its_own_image(self):
         for variant in app_space.FIRMWARE_VARIANTS:
-            self.assertIn("$(APP_SPACE) check " + variant + "\n", self.makefile)
+            self.assertIn("$(APP_SPACE) measure " + variant + "\n", self.makefile)
+
+    def test_no_build_target_gates_on_size_so_every_firmware_is_still_built(self):
+        self.assertNotIn("$(APP_SPACE) check", self.makefile)
 
     def test_artifact_paths_are_not_duplicated_into_the_makefile(self):
         invocations = re.findall(r"\$\(APP_SPACE\)[^\n]*", self.makefile)
 
         self.assertTrue(invocations)
         for invocation in invocations:
-            self.assertRegex(invocation, r"^\$\(APP_SPACE\) (report|check \w+)$")
+            self.assertRegex(invocation, r"^\$\(APP_SPACE\) (report|measure \w+)$")
 
     def test_a_local_full_build_ends_with_the_report(self):
         recipe = self.makefile.split("all: esp32", 1)[1].splitlines()[1]
@@ -305,7 +364,7 @@ class BuildIntegrationTest(unittest.TestCase):
         self.assertEqual(recipe.strip(), "@$(APP_SPACE) report")
 
     def test_ci_runs_the_report_as_a_dedicated_final_step(self):
-        step = self.workflow.split("- name: Report Firmware Application Space", 1)[1]
+        step = self.workflow.split("- name: Check Firmware Application Space", 1)[1]
         step = step.split("- name:", 1)[0]
 
         self.assertIn("if: always()", step)

--- a/tools/test_app_space.py
+++ b/tools/test_app_space.py
@@ -31,6 +31,11 @@ class AppSpaceTest(unittest.TestCase):
             source,
         )
 
+    def test_build_checks_are_warning_only_until_limits_are_confirmed(self):
+        makefile = pathlib.Path(__file__).parents[1] / "Makefile"
+
+        self.assertIn("APP_SPACE_CHECK = python3 tools/app_space.py --warning-only", makefile.read_text())
+
     def test_reports_remaining_space_in_kib(self):
         report = app_space.check_application_space("u64", 0x170000 - 100 * 1024)
 

--- a/tools/test_app_space.py
+++ b/tools/test_app_space.py
@@ -18,6 +18,19 @@ class AppSpaceTest(unittest.TestCase):
         self.assertEqual(app_space.application_limit_bytes("u64"), 0x170000)
         self.assertEqual(app_space.application_limit_bytes("u64ii"), 0x1C0000)
 
+    def test_u2_guard_checks_the_flashed_binary(self):
+        makefile = pathlib.Path(__file__).parents[1] / "Makefile"
+        source = makefile.read_text()
+
+        self.assertIn(
+            "$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.bin",
+            source,
+        )
+        self.assertNotIn(
+            "$(APP_SPACE_CHECK) u2 target/u2/riscv/ultimate/result/ultimate.app",
+            source,
+        )
+
     def test_reports_remaining_space_in_kib(self):
         report = app_space.check_application_space("u64", 0x170000 - 100 * 1024)
 

--- a/tools/test_app_space.py
+++ b/tools/test_app_space.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Regression tests for the firmware application-space build guard."""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+import app_space
+
+
+class AppSpaceTest(unittest.TestCase):
+    def test_uses_application_partition_limits(self):
+        self.assertEqual(app_space.application_limit_bytes("u2"), 0xC6000)
+        self.assertEqual(app_space.application_limit_bytes("u2plus"), 0x140000)
+        self.assertEqual(app_space.application_limit_bytes("u2pl"), 0x160000)
+        self.assertEqual(app_space.application_limit_bytes("u64"), 0x170000)
+        self.assertEqual(app_space.application_limit_bytes("u64ii"), 0x1C0000)
+
+    def test_reports_remaining_space_in_kib(self):
+        report = app_space.check_application_space("u64", 0x170000 - 100 * 1024)
+
+        self.assertEqual(report.remaining_bytes, 100 * 1024)
+        self.assertIn("100.0 KiB remaining", report.message())
+        self.assertFalse(report.is_below_warning_threshold)
+
+    def test_fails_only_below_five_percent_remaining(self):
+        limit = app_space.application_limit_bytes("u2plus")
+        threshold = limit * 5 // 100
+
+        self.assertFalse(
+            app_space.check_application_space("u2plus", limit - threshold)
+            .is_below_warning_threshold
+        )
+        self.assertTrue(
+            app_space.check_application_space("u2plus", limit - threshold + 1)
+            .is_below_warning_threshold
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The U2 (original) application partition is a fixed 811,008-byte (`0xC6000`) flash region, the same on both the AT45 and W25Q flash variants of the original board, so it is a hardware limit, not a config choice. Recent additions (the interactive machine-code monitor, FTP client/server support, and other features) pushed the U2 build past that limit.

This PR removes two U2-only features that are dead-code-safe to drop, merges in #754's firmware application-space CI gate so the fix gets checked against a real gate instead of a projection, and fixes a CI workflow bug that built every commit twice.

## Remove the machine-code monitor and FTP client from U2 (original)

The interactive 6502 machine-code monitor/debugger (`software/monitor/*`) has one call site, a weak symbol (`get_machine_monitor_task`, `software/monitor/monitor_init.h:13`) guarded with `if (get_machine_monitor_task) { ... }` in `tree_browser.cc`. Removing the translation units from the U2 `Makefile` leaves that check false and the rest of the UI unaffected.

The FTP client that lets the U2 file manager browse a remote FTP server as a filesystem (`software/network/ftp_client.cc`, `software/filesystem/filesystem_ftp.cc`) is separate from the FTP *server* daemon (`ftpd.cc`), which stays in the U2 build. The client self-registers into the file manager root via a static `InitFunction`; no other file references `FileSystemFTP`, `FTPClient`, or that registration function.

Only `target/u2/riscv/ultimate/Makefile` changes for this part (10 `SRCS_CC` lines removed). Every other hardware target (U2+, U2+L, U64, U64-II) keeps its own independent `SRCS_CC` list and is untouched.

**Measurements.** Rebuilt locally with the Docker image tag the self-hosted CI runner uses (`my_docker_image:latest`), `make -C target/u2/riscv/ultimate`, comparing `riscv32-unknown-elf-size` on the resulting `.elf` before and after:

| Build | `ultimate.bin` |
|---|---:|
| `test-merge` tip, unmodified | 904,788 |
| − machine-code monitor only | 841,756 |
| − monitor + FTP client (this PR) | 824,976 |

Both link cleanly with no undefined-symbol errors. Local absolute numbers run larger than what CI reports for the same source, a known toolchain drift between the locally cached image and whatever the self-hosted runner actually pulls (the Docker tag is not a content pin). What transfers reliably across that drift is the delta from a controlled single-variable rebuild: applying the measured 79,812-byte delta to the most recent CI-reported number for a size-equivalent commit (882,220 bytes) projects to roughly 802,408 bytes, about 1% under the 811,008-byte partition limit. The merged-in gate below gives a real, non-projected number instead of relying on that estimate.

## Firmware application-space CI gate (merged from #754)

Every firmware image links into a fixed flash partition; an image that outgrows its partition cannot be flashed. `tools/app_space.py` measures each build's image against its partition and fails CI on an oversized one. It holds no size constants of its own: the limit for each variant is parsed at run time from the `FLASH_ID_APPL` entry of the `t_flash_address` tables in `software/io/flash/w25q_flash.cc` and `software/io/flash/at45_flash.cc`, the same numbers the firmware itself uses to address flash, so the budget can't drift out of sync with the hardware.

`tools/app_space.py measure <variant>` runs inside each firmware build target right after linking. It prints that image's row and always exits 0, even when the image is over its limit, so every remaining firmware still gets built and measured in the same run. `tools/app_space.py report` is the single gate: it reads every variant's artifact, prints one table, and exits non-zero if any image is over its limit. This runs as a dedicated `Check Firmware Application Space` CI step with `if: always()`, so the table appears even if an earlier step failed for an unrelated reason. It also emits one `::error::` annotation per oversized image and one `::warning::` per image near its limit, and appends a markdown copy of the table to the job summary.

An image passes with more than 1% of its partition free, passes with a warning below 1% free (including exactly at the limit), and fails only when it is actually over. `make app_space` runs the same check locally, and `make all`/`build-tool` run it automatically as the last build step.

`tools/test_app_space.py` holds 36 tests covering the partition parser, the status thresholds, the table rendering, both subcommands, the GitHub annotations, and the job summary write. Three are load-bearing for the design: one confirms `measure` always exits 0 so a run finishes and reports on every firmware, one confirms no build target invokes a gating subcommand directly, and one confirms none of the parsed size limits is duplicated as a literal anywhere else in the tree, so a stale constant can't creep back in beside the parsed one.

## CI: build once per PR, once per merge

`.github/workflows/build.yml` declared `on: [push, pull_request]` unconditionally, which fires both a `push` build and a `pull_request` (synchronize) build for the same commit whenever a branch lives in this repo and has an open PR — confirmed directly on this branch, where an early commit triggered two full builds. Restricting `push` to specific branches was considered and rejected, since people often push work-in-progress branches with no PR open yet, and those still need to build.

The fix keeps `on: [push, pull_request]` unrestricted, so every branch still builds on push whether or not it has a PR. The `build` job instead skips itself on a `pull_request` event when the PR head is this same repo, since `push` already built that exact commit; it still runs on `pull_request` when the head is a fork, since a fork's push never reaches this repo and `pull_request` is the only signal for those. Verified on this branch: the latest commit produced one `push` run that built, and the matching `pull_request` run for the same commit completed as `skipped`.

## Test plan

- [x] `make -C target/u2/riscv/ultimate` links cleanly for U2 (original) with both features removed, no undefined symbols.
- [x] Only `target/u2/riscv/ultimate/Makefile` changed for the size fix; U2+/U2+L/U64/U64-II Makefiles are untouched.
- [x] `python3 -m pytest tools/test_app_space.py`, 36/36 pass after the merge.
- [x] Confirmed the build-once fix on this branch's own CI runs: one `push` run built, the paired `pull_request` run for the same commit shows `skipped`.
- [ ] Real CI confirmation of the final U2 image size against the merged-in gate, this PR's own `Check Firmware Application Space` step is the first place that gets checked against the actual self-hosted-runner toolchain rather than the delta-transfer projection above.
