### PR TITLE
Apply only groups loaded from CFG files

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -129,6 +129,8 @@ SUITES: Sequence[Suite] = (
           "-H @HOST@ -p @PASS@ --mode @MODE@"),
     Suite("e2e", "temp-auto-cleanup", "tests/e2e/filemanager/temp_auto_cleanup_test.py",
           "-H @HOST@ -p @PASS@ --mode @MODE@"),
+    Suite("e2e", "cfg-single-group", "tests/e2e/filemanager/cfg_single_group_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
     Suite("e2e", "printer", "tests/e2e/io/printer/printer_test.py", "-H @HOST@ -p @PASS@"),
     # Drives the UCI control and SoftIEC targets over $DF1B-$DF1F; reproduces #740.
     # A #740 regression leaves the interface stuck in Command Busy for every target

--- a/software/filetypes/filetype_cfg.cc
+++ b/software/filetypes/filetype_cfg.cc
@@ -79,7 +79,8 @@ SubsysResultCode_e FileTypeCfg :: execute(SubsysCommand *cmd)
     StreamTextLog log(8192);
 
     if(file) {
-        bool ok = ConfigIO :: S_read_from_file(file, &log);
+        IndexedList<ConfigStore *> loaded_stores(8, NULL);
+        bool ok = ConfigIO :: S_read_from_file(file, &log, loaded_stores);
         fm->fclose(file);
         if (ok) {
             cmd->user_interface->popup("Loading configuration successful!", BUTTON_OK);
@@ -87,11 +88,8 @@ SubsysResultCode_e FileTypeCfg :: execute(SubsysCommand *cmd)
             cmd->user_interface->popup("There were errors.", BUTTON_OK);
             cmd->user_interface->run_editor(log.getText(), log.getLength());
         }
-        ConfigStore *s;
-        ConfigManager *cm = ConfigManager :: getConfigManager();
-        IndexedList<ConfigStore*> *stores = cm->getStores();
-        for(int n = 0; n < stores->get_elements();n++) {
-            s = (*stores)[n];
+        for(int n = 0; n < loaded_stores.get_elements();n++) {
+            ConfigStore *s = loaded_stores[n];
             if (s->need_effectuate()) {
                 printf("Effectuating settings of store '%s' after loading.\n", s->get_store_name());
                 s->effectuate();

--- a/software/userinterface/configio.cc
+++ b/software/userinterface/configio.cc
@@ -224,13 +224,13 @@ void ConfigIO :: S_write_store_to_file(ConfigStore *st, File *f)
     f->write(buffer, len, &tr);
 }
 
-bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log)
+bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log, IndexedList<ConfigStore *> &loaded_stores)
 {
     char c;
     char line[128];
     uint32_t tr;
     bool allOK = true;
-    ConfigStore *store;
+    ConfigStore *store = NULL;
     ConfigManager *cm = ConfigManager :: getConfigManager();
     int linenr = 0;
 
@@ -255,6 +255,7 @@ bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log)
             continue;
         }
         if (line[0] == '[') {
+            store = NULL;
             for(int i=1;i<128;i++) {
                 if (line[i] == ']') {
                     line[i] = 0;
@@ -270,7 +271,20 @@ bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log)
         // trim line? well for now let's assume correct spacing
         if (strlen(line) > 0) {
             if (store) {
-                allOK &= S_read_store_element(store, line, linenr, log);
+                bool loaded = S_read_store_element(store, line, linenr, log);
+                allOK &= loaded;
+                if (loaded) {
+                    bool found = false;
+                    for (int n = 0; n < loaded_stores.get_elements(); n++) {
+                        if (loaded_stores[n] == store) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        loaded_stores.append(store);
+                    }
+                }
             } else {
                 log->format("Line %d: Not inside valid store.\n", linenr);
                 allOK = false;

--- a/software/userinterface/configio.h
+++ b/software/userinterface/configio.h
@@ -41,7 +41,7 @@ public:
     static SubsysResultCode_e S_restore(SubsysCommand *cmd);
     static SubsysResultCode_e S_reset(SubsysCommand *cmd);
     static SubsysResultCode_e S_clear(SubsysCommand *cmd);
-    static bool S_read_from_file(File *f, StreamTextLog *log);
+    static bool S_read_from_file(File *f, StreamTextLog *log, IndexedList<ConfigStore *> &loaded_stores);
 };
 
 

--- a/tests/e2e/filemanager/cfg_single_group_test.py
+++ b/tests/e2e/filemanager/cfg_single_group_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""E2E: a CFG file applies only the configuration groups it contains.
+
+The fixture changes one Audio Mixer setting, then loads it through the real
+browser action.  The device debug log is the external record of which stores
+the loader considered for effectuation, as exposed by the existing loader
+diagnostics.  The test restores the mixer setting through the public config
+API and removes both files it creates.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+from api import UltimateApi
+import ftp as ftp_lib
+from report import Failure, check, format_exception, suite_fail, suite_ok
+from ui_backend import add_mode_argument, make_browser
+
+
+STORE = "Audio Mixer"
+ITEM = "Vol Master"
+CFG_NAME = "cfg-single-group-e2e.cfg"
+LOG_NAME = "cfg-single-group-e2e.log"
+ENTRY_ROWS = range(2, 24)
+STATUS_ROW = 24
+TELNET_ENTRY_ROWS = range(2, 23)
+TELNET_STATUS_ROW = 23
+
+
+def alternate_value(api: UltimateApi, current: str) -> str:
+    values = api.configs.item(STORE, ITEM).get("values", [])
+    for value in values:
+        if isinstance(value, str) and value != current:
+            return value
+    raise Failure(f"{STORE}/{ITEM} has no alternative value: {values!r}")
+
+
+def upload_fixture(host: str, password: str, value: str) -> None:
+    payload = f"[{STORE}]\n{ITEM}={value}\n".encode("ascii")
+    with ftp_lib.session(host, password, timeout=20) as ftp:
+        ftp_lib.store(ftp, f"/Temp/{CFG_NAME}", payload)
+
+
+def load_fixture(browser) -> None:
+    browser.invoke_task_action("Developer", "Clear Debug Log")
+    browser.go_to_directory("Temp")
+    browser.select_entry(CFG_NAME)
+    browser.invoke_context_action("Load Settings")
+    browser.wait_for_text("Loading configuration successful!")
+    browser.press_popup_button("o")
+    browser.invoke_task_action("Developer", "Save Debug Log")
+    browser.fill_edit_field(LOG_NAME)
+
+
+def loading_stores(host: str, password: str) -> List[str]:
+    with ftp_lib.session(host, password, timeout=20) as ftp:
+        text = ftp_lib.retrieve(ftp, f"/Temp/{LOG_NAME}").decode("ascii", "replace")
+    stores = []
+    for line in text.splitlines():
+        if line.startswith("Effectuating settings of store '"):
+            stores.append(line.split("'", 2)[1])
+        elif line.startswith("Store '") and line.endswith("is clean after loading."):
+            stores.append(line.split("'", 2)[1])
+    return stores
+
+
+def cleanup(host: str, password: str) -> None:
+    try:
+        with ftp_lib.session(host, password, timeout=20) as ftp:
+            ftp_lib.delete_quietly(ftp, f"/Temp/{CFG_NAME}")
+            ftp_lib.delete_quietly(ftp, f"/Temp/{LOG_NAME}")
+    except Exception:
+        pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    parser.add_argument("-t", "--timeout", type=float, default=float(os.environ.get("U64_TIMEOUT", "5.0")))
+    parser.add_argument("--telnet-port", type=int, default=int(os.environ.get("U64_TELNET_PORT", "23")))
+    add_mode_argument(parser)
+    args = parser.parse_args()
+
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    original = api.configs.current(STORE, ITEM)
+    browser = make_browser(
+        args.mode, args.host, args.password or None, args.timeout,
+        entry_rows=ENTRY_ROWS, status_row=STATUS_ROW, telnet_port=args.telnet_port,
+        telnet_entry_rows=TELNET_ENTRY_ROWS, telnet_status_row=TELNET_STATUS_ROW,
+    )
+    try:
+        with check("load a one-group CFG file through the browser"):
+            upload_fixture(args.host, args.password, alternate_value(api, original))
+            load_fixture(browser)
+
+        with check("only the CFG group is considered after loading"):
+            stores = loading_stores(args.host, args.password)
+            if len(stores) != 1 or not stores[0].startswith("Audio M"):
+                raise Failure(f"Expected [{STORE!r}] after CFG load, got {stores!r}")
+
+        suite_ok("cfg_single_group_test")
+        return 0
+    except Failure as exc:
+        suite_fail("cfg_single_group_test", str(exc))
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        suite_fail("cfg_single_group_test", format_exception(exc))
+        return 1
+    finally:
+        try:
+            api.configs.set(STORE, ITEM, original)
+        except Exception:
+            pass
+        try:
+            browser.close()
+        except Exception:
+            pass
+        cleanup(args.host, args.password)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Overview

Loading a CFG file applies settings only from stores that successfully loaded an item from that file. A one-group file therefore cannot effectuate SID, network, drive, UI, or other unrelated settings.

## Implementation

`ConfigIO::S_read_from_file()` records each distinct store that successfully loads an item. `FileTypeCfg` effectuates only those stores. The existing effectuation and flash dirty flags retain their ownership, so unrelated pending stores are neither applied nor cleared. An invalid section clears the active store.

## Regression coverage

`cfg-single-group` is registered in `run-tests`. It loads a browser-selected CFG containing only `[Audio Mixer]`, saves the device debug log, and asserts that exactly that store is effectuated. It restores the modified setting and removes its fixtures. Navigation reuses shared quick-seek and overlay routing.

### Hardware red/green

```sh
python3 tests/e2e/filemanager/cfg_single_group_test.py -H u64 --mode overlay
```

```text
# Red
cfg_single_group_test: FAIL (Expected ["Audio Mixer"] after CFG load, got unrelated stores...)

# Green
[01] load a one-group CFG file through the browser ... OK
[02] only the CFG group is considered after loading ... OK
cfg_single_group_test: OK (2 checks, 6.443s)
```

A host unit test was not added: ConfigIO has no host harness, and a faithful test requires flash, file-manager, UI, stream-log, and config-store scaffolding. The hardware regression covers the real parser-to-effectuation path with less test-only code.

## Validation

- `BUILD_TOOL_ALLOW_PARTIAL=1 ./build-tool -s u64` — pass
- JTAG deployment of the PR-head U64 image `update_6fd9cdc9.u64` — pass
- `BUILD_TOOL_ALLOW_PARTIAL=1 ./build-tool -s u64 u64ii u2 u2pl` — U64/U64-II pass; U2/U2+L applications compile and their updater builds stop at known absent software-only FPGA artifacts (`rv700dd.chk`, `u2p_ecp5_impl1.bit`).

### Full E2E gate

Executed against JTAG-deployed `agent/cfg-single-group-upstream` commit `6fd9cdc9`:

```sh
./run-tests -H u64
```

Result: **19/19 suites passed in 698 seconds**, including `cfg-single-group`, `machine-code-monitor`, and `assembly64`.

[Full 54,553-byte transcript](https://gist.github.com/chrisgleissner/4f23105878dd1d6fdbef08d72f4be284)