### PR TITLE
Declare the host packages the test suites need

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,29 @@ unit tests live next to their owning code, such as `software/api/tests/`,
 to run more, and `-m` to repeat the E2E suites in more than one UI profile:
 `./run-tests --all -m all` runs everything. See `./run-tests --help`.
 
+## Host requirements
+
+The suites run on the machine driving the device, so a few Python packages have
+to be present there. The firmware needs none of them.
+
+```sh
+pip install -r tests/requirements.txt
+```
+
+| Package | Needed by |
+| --- | --- |
+| `Pillow` | `e2e/api/input_test.py`, `e2e/io/printer/printer_test.py` |
+| `pyftpdlib` | `e2e/filesystem/ftp_client_test.py` |
+| `pytesseract` | `e2e/io/printer/printer_test.py`, only under `--stage verify` |
+
+`pytesseract` is a wrapper around a separate binary, so it also needs
+`tesseract` on `PATH` (`brew install tesseract`, or `apt install
+tesseract-ocr`).
+
+A package that is missing either fails its suite with a message naming what to
+install, or reports the coverage it had to leave out. Neither case passes
+quietly.
+
 ## Command-line conventions
 
 The runner and every suite it starts take the same flags for the same things,

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -88,7 +88,10 @@ fails the run.
 7. Reuse `lib/` for shared protocol decoding or screen models instead of
    copying it. Keep support code local until a second suite needs it.
 8. State supported targets and unusual dependencies in the suite docstring.
-   Keep this file structural; do not copy per-suite CLI help into it.
+   Keep this file structural; do not copy per-suite CLI help into it. A suite
+   that needs a host Python package adds it to [`tests/requirements.txt`](../requirements.txt)
+   and to the table in [`tests/README.md`](../README.md) in the same change, so
+   a fresh checkout can run the gate without guessing.
 9. Keep each check under ten seconds. Above that `tests/lib/report.py` marks
    the duration `SLOW` in yellow, which is a prompt to look rather than a
    failure. The whole gate is run repeatedly by people waiting for it, so a

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,12 @@
+# Host-side Python packages the test suites need. These install on the machine
+# driving the device, not on the device itself.
+#
+#   pip install -r tests/requirements.txt
+#
+# pytesseract is a wrapper and additionally needs the tesseract binary on PATH:
+#   macOS         brew install tesseract
+#   Debian/Ubuntu apt install tesseract-ocr
+
+Pillow          # e2e/api/input_test.py, e2e/io/printer/printer_test.py
+pyftpdlib       # e2e/filesystem/ftp_client_test.py
+pytesseract     # e2e/io/printer/printer_test.py, only under --stage verify


### PR DESCRIPTION
The E2E tree imports three Python packages that nothing in the repository mentions. There is no requirements file, and `tests/README.md` documents the device side only — so a fresh checkout finds them one failed run at a time.

| Package | Needed by |
|---|---|
| `Pillow` | `e2e/api/input_test.py`, `e2e/io/printer/printer_test.py` |
| `pyftpdlib` | `e2e/filesystem/ftp_client_test.py` |
| `pytesseract` | `e2e/io/printer/printer_test.py`, only under `--stage verify` |

`pytesseract` is a wrapper around a separate binary, so `tesseract` also has to be on `PATH`. That is a system package rather than a pip one, so the note calls it out separately.

I hit this preparing the full E2E run for #760: `ftp-client` failed outright because `pyftpdlib` was absent. The suite fails loudly with an actionable message, which is the right behaviour — there is just nothing telling you in advance.

**The change**

- `tests/requirements.txt`, with each entry annotated by the suite that needs it
- a `Host requirements` section in `tests/README.md`, placed there rather than in `tests/e2e/README.md` because `Pillow` is also reachable from the perf and soak paths
- rule 8 in `tests/e2e/README.md` extended, so a suite taking on a new host package declares it in the same change and this does not drift again

Documentation and a requirements file only. No test or firmware behaviour changes.

**Verified** by installing `tests/requirements.txt` into a clean `venv` and importing all three.

Full `./run-tests` output follows in a comment, per the convention from #760.