### PR TITLE
Add a machine:heap endpoint for measuring heap leaks

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -169,6 +169,10 @@ SUITES: Sequence[Suite] = (
           "-H @HOST@ -p @PASS@ --mode @MODE@"),
 
     # --------------------------------------------------------------- soak --
+    # Creates disk images to measure whether the heap comes back, so it needs a
+    # writable directory. Skips entirely on firmware without machine:heap.
+    Suite("soak", "heap-leak", "tests/soak/api/heap_leak_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     Suite("soak", "listener-soak", "tests/soak/network/listener_soak_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     # The stress profile is the bounded one, at about two minutes. The soak

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -393,3 +393,20 @@ API_CALL(GET, machine, measure, NULL, ARRAY( {  }))
     }
     free(buffer);
 }
+
+// Heap statistics. Every dynamic allocation on this target reaches the FreeRTOS
+// heap -- operator new goes through get_mem() and malloc through __wrap_malloc,
+// and both call pvPortMalloc (software/system/memory_wrap.cc). So one free-bytes
+// figure accounts for all of it, which is what makes a leak visible from outside:
+// sample before and after a body of work, then compare.
+//
+// "free" is the number to diff. "min_ever_free" is the low-water mark since boot,
+// useful for headroom but not for leaks: it never recovers, so it cannot tell a
+// leak from a transient peak.
+API_CALL(GET, machine, heap, NULL, ARRAY( {  }))
+{
+    resp->json->add("free", (int)xPortGetFreeHeapSize());
+    resp->json->add("min_ever_free", (int)xPortGetMinimumEverFreeHeapSize());
+    resp->json->add("total", (int)configTOTAL_HEAP_SIZE);
+    resp->json_response(HTTP_OK);
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,6 +38,19 @@ A package that is missing either fails its suite with a message naming what to
 install, or reports the coverage it had to leave out. Neither case passes
 quietly.
 
+## Measuring heap leaks
+
+`tests/soak/api/heap_leak_test.py` asserts that repeated REST operations give
+their memory back, using `GET /v1/machine:heap`. A device running firmware
+older than that endpoint answers 404 and the suite skips, so it is safe to run
+against any image.
+
+It measures the *slope* over repeated operations after a warmup, not a single
+before/after. A first run legitimately allocates one-time caches and lazy
+singletons that never come back; only a cost that repeats every iteration is a
+leak. Comparing one cold run against another warm one reads those one-time
+costs as a leak and is the easiest way to get this wrong.
+
 ## Command-line conventions
 
 The runner and every suite it starts take the same flags for the same things,

--- a/tests/soak/api/heap_leak_test.py
+++ b/tests/soak/api/heap_leak_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Soak: assert REST operations return the heap they borrow.
+
+Every dynamic allocation on this target reaches the FreeRTOS heap, so one
+free-bytes figure accounts for all of it. Repeating an operation and watching
+that figure is the only way to see a leak from outside the device -- nothing
+else in the REST surface exposes it.
+
+Uses GET /v1/machine:heap. Firmware predating that endpoint answers 404 and
+every check here skips, so the suite is safe to run against any image.
+
+Method: measure the steady-state slope, not a single before/after. The first
+iteration of anything also pays one-time costs -- lazy singletons, caches,
+first-touch filesystem structures -- that never come back and are not leaks.
+Those land entirely in the warmup, so the slope over the measured iterations
+is the per-operation leak alone.
+"""
+
+import argparse
+import ftplib
+import os
+import sys
+import urllib.parse
+from typing import Optional
+
+# tests/lib holds the reporting rules and the one shared REST client.
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"))
+import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
+from report import (  # noqa: E402
+    Failure, check, check_ok, check_skip, check_start, detail, format_exception,
+    section, suite_fail, suite_ok)
+
+HEAP_PATH = "/v1/machine:heap"
+# A disk image is the cheapest REST call that allocates a large buffer, which
+# is what makes it a good canary: create_file_of_size -> write_zeros.
+CREATE_PATH = "/v1/files/{dir}/{name}:create_d64"
+# Enough iterations that a 16 KB-per-call leak is unmistakable, few enough that
+# the suite stays inside a soak run's patience.
+WARMUP = 3
+MEASURED = 12
+# Per-operation slope we are willing to call "no leak". The observed noise
+# floor on an idle device is a few hundred bytes across a dozen operations;
+# a real leak in this path is thousands of bytes per call.
+TOLERANCE_BYTES_PER_OP = 512
+
+
+class Device:
+    """The device under measurement, over the shared REST client.
+
+    Everything HTTP goes through tests/lib/rest.py so this suite inherits the
+    one retry policy rather than growing another copy of it.
+    """
+
+    def __init__(self, host: str, password: Optional[str], timeout: float) -> None:
+        self.host = host
+        self.rest = rest_lib.RestClient(host, password, timeout)
+
+    def heap_free(self) -> int:
+        data = self.rest.json(HEAP_PATH)
+        return int(data["free"])
+
+    def heap_available(self) -> bool:
+        return self.rest.status("GET", HEAP_PATH) == 200
+
+    def create_d64(self, directory: str, name: str) -> None:
+        path = CREATE_PATH.format(dir=urllib.parse.quote(directory),
+                                  name=urllib.parse.quote(name))
+        # Idempotent is false: this creates a file, and a blind retry after a
+        # sent request would hit FA_CREATE_NEW and fail on the second attempt.
+        self.rest.expect("PUT", path, params={"diskname": "LEAK"})
+
+
+def cleanup(host: str, directory: str, names) -> int:
+    """Remove what the measurement created. FTP, because the REST surface has
+    no delete verb for files."""
+    removed = 0
+    try:
+        ftp = ftplib.FTP()
+        ftp.connect(host, 21, timeout=20)
+        ftp.login()
+        ftp.cwd(f"/{directory}")
+        for n in names:
+            try:
+                ftp.delete(n)
+                removed += 1
+            except ftplib.all_errors:
+                pass
+        ftp.quit()
+    except ftplib.all_errors:
+        pass
+    return removed
+
+
+def run_create_d64_slope(dev: Device, directory: str) -> bool:
+    """Repeat create_d64 and require the heap to come back each time."""
+    section("create_d64 returns the heap it borrows")
+    created = []
+    try:
+        with check(f"warm up ({WARMUP} images, one-time costs land here)"):
+            for i in range(WARMUP):
+                name = f"leakw{i}.d64"
+                dev.create_d64(directory, name)
+                created.append(name)
+
+        measured = {}
+        try:
+            with check(f"free heap is flat across {MEASURED} more images"):
+                before = dev.heap_free()
+                for i in range(MEASURED):
+                    name = f"leakm{i}.d64"
+                    dev.create_d64(directory, name)
+                    created.append(name)
+                after = dev.heap_free()
+                consumed = before - after
+                measured.update(before=before, after=after, consumed=consumed,
+                                per_op=consumed / MEASURED)
+                if measured["per_op"] > TOLERANCE_BYTES_PER_OP:
+                    raise Failure(
+                        f"create_d64 leaks about {measured['per_op']:.0f} bytes per "
+                        f"call ({consumed} bytes over {MEASURED} calls)")
+            ok = True
+        except Failure:
+            ok = False
+        if measured:
+            detail(f"free before {measured['before']}, after {measured['after']}")
+            detail(f"consumed {measured['consumed']} bytes over {MEASURED} images "
+                   f"= {measured['per_op']:.0f} bytes/image "
+                   f"(tolerance {TOLERANCE_BYTES_PER_OP})")
+        return ok
+    finally:
+        removed = cleanup(dev.host, directory, created)
+        detail(f"removed {removed} of {len(created)} images created by this suite")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assert that repeated REST operations do not consume heap. "
+                    "Skips if the firmware has no machine:heap endpoint.")
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS"))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "30.0")))
+    parser.add_argument("-d", "--directory", default="Temp",
+                        help="Writable device directory to create images in.")
+    args = parser.parse_args()
+
+    dev = Device(args.host, args.password, args.timeout)
+
+    check_start("device exposes GET /v1/machine:heap")
+    if not dev.heap_available():
+        check_skip("firmware predates GET /v1/machine:heap, nothing to measure")
+        section("summary")
+        detail("skipped: device firmware has no machine:heap endpoint")
+        suite_ok("heap_leak_test")
+        return 0
+    check_ok()
+
+    ok = run_create_d64_slope(dev, args.directory)
+
+    section("summary")
+    detail(f"create_d64 slope: {'OK' if ok else 'FAIL'}")
+    if ok:
+        suite_ok("heap_leak_test")
+        return 0
+    suite_fail("heap_leak_test", "see the summary above")
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        suite_fail("heap_leak_test", format_exception(exc))
+        raise SystemExit(1)


### PR DESCRIPTION
Tooling from #763. @chrisgleissner and @GideonZ both preferred this not be hidden behind a build flag, so it is now always compiled — the `HEAP_DIAG` flag and the `EXTRA_DEFINES` Makefile hook from the draft are gone. Undocumented is your call.

Agreed on the reasoning: `machine:debugreg` and `machine:measure` are already unconditional developer endpoints, so the category exists. And behind a flag this only helps people who build and flash their own firmware, which is exactly the group least in need of help.

> **Merge this before #764.** #764 carries a second soak suite (`soak/prg-context-menu-leak`) that needs this endpoint; without it that suite skips and the leak it guards is unmeasured. Both PRs add an entry to the same block in `run-tests`, arranged so they do not collide — confirmed by a trial merge of the two branches.

### `GET /v1/machine:heap`

```json
{ "free": 5311204, "min_ever_free": 5311172, "total": 8388608 }
```

Every dynamic allocation on this target reaches the FreeRTOS heap — `operator new` through `get_mem()` and `malloc` through `__wrap_malloc` both call `pvPortMalloc` (`software/system/memory_wrap.cc`). One free-bytes figure accounts for all of it, which is what makes a leak visible from outside.

`free` is the number to diff. `min_ever_free` is the low-water mark since boot: useful for headroom, but it never recovers, so it cannot tell a leak from a transient peak.

### `tests/soak/api/heap_leak_test.py`

Registered as `soak/heap-leak`. Asserts repeated `create_d64` calls give their memory back, and skips on firmware without the endpoint so it is safe against any image.

The design point worth reviewing: it measures the **steady-state slope** after a warmup, not a single before/after. A first run legitimately allocates one-time caches and lazy singletons that never come back. During this work `ui-backend-smoke` looked like a 7.5 KB leak on a first pass and is simply first-use initialisation — a naive before/after would have sent us chasing a bug that does not exist.

### Verification

Full E2E gate on this build, **all 18 suite runs passed** (log below).

The soak suite **fails on this branch, and should**: it is based on `test-merge`, which still has the `write_zeros` leak that #764 fixes.

```
[03] free heap is flat across 12 more images ... FAIL
     consumed 196704 bytes over 12 images = 16392 bytes/image (tolerance 512)
```

With #764 applied the same suite reads `0 bytes/image`, with an identical free heap byte for byte. Known-positive and known-negative, so you can confirm the instrument reads true without taking my word for it.

### One question for later

@chrisgleissner mentioned a possible Prometheus metrics endpoint. If that is coming, `machine:heap` may want folding into it. Not a blocker, but easier to decide now than once people are using it — undocumented or not.

### Not included

The per-suite survey harness and the per-check bisection wrapper that actually located the leak (it patches `report.check_start` to sample the endpoint around every check). Left out to keep this reviewable; happy to add either if you want them in the tree.

#763 has the full method. Leaks remain, but fewer than when this opened: #764 now also fixes a file handle leaked on every context-menu PRG load, which accounted for most of `prg-context-menu`. About 4 KB per action still leaks on the D64 path, and `assembly64` (~33 KB/run) has not been bisected at all.

<details>
<summary><b>Full <code>./run-tests -H &lt;device&gt;</code> output (1063 lines, all 18 passed)</b></summary>

```

============================================================
Ultimate hardware test run
============================================================
     host:       192.168.1.62
     categories: e2e
     modes:      overlay
     timeout:    30.0s
     on failure: continue
     health:    answers + health sweep, retry after recovery

============================================================
E2E  transport-usage  (overlay)
============================================================
UI state dirty: the root browser is not on top; a nested object still holds the UI; repairing
UI state repaired
     transport-usage: health: ping=22ms rest=20ms ftp=26ms telnet=42ms ident=19ms dma=29ms raster=39ms jiffy=42ms -> OK
check_transport_usage: OK (41 files, 0.184s)
transport-usage: OK (0.218s)

============================================================
E2E  runner-policy  (overlay)
============================================================
     runner-policy: health: ping=22ms rest=31ms ftp=16ms telnet=45ms ident=57ms dma=12ms raster=38ms jiffy=47ms -> OK
[01] a clean run exits 0 ... OK (0.000s)
[02] a failed suite exits 1 ... OK (0.000s)
[03] a recovery with no failure exits 3 ... OK (0.000s)
[04] a failure outranks a recovery ... OK (0.000s)
[05] a device that cannot be made healthy exits 4, outranking a failure ... OK (0.000s)
[06] a device that answers is never recovered ... OK (0.000s)
[07] recovery runs only once the ordinary wait has given up ... OK (0.011s)
     fixture: the device is unhealthy: it is not answering
[08] a recovery that does not bring the device back reports so ... OK (0.068s)
     fixture: the device is unhealthy: it is not answering
[09] a recovery command that exits non-zero is still followed by a probe ... OK (0.006s)
     fixture: the device is unhealthy: it is not answering
[10] a recovery command that hangs is bounded by --recover-timeout ... OK (0.203s)
     fixture: the device is unhealthy: it is not answering
[11] a recovery command the shell cannot find is a failed recovery ... OK (0.070s)
     fixture: the device is unhealthy: it is not answering
[12] no recovery command means no recovery ... OK (0.000s)
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: no --recover-command was given
[13] a suite gives up after --recover-max-per-suite recoveries ... OK (0.135s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
[14] the per-suite budget starts again at the next suite ... OK (0.076s)
     fixture: the device is unhealthy: it is not answering
[15] the run gives up after --recover-max-total recoveries ... OK (0.137s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
[16] the refusal says which ceiling was reached ... OK (0.073s)
     fixture: the device is unhealthy: it is not answering
[17] a healthy sweep after a failed suite recovers nothing ... OK (0.000s)
     fixture: health: rest=9ms -> OK
[18] a degraded but reachable device is recovered ... OK (0.011s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms -> OK
[19] a device still degraded after recovering is reported, not retried ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
[20] a degraded device is not recovered past its ceiling ... OK (0.011s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: not recovering: the run has already used its 1 recoveries
[21] --no-health-check takes the sweep out of the decision ... OK (0.000s)
[22] --no-health-check still recovers a device that has gone ... OK (0.060s)
     fixture: the device is unhealthy: it is not answering
[23] consecutive resets collapse into one ... OK (0.000s)
[24] a read between two resets does not warrant the second ... OK (0.000s)
[25] a mutating call between two resets warrants the second ... OK (0.000s)
[26] force resets even when nothing has changed ... OK (0.000s)
[27] a suite told the device was just reset does not reset again ... OK (0.000s)
[28] a suite not told that still resets ... OK (0.000s)
[29] a suite that fails on a healthy device is not run again ... OK (0.026s)
[30] a suite that fails on an unhealthy device runs again after recovery ... OK (0.076s)
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
[31] --no-retry keeps the recovery and drops the extra attempt ... OK (0.028s)
[32] a device that cannot be made healthy ends the run ... OK (0.025s)
fixture: OK (1.500s)
[33] a health sweep reaches the JSONL with a latency per check ... OK (0.000s)
[34] a suite record carries the profile, attempt and recoveries ... OK (0.000s)
[35] the run record agrees with the exit status ... OK (0.000s)
[36] a sweep with every check passing is healthy ... OK (0.000s)
[37] a failed check makes the sweep degraded and names it ... OK (0.000s)
[38] a skipped check never makes the sweep degraded ... OK (0.000s)
[39] the one-line summary carries every latency and the verdict ... OK (0.000s)
     the recovery command runs on a degraded or unreachable device, never on a suite that merely failed
runner_policy_test: OK (39 checks, 1.051s)
runner-policy: OK (1.110s)

============================================================
E2E  ui-backend-smoke  (overlay)
============================================================
     ui-backend-smoke: health: ping=12ms rest=14ms ftp=14ms telnet=45ms ident=27ms dma=12ms raster=32ms jiffy=54ms -> OK

--- Overlay navigation planner
[01] a unique first letter jumps straight to the item ... OK (0.000s)
[02] a shared first letter extends the prefix rather than walking ... OK (0.000s)
[03] walking wins when the item is already next to the cursor ... OK (0.000s)
[04] the seek lands on the first match and the walk covers the rest ... OK (0.000s)
[05] a prefix never contains a space, which selects rather than seeks ... OK (0.000s)
[06] a plan is never longer than walking from the top ... OK (0.000s)
[07] an upward walk is planned when that is the shorter route ... OK (0.000s)
--- OK (7 checks, 0.000s)

--- Telnet backend
[08] Telnet: connect, navigate, teardown ... OK (1.946s)
--- OK (1 checks, 1.946s)

--- REST backend, Interface Type = Freeze
[09] REST/Freeze: connect, navigate, teardown ... OK (3.008s)
--- OK (1 checks, 3.008s)

--- REST backend, Interface Type = Overlay on HDMI
[10] REST/Overlay: connect, navigate, teardown ... OK (3.035s)
--- OK (1 checks, 3.035s)
ui_backend_smoke_test: OK (10 checks, 7.999s)
ui-backend-smoke: OK (8.064s)

============================================================
E2E  readmem-writemem  (overlay)
============================================================
     readmem-writemem: health: ping=11ms rest=14ms ftp=13ms telnet=40ms ident=16ms dma=10ms raster=27ms jiffy=43ms -> OK
[01] reset C64 to a clean, stable state ... OK (0.026s)
[02] read User Interface Settings config ... OK (0.023s)
     current Interface Type: Freeze

--- bounds: readmem rejects out-of-range parameters before allocating, and max-size reads do not degrade the device
[03] readmem rejects zero length ... OK (0.017s)
[04] readmem rejects negative length ... OK (0.015s)
[05] readmem rejects length one past the 64KB cap ... OK (0.014s)
[06] readmem rejects length far past the cap ... OK (0.032s)
[07] readmem rejects length that overflows a long ... OK (0.023s)
[08] readmem rejects read running past $FFFF ... OK (0.015s)
[09] readmem rejects address above $FFFF ... OK (0.014s)
[10] readmem rejects negative address ... OK (0.013s)
[11] 8 back-to-back max-size reads ($0000, 65536 bytes) all succeed ... OK (1.801s)
[12] 25 unsupported machine:measure calls leave readmem working ... OK (0.627s)
[13] switch to Overlay on HDMI to probe live background activity ... OK (0.013s)
[14] probe addresses that change on their own while the C64 runs ... OK (6.198s)
     6 address(es) treated as expected live background noise: $00A1, $00A2, $00CD, $00CF, $01F2, $0287
[15] set Interface Type = Freeze ... OK (0.015s)
[16] open menu (Freeze) ... OK (0.303s)
[17] write full-range pattern (Freeze) ... OK (0.426s)
[18] read back full range (Freeze) ... OK (0.231s)
[19] menu still open after write+read (Freeze) ... OK (0.024s)
--- OK (17 checks, 9.815s)

--- selfcheck-freeze: write and read both happen in Freeze (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-freeze] ignored ROM mismatches (writes to real ROM are no-ops): 16330
     [selfcheck-freeze] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-freeze] ignored known-live-noise mismatches: 0
     [selfcheck-freeze] color RAM (low nibble) mismatches: 0
     [selfcheck-freeze] RAM mismatches: 0
[20] close menu (Freeze) ... OK (0.312s)
[21] set Interface Type = Overlay on HDMI ... OK (0.015s)
[22] open menu (Overlay on HDMI) ... OK (0.303s)
[23] pause C64 for exact round trip (Overlay on HDMI) ... OK (0.016s)
[24] write full-range pattern (Overlay on HDMI) ... OK (0.495s)
[25] read back full range (Overlay on HDMI) ... OK (0.217s)
[26] resume C64 after exact round trip (Overlay on HDMI) ... OK (0.013s)
[27] menu still open after write+read (Overlay on HDMI) ... OK (0.017s)
--- OK (8 checks, 1.412s)

--- selfcheck-overlay-on-hdmi: write and read both happen in Overlay on HDMI (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-overlay-on-hdmi] ignored ROM mismatches (writes to real ROM are no-ops): 0
     [selfcheck-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-overlay-on-hdmi] ignored known-live-noise mismatches: 0
     [selfcheck-overlay-on-hdmi] color RAM (low nibble) mismatches: 0
     [selfcheck-overlay-on-hdmi] RAM mismatches: 0
[28] close menu (Overlay on HDMI) ... OK (0.311s)
[29] close menu for the screen round trip (Overlay on HDMI) ... OK (0.046s)
[30] pause C64 for the screen round trip (Overlay on HDMI) ... OK (0.014s)
[31] write and read back $0400-$07FF (Overlay on HDMI) ... OK (0.105s)
[32] resume C64 after the screen round trip (Overlay on HDMI) ... OK (0.016s)
--- OK (5 checks, 0.515s)

--- screen-round-trip-overlay-on-hdmi: screen RAM round-trips exactly with no menu open
     [screen-round-trip-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected 0)
[33] set Interface Type = Overlay on HDMI ... OK (0.016s)
[34] open menu (Overlay on HDMI) ... OK (0.342s)
[35] write full-range pattern (Overlay on HDMI) ... OK (0.596s)
[36] capture ground truth in Overlay on HDMI mode ... OK (0.228s)
[37] close menu (Overlay on HDMI) ... OK (0.303s)
[38] set Interface Type = Freeze ... OK (0.016s)
[39] open menu (Freeze) ... OK (0.360s)
[40] read full range (Freeze) ... OK (0.250s)
[41] menu still open after cross-mode read (Freeze) ... OK (0.037s)
--- OK (9 checks, 2.152s)

--- overlay-on-hdmi-write_freeze-read: bytes written while Overlay on HDMI must read back the same while Freeze, except screen RAM (menu-owned while frozen)
     [overlay-on-hdmi-write_freeze-read] screen ($0400-$07FF) mismatches: 996 (expected, menu owns this range while frozen)
     [overlay-on-hdmi-write_freeze-read] ignored known-live-noise mismatches: 0
     [overlay-on-hdmi-write_freeze-read] color RAM (low nibble) mismatches: 0
     [overlay-on-hdmi-write_freeze-read] RAM mismatches: 0
[42] close menu (Freeze) ... OK (0.336s)
[43] set Interface Type = Freeze ... OK (0.015s)
[44] open menu (Freeze) ... OK (0.346s)
[45] write full-range pattern (Freeze) ... OK (0.565s)
[46] capture ground truth in Freeze mode ... OK (0.221s)
[47] close menu (Freeze) ... OK (0.307s)
[48] set Interface Type = Overlay on HDMI ... OK (0.016s)
[49] open menu (Overlay on HDMI) ... OK (0.302s)
[50] read full range (Overlay on HDMI) ... OK (0.211s)
[51] menu still open after cross-mode read (Overlay on HDMI) ... OK (0.019s)
--- OK (10 checks, 2.362s)

--- freeze-write_overlay-on-hdmi-read: bytes written while Freeze must read back the same while Overlay on HDMI, except screen RAM (menu-owned while frozen)
     [freeze-write_overlay-on-hdmi-read] screen ($0400-$07FF) mismatches: 1020 (expected, menu owns this range while frozen)
     [freeze-write_overlay-on-hdmi-read] ignored known-live-noise mismatches: 0
     [freeze-write_overlay-on-hdmi-read] color RAM (low nibble) mismatches: 0
     [freeze-write_overlay-on-hdmi-read] RAM mismatches: 0
[52] close menu (Overlay on HDMI) ... OK (0.324s)
     restored Interface Type to 'Freeze'
--- OK (1 checks, 2.593s)

--- summary
     bounds: OK
     selfcheck-freeze: OK
     selfcheck-overlay: OK
     screen-round-trip: OK
     overlay-to-freeze: OK
     freeze-to-overlay: OK
readmem_writemem_test: OK (52 checks, 25.0s)
readmem-writemem: OK (25.1s)

============================================================
E2E  menu-screen  (overlay)
============================================================
     menu-screen: health: ping=12ms rest=19ms ftp=13ms telnet=52ms ident=17ms dma=13ms raster=49ms jiffy=29ms -> OK
[01] open menu ... OK (0.015s)
[02] GET menu_screen contract ... OK (0.019s)
[03] menu_screen renders a real menu ... OK (0.000s)
[04] close menu ... OK (0.014s)
[05] GET menu_screen unavailable ... OK (0.014s)
[06] GET menu_screen auth ... SKIP (--password not supplied, 0.000s)
menu_screen_test: OK (6 checks, 1.272s)
menu-screen: OK (1.325s)

============================================================
E2E  input  (overlay)
============================================================
     input: health: ping=22ms rest=17ms ftp=19ms telnet=41ms ident=29ms dma=11ms raster=32ms jiffy=794ms -> OK
[01] input snapshot has stable empty response shape ... OK (0.037s)
[02] POST accepts 64 event batch ... OK (0.084s)
[03] bad content-type is rejected without mutation ... OK (0.104s)
[04] missing JSON body is rejected without mutation ... OK (0.096s)
[05] malformed JSON is rejected without mutation ... OK (0.091s)
[06] unknown root field is rejected without mutation ... OK (0.107s)
[07] late invalid event keeps whole batch atomic ... OK (0.110s)
[08] joystick port 2 fire keeps Anykey buttons 2 and 3 released ... OK (0.321s)
[09] joystick port 2 fire2 lights only Anykey button 2 ... OK (0.305s)
[10] joystick port 2 fire3 lights only Anykey button 3 ... OK (0.212s)
[11] joystick port 1 up press is visible on CIA reads ... OK (0.195s)
[12] joystick port 1 all inputs and idempotent release are visible on CIA reads ... OK (0.175s)
[13] joystick port 2 diagonal and fire are visible on CIA reads ... OK (0.157s)
[14] joystick partial release is visible on CIA reads ... OK (0.193s)
[15] joystick fire2/fire3 round-trip through REST state ... OK (0.290s)
[16] joystick release_all then press in same batch is visible on CIA reads ... OK (0.135s)
[17] joystick unusual combination is visible on CIA reads ... OK (0.145s)
[18] joystick tap does not release persistent input ... OK (0.359s)
[19] joystick tap auto releases ... OK (0.378s)
[20] invalid joystick batch does not mutate state ... OK (0.222s)
[21] joystick release_all clears both ports ... OK (0.149s)
[22] machine reset clears keyboard and joystick REST state ... OK (3.145s)
[23] keyboard single-tap batch is consumed by BASIC in order ... OK (0.925s)
[24] keyboard 10 Hz mixed alphabet echo has no missed presses ... OK (5.498s)
[25] keyboard 20 Hz alternating ab echo has no missed presses ... OK (6.343s)
[26] keyboard 5 Hz alternating ab echo has no missed presses ... OK (3.882s)
[27] keyboard single letter reaches the live C64 matrix ... OK (0.215s)
[28] keyboard shifted pair reaches the live C64 matrix ... OK (0.327s)
[29] keyboard batch applies multiple presses atomically ... OK (0.359s)
[30] keyboard ordered batch and idempotent release ... OK (0.104s)
[31] keyboard release_all can be followed by press in same batch ... OK (0.096s)
[32] keyboard accepts eight simultaneous inputs ... OK (0.170s)
[33] keyboard tap does not release persistent key ... OK (0.196s)
[34] keyboard release_all clears state ... OK (0.102s)
[35] keyboard restore tap auto releases ... OK (0.274s)
[36] keyboard special-key taps snapshot correctly and auto release ... OK (2.737s)
[37] keyboard tap is visible in the live hardware snapshot and auto releases ... OK (0.298s)
[38] keyboard cursor-left tap is visible in the live hardware snapshot and auto releases ... OK (0.366s)
[39] keyboard tap batch drains through the live matrix path ... OK (1.332s)
[40] keyboard long repeated tap train drains fully without sticky state ... OK (6.138s)
[41] invalid keyboard batch does not mutate state ... OK (0.066s)
[42] menu editor accepts an unshifted control character ... OK (1.008s)
[43] menu editor keeps separate-batch shift active across POSTs ... OK (2.853s)
[44] menu editor repeats a held printable key ... OK (3.661s)
[45] menu editor stops printable repeat after release ... OK (5.819s)
[46] menu editor accepts a single cursor-left control ... OK (4.615s)
[47] menu editor repeats a held cursor-left control ... OK (4.737s)
[48] menu editor stops cursor repeat after release ... OK (6.362s)
input_test: OK (48 checks, 81.9s)
input: OK (82.1s)

============================================================
E2E  prg-context-menu  (overlay)
============================================================
     prg-context-menu: health: ping=23ms rest=15ms ftp=14ms telnet=51ms ident=25ms dma=17ms raster=31ms jiffy=38ms -> OK
[01] reset the machine to a clean starting state ... OK (2.922s)
[02] seed /Temp with prgmenu02269.prg, prgmenu02269.d64 and a long-named PRG ... OK (0.740s)

--- every context-menu action on a plain PRG
[03] read the context menu of a plain PRG ... OK (2.427s)
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
[04] a plain PRG: every offered action is covered ... OK (0.000s)
[05] Run on a plain PRG ... OK (7.315s)
[06] Load on a plain PRG ... OK (6.092s)
[07] DMA on a plain PRG ... OK (8.142s)
[08] View on a plain PRG ... OK (3.596s)
[09] Hex View on a plain PRG ... OK (3.915s)
[10] Copy to... on a plain PRG ... OK (6.759s)
[11] Rename on a plain PRG ... OK (6.563s)
[12] Move to... on a plain PRG ... OK (7.063s)
[13] Delete on a plain PRG ... OK (4.297s)
--- OK (11 checks, 56.2s)

--- every context-menu action on a PRG inside a D64
[14] read the context menu of a PRG inside a D64 ... OK (3.465s)
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
[15] a PRG inside a D64: every offered action is covered ... OK (0.000s)
[16] Run on a PRG inside a D64 ... OK (8.909s)
[17] Load on a PRG inside a D64 ... OK (7.195s)
[18] DMA on a PRG inside a D64 ... OK (9.356s)
[19] Mount & Run on a PRG inside a D64 ... OK (9.852s)
[20] Real Run on a PRG inside a D64 ... OK (12.8s SLOW)
[21] View on a PRG inside a D64 ... OK (5.217s)
[22] Hex View on a PRG inside a D64 ... OK (5.068s)
[23] Copy to... on a PRG inside a D64 ... OK (8.443s)
[24] Rename on a PRG inside a D64 ... OK (8.362s)
[25] Move to... on a PRG inside a D64 ... OK (9.978s)
[26] Delete on a PRG inside a D64 ... OK (5.958s)
[27] Run a PRG whose name is far longer than the boot-cart display ... OK (8.643s)
--- OK (14 checks, 103s)
prg_context_menu_test: OK (23 actions, 164s)
prg-context-menu: OK (165s)

============================================================
E2E  browser-long-filename  (overlay)
============================================================
     browser-long-filename: health: ping=25ms rest=15ms ftp=31ms telnet=43ms ident=21ms dma=33ms raster=119ms jiffy=29ms -> OK
[01] reset the machine to a clean starting state ... OK (0.572s)
[02] seed long-name fixture for rename ... OK (1.102s)
[03] browser rename on long filename ... OK (7.748s)
[04] reseed long-name fixture for mount ... OK (1.446s)
[05] browser mount on long filename ... OK (5.149s)
browser_long_filename_test: OK (5 checks, 16.7s)
browser-long-filename: OK (17.9s)

============================================================
E2E  browser-filesystem-refresh  (overlay)
============================================================
     browser-filesystem-refresh: health: ping=17ms rest=28ms ftp=21ms telnet=55ms ident=28ms dma=23ms raster=48ms jiffy=38ms -> OK
[01] reset the machine to a clean starting state ... OK (0.675s)
[02] prepare fixture directories ... OK (0.143s)
[03] open Menu, Telnet and FTP on the fixture directory ... OK (4.382s)
[04] rename from the Menu ... OK (4.058s)
[05] rename from Telnet ... OK (3.277s)
[06] rename from FTP ... OK (1.481s)
[07] rename under observer-queue pressure from the Menu ... OK (5.650s)
[08] rename under observer-queue pressure from Telnet ... OK (4.852s)
[09] rename a directory from the Menu ... OK (3.655s)
[10] rename a directory from Telnet ... OK (2.999s)
[11] delete from the Menu ... OK (2.658s)
[12] delete from Telnet ... OK (2.851s)
[13] delete from FTP ... OK (1.046s)
[14] delete a non-empty directory from the Menu ... OK (2.581s)
[15] delete a non-empty directory from Telnet ... OK (2.406s)
[16] remove a directory from FTP ... OK (0.928s)
[17] select all and bulk delete from the Menu ... OK (2.449s)
[18] create from the Menu ... OK (3.713s)
[19] create from Telnet ... OK (3.375s)
[20] create from FTP ... OK (1.404s)
     STOR phase 1 (open, 0 bytes committed): Menu=<empty>; Telnet=<empty>; FTP=<empty>
[21] create from FTP (mkd) ... OK (0.876s)
[22] create from REST (d64) ... OK (0.874s)
[23] create from REST (d71) ... OK (0.912s)
[24] create from REST (d81) ... OK (0.926s)
[25] create from REST (dnp) ... OK (0.913s)
[26] write from the Menu ... OK (2.880s)
[27] write from Telnet ... OK (3.069s)
[28] write from FTP ... OK (1.924s)
     STOR phase 1 (open, truncated): Menu=wftp1.tst[ 100 ]; Telnet=wftp1.tst[ 100 ]; FTP=wftp1.tst[ 100 ]=100
[29] copy over an existing file from the Menu ... OK (11.7s SLOW)
[30] copy over an existing file from Telnet ... OK (10.8s SLOW)
[31] move an entry out of the watched directory from the Menu ... OK (5.787s)
[32] move an entry out of the watched directory from Telnet ... OK (5.129s)
[33] paste into the watched directory from the Menu ... OK (7.380s)
[34] paste into the watched directory from Telnet ... OK (7.620s)
[35] failed rename shows nothing ... OK (1.167s)
[36] failed delete removes nothing ... OK (1.118s)
[37] failed write creates nothing ... OK (0.955s)
[38] short write commits consistently ... OK (1.007s)
     short write committed 100 bytes

operation x origin x observer matrix
------------------------------------------------------------------------------
  rename       Menu    Menu    OK    0.23s
  rename       Menu    Telnet  OK    0.23s
  rename       Menu    FTP     OK    0.23s
  rename       Menu    REST    OK    0.23s
  rename       Telnet  Menu    OK    0.23s
  rename       Telnet  Telnet  OK    0.23s
  rename       Telnet  FTP     OK    0.23s
  rename       Telnet  REST    OK    0.23s
  rename       FTP     Menu    OK    0.76s
  rename       FTP     Telnet  OK    0.76s
  rename       FTP     FTP     OK    0.76s
  rename       FTP     REST    OK    0.76s
  rename-under-load Menu    Menu    OK    0.21s
  rename-under-load Menu    Telnet  OK    0.21s
  rename-under-load Menu    FTP     OK    0.21s
  rename-under-load Menu    REST    OK    0.21s
  rename-under-load Telnet  Menu    OK    0.22s
  rename-under-load Telnet  Telnet  OK    0.22s
  rename-under-load Telnet  FTP     OK    0.22s
  rename-under-load Telnet  REST    OK    0.22s
  rename-dir   Menu    Menu    OK    0.21s
  rename-dir   Menu    Telnet  OK    0.21s
  rename-dir   Menu    FTP     OK    0.21s
  rename-dir   Menu    REST    OK    0.21s
  rename-dir   Telnet  Menu    OK    0.21s
  rename-dir   Telnet  Telnet  OK    0.21s
  rename-dir   Telnet  FTP     OK    0.21s
  rename-dir   Telnet  REST    OK    0.21s
  delete       Menu    Menu    OK    0.22s
  delete       Menu    Telnet  OK    0.22s
  delete       Menu    FTP     OK    0.22s
  delete       Menu    REST    OK    0.22s
  delete       Telnet  Menu    OK    0.22s
  delete       Telnet  Telnet  OK    0.22s
  delete       Telnet  FTP     OK    0.22s
  delete       Telnet  REST    OK    0.22s
  delete       FTP     Menu    OK    0.54s
  delete       FTP     Telnet  OK    0.54s
  delete       FTP     FTP     OK    0.54s
  delete       FTP     REST    OK    0.54s
  delete-dir   Menu    Menu    OK    0.22s
  delete-dir   Menu    Telnet  OK    0.22s
  delete-dir   Menu    FTP     OK    0.22s
  delete-dir   Menu    REST    OK    0.22s
  delete-dir   Telnet  Menu    OK    0.22s
  delete-dir   Telnet  Telnet  OK    0.22s
  delete-dir   Telnet  FTP     OK    0.22s
  delete-dir   Telnet  REST    OK    0.22s
  delete-dir   FTP/rmd Menu    OK    0.25s
  delete-dir   FTP/rmd Telnet  OK    0.25s
  delete-dir   FTP/rmd FTP     OK    0.25s
  delete-dir   FTP/rmd REST    OK    0.25s
  delete-bulk  Menu    Menu    OK    0.22s
  delete-bulk  Menu    Telnet  OK    0.22s
  delete-bulk  Menu    FTP     OK    0.22s
  delete-bulk  Menu    REST    OK    0.22s
  create       Menu    Menu    OK    0.22s
  create       Menu    Telnet  OK    0.22s
  create       Menu    FTP     OK    0.22s
  create       Menu    REST    OK    0.22s
  create       Telnet  Menu    OK    0.22s
  create       Telnet  Telnet  OK    0.22s
  create       Telnet  FTP     OK    0.22s
  create       Telnet  REST    OK    0.22s
  create       FTP     Menu    OK    0.33s
  create       FTP     Telnet  OK    0.33s
  create       FTP     FTP     OK    0.33s
  create       FTP     REST    OK    0.33s
  create       FTP/mkd Menu    OK    0.27s
  create       FTP/mkd Telnet  OK    0.27s
  create       FTP/mkd FTP     OK    0.27s
  create       FTP/mkd REST    OK    0.27s
  create       REST/d64 Menu    OK    0.33s
  create       REST/d64 Telnet  OK    0.33s
  create       REST/d64 FTP     OK    0.33s
  create       REST/d64 REST    OK    0.33s
  create       REST/d71 Menu    OK    0.29s
  create       REST/d71 Telnet  OK    0.29s
  create       REST/d71 FTP     OK    0.29s
  create       REST/d71 REST    OK    0.29s
  create       REST/d81 Menu    OK    0.27s
  create       REST/d81 Telnet  OK    0.27s
  create       REST/d81 FTP     OK    0.27s
  create       REST/d81 REST    OK    0.27s
  create       REST/dnp Menu    OK    0.29s
  create       REST/dnp Telnet  OK    0.29s
  create       REST/dnp FTP     OK    0.29s
  create       REST/dnp REST    OK    0.29s
  write        Menu    Menu    OK    0.22s
  write        Menu    Telnet  OK    0.22s
  write        Menu    FTP     OK    0.22s
  write        Menu    REST    OK    0.22s
  write        Telnet  Menu    OK    0.22s
  write        Telnet  Telnet  OK    0.22s
  write        Telnet  FTP     OK    0.22s
  write        Telnet  REST    OK    0.22s
  write        FTP     Menu    OK    0.54s
  write        FTP     Telnet  OK    0.54s
  write        FTP     FTP     OK    0.54s
  write        FTP     REST    OK    0.54s
  copy-write   Menu    Menu    N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Menu    Telnet  OK    0.20s
  copy-write   Menu    FTP     OK    0.20s
  copy-write   Menu    REST    OK    0.20s
  copy-arrival Menu    Menu    OK    no stale cache on re-entry
  copy-write   Telnet  Telnet  N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Telnet  Menu    OK    0.09s
  copy-write   Telnet  FTP     OK    0.09s
  copy-write   Telnet  REST    OK    0.09s
  copy-arrival Telnet  Telnet  OK    no stale cache on re-entry
  move-out     Menu    Menu    OK    0.22s
  move-out     Menu    Telnet  OK    0.22s
  move-out     Menu    FTP     OK    0.22s
  move-out     Menu    REST    OK    0.22s
  move-out     Telnet  Menu    OK    0.21s
  move-out     Telnet  Telnet  OK    0.21s
  move-out     Telnet  FTP     OK    0.21s
  move-out     Telnet  REST    OK    0.21s
  paste-write  Menu    Menu    OK    0.22s
  paste-write  Menu    Telnet  OK    0.22s
  paste-write  Menu    FTP     OK    0.22s
  paste-write  Menu    REST    OK    0.22s
  paste-write  Telnet  Menu    OK    0.33s
  paste-write  Telnet  Telnet  OK    0.33s
  paste-write  Telnet  FTP     OK    0.33s
  paste-write  Telnet  REST    OK    0.33s
  rename-fail  FTP     Menu    OK    0.23s
  rename-fail  FTP     Telnet  OK    0.23s
  rename-fail  FTP     FTP     OK    0.23s
  rename-fail  FTP     REST    OK    0.23s
  delete-fail  FTP     Menu    OK    0.25s
  delete-fail  FTP     Telnet  OK    0.25s
  delete-fail  FTP     FTP     OK    0.25s
  delete-fail  FTP     REST    OK    0.25s
  write-fail   FTP     Menu    OK    0.21s
  write-fail   FTP     Telnet  OK    0.21s
  write-fail   FTP     FTP     OK    0.21s
  write-fail   FTP     REST    OK    0.21s
  short-write  FTP     Menu    OK    0.27s
  short-write  FTP     Telnet  OK    0.27s
  short-write  FTP     FTP     OK    0.27s
  short-write  FTP     REST    OK    0.27s
------------------------------------------------------------------------------
  N/A=2, OK=140
browser_filesystem_refresh_test: OK (38 checks, 121s)
browser-filesystem-refresh: OK (123s)

============================================================
E2E  ftp-client  (overlay)
============================================================
     ftp-client: health: ping=12ms rest=15ms ftp=20ms telnet=41ms ident=19ms dma=11ms raster=60ms jiffy=414ms -> OK
     inferred --ftp-advertised-host 192.168.1.78
     controlled FTP server on 0.0.0.0:2121 (advertised 192.168.1.78)
[I 2026-08-10 18:56:20] concurrency model: async
[I 2026-08-10 18:56:20] masquerade (NAT) address: 192.168.1.78
[I 2026-08-10 18:56:20] passive ports: 30000->30019
[I 2026-08-10 18:56:20] >>> starting FTP server on 0.0.0.0:2121, pid=73329 <<<
     server root: /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-d1dtxrhj (marker E2E-1786402580)
[01] GET /v1/version reachable ... OK (0.1, 0.047s)
[02] menu closed -> menu_screen 404 ... OK (0.068s)
[03] menu_button opens menu ... OK (0.321s)
[04] menu_screen returns 2000-byte matrix ... OK (2000 bytes, 0.020s)
[05] input release_all works ... OK (0.020s)
[06] menu closes from anywhere ... OK (0.361s)
[07] remove any stale hosts left by a prior run ... OK (0 removed, 1.368s)

--- stage: smoke
[08] create FTP host 'E2EFTP25805a5d' through the New Host form ... OK (6.328s)
[09] new alias appears under /ftp ... OK (1.139s)
[10] enter host: server sees login + TYPE I + LIST ... [I 2026-08-10 18:56:31] 192.168.1.62:52432-[] FTP session opened (connect)
[I 2026-08-10 18:56:31] 192.168.1.62:52432-[u64e2e] USER 'u64e2e' logged in.
OK (PASS,TYPE,LIST, 1.263s)
[11] root listing shows fixture entries ... OK (README,DIRA,SMALL, 0.031s)
[12] open README.TXT -> RETR (52 bytes) ... [I 2026-08-10 18:56:33] 192.168.1.62:52432-[u64e2e] RETR /private/var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-d1dtxrhj/README.TXT completed=1 bytes=52 seconds=0.001
OK (52 bytes, 2.471s)
[13] remove host and confirm it disappears ... [I 2026-08-10 18:56:35] 192.168.1.62:52432-[u64e2e] FTP session closed (disconnect).
OK (3.409s)
--- OK (6 checks, 14.6s)

--- cleanup
     preserved: nothing

--- summary
     Phase    Operation              Result             Commands       Fixture/Notes
     ------------------------------------------------------------------------------
     smoke    create host            OK                                E2EFTP25805a5d
     smoke    list host              OK                                E2EFTP25805a5d
     smoke    enter/LIST             OK                 USER/PASS/TYPE E2EFTP25805a5d
     smoke    root entries           OK                 LIST           README/DIRA/SMALL
     smoke    RETR README            OK                 RETR           README.TXT 52 bytes
     smoke    remove host            OK                                E2EFTP25805a5d
     ------------------------------------------------------------------------------
     Total REST requests   : 155
     Total menu snapshots  : 65
     Total keyboard events : 102
     Total FTP commands    : 24
     Created host alias    : (removed)
     Remote root path      : /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-d1dtxrhj
     Cleanup status        : clean
Exception in thread Thread-1 (serve_forever):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/servers.py", line 254, in serve_forever
    self.ioloop.loop(timeout, blocking)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 376, in loop
    poll(timeout)
    ~~~~^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 741, in poll
    kevents = self._kqueue.control(
        None, _len(self.socket_map), timeout
    )
OSError: [Errno 9] Bad file descriptor
ftp-client: OK (18.3s)

============================================================
E2E  prg-load-path-trim  (overlay)
============================================================
     prg-load-path-trim: health: ping=12ms rest=17ms ftp=33ms telnet=42ms ident=16ms dma=27ms raster=36ms jiffy=44ms -> OK

--- Ultimate 64 PRG load path trim
     host: 192.168.1.62
     PUT file path: /Temp/rest-prg-path-trim-target-example.prg
     POST upload name: rest-prg-path-trim-upload-example.prg

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configure Temp Settings
[01] set Temp Auto Cleanup to Enabled ... OK (0.017s)
[02] set Temp Subfolders to Enabled ... OK (0.018s)
--- OK (2 checks, 0.035s)

--- 3. Prepare PRG Fixture
[03] upload PUT fixture rest-prg-path-trim-target-example.prg ... OK (0.211s)
--- OK (1 checks, 0.211s)

--- 4. Validate PUT Endpoints
[04] exercise PUT runners:load_prg ... OK (0.414s)
     PUT load_prg boot-cart name: ...T-EXAMPLE
[05] exercise PUT runners:run_prg ... OK (1.780s)
     PUT run_prg boot-cart name: ...T-EXAMPLE
--- OK (2 checks, 2.384s)

--- 5. Validate POST Endpoints
[06] exercise POST runners:load_prg ... OK (0.424s)
     POST load_prg boot-cart name: ...D-EXAMPLE
[07] exercise POST runners:run_prg ... OK (1.786s)
     POST run_prg boot-cart name: ...D-EXAMPLE
--- OK (2 checks, 3.022s)
prg_load_path_trim_test: OK (7 checks, 6.336s)

--- restore User Interface Settings
[08] set Temp Auto Cleanup to Enabled ... OK (0.018s)
[09] set Temp Subfolders to Enabled ... OK (0.018s)
prg-load-path-trim: OK (7.273s)

============================================================
E2E  temp-auto-cleanup  (overlay)
============================================================
     temp-auto-cleanup: health: ping=12ms rest=37ms ftp=14ms telnet=53ms ident=29ms dma=13ms raster=30ms jiffy=51ms -> OK

--- Ultimate 64 Temp auto cleanup
     host: 192.168.1.62

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configuration Setup
[01] set Temp Auto Cleanup to Enabled ... OK (0.026s)
[02] set Temp Subfolders to Enabled ... OK (0.016s)
--- OK (2 checks, 0.042s)

--- 3. Purging /Temp
     purge complete

--- 4. Mounting D64 Images
[03] create /Temp/mount-drive-8.d64 ... OK (0.055s)
[04] download mount-drive-8.d64 for the upload mount ... OK (0.470s)
[05] remove staging source mount-drive-8.d64 ... OK (0.078s)
[06] mount drive A ... OK (1.131s)
OK (1.131s)
[07] create /Temp/mount-drive-9.d64 ... OK (0.057s)
[08] download mount-drive-9.d64 for the upload mount ... OK (0.712s)
[09] remove staging source mount-drive-9.d64 ... OK (0.048s)
[10] mount drive B ... OK (1.109s)
OK (1.109s)
--- OK (10 checks, 3.661s)

--- 5. Seeding Baseline (10 files)
[11] upload base_1.bin ... OK (1.662s)
[12] upload base_2.bin ... OK (1.652s)
[13] upload base_3.bin ... OK (1.920s)
[14] upload base_4.bin ... OK (1.736s)
[15] upload base_5.bin ... OK (1.810s)
[16] upload base_6.bin ... OK (1.715s)
[17] upload base_7.bin ... OK (1.631s)
[18] upload base_8.bin ... OK (1.945s)
[19] upload base_9.bin ... OK (1.708s)
[20] upload base_10.bin ... OK (1.888s)
--- OK (10 checks, 17.7s)

--- 6. Managed Temp File Limit (Target: 10)
[21] upload managed_1.bin over REST ... OK (4.731s)
     managed count=1 (limit=10)
[22] upload managed_2.bin over REST ... OK (4.643s)
     managed count=2 (limit=10)
[23] upload managed_3.bin over REST ... OK (4.636s)
     managed count=3 (limit=10)
[24] upload managed_4.bin over REST ... OK (4.579s)
     managed count=4 (limit=10)
[25] upload managed_5.bin over REST ... OK (4.644s)
     managed count=5 (limit=10)
[26] upload managed_6.bin over REST ... OK (4.641s)
     managed count=6 (limit=10)
[27] upload managed_7.bin over REST ... OK (4.643s)
     managed count=7 (limit=10)
[28] upload managed_8.bin over REST ... OK (4.602s)
     managed count=8 (limit=10)
[29] upload managed_9.bin over REST ... OK (4.577s)
     managed count=9 (limit=10)
[30] upload managed_10.bin over REST ... OK (4.626s)
     managed count=10 (limit=10)
[31] upload managed_11.bin over REST ... OK (4.730s)
     managed count=10 (limit=10)
[32] upload managed_12.bin over REST ... OK (4.772s)
     managed count=10 (limit=10)
OK (5.251s)
OK (5.350s)
--- OK (14 checks, 61.3s)

--- 7. Unmounted Uploads Rejoin Cleanup
[33] remove drive A ... OK (0.133s)
[34] upload post_a_1.bin over REST ... OK (4.638s)
OK (4.750s)
     removed after 1 uploads
[35] remove drive B ... OK (0.125s)
[36] upload post_b_1.bin over REST ... OK (4.675s)
     removed after 1 uploads
--- OK (5 checks, 10.1s)

--- 8. Final Integrity Check
     user files intact
temp_auto_cleanup_test: OK (36 checks, 95.9s)

--- restore User Interface Settings
[37] set Temp Auto Cleanup to Enabled ... OK (0.019s)
[38] set Temp Subfolders to Enabled ... OK (0.019s)
temp-auto-cleanup: OK (96.5s)

============================================================
E2E  printer  (overlay)
============================================================
     printer: health: ping=11ms rest=14ms ftp=23ms telnet=50ms ident=20ms dma=34ms raster=40ms jiffy=57ms -> OK
[01] REST reachable at 192.168.1.62 ... OK (0.029s)
[02] reset before run ... OK (0.161s)
[03] load printer_e2e.prg ... OK (914 bytes, 0.000s)
[04] capture original Printer Settings ... OK (0.248s)
[05] print epson/bitmap: apply settings + run PRG ... OK (phase=printer closed heartbeat=4, 2.993s)
[06] print epson/bitmap: Flush/Eject via on-screen menu ... OK (3.766s)

--- restoring original Printer Settings
     IEC printer: Disabled
     Bus ID: 4
     Output file: /Usb0/printer
     Output type: PNG B&W
     Ink density: Medium
     Page top margin (default is 5): 5
     Page height (default is 60): 60
     Emulation: Commodore MPS
     Commodore charset: USA/UK
     Epson charset: Basic
     IBM table 2: International 1

--- summary
     epson      bitmap PASS_NO_VERIFY       /USB1/printer/e2e-ebc20d
printer: OK (8.351s)

============================================================
E2E  uci-targets  (overlay)
============================================================
     uci-targets: health: ping=84ms rest=28ms ftp=34ms telnet=50ms ident=23ms dma=23ms raster=48ms jiffy=83ms -> OK
[01] reset the C64 so the command interface starts idle ... OK (3.076s)
[02] read 'C64 and Cartridge Settings' ... OK (0.043s)
     current: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}
[03] enable the Command Interface registers at $DF1B-$DF1F ... OK (0.166s)
[04] transport: an empty command returns an empty reply ... OK (0.250s)
     <empty> -> 0.04s, data b'', status b''
[05] transport: unregistered target answers IDENTIFY ... OK (1.093s)
     0f 01 -> 0.10s, data b'NO TARGET', status b'00,OK'
[06] transport: unregistered target rejects anything else ... OK (1.159s)
     0f 7f -> 0.11s, data b'', status b'21,UNKNOWN COMMAND'
[07] transport: a no-reply command returns straight to Idle ... OK (0.213s)
[08] transport: pushing while a reply is pending sets and clears ERROR ... OK (1.466s)
[09] transport: the next command is not prefixed by leftover bytes ... OK (1.433s)
     04 28 00 -> 0.13s, data b'Ultimate 64 Elite', status b'00,OK'
[10] transport: ABORT releases a pending reply back to Idle ... OK (0.233s)
[11] control-target: IDENTIFY answers with the target name ... OK (1.362s)
     04 01 -> 0.08s, data b'CONTROL TARGET V1.1', status b'00,OK'
[12] control-target: an unimplemented command is reported as unknown ... OK (1.096s)
     04 7f -> 0.10s, data b'', status b'21,UNKNOWN COMMAND'
[13] control-target: LOAD_REU without a filename is rejected, not run ... OK (1.212s)
     04 08 -> 0.08s, data b'', status b'81,INVALID PARAMS'
[14] control-target: SAVE_REU without a filename is rejected, not run ... OK (0.984s)
     04 09 -> 0.09s, data b'', status b'81,INVALID PARAMS'
[15] control-target: GET_HWINFO rejects a device number it does not have ... OK (1.191s)
     04 28 02 -> 0.11s, data b'', status b'81,INVALID PARAMS'
[16] issue-740-matrix: confirm /Temp/uci_e2e_absent.reu does not exist ... OK (0.028s)
[17] issue-740-matrix: put a 16384-byte image at /Temp/uci_e2e_present.reu ... OK (0.183s)
[18] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... OK (4.655s)
     04 08 52 45 55 2e 49 4d 47 -> 0.21s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[19] issue-740-matrix: REU Enabled, image absent, name at offset 4 ... OK (4.641s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.29s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[20] issue-740-matrix: REU Disabled, image absent, name at offset 2 ... OK (1.395s)
     04 08 52 45 55 2e 49 4d 47 -> 0.23s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[21] issue-740-matrix: REU Disabled, image absent, name at offset 4 ... OK (1.375s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.26s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[22] issue-740-matrix: REU Enabled, image present, name at offset 2 ... OK (4.312s)
     04 08 52 45 55 2e 49 4d 47 -> 0.24s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[23] issue-740-matrix: REU Enabled, image present, name at offset 4 ... OK (4.323s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.38s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[24] save-reu-offset-past-end: put the preload offset at the end of a 128 KB REU ... OK (0.055s)
[25] save-reu-offset-past-end: SAVE_REU reports the offset and saves nothing ... OK (6.195s)
     04 09 52 45 55 2e 49 4d 47 -> 0.24s, data b'\xfd\xff\xff\xffREU SAVE: OFFSET 131072 >= REU SIZE 131072, SKIPPING', status b'86,REU OFFSET > SIZE. NOT SAVED'
[26] load-reu-disabled: disable the REU ... OK (0.016s)
[27] load-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.190s)
     04 28 00 -> 0.10s, data b'Ultimate 64 Elite', status b'00,OK'
[28] load-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.361s)
     04 08 52 45 55 2e 49 4d 47 -> 0.22s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[29] save-reu-disabled: disable the REU ... OK (0.027s)
[30] save-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.190s)
     04 28 00 -> 0.09s, data b'Ultimate 64 Elite', status b'00,OK'
[31] save-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.268s)
     04 09 52 45 55 2e 49 4d 47 -> 0.23s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[32] softiec-single-part-reply: SoftIEC target answers IDENTIFY ... OK (1.465s)
     05 01 -> 0.08s, data b'SOFTWARE IEC TARGET V1.0', status b'00,OK'
[33] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... OK (0.707s)
     05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 -> 0.46s, data b'', status b'\x01'
[34] softiec-single-part-reply: GET_FATNAME reply completes in one part ... OK (0.710s)
     05 22 02 23 -> 0.18s, data b'/buffer', status b'\x00'
[35] softiec-single-part-reply: an unimplemented SoftIEC command is reported as unknown ... OK (0.307s)
     05 7f -> 0.09s, data b'', status b'\x04'
[36] interface-usable-after: the control target still answers IDENTIFY ... OK (1.269s)
     04 01 -> 0.09s, data b'CONTROL TARGET V1.1', status b'00,OK'
     restored C64 and Cartridge Settings: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}

--- summary
     transport: OK
     control-target: OK
     issue-740-matrix: OK
     save-reu-offset-past-end: OK
     load-reu-disabled: OK
     save-reu-disabled: OK
     softiec-single-part-reply: OK
     interface-usable-after: OK
     cleanup: OK
uci_targets_test: OK (36 checks, 52.0s)
uci-targets: OK (52.0s)

============================================================
E2E  machine-code-monitor  (overlay)
============================================================
     machine-code-monitor: health: ping=20ms rest=22ms ftp=29ms telnet=43ms ident=19ms dma=13ms raster=37ms jiffy=35ms -> OK
[01] initial CPU7/KERNAL monitor status ... OK (0.019s)
[02] KERNAL $E000 hex view and REST match ... OK (0.704s)
[03] paging away and back keeps memory view stable ... OK (0.697s)
[04] KERNAL disassembly formatting ... OK (1.560s)
[05] KERNAL $E010 REST match ... OK (0.985s)
[06] CPU6 RAM under BASIC write/read ... OK (4.742s)
[07] CPU5 RAM under KERNAL status ... OK (3.038s)
[08] ASCII view width and scrolling ... OK (7.354s)
[09] ASCII and Screen mapping semantics ... OK (12.9s SLOW)
[10] HEX edit writes both nibbles ... OK (3.122s)
[11] CPU bank cycling reaches CHAR and RAM mappings ... OK (3.656s)
[12] COMPARE reports differing address ... OK (4.192s)
[13] G executes finite loop and returns to monitor ... OK (2.399s)
[14] G repeated execution updates RAM sentinel ... OK (7.729s)
[15] G handoff preserves stable VIC state ... SKIP (the on-device UI owns the VIC while it is up; only comparable over telnet, 0.000s)
OK (0.000s)
[16] bookmarks recall, set, list, and label edit ... OK (7.615s)
[17] memory bookmark jump restores width 16 ... OK (6.197s)
[18] binary width cycling and bookmark jump restores width 4 ... OK (6.497s)
[19] follow and return navigation ... OK (5.804s)
[20] asm edit mnemonic validation and Return advance ... OK (8.231s)
[21] number popup arithmetic ... OK (2.899s)
[22] save/load round-trip to top-level /Temp file ... OK (10.0s SLOW)
[23] save/load round-trip to file in new /Temp D64 ... OK (19.2s SLOW)

--- Telnet transport checks
[24] telnet blocks poll mode ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
[25] telnet opcode dropdown scroll does not flood the connection ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
--- SKIP (4 checks, 0.160s)
monitor_test: OK (25 checks, 122s)
machine-code-monitor: OK (122s)

============================================================
E2E  ftp-server  (overlay)
============================================================
     ftp-server: health: ping=20ms rest=13ms ftp=14ms telnet=41ms ident=25ms dma=10ms raster=44ms jiffy=48ms -> OK

--- a name the listing reports can address the file it names
[01] a 40-character name is listed unchanged ... OK (0.080s)
[02] that file is removed by the name the listing reported ... OK (0.128s)
[03] a 100-character name is listed unchanged ... OK (0.096s)
     100 characters survived the listing
[04] SIZE answers for the long name the listing reported ... OK (0.061s)
[05] that file is removed by the name the listing reported ... OK (0.107s)
--- OK (5 checks, 0.596s)
ftp_server_test: OK (5 checks, 0.600s)
ftp-server: OK (0.648s)

============================================================
E2E  assembly64  (overlay)
============================================================
     assembly64: health: ping=12ms rest=27ms ftp=36ms telnet=45ms ident=17ms dma=35ms raster=29ms jiffy=35ms -> OK

--- the form opens from the task menu and closes again
[01] open the Assembly 64 query form ... OK (0.938s)
[02] the form leaves cleanly with RUN/STOP ... OK (0.447s)
--- OK (2 checks, 1.508s)

--- a real query is sent to the Assembly 64 service
[03] open the form and enter the first field ... OK (1.171s)
[04] the typed term lands in the Name field ... OK (0.729s)
[05] the service answers and the results match what was asked for ... OK (1.169s)
--- OK (3 checks, 3.577s)

--- the menu button must work from inside the edit field
[06] open the form and enter the edit field ... OK (1.016s)
[07] the menu button closes the menu from inside the field ... OK (0.128s)
[08] the menu opens again, so the UI task left string_edit ... OK (0.046s)
--- OK (3 checks, 1.792s)

--- an aborted edit must not wedge the form
[09] open the form, type into a field, then abort ... OK (1.582s)
[10] the form is still usable after the abort ... OK (0.020s)
--- OK (2 checks, 2.187s)

--- over-long and empty input
[11] type more than the field accepts ... OK (2.329s)
[12] an empty query is refused rather than sent ... OK (2.915s)
[13] the warning is dismissed and the form is still usable ... OK (0.333s)
--- OK (3 checks, 6.213s)

--- a user mashing keys while the form is busy
[14] submit a query and hammer keys while it runs ... OK (5.498s)
[15] the device is still answering after the mashing ... OK (0.014s)
--- OK (2 checks, 6.186s)

--- opening and abandoning the form repeatedly
[16] open and abandon the form three times ... OK (3.459s)
[17] the menu button closes and reopens the form three times ... OK (3.775s)
--- OK (2 checks, 7.579s)
assembly64_test: OK (17 checks, 29.5s)
assembly64: OK (29.5s)

============================================================
E2E  freeze-menu  (overlay)
============================================================
     freeze-menu: health: ping=12ms rest=16ms ftp=20ms telnet=54ms ident=18ms dma=13ms raster=100ms jiffy=38ms -> OK
     captured 'Interface Type'=Freeze, 'Auto Address Mirroring'=Enabled

--- menu cycle with Auto Address Mirroring Disabled
[01] select 'Freeze' interface with mirroring disabled ... OK (0.060s)
[02] C64 running before the menu is opened ... OK (1.075s)
[03] open the menu ... OK (0.305s)
[04] C64 frozen while the menu is open ... OK (0.549s)
[05] close the menu ... OK (0.308s)
[06] C64 resumed after the menu closed ... OK (0.541s)
--- OK (6 checks, 2.853s)

--- Auto Address Mirroring switched off while the menu is open
[07] select 'Freeze' interface with mirroring enabled ... OK (0.032s)
[08] C64 running before the menu is opened ... OK (0.554s)
[09] open the menu ... OK (0.305s)
[10] C64 frozen while the menu is open ... OK (0.538s)
[11] set Auto Address Mirroring to Disabled while the menu is open ... OK (0.016s)
[12] close the menu ... OK (0.283s)
[13] C64 resumed after the menu closed ... OK (0.559s)
--- OK (7 checks, 2.302s)

--- menu cycle with Auto Address Mirroring Enabled
[14] select 'Freeze' interface with mirroring enabled ... OK (0.037s)
[15] C64 running before the menu is opened ... OK (0.544s)
[16] open the menu ... OK (0.297s)
[17] C64 frozen while the menu is open ... OK (0.539s)
[18] close the menu ... OK (0.290s)
[19] C64 resumed after the menu closed ... OK (0.548s)
--- OK (6 checks, 2.281s)

--- reopen the freezer menu with a context menu left open
[20] select 'Freeze' interface with mirroring enabled ... OK (0.046s)
[21] C64 running before the menu is opened ... OK (0.555s)
[22] open the menu ... OK (0.299s)
[23] C64 frozen while the menu is open ... OK (0.534s)
[24] open the context menu on the first browser entry ... OK (7.615s)
[25] close the menu ... OK (0.290s)
[26] C64 resumed after the menu closed ... OK (0.535s)
[27] reopen the menu with the context menu still on the object stack ... OK (0.292s)
[28] dismiss the restored context menu ... OK (0.304s)
[29] close the menu ... OK (0.298s)
[30] C64 resumed after the menu closed ... OK (0.626s)
--- OK (11 checks, 11.4s)

--- the menu button works inside the Assembly 64 query form
[31] select 'Freeze' interface with mirroring enabled ... OK (0.047s)
[32] C64 running before the menu is opened ... OK (0.557s)
[33] open the menu ... OK (0.299s)
[34] C64 frozen while the menu is open ... OK (0.532s)
[35] open the task menu ... OK (0.351s)
[36] open the Assembly 64 query form ... OK (0.309s)
[37] enter the form's first edit field ... OK (0.297s)
[38] the menu button closes the menu from inside the edit field ... OK (0.299s)
[39] the menu opens again afterwards ... OK (0.299s)
[40] leave the query form ... OK (0.395s)
[41] close the menu ... OK (0.296s)
[42] C64 resumed after the menu closed ... OK (0.539s)
--- OK (12 checks, 4.360s)
freeze_menu_test: OK (42 checks, 24.5s)
freeze-menu: OK (24.5s)

TEARDOWN (overlay): release input ... OK (0.033s)
TEARDOWN (overlay): close active menu UI ... OK (0.043s)
TEARDOWN (overlay): reset machine ... OK (0.065s)

============================================================
Summary
============================================================
     OK   e2e overlay    783s (18 ok)
     slowest: prg-context-menu 165s, browser-filesystem-refresh 123s, machine-code-monitor 122s
     783s in suites, 29.7s in health checks, the UI-state gate and teardown
     812s total

OK  all 18 suite runs passed.
RUNNER EXIT: 0
```

</details>

