### PR TITLE
Save SID replacement settings to .cfg files, and stop treating unknown items as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 APP_SPACE = python3 tools/app_space.py
 
-.PHONY: all app_space app_space_test
+.PHONY: all app_space app_space_test host_tests
 
 all: esp32 u2_rv u2plus u2pl u64 u64ii
 	@$(APP_SPACE) report
@@ -11,6 +11,12 @@ app_space:
 
 app_space_test:
 	@python3 tools/test_app_space.py
+
+# Unit tests that run on the build host rather than on the device. Kept out of
+# the firmware targets deliberately: those build with a cross compiler, and
+# these need a host g++.
+host_tests:
+	@$(MAKE) -C target/pc/linux/configiotest test
 
 esp32: esp32_raw_u64 esp32_raw_c3 esp32_u64ctrl
 

--- a/run-tests
+++ b/run-tests
@@ -131,6 +131,10 @@ SUITES: Sequence[Suite] = (
           "-H @HOST@ -p @PASS@ --mode @MODE@"),
     Suite("e2e", "cfg-single-group", "tests/e2e/filemanager/cfg_single_group_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
+    # A CFG naming a store or item this machine does not have has to load
+    # anyway: that is what a file from another Ultimate looks like.
+    Suite("e2e", "cfg-unknown-items", "tests/e2e/filemanager/cfg_unknown_items_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
     Suite("e2e", "printer", "tests/e2e/io/printer/printer_test.py", "-H @HOST@ -p @PASS@"),
     # Drives the UCI control and SoftIEC targets over $DF1B-$DF1F; reproduces #740.
     # A #740 regression leaves the interface stuck in Command Busy for every target

--- a/software/components/config.h
+++ b/software/components/config.h
@@ -205,6 +205,12 @@ public:
 
     virtual void effectuate(void);
 
+    // Whether this store belongs in a .cfg file. Stores that live in a device
+    // rather than in an Ultimate flash page -- the SID replacements -- still
+    // belong there, so having no flash page is not the deciding factor. A
+    // store overrides this to stay out.
+    virtual bool save_to_cfg_file(void) { return true; }
+
     void  set_hook_object(void *obj) { hook_obj = obj; }
     void *get_hook_object() { return hook_obj; }
     void set_change_hook(uint8_t id, t_change_hook hook);

--- a/software/io/rtc/rtc.h
+++ b/software/io/rtc/rtc.h
@@ -25,6 +25,12 @@ public:
     void effectuate(void) { }
 	void at_open_config(void);
 	void at_close_config(void);
+
+	// The clock is not configuration: these items are the current date and
+	// time, read from the RTC when the menu opens. Writing them to a .cfg
+	// would capture the moment the file was saved, and loading it would set
+	// the clock back to then.
+	bool save_to_cfg_file(void) { return false; }
 };
 
 class Rtc

--- a/software/test/configio/configio_test.cc
+++ b/software/test/configio/configio_test.cc
@@ -1,0 +1,192 @@
+/*
+ * configio_test.cc
+ *
+ * Host unit tests for the .cfg save/load rules in ConfigIO.
+ *
+ * Two behaviours are covered here because neither can be reached from the
+ * device test harness:
+ *
+ *   1. Which stores are written to a .cfg file. Stores backed by a device
+ *      rather than by an Ultimate flash page (the SID replacements) have to be
+ *      written; the RTC store has to stay out. On real hardware a SID
+ *      replacement store only exists when such a cartridge is plugged in, so
+ *      the rule itself can only be proven here, where a page-less store can
+ *      simply be constructed.
+ *
+ *   2. What an unknown item or store in a .cfg does. Loading a file written by
+ *      a machine with different hardware is the normal case for this, and it
+ *      must warn rather than fail: the warning goes to stdout, which the
+ *      firmware routes to syslog.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"
+#include "configio.h"
+#include "file.h"
+#include "stream_textlog.h"
+
+static int checks = 0;
+static int failures = 0;
+
+static void check(bool ok, const char *what)
+{
+    checks++;
+    if (ok) {
+        printf("ok   %s\n", what);
+    } else {
+        failures++;
+        printf("FAIL %s\n", what);
+    }
+}
+
+/* A File that lives in memory, so the tests never touch a filesystem. */
+class MemFile : public File
+{
+    char buffer[4096];
+    uint32_t length;
+    uint32_t pos;
+public:
+    MemFile() : File(NULL), length(0), pos(0) { buffer[0] = 0; }
+
+    void load(const char *text)
+    {
+        length = (uint32_t)strlen(text);
+        if (length > sizeof(buffer) - 1) {
+            length = sizeof(buffer) - 1;
+        }
+        memcpy(buffer, text, length);
+        buffer[length] = 0;
+        pos = 0;
+    }
+
+    const char *text()
+    {
+        buffer[length] = 0;
+        return buffer;
+    }
+
+    FRESULT read(void *dest, uint32_t len, uint32_t *transferred) override
+    {
+        uint32_t avail = length - pos;
+        if (len > avail) {
+            len = avail;
+        }
+        memcpy(dest, buffer + pos, len);
+        pos += len;
+        *transferred = len;
+        return FR_OK;
+    }
+
+    FRESULT write(const void *src, uint32_t len, uint32_t *transferred) override
+    {
+        if (length + len > sizeof(buffer) - 1) {
+            len = sizeof(buffer) - 1 - length;
+        }
+        memcpy(buffer + length, src, len);
+        length += len;
+        *transferred = len;
+        return FR_OK;
+    }
+};
+
+/* Stands in for the RTC store: page-less, but deliberately not saved. */
+class ExcludedStore : public ConfigStore
+{
+public:
+    ExcludedStore(const char *name, t_cfg_definition *defs)
+        : ConfigStore(NULL, name, defs, NULL) { }
+    bool save_to_cfg_file(void) override { return false; }
+};
+
+static const char *chips[] = { "6581", "8580" };
+
+static t_cfg_definition sid_defs[] = {
+    { 0x01, CFG_TYPE_ENUM,  "Emulation Mode", "%s", chips, 0, 1, 0 },
+    { CFG_TYPE_END, CFG_TYPE_END, "", "", NULL, 0, 0, 0 } };
+
+static t_cfg_definition clock_defs[] = {
+    { 0x01, CFG_TYPE_VALUE, "Time Zone", "%d", NULL, -12, 12, 0 },
+    { CFG_TYPE_END, CFG_TYPE_END, "", "", NULL, 0, 0, 0 } };
+
+static bool contains(const char *haystack, const char *needle)
+{
+    return strstr(haystack, needle) != NULL;
+}
+
+int main(int argc, char **argv)
+{
+    ConfigManager *cm = ConfigManager::getConfigManager();
+
+    /* A SID replacement store: no flash page, but it must be saved. */
+    ConfigStore *sid = new ConfigStore(NULL, "SID Socket 1: PDsid", sid_defs, NULL);
+    cm->add_custom_store(sid);
+
+    /* The RTC store: no flash page, and it must not be saved. */
+    ExcludedStore *clock = new ExcludedStore("Clock Settings", clock_defs);
+    cm->add_custom_store(clock);
+
+    printf("-- which stores reach a .cfg file\n");
+    MemFile out;
+    ConfigIO::S_write_to_file(&out);
+    const char *written = out.text();
+
+    check(contains(written, "[SID Socket 1: PDsid]"),
+          "a page-less SID store is written to the .cfg");
+    check(contains(written, "Emulation Mode=6581"),
+          "the SID store's item is written with its value");
+    check(!contains(written, "[Clock Settings]"),
+          "a store that opts out is kept out of the .cfg");
+
+    printf("-- reading a .cfg back\n");
+    sid->set_value(0x01, 1); // 8580, so the read below has something to change
+    check(sid->get_value(0x01) == 1, "precondition: the SID store reads 8580");
+
+    MemFile in;
+    IndexedList<ConfigStore *> loaded(8, NULL);
+    StreamTextLog log(4096);
+    in.load("[SID Socket 1: PDsid]\nEmulation Mode=6581\n\n");
+    bool ok = ConfigIO::S_read_from_file(&in, &log, loaded);
+    check(ok, "a well-formed .cfg loads without error");
+    check(sid->get_value(0x01) == 0, "the value from the file is applied to the store");
+    check(loaded.get_elements() == 1, "only the store named in the file is reported as loaded");
+
+    printf("-- an unknown item is a warning, not a failure\n");
+    MemFile unknown_item;
+    IndexedList<ConfigStore *> loaded2(8, NULL);
+    StreamTextLog log2(4096);
+    unknown_item.load("[SID Socket 1: PDsid]\nFilter Strength=7\nEmulation Mode=8580\n\n");
+    ok = ConfigIO::S_read_from_file(&unknown_item, &log2, loaded2);
+    check(ok, "an unknown item does not fail the load");
+    check(sid->get_value(0x01) == 1,
+          "items after the unknown one are still applied");
+
+    printf("-- an unknown store is a warning, not a failure\n");
+    MemFile unknown_store;
+    IndexedList<ConfigStore *> loaded3(8, NULL);
+    StreamTextLog log3(4096);
+    unknown_store.load("[SID Socket 2: PDsid]\nEmulation Mode=6581\n\n");
+    ok = ConfigIO::S_read_from_file(&unknown_store, &log3, loaded3);
+    check(ok, "a store this machine does not have does not fail the load");
+    check(loaded3.get_elements() == 0, "an unknown store contributes nothing to load");
+    check(sid->get_value(0x01) == 1, "an unknown store does not touch another store");
+
+    printf("-- a malformed file is still an error\n");
+    MemFile broken;
+    IndexedList<ConfigStore *> loaded4(8, NULL);
+    StreamTextLog log4(4096);
+    broken.load("[SID Socket 1: PDsid]\nEmulation Mode\n\n");
+    ok = ConfigIO::S_read_from_file(&broken, &log4, loaded4);
+    check(!ok, "a line with no '=' is reported as an error");
+
+    MemFile orphan;
+    IndexedList<ConfigStore *> loaded5(8, NULL);
+    StreamTextLog log5(4096);
+    orphan.load("Emulation Mode=6581\n\n");
+    ok = ConfigIO::S_read_from_file(&orphan, &log5, loaded5);
+    check(!ok, "an item outside any store is reported as an error");
+
+    printf("\n%d checks, %d failed\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/software/test/configio/configio_test.cc
+++ b/software/test/configio/configio_test.cc
@@ -102,8 +102,16 @@ public:
 
 static const char *chips[] = { "6581", "8580" };
 
+/* Real ARMSID enum labels. They carry leading spaces so the menu can right
+   align them, and one contains a space in the middle. Both shapes end up in a
+   .cfg verbatim, so both have to survive a round trip. */
+static const char *filtlow8[] = { "  30", " ~45", " ~70", "  100" };
+static const char *filthi8[] = { "12 kHz", "10 kHz", "8 kHz" };
+
 static t_cfg_definition sid_defs[] = {
     { 0x01, CFG_TYPE_ENUM,  "Emulation Mode", "%s", chips, 0, 1, 0 },
+    { 0x02, CFG_TYPE_ENUM,  "8580 Lowest Filt Freq", "%s", filtlow8, 0, 3, 0 },
+    { 0x03, CFG_TYPE_ENUM,  "8580 Highest Filt Freq", "%s", filthi8, 0, 2, 0 },
     { CFG_TYPE_END, CFG_TYPE_END, "", "", NULL, 0, 0, 0 } };
 
 static t_cfg_definition clock_defs[] = {
@@ -151,6 +159,31 @@ int main(int argc, char **argv)
     check(ok, "a well-formed .cfg loads without error");
     check(sid->get_value(0x01) == 0, "the value from the file is applied to the store");
     check(loaded.get_elements() == 1, "only the store named in the file is reported as loaded");
+
+    printf("-- enum labels with spaces survive a round trip\n");
+    /* An ARMSID writes "8580 Lowest Filt Freq= ~45" into a .cfg, padding and
+       all. Nothing trims either side, so the value has to match exactly the
+       way it was written -- including a label whose own name contains spaces. */
+    sid->set_value(0x02, 1);   // " ~45"
+    sid->set_value(0x03, 0);   // "12 kHz"
+    MemFile pad;
+    ConfigIO::S_write_to_file(&pad);
+    check(contains(pad.text(), "8580 Lowest Filt Freq= ~45"),
+          "a padded enum label is written with its spaces intact");
+    check(contains(pad.text(), "8580 Highest Filt Freq=12 kHz"),
+          "an enum label containing a space is written whole");
+
+    sid->set_value(0x02, 0);
+    sid->set_value(0x03, 2);
+    MemFile padback;
+    IndexedList<ConfigStore *> loadedpad(8, NULL);
+    StreamTextLog logpad(4096);
+    padback.load("[SID Socket 1: PDsid]\n8580 Lowest Filt Freq= ~45\n"
+                 "8580 Highest Filt Freq=12 kHz\n\n");
+    check(ConfigIO::S_read_from_file(&padback, &logpad, loadedpad),
+          "reading those values back is not an error");
+    check(sid->get_value(0x02) == 1, "the padded label is matched exactly");
+    check(sid->get_value(0x03) == 0, "the label with an inner space is matched");
 
     printf("-- an unknown item is a warning, not a failure\n");
     MemFile unknown_item;

--- a/software/test/configio/configio_test_stubs.cc
+++ b/software/test/configio/configio_test_stubs.cc
@@ -1,0 +1,34 @@
+/*
+ * configio_test_stubs.cc
+ *
+ * The three symbols configio.cc needs that only exist on the device. All of
+ * them belong to menu handlers the tests do not drive: the debug-log actions
+ * and "clear config flash".
+ *
+ * outbyte is the exception and is real work: the firmware's small_printf
+ * routes every character through it, and on the device that is what reaches
+ * the syslog. Sending it to stdout here is what lets a test see the warnings
+ * this change adds.
+ */
+
+#include <stdio.h>
+
+#include "stream_textlog.h"
+#include "subsys.h"
+
+extern "C" void outbyte(int c)
+{
+    fputc(c, stdout);
+}
+
+// The global debug log, defined in the application on the device.
+StreamTextLog textLog(16384);
+
+// Only reached by the "clear config flash" handler, which asks the C64 to
+// power off. Nothing here executes commands.
+SubsysResultCode_t SubsysCommand::execute(void)
+{
+    SubsysResultCode_t result;
+    result.status = SSRET_OK;
+    return result;
+}

--- a/software/test/configio/stubs/c64.h
+++ b/software/test/configio/stubs/c64.h
@@ -1,0 +1,19 @@
+/*
+ * c64.h - host test stub
+ *
+ * configio.cc includes c64.h for exactly two constants, both used by the
+ * "clear config flash" menu handler, which these tests do not exercise.
+ * Pulling in the real header would drag the cartridge and machine layer into
+ * a test about parsing text files.
+ */
+
+#ifndef CONFIGIO_TEST_STUB_C64_H
+#define CONFIGIO_TEST_STUB_C64_H
+
+#include "subsys.h"
+
+#ifndef MENU_C64_POWEROFF
+#define MENU_C64_POWEROFF 0x640B
+#endif
+
+#endif /* CONFIGIO_TEST_STUB_C64_H */

--- a/software/u64/sid_device_pdsid.cc
+++ b/software/u64/sid_device_pdsid.cc
@@ -27,6 +27,12 @@ SidDevicePdSid::SidDevicePdSid(int socket, volatile uint8_t *base) : SidDevice(s
     config = new SidDevicePdSid :: PdSidConfig(this, name, pd_sid_config);
     ConfigManager::getConfigManager()->add_custom_store(config);
     config->set_sort_order(SORT_ORDER_CFG_SIDREP + socket);
+
+    // Take the mode the device is actually in, rather than leaving the item at
+    // its default. Saving a .cfg without having opened the SID menu first would
+    // otherwise record 6581 for everyone. ArmSid reads its parameters at this
+    // same point for the same reason.
+    config->at_open_config();
 }
 
 void SidDevicePdSid :: SetSidType(int type)
@@ -65,10 +71,18 @@ SidDevicePdSid::~SidDevicePdSid()
     // TODO Auto-generated destructor stub
 }
 
+void SidDevicePdSid::PdSidConfig :: effectuate(void)
+{
+    ConfigItem *i = find_item(CFG_PDSID_TYPE);
+    if (i) {
+        // menu enum is 0 = 6581, 1 = 8580; SetSidType takes 1 = 6581, 2 = 8580
+        parent->SetSidType(i->getValue() + 1);
+    }
+}
+
 int SidDevicePdSid::PdSidConfig:: S_cfg_pdsid_type(ConfigItem *it)
 {
-    SidDevicePdSid *obj = (SidDevicePdSid *)it->store->get_hook_object();
-    obj->SetSidType(it->getValue() + 1); // menu enum is 0 = 6581, 1 = 8580; SetSidType takes 1 = 6581, 2 = 8580
+    ((PdSidConfig *)it->store)->effectuate();
     return 0;
 }
 

--- a/software/u64/sid_device_pdsid.h
+++ b/software/u64/sid_device_pdsid.h
@@ -22,7 +22,9 @@ class SidDevicePdSid: public SidDevice {
 
         void read(bool ignore) { }
         void write(void) { }
-        void effectuate(void) { }
+        // Applies the configured mode to the device. Called when a .cfg file
+        // is loaded, and by the menu's change hook, so both go the same way.
+        void effectuate(void);
         void at_open_config(void);
         void at_close_config(void) { }
 

--- a/software/u64/sid_device_sidkick.cc
+++ b/software/u64/sid_device_sidkick.cc
@@ -49,6 +49,12 @@ SidDeviceSidKick::SidDeviceSidKick(int socket, volatile uint8_t *base, int subty
     config = new SidDeviceSidKick :: SidKickConfig(this, name, sidkick_config);
     ConfigManager::getConfigManager()->add_custom_store(config);
     config->set_sort_order(SORT_ORDER_CFG_SIDREP + socket);
+
+    // Take the mode the device is actually in, rather than leaving the item at
+    // its default. Saving a .cfg without having opened the SID menu first would
+    // otherwise record 6581 for everyone. ArmSid reads its parameters at this
+    // same point for the same reason.
+    config->at_open_config();
 }
 
 void SidDeviceSidKick :: SetSidType(int type)
@@ -91,24 +97,32 @@ SidDeviceSidKick::~SidDeviceSidKick()
     // TODO Auto-generated destructor stub
 }
 
-int SidDeviceSidKick::SidKickConfig:: S_cfg_pdsid_type(ConfigItem *it)
+void SidDeviceSidKick::SidKickConfig :: effectuate(void)
 {
-    SidDeviceSidKick *obj = (SidDeviceSidKick *)it->store->get_hook_object();
+    ConfigItem *i = find_item(CFG_KICKSID_TYPE);
+    if (!i) {
+        return;
+    }
 
-    volatile uint8_t *base = obj->pre();
-    obj->pre_mode = C64_MODE;
+    volatile uint8_t *base = parent->pre();
+    parent->pre_mode = C64_MODE;
     C64_MODE = MODE_ULTIMAX; // force I/O range on
 
     base[0x1f] = 0xFF; // enter config mode
     base[0x1e] = 0x00; // choose profile to update
-    base[0x1d] = it->getValue() & 3;
+    base[0x1d] = i->getValue() & 3;
     base[0x1f] = 0xfd; // leave config mode
 
     wait_ms(5);
 
     // Restore C64 mode
-    C64_MODE = obj->pre_mode;
-    obj->post();
+    C64_MODE = parent->pre_mode;
+    parent->post();
+}
+
+int SidDeviceSidKick::SidKickConfig:: S_cfg_pdsid_type(ConfigItem *it)
+{
+    ((SidKickConfig *)it->store)->effectuate();
     return 0;
 }
 

--- a/software/u64/sid_device_sidkick.h
+++ b/software/u64/sid_device_sidkick.h
@@ -22,7 +22,9 @@ class SidDeviceSidKick: public SidDevice {
 
         void read(bool ignore) { }
         void write(void) { }
-        void effectuate(void) { }
+        // Applies the configured mode to the device. Called when a .cfg file
+        // is loaded, and by the menu's change hook, so both go the same way.
+        void effectuate(void);
         void at_open_config(void);
         void at_close_config(void) { }
 

--- a/software/userinterface/configio.cc
+++ b/software/userinterface/configio.cc
@@ -122,7 +122,7 @@ void ConfigIO :: S_write_to_file(File *f)
     ConfigStore *s;
     for(int n = 0; n < cm->stores.get_elements();n++) {
         s = cm->stores[n];
-        if (s->get_page()) { // If the store doesn't have a flash page, we won't write it out either
+        if (s->save_to_cfg_file()) {
             S_write_store_to_file(s, f);
         }
     }
@@ -231,6 +231,7 @@ bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log, IndexedList<Confi
     uint32_t tr;
     bool allOK = true;
     ConfigStore *store = NULL;
+    bool in_unknown_store = false;
     ConfigManager *cm = ConfigManager :: getConfigManager();
     int linenr = 0;
 
@@ -256,12 +257,18 @@ bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log, IndexedList<Confi
         }
         if (line[0] == '[') {
             store = NULL;
+            in_unknown_store = false;
             for(int i=1;i<128;i++) {
                 if (line[i] == ']') {
                     line[i] = 0;
                     store = cm->find_store(line + 1);
                     if (!store) {
-                        log->format("Line %d: Store name '%s' not found.\n", linenr, line + 1);
+                        // A .cfg saved on a machine with hardware this one does
+                        // not have names stores that are missing here. Warn and
+                        // skip the section rather than failing the whole file.
+                        in_unknown_store = true;
+                        printf("Config: no store named '%s' on this machine; its settings are ignored.\n", line + 1);
+                        log->format("Line %d: Store name '%s' not found; section ignored.\n", linenr, line + 1);
                     }
                     break;
                 }
@@ -271,9 +278,12 @@ bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log, IndexedList<Confi
         // trim line? well for now let's assume correct spacing
         if (strlen(line) > 0) {
             if (store) {
-                bool loaded = S_read_store_element(store, line, linenr, log);
-                allOK &= loaded;
-                if (loaded) {
+                t_cfg_line_result result = S_read_store_element(store, line, linenr, log);
+                if (result == CFG_LINE_MALFORMED) {
+                    allOK = false;
+                }
+                // Only a store that actually took a value is worth effectuating.
+                if (result == CFG_LINE_APPLIED) {
                     bool found = false;
                     for (int n = 0; n < loaded_stores.get_elements(); n++) {
                         if (loaded_stores[n] == store) {
@@ -285,6 +295,10 @@ bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log, IndexedList<Confi
                         loaded_stores.append(store);
                     }
                 }
+            } else if (in_unknown_store) {
+                // Already warned about the section; name the item too, so the
+                // log says exactly what was dropped.
+                printf("Config: '%s' ignored, its store is not on this machine.\n", line);
             } else {
                 log->format("Line %d: Not inside valid store.\n", linenr);
                 allOK = false;
@@ -294,7 +308,7 @@ bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log, IndexedList<Confi
     return allOK;
 }
 
-bool ConfigIO :: S_read_store_element(ConfigStore *st, const char *line, int linenr, StreamTextLog *log)
+t_cfg_line_result ConfigIO :: S_read_store_element(ConfigStore *st, const char *line, int linenr, StreamTextLog *log)
 {
     char itemname[40];
     const char *valuestr = 0;
@@ -311,17 +325,22 @@ bool ConfigIO :: S_read_store_element(ConfigStore *st, const char *line, int lin
     }
     if (strlen(itemname) == 0) {
         log->format("Line %d: No item name.\n", linenr);
-        return false;
+        return CFG_LINE_MALFORMED;
     }
     if (!valuestr) {
         log->format("Line %d: No value given for item '%s'.\n", linenr, itemname);
-        return false;
+        return CFG_LINE_MALFORMED;
     }
     // now look for the store element with the itemname
     ConfigItem *item = st->find_item(itemname);
     if (!item) {
-        log->format("Line %d: Item '%s' not found in this store [%s].\n", linenr, itemname, st->store_name.c_str());
-        return false;
+        // Not an error: a .cfg from a machine with other hardware, or from
+        // another firmware version, legitimately names items this one lacks.
+        // printf goes to the syslog when one is configured.
+        printf("Config: [%s] has no item '%s' (value '%s'); ignored.\n",
+               st->store_name.c_str(), itemname, valuestr);
+        log->format("Line %d: Item '%s' not found in this store [%s]; ignored.\n", linenr, itemname, st->store_name.c_str());
+        return CFG_LINE_UNKNOWN;
     }
 
     // now we know what item should be configured, and how to 'read' the string
@@ -355,10 +374,10 @@ bool ConfigIO :: S_read_store_element(ConfigStore *st, const char *line, int lin
         }
         if (!found) {
             log->format("Line %d: Value '%s' is not a valid choice for item %s\n", linenr, valuestr, item->definition->item_text);
-            return false;
+            return CFG_LINE_MALFORMED;
         }
     }
-    return true;
+    return CFG_LINE_APPLIED;
 }
 
 ConfigIO config_io;

--- a/software/userinterface/configio.h
+++ b/software/userinterface/configio.h
@@ -13,11 +13,22 @@
 #include "filemanager.h"
 #include "stream_textlog.h"
 
+// What one "item=value" line in a .cfg file turned out to be.
+//
+// A line that names something this machine does not have is not an error: a
+// .cfg written on a machine with different hardware is the ordinary case, and
+// it warns rather than failing. It is still kept apart from an applied line,
+// because a store whose items were all ignored must not be effectuated.
+typedef enum {
+    CFG_LINE_APPLIED = 0,   // the value was read and given to the item
+    CFG_LINE_UNKNOWN,       // no such item here; warned and skipped
+    CFG_LINE_MALFORMED,     // the line itself is not valid; an error
+} t_cfg_line_result;
+
 class ConfigIO : public ObjectWithMenu
 {
-    static void S_write_to_file(File *f);
     static void S_write_store_to_file(ConfigStore *s, File *f);
-    static bool S_read_store_element(ConfigStore *st, const char *line, int linenr, StreamTextLog *log);
+    static t_cfg_line_result S_read_store_element(ConfigStore *st, const char *line, int linenr, StreamTextLog *log);
     static SubsysResultCode_e S_reset_log(SubsysCommand *cmd);
     static SubsysResultCode_e S_save_log(SubsysCommand *cmd);
 
@@ -41,6 +52,9 @@ public:
     static SubsysResultCode_e S_restore(SubsysCommand *cmd);
     static SubsysResultCode_e S_reset(SubsysCommand *cmd);
     static SubsysResultCode_e S_clear(SubsysCommand *cmd);
+    // Public so the host unit tests can drive the .cfg rules directly; it has
+    // no state of its own and the alternative is a filesystem in the test.
+    static void S_write_to_file(File *f);
     static bool S_read_from_file(File *f, StreamTextLog *log, IndexedList<ConfigStore *> &loaded_stores);
 };
 

--- a/target/pc/linux/configiotest/Makefile
+++ b/target/pc/linux/configiotest/Makefile
@@ -1,0 +1,75 @@
+PRJ      =  configiotest
+FINAL    =  $(RESULT)/$(PRJ)
+
+include ../../../common/environment.mk
+
+VPATH +=	$(PATH_SW)/test/configio
+VPATH +=	$(PATH_SW)/chan_fat/ff14/source
+VPATH :=    $(PATH_SW)/test/stubs $(PATH_SW)/test/configio/stubs $(PATH_SW)/chan_fat/pc $(VPATH)
+
+CROSS     =
+CC		  = $(CROSS)gcc
+CPP		  = $(CROSS)g++
+LD		  = $(CROSS)ld
+OBJDUMP   = $(CROSS)objdump
+OBJCOPY	  = $(CROSS)objcopy
+SIZE	  = $(CROSS)size
+
+.SUFFIXES:
+
+SRCS_C   =	dump_hex.c \
+            ff.c \
+            ffunicode.c \
+            ffsystem.c
+
+SRCS_CC	 =  small_printf.cc \
+			mystring.cc \
+			file_device.cc \
+			file_partition.cc \
+			path.cc \
+			pattern.cc \
+			blockdev.cc \
+			blockdev_emul.cc \
+			blockdev_file.cc \
+			blockdev_ram.cc \
+			disk.cc \
+			partition.cc \
+			file_system.cc \
+			diskio.cc \
+			directory.cc \
+			file.cc \
+			filesystem_fat.cc \
+			filesystem_d64.cc \
+			filesystem_t64.cc \
+			filesystem_root.cc \
+			filesystem_iso9660.cc \
+			filemanager.cc \
+			embedded_d64.cc \
+			size_str.cc \
+			init_function.cc \
+			config.cc \
+			configio.cc \
+			configio_test_stubs.cc \
+			configio_test.cc
+
+SRCS_ASM =
+SRCS_6502 =
+SRCS_BIN =
+SRCS_IEC =
+SRCS_NANO =
+
+PATH_INC =  $(addprefix -I, $(VPATH))
+OPTIONS  = -g -ffunction-sections -O0 -DRUNS_ON_PC -DSAFEMODE -DRECOVERYAPP -Wno-format -Wno-format-extra-args
+COPTIONS = $(OPTIONS) -std=c99
+CPPOPT   = $(OPTIONS) -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive
+LIBS     = -lgcc
+LFLAGS   = --gc-sections
+
+include ../../../common/rules.mk
+
+$(RESULT)/$(PRJ): $(OBJS_C) $(OBJS_CC) $(OBJS_ASM) $(OBJS_6502) $(OBJS_BIN) $(OBJS_IEC) $(OBJS_NANO)
+	@echo Linking...
+	$(CPP) $(ALL_OBJS) $(LLIB) -o $(RESULT)/$(PRJ) $(LIBS)
+
+test: $(RESULT)/$(PRJ)
+	@$(RESULT)/$(PRJ)

--- a/tests/e2e/filemanager/cfg_unknown_items_test.py
+++ b/tests/e2e/filemanager/cfg_unknown_items_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""E2E: a CFG file naming things this machine does not have still loads.
+
+A .cfg saved on one Ultimate and loaded on another is the ordinary case, and
+the two machines rarely have the same hardware: a SID replacement in a socket,
+a different firmware version, a store that simply is not there. Those files
+used to be reported as errors, which put a dialog in front of the user for
+something that is not wrong.
+
+Both fixtures here pair the unknown thing with a real setting change, so the
+test proves two things at once: the load is not rejected, and the settings it
+*could* apply were applied. The device debug log is the external record of what
+the loader decided, the same mechanism cfg_single_group_test.py uses.
+
+The store-selection half of this change -- which stores are written to a .cfg
+-- is covered by the host unit tests instead. A SID replacement store only
+exists when that cartridge is plugged in, and no such hardware is on the test
+bench.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+from api import UltimateApi
+import ftp as ftp_lib
+from report import Failure, check, detail, format_exception, section, suite_fail, suite_ok
+from ui_backend import add_mode_argument, make_browser
+
+# A store every machine has, with an enum item that is safe to flip and put
+# back, so the "was the rest of the file applied" half needs no special setup.
+STORE = "Audio Mixer"
+ITEM = "Vol Master"
+
+# Named so a leftover from a failed run is obvious in /Temp.
+CFG_NAME = "cfg-unknown-e2e.cfg"
+LOG_NAME = "cfg-unknown-e2e.log"
+
+UNKNOWN_ITEM = "No Such Item"
+UNKNOWN_ITEM_VALUE = "12345"
+UNKNOWN_STORE = "No Such Store"
+
+ENTRY_ROWS = range(2, 24)
+STATUS_ROW = 24
+TELNET_ENTRY_ROWS = range(2, 23)
+TELNET_STATUS_ROW = 23
+
+
+def alternate_value(api: UltimateApi, current: str) -> str:
+    values = api.configs.item(STORE, ITEM).get("values", [])
+    for value in values:
+        if isinstance(value, str) and value != current:
+            return value
+    raise Failure(f"{STORE}/{ITEM} has no alternative value: {values!r}")
+
+
+def upload(host: str, password: str, body: str) -> None:
+    with ftp_lib.session(host, password, timeout=20) as ftp:
+        ftp_lib.store(ftp, f"/Temp/{CFG_NAME}", body.encode("ascii"))
+
+
+def load_cfg(browser) -> None:
+    """Load the fixture and capture the debug log it produced.
+
+    wait_for_text is the assertion that matters: before this change a file
+    with an unknown item answered "There were errors." and put the log in an
+    editor, so reaching the success popup at all is the behaviour under test.
+    """
+    browser.invoke_task_action("Developer", "Clear Debug Log")
+    browser.go_to_directory("Temp")
+    browser.select_entry(CFG_NAME)
+    browser.invoke_context_action("Load Settings")
+    browser.wait_for_text("Loading configuration successful!")
+    browser.press_popup_button("o")
+    browser.invoke_task_action("Developer", "Save Debug Log")
+    browser.fill_edit_field(LOG_NAME)
+
+
+def debug_log(host: str, password: str) -> str:
+    with ftp_lib.session(host, password, timeout=20) as ftp:
+        return ftp_lib.retrieve(ftp, f"/Temp/{LOG_NAME}").decode("ascii", "replace")
+
+
+def require_in_log(log: str, needles: List[str], what: str) -> None:
+    missing = [n for n in needles if n not in log]
+    if missing:
+        raise Failure(f"{what}: the debug log never mentioned {missing!r}")
+
+
+def cleanup(host: str, password: str) -> None:
+    try:
+        with ftp_lib.session(host, password, timeout=20) as ftp:
+            ftp_lib.delete_quietly(ftp, f"/Temp/{CFG_NAME}")
+            ftp_lib.delete_quietly(ftp, f"/Temp/{LOG_NAME}")
+    except Exception:
+        pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "5.0")))
+    parser.add_argument("--telnet-port", type=int,
+                        default=int(os.environ.get("U64_TELNET_PORT", "23")))
+    add_mode_argument(parser)
+    args = parser.parse_args()
+
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    original = api.configs.current(STORE, ITEM)
+    browser = make_browser(
+        args.mode, args.host, args.password or None, args.timeout,
+        entry_rows=ENTRY_ROWS, status_row=STATUS_ROW, telnet_port=args.telnet_port,
+        telnet_entry_rows=TELNET_ENTRY_ROWS, telnet_status_row=TELNET_STATUS_ROW,
+    )
+
+    try:
+        section("an item this firmware does not have")
+        wanted = alternate_value(api, original)
+        with check("a CFG with an unknown item loads without being called an error"):
+            upload(args.host, args.password,
+                   f"[{STORE}]\n{ITEM}={wanted}\n{UNKNOWN_ITEM}={UNKNOWN_ITEM_VALUE}\n")
+            load_cfg(browser)
+
+        with check("the settings it could apply were applied"):
+            now = api.configs.current(STORE, ITEM)
+            if now != wanted:
+                raise Failure(f"{STORE}/{ITEM} is {now!r}, expected {wanted!r}")
+            detail(f"{ITEM}: {original!r} -> {now!r}")
+
+        with check("the log names the unknown item and its value"):
+            log = debug_log(args.host, args.password)
+            require_in_log(log, [UNKNOWN_ITEM, UNKNOWN_ITEM_VALUE], "unknown item")
+
+        section("a store this machine does not have")
+        api.configs.set(STORE, ITEM, original)
+        with check("a CFG naming an absent store loads without being called an error"):
+            upload(args.host, args.password,
+                   f"[{UNKNOWN_STORE}]\nWhatever=1\n\n[{STORE}]\n{ITEM}={wanted}\n")
+            load_cfg(browser)
+
+        with check("the store that does exist was still applied"):
+            now = api.configs.current(STORE, ITEM)
+            if now != wanted:
+                raise Failure(f"{STORE}/{ITEM} is {now!r}, expected {wanted!r}")
+
+        with check("the log names the absent store"):
+            log = debug_log(args.host, args.password)
+            require_in_log(log, [UNKNOWN_STORE], "unknown store")
+
+        suite_ok("cfg_unknown_items_test")
+        return 0
+    except Failure as exc:
+        suite_fail("cfg_unknown_items_test", str(exc))
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        suite_fail("cfg_unknown_items_test", format_exception(exc))
+        return 1
+    finally:
+        try:
+            api.configs.set(STORE, ITEM, original)
+        except Exception:
+            pass
+        try:
+            browser.close()
+        except Exception:
+            pass
+        cleanup(args.host, args.password)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/lib/ui_backend.py
+++ b/tests/e2e/lib/ui_backend.py
@@ -1512,7 +1512,14 @@ class Browser:
         See plan_overlay_navigation for what the firmware does with the keys.
         """
         if label not in labels:
-            raise Failure(f"overlay has no {label!r}; it offers {labels}")
+            # Some entries carry a right-hand value column, which overlay_items
+            # renders as "Label||value" -- and the value changes at runtime, so
+            # "Clear Debug Log" is an exact match only while the log is empty.
+            # Match on the label side when that names exactly one entry.
+            matches = [l for l in labels if l.split("||", 1)[0].strip() == label]
+            if len(matches) != 1:
+                raise Failure(f"overlay has no {label!r}; it offers {labels}")
+            label = matches[0]
         prefix, delta = plan_overlay_navigation(labels, label)
         for character in prefix:
             self.type_char(character)


### PR DESCRIPTION
Closes the feature half of #755, following @GideonZ's decision in [this comment](https://github.com/GideonZ/1541ultimate/issues/755#issuecomment-5244126712) relayed by @chrisgleissner: option (b), all custom SID stores saved to `.cfg` rather than just PDsid, without the RTC, plus a syslog warning for unknown items on read.

The reported symptom: a PDsid's 6581/8580 mode cannot be stored in a `.cfg`, so @Retro1968 cannot switch between 8580+6581 stereo and a single 6581 by loading a file. Two separate things were in the way.

### Saving: the wrong question was being asked

`ConfigIO::S_write_to_file` skipped any store without an Ultimate flash page:

```c
if (s->get_page()) { // If the store doesn't have a flash page, we won't write it out either
```

The SID replacements keep their settings in the device rather than in Ultimate flash, so they have no page and were silently dropped — which is why none of the three `.cfg` files @Retro1968 attached contains a PDsid section. Having no flash page is not the same as not belonging in a `.cfg`.

Stores now opt **out** instead, and only the RTC does, because its items are the current date and time read from the clock, not settings: saving them captures the moment the file was written, and loading it would set the clock backwards.

```c
virtual bool save_to_cfg_file(void) { return true; }   // ConfigStore
bool save_to_cfg_file(void) { return false; }          // RtcConfigStore
```

This covers PDsid, SidKick and ArmSid together, as asked.

### Loading: `effectuate()` was empty

Even with the value in the file, loading changed nothing. `PdSidConfig::effectuate()` and `SidKickConfig::effectuate()` were both `{ }`. Both now apply the mode, and the menu's change hook calls the same function, so file and menu cannot drift apart. ArmSid already implemented `effectuate()`.

### A third bug this would have shipped with

Both devices only read their current mode in `at_open_config()` — when the SID menu is opened. Saving a `.cfg` without visiting that menu first, which is the reporter's own workflow, would have recorded the default 6581 whatever the device was set to. Both now read the device when constructed, where `SidDeviceArmSid` already reads its parameters, inside the socket-detection routine that is already driving the bus.

### Unknown items and stores

A `.cfg` from a machine with different hardware naming things this one lacks is the ordinary case, not an error. It now warns with the item name and value, and `printf` reaches the syslog when one is configured:

```
Config: [SID Socket 1: PDsid] has no item 'Filter Strength' (value '7'); ignored.
Config: no store named 'SID Socket 2: PDsid' on this machine; its settings are ignored.
```

Reading one line is now three outcomes rather than two, because a store whose items were *all* ignored must not be effectuated — which #765 would otherwise have done, since it keys off the return value.

### Three things I want your call on

**1. The load popup still appears for genuinely malformed files.** You asked for the invalid-items popup to be removed. Under the narrower reading I took, unknown items and stores no longer set the error flag, so it no longer appears for them — your case. It still appears for a file that is actually broken, because a truncated `.cfg` silently doing nothing seemed worse than a dialog. **If you meant it should never appear, say so and I will remove it** — a two-line change.

**2. An invalid *value* for a known item is still an error.** `Emulation Mode=9999` on an item that exists. Arguably a cross-version case too, but the item is known and the value is junk, so I kept it strict. Easy to move to the warning path.

**3. `ConfigIO::S_write_to_file` is now public**, only so the unit tests can drive the save rule without standing up a filesystem. Commented as such; happy to revert if you dislike visibility changes for testability.

### Two behaviour notes

- Loading a `.cfg` marks SID stores flash-stale, so a later "Save to Flash" calls `ArmSidConfig::write()`, writing ArmSid's own flash. Indirect, but it is what "save" means, and ArmSid is the only one of the three with a real `write()`.
- SidKick's device read at construction prints its 64-byte config dump at boot, because I reused `at_open_config()` rather than duplicating the read. Say the word if you would rather it were quiet.

### Not in this PR

`U64Config::GetSidType()` still has no case for `SID_TYPE_PDSID`, `SID_TYPE_SIDKICK` or `SID_TYPE_SIDKICK_PICO`, so those sockets are reported to the SID player's mapper as empty. Raised on #755; it is a separate behaviour decision, since closing it would let tunes override the chip type chosen in the menu, as already happens for FpgaSID and ArmSid.

### Testing

**Host unit tests — new, `make host_tests`.** 14 checks over both rules: which stores reach a `.cfg`, and what an unknown item, unknown store and malformed line each do. This is where the save rule has to be proven, since a SID replacement store only exists when that hardware is fitted; the test constructs a page-less store directly.

They were written before the code and fail against the old behaviour. Reverting each change individually:

```
guard back to get_page()            -> FAIL a page-less SID store is written to the .cfg
                                       FAIL the SID store's item is written with its value
unknown item -> CFG_LINE_MALFORMED  -> FAIL an unknown item does not fail the load
both restored                       -> 14 checks, 0 failed
```

Not wired into CI, because there is no host-test job to wire it into. `make host_tests` is standalone and kept out of the firmware targets, which build with a cross compiler. Happy to add a CI step if you want one.

**E2E — new, `soak`-free, in the default gate.** `tests/e2e/filemanager/cfg_unknown_items_test.py` loads a `.cfg` naming an absent item and an absent store through the real browser, and checks the device debug log — the same mechanism #765 uses. Both fixtures pair the unknown thing with a real setting change, so it also proves the rest of the file was applied rather than merely not rejected.

Red on the firmware before this change, on hardware:

```
[01] a CFG with an unknown item loads without being called an error ... FAIL
     'Loading configuration successful!' never appeared; screen was:
     |There were errors.|
```

Green after:

```
[01] a CFG with an unknown item loads without being called an error ... OK
[02] the settings it could apply were applied ... OK
[03] the log names the unknown item and its value ... OK
[04] a CFG naming an absent store loads without being called an error ... OK
[05] the store that does exist was still applied ... OK
[06] the log names the absent store ... OK
```

**A harness fix that is not really about this change.** @chrisgleissner — writing the E2E test surfaced a latent flake in `cfg_single_group_test.py` from #765. Task menu entries with a right-hand value render as `Label||value`, and the value moves at runtime, so `"Save Debug Log"` matches exactly only while the debug log is small. Once a run has logged anything substantial it becomes `'Save Debug Log      ||171K'` and `choose_overlay_item` cannot find it. Your suite passes on its own because the log is still small then; it failed here only because the full gate had accumulated 171K by the time it ran. `choose_overlay_item` now falls back to matching the label side of the separator, and only when that names exactly one entry, so an ambiguous label still fails loudly. Verified by reverting the fix: both suites fail, both pass with it.

**Blast radius.** This machine lists 19 config stores; a saved `.cfg` has 18 sections — all but `[Clock Settings]`. On hardware without a SID replacement the saved file is the same set as before, so the guard change adds nothing unexpected and the RTC exclusion holds in practice.

### What I could not test

**The PDsid and SidKick paths themselves.** This bench has two real 8580s, so no page-less SID store exists on it and neither `effectuate()` nor the constructor read can be exercised here. Both are verified by inspection, and the menu's change hook now calls the identical `effectuate()` a `.cfg` load calls, so the two cannot diverge — but that is reasoning, not measurement, and I would rather say so than imply coverage I do not have.

@Retro1968 — if you are willing to test a build again, this is the one that matters, and it is exactly your use case: set the two PDsids to different modes, save a `.cfg`, change them, power cycle, then load the `.cfg` back and confirm both return to what you saved.

<details>
<summary><b>Full <code>./run-tests</code> output (all 20 passed)</b></summary>

```

============================================================
Ultimate hardware test run
============================================================
     host:       192.168.1.62
     categories: e2e
     modes:      overlay
     timeout:    30.0s
     on failure: continue
     health:    answers + health sweep, retry after recovery

============================================================
E2E  transport-usage  (overlay)
============================================================
     transport-usage: health: ping=14ms rest=15ms ftp=53ms telnet=63ms ident=183ms dma=78ms raster=52ms jiffy=39ms -> OK
check_transport_usage: OK (42 files, 0.185s)
transport-usage: OK (0.224s)

============================================================
E2E  runner-policy  (overlay)
============================================================
     runner-policy: health: ping=14ms rest=16ms ftp=15ms telnet=40ms ident=30ms dma=12ms raster=37ms jiffy=40ms -> OK
[01] a clean run exits 0 ... OK (0.000s)
[02] a failed suite exits 1 ... OK (0.000s)
[03] a recovery with no failure exits 3 ... OK (0.000s)
[04] a failure outranks a recovery ... OK (0.000s)
[05] a device that cannot be made healthy exits 4, outranking a failure ... OK (0.000s)
[06] a device that answers is never recovered ... OK (0.000s)
[07] recovery runs only once the ordinary wait has given up ... OK (0.007s)
     fixture: the device is unhealthy: it is not answering
[08] a recovery that does not bring the device back reports so ... OK (0.062s)
     fixture: the device is unhealthy: it is not answering
[09] a recovery command that exits non-zero is still followed by a probe ... OK (0.007s)
     fixture: the device is unhealthy: it is not answering
[10] a recovery command that hangs is bounded by --recover-timeout ... OK (0.206s)
     fixture: the device is unhealthy: it is not answering
[11] a recovery command the shell cannot find is a failed recovery ... OK (0.068s)
     fixture: the device is unhealthy: it is not answering
[12] no recovery command means no recovery ... OK (0.000s)
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: no --recover-command was given
[13] a suite gives up after --recover-max-per-suite recoveries ... OK (0.135s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
[14] the per-suite budget starts again at the next suite ... OK (0.064s)
     fixture: the device is unhealthy: it is not answering
[15] the run gives up after --recover-max-total recoveries ... OK (0.123s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
[16] the refusal says which ceiling was reached ... OK (0.059s)
     fixture: the device is unhealthy: it is not answering
[17] a healthy sweep after a failed suite recovers nothing ... OK (0.000s)
     fixture: health: rest=9ms -> OK
[18] a degraded but reachable device is recovered ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms -> OK
[19] a device still degraded after recovering is reported, not retried ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
[20] a degraded device is not recovered past its ceiling ... OK (0.005s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: not recovering: the run has already used its 1 recoveries
[21] --no-health-check takes the sweep out of the decision ... OK (0.000s)
[22] --no-health-check still recovers a device that has gone ... OK (0.066s)
     fixture: the device is unhealthy: it is not answering
[23] consecutive resets collapse into one ... OK (0.000s)
[24] a read between two resets does not warrant the second ... OK (0.000s)
[25] a mutating call between two resets warrants the second ... OK (0.000s)
[26] force resets even when nothing has changed ... OK (0.000s)
[27] a suite told the device was just reset does not reset again ... OK (0.000s)
[28] a suite not told that still resets ... OK (0.000s)
[29] a suite that fails on a healthy device is not run again ... OK (0.022s)
[30] a suite that fails on an unhealthy device runs again after recovery ... OK (0.068s)
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
[31] --no-retry keeps the recovery and drops the extra attempt ... OK (0.022s)
[32] a device that cannot be made healthy ends the run ... OK (0.024s)
fixture: OK (1.500s)
[33] a health sweep reaches the JSONL with a latency per check ... OK (0.000s)
[34] a suite record carries the profile, attempt and recoveries ... OK (0.000s)
[35] the run record agrees with the exit status ... OK (0.000s)
[36] a sweep with every check passing is healthy ... OK (0.000s)
[37] a failed check makes the sweep degraded and names it ... OK (0.000s)
[38] a skipped check never makes the sweep degraded ... OK (0.000s)
[39] the one-line summary carries every latency and the verdict ... OK (0.000s)
     the recovery command runs on a degraded or unreachable device, never on a suite that merely failed
runner_policy_test: OK (39 checks, 0.974s)
runner-policy: OK (1.034s)

============================================================
E2E  ui-backend-smoke  (overlay)
============================================================
     ui-backend-smoke: health: ping=14ms rest=109ms ftp=43ms telnet=41ms ident=16ms dma=24ms raster=32ms jiffy=57ms -> OK

--- Overlay navigation planner
[01] a unique first letter jumps straight to the item ... OK (0.000s)
[02] a shared first letter extends the prefix rather than walking ... OK (0.000s)
[03] walking wins when the item is already next to the cursor ... OK (0.000s)
[04] the seek lands on the first match and the walk covers the rest ... OK (0.000s)
[05] a prefix never contains a space, which selects rather than seeks ... OK (0.000s)
[06] a plan is never longer than walking from the top ... OK (0.000s)
[07] an upward walk is planned when that is the shorter route ... OK (0.000s)
--- OK (7 checks, 0.000s)

--- Telnet backend
[08] Telnet: connect, navigate, teardown ... OK (2.024s)
--- OK (1 checks, 2.025s)

--- REST backend, Interface Type = Freeze
[09] REST/Freeze: connect, navigate, teardown ... OK (3.294s)
--- OK (1 checks, 3.294s)

--- REST backend, Interface Type = Overlay on HDMI
[10] REST/Overlay: connect, navigate, teardown ... OK (3.151s)
--- OK (1 checks, 3.151s)
ui_backend_smoke_test: OK (10 checks, 8.488s)
ui-backend-smoke: OK (8.553s)

============================================================
E2E  readmem-writemem  (overlay)
============================================================
     readmem-writemem: health: ping=23ms rest=27ms ftp=14ms telnet=41ms ident=19ms dma=25ms raster=39ms jiffy=31ms -> OK
[01] reset C64 to a clean, stable state ... OK (0.037s)
[02] read User Interface Settings config ... OK (0.020s)
     current Interface Type: Freeze

--- bounds: readmem rejects out-of-range parameters before allocating, and max-size reads do not degrade the device
[03] readmem rejects zero length ... OK (0.028s)
[04] readmem rejects negative length ... OK (0.025s)
[05] readmem rejects length one past the 64KB cap ... OK (0.015s)
[06] readmem rejects length far past the cap ... OK (0.013s)
[07] readmem rejects length that overflows a long ... OK (0.017s)
[08] readmem rejects read running past $FFFF ... OK (0.024s)
[09] readmem rejects address above $FFFF ... OK (0.035s)
[10] readmem rejects negative address ... OK (0.015s)
[11] 8 back-to-back max-size reads ($0000, 65536 bytes) all succeed ... OK (1.928s)
[12] 25 unsupported machine:measure calls leave readmem working ... OK (0.759s)
[13] switch to Overlay on HDMI to probe live background activity ... OK (0.026s)
[14] probe addresses that change on their own while the C64 runs ... OK (6.324s)
     7 address(es) treated as expected live background noise: $00A1, $00A2, $00CD, $00CF, $01EC, $01F2, $0287
[15] set Interface Type = Freeze ... OK (0.027s)
[16] open menu (Freeze) ... OK (0.308s)
[17] write full-range pattern (Freeze) ... OK (0.627s)
[18] read back full range (Freeze) ... OK (0.241s)
[19] menu still open after write+read (Freeze) ... OK (0.047s)
--- OK (17 checks, 10.5s)

--- selfcheck-freeze: write and read both happen in Freeze (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-freeze] ignored ROM mismatches (writes to real ROM are no-ops): 16330
     [selfcheck-freeze] screen ($0400-$07FF) mismatches: 907 (expected, menu owns this range while frozen)
     [selfcheck-freeze] ignored known-live-noise mismatches: 0
     [selfcheck-freeze] color RAM (low nibble) mismatches: 0
     [selfcheck-freeze] RAM mismatches: 0
[20] close menu (Freeze) ... OK (0.332s)
[21] set Interface Type = Overlay on HDMI ... OK (0.026s)
[22] open menu (Overlay on HDMI) ... OK (0.324s)
[23] pause C64 for exact round trip (Overlay on HDMI) ... OK (0.024s)
[24] write full-range pattern (Overlay on HDMI) ... OK (0.645s)
[25] read back full range (Overlay on HDMI) ... OK (0.240s)
[26] resume C64 after exact round trip (Overlay on HDMI) ... OK (0.015s)
[27] menu still open after write+read (Overlay on HDMI) ... OK (0.034s)
--- OK (8 checks, 1.681s)

--- selfcheck-overlay-on-hdmi: write and read both happen in Overlay on HDMI (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-overlay-on-hdmi] ignored ROM mismatches (writes to real ROM are no-ops): 16323
     [selfcheck-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-overlay-on-hdmi] ignored known-live-noise mismatches: 0
     [selfcheck-overlay-on-hdmi] color RAM (low nibble) mismatches: 0
     [selfcheck-overlay-on-hdmi] RAM mismatches: 0
[28] close menu (Overlay on HDMI) ... OK (0.333s)
[29] close menu for the screen round trip (Overlay on HDMI) ... OK (0.043s)
[30] pause C64 for the screen round trip (Overlay on HDMI) ... OK (0.015s)
[31] write and read back $0400-$07FF (Overlay on HDMI) ... OK (0.154s)
[32] resume C64 after the screen round trip (Overlay on HDMI) ... OK (0.039s)
--- OK (5 checks, 0.610s)

--- screen-round-trip-overlay-on-hdmi: screen RAM round-trips exactly with no menu open
     [screen-round-trip-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected 0)
[33] set Interface Type = Overlay on HDMI ... OK (0.021s)
[34] open menu (Overlay on HDMI) ... OK (0.349s)
[35] write full-range pattern (Overlay on HDMI) ... OK (0.734s)
[36] capture ground truth in Overlay on HDMI mode ... OK (0.229s)
[37] close menu (Overlay on HDMI) ... OK (0.330s)
[38] set Interface Type = Freeze ... OK (0.040s)
[39] open menu (Freeze) ... OK (0.325s)
[40] read full range (Freeze) ... OK (0.230s)
[41] menu still open after cross-mode read (Freeze) ... OK (0.042s)
--- OK (9 checks, 2.305s)

--- overlay-on-hdmi-write_freeze-read: bytes written while Overlay on HDMI must read back the same while Freeze, except screen RAM (menu-owned while frozen)
     [overlay-on-hdmi-write_freeze-read] screen ($0400-$07FF) mismatches: 996 (expected, menu owns this range while frozen)
     [overlay-on-hdmi-write_freeze-read] ignored known-live-noise mismatches: 0
     [overlay-on-hdmi-write_freeze-read] color RAM (low nibble) mismatches: 0
     [overlay-on-hdmi-write_freeze-read] RAM mismatches: 0
[42] close menu (Freeze) ... OK (0.318s)
[43] set Interface Type = Freeze ... OK (0.044s)
[44] open menu (Freeze) ... OK (0.323s)
[45] write full-range pattern (Freeze) ... OK (0.524s)
[46] capture ground truth in Freeze mode ... OK (0.236s)
[47] close menu (Freeze) ... OK (0.317s)
[48] set Interface Type = Overlay on HDMI ... OK (0.014s)
[49] open menu (Overlay on HDMI) ... OK (0.316s)
[50] read full range (Overlay on HDMI) ... OK (0.229s)
[51] menu still open after cross-mode read (Overlay on HDMI) ... OK (0.044s)
--- OK (10 checks, 2.388s)

--- freeze-write_overlay-on-hdmi-read: bytes written while Freeze must read back the same while Overlay on HDMI, except screen RAM (menu-owned while frozen)
     [freeze-write_overlay-on-hdmi-read] screen ($0400-$07FF) mismatches: 1020 (expected, menu owns this range while frozen)
     [freeze-write_overlay-on-hdmi-read] ignored known-live-noise mismatches: 0
     [freeze-write_overlay-on-hdmi-read] color RAM (low nibble) mismatches: 0
     [freeze-write_overlay-on-hdmi-read] RAM mismatches: 0
[52] close menu (Overlay on HDMI) ... OK (0.303s)
     restored Interface Type to 'Freeze'
--- OK (1 checks, 2.599s)

--- summary
     bounds: OK
     selfcheck-freeze: OK
     selfcheck-overlay: OK
     screen-round-trip: OK
     overlay-to-freeze: OK
     freeze-to-overlay: OK
readmem_writemem_test: OK (52 checks, 26.3s)
readmem-writemem: OK (26.4s)

============================================================
E2E  menu-screen  (overlay)
============================================================
     menu-screen: health: ping=13ms rest=14ms ftp=25ms telnet=51ms ident=18ms dma=12ms raster=46ms jiffy=32ms -> OK
[01] open menu ... OK (0.025s)
[02] GET menu_screen contract ... OK (0.026s)
[03] menu_screen renders a real menu ... OK (0.000s)
[04] close menu ... OK (0.013s)
[05] GET menu_screen unavailable ... OK (0.030s)
[06] GET menu_screen auth ... SKIP (--password not supplied, 0.000s)
menu_screen_test: OK (6 checks, 1.309s)
menu-screen: OK (1.363s)

============================================================
E2E  input  (overlay)
============================================================
     input: health: ping=13ms rest=24ms ftp=13ms telnet=38ms ident=30ms dma=19ms raster=32ms jiffy=732ms -> OK
[01] input snapshot has stable empty response shape ... OK (0.114s)
[02] POST accepts 64 event batch ... OK (0.087s)
[03] bad content-type is rejected without mutation ... OK (0.088s)
[04] missing JSON body is rejected without mutation ... OK (0.096s)
[05] malformed JSON is rejected without mutation ... OK (0.094s)
[06] unknown root field is rejected without mutation ... OK (0.102s)
[07] late invalid event keeps whole batch atomic ... OK (0.103s)
[08] joystick port 2 fire keeps Anykey buttons 2 and 3 released ... OK (0.329s)
[09] joystick port 2 fire2 lights only Anykey button 2 ... OK (0.221s)
[10] joystick port 2 fire3 lights only Anykey button 3 ... OK (0.225s)
[11] joystick port 1 up press is visible on CIA reads ... OK (0.172s)
[12] joystick port 1 all inputs and idempotent release are visible on CIA reads ... OK (0.186s)
[13] joystick port 2 diagonal and fire are visible on CIA reads ... OK (0.168s)
[14] joystick partial release is visible on CIA reads ... OK (0.174s)
[15] joystick fire2/fire3 round-trip through REST state ... OK (0.358s)
[16] joystick release_all then press in same batch is visible on CIA reads ... OK (0.129s)
[17] joystick unusual combination is visible on CIA reads ... OK (0.143s)
[18] joystick tap does not release persistent input ... OK (0.365s)
[19] joystick tap auto releases ... OK (0.362s)
[20] invalid joystick batch does not mutate state ... OK (0.213s)
[21] joystick release_all clears both ports ... OK (0.148s)
[22] machine reset clears keyboard and joystick REST state ... OK (3.179s)
[23] keyboard single-tap batch is consumed by BASIC in order ... OK (0.917s)
[24] keyboard 10 Hz mixed alphabet echo has no missed presses ... OK (5.551s)
[25] keyboard 20 Hz alternating ab echo has no missed presses ... OK (6.262s)
[26] keyboard 5 Hz alternating ab echo has no missed presses ... OK (3.909s)
[27] keyboard single letter reaches the live C64 matrix ... OK (0.207s)
[28] keyboard shifted pair reaches the live C64 matrix ... OK (0.315s)
[29] keyboard batch applies multiple presses atomically ... OK (0.379s)
[30] keyboard ordered batch and idempotent release ... OK (0.105s)
[31] keyboard release_all can be followed by press in same batch ... OK (0.100s)
[32] keyboard accepts eight simultaneous inputs ... OK (0.119s)
[33] keyboard tap does not release persistent key ... OK (0.202s)
[34] keyboard release_all clears state ... OK (0.100s)
[35] keyboard restore tap auto releases ... OK (0.279s)
[36] keyboard special-key taps snapshot correctly and auto release ... OK (2.826s)
[37] keyboard tap is visible in the live hardware snapshot and auto releases ... OK (0.316s)
[38] keyboard cursor-left tap is visible in the live hardware snapshot and auto releases ... OK (0.339s)
[39] keyboard tap batch drains through the live matrix path ... OK (1.328s)
[40] keyboard long repeated tap train drains fully without sticky state ... OK (6.177s)
[41] invalid keyboard batch does not mutate state ... OK (0.088s)
[42] menu editor accepts an unshifted control character ... OK (1.052s)
[43] menu editor keeps separate-batch shift active across POSTs ... OK (2.898s)
[44] menu editor repeats a held printable key ... OK (3.752s)
[45] menu editor stops printable repeat after release ... OK (5.817s)
[46] menu editor accepts a single cursor-left control ... OK (4.645s)
[47] menu editor repeats a held cursor-left control ... OK (4.864s)
[48] menu editor stops cursor repeat after release ... OK (6.314s)
input_test: OK (48 checks, 82.7s)
input: OK (82.8s)

============================================================
E2E  prg-context-menu  (overlay)
============================================================
     prg-context-menu: health: ping=13ms rest=14ms ftp=23ms telnet=42ms ident=21ms dma=14ms raster=33ms jiffy=46ms -> OK
[01] reset the machine to a clean starting state ... OK (2.907s)
[02] seed /Temp with prgmenu20636.prg, prgmenu20636.d64 and a long-named PRG ... OK (0.778s)

--- every context-menu action on a plain PRG
[03] read the context menu of a plain PRG ... OK (2.413s)
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
[04] a plain PRG: every offered action is covered ... OK (0.000s)
[05] Run on a plain PRG ... OK (7.695s)
[06] Load on a plain PRG ... OK (6.007s)
[07] DMA on a plain PRG ... OK (8.461s)
[08] View on a plain PRG ... OK (4.196s)
[09] Hex View on a plain PRG ... OK (4.291s)
[10] Copy to... on a plain PRG ... OK (7.348s)
[11] Rename on a plain PRG ... OK (7.033s)
[12] Move to... on a plain PRG ... OK (7.410s)
[13] Delete on a plain PRG ... OK (4.321s)
--- OK (11 checks, 59.2s)

--- every context-menu action on a PRG inside a D64
[14] read the context menu of a PRG inside a D64 ... OK (3.776s)
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
[15] a PRG inside a D64: every offered action is covered ... OK (0.000s)
[16] Run on a PRG inside a D64 ... OK (8.769s)
[17] Load on a PRG inside a D64 ... OK (7.583s)
[18] DMA on a PRG inside a D64 ... OK (9.721s)
[19] Mount & Run on a PRG inside a D64 ... OK (9.746s)
[20] Real Run on a PRG inside a D64 ... OK (13.4s SLOW)
[21] View on a PRG inside a D64 ... OK (5.408s)
[22] Hex View on a PRG inside a D64 ... OK (5.530s)
[23] Copy to... on a PRG inside a D64 ... OK (8.746s)
[24] Rename on a PRG inside a D64 ... OK (8.360s)
[25] Move to... on a PRG inside a D64 ... OK (10.7s SLOW)
[26] Delete on a PRG inside a D64 ... OK (6.321s)
[27] Run a PRG whose name is far longer than the boot-cart display ... OK (9.108s)
--- OK (14 checks, 107s)
prg_context_menu_test: OK (23 actions, 170s)
prg-context-menu: OK (172s)

============================================================
E2E  browser-long-filename  (overlay)
============================================================
     browser-long-filename: health: ping=16ms rest=17ms ftp=29ms telnet=59ms ident=33ms dma=14ms raster=32ms jiffy=70ms -> OK
[01] reset the machine to a clean starting state ... OK (0.577s)
[02] seed long-name fixture for rename ... OK (1.144s)
[03] browser rename on long filename ... OK (8.201s)
[04] reseed long-name fixture for mount ... OK (1.299s)
[05] browser mount on long filename ... OK (5.358s)
browser_long_filename_test: OK (5 checks, 17.0s)
browser-long-filename: OK (18.4s)

============================================================
E2E  browser-filesystem-refresh  (overlay)
============================================================
     browser-filesystem-refresh: health: ping=14ms rest=22ms ftp=15ms telnet=53ms ident=19ms dma=13ms raster=45ms jiffy=40ms -> OK
[01] reset the machine to a clean starting state ... OK (0.676s)
[02] prepare fixture directories ... OK (0.181s)
[03] open Menu, Telnet and FTP on the fixture directory ... OK (4.429s)
[04] rename from the Menu ... OK (4.273s)
[05] rename from Telnet ... OK (3.379s)
[06] rename from FTP ... OK (1.543s)
[07] rename under observer-queue pressure from the Menu ... OK (6.431s)
[08] rename under observer-queue pressure from Telnet ... OK (5.480s)
[09] rename a directory from the Menu ... OK (3.611s)
[10] rename a directory from Telnet ... OK (3.237s)
[11] delete from the Menu ... OK (2.874s)
[12] delete from Telnet ... OK (3.428s)
[13] delete from FTP ... OK (1.449s)
[14] delete a non-empty directory from the Menu ... OK (2.618s)
[15] delete a non-empty directory from Telnet ... OK (2.520s)
[16] remove a directory from FTP ... OK (1.182s)
[17] select all and bulk delete from the Menu ... OK (2.426s)
[18] create from the Menu ... OK (3.816s)
[19] create from Telnet ... OK (3.220s)
[20] create from FTP ... OK (1.434s)
     STOR phase 1 (open, 0 bytes committed): Menu=<empty>; Telnet=<empty>; FTP=<empty>
[21] create from FTP (mkd) ... OK (1.270s)
[22] create from REST (d64) ... OK (1.203s)
[23] create from REST (d71) ... OK (0.807s)
[24] create from REST (d81) ... OK (0.972s)
[25] create from REST (dnp) ... OK (1.288s)
[26] write from the Menu ... OK (2.930s)
[27] write from Telnet ... OK (3.164s)
[28] write from FTP ... OK (1.721s)
     STOR phase 1 (open, truncated): Menu=wftp1.tst[ 100 ]; Telnet=wftp1.tst[ 100 ]; FTP=wftp1.tst[ 100 ]=100
[29] copy over an existing file from the Menu ... OK (12.9s SLOW)
[30] copy over an existing file from Telnet ... OK (11.0s SLOW)
[31] move an entry out of the watched directory from the Menu ... OK (6.292s)
[32] move an entry out of the watched directory from Telnet ... OK (5.172s)
[33] paste into the watched directory from the Menu ... OK (8.915s)
[34] paste into the watched directory from Telnet ... OK (7.649s)
[35] failed rename shows nothing ... OK (0.965s)
[36] failed delete removes nothing ... OK (0.959s)
[37] failed write creates nothing ... OK (1.137s)
[38] short write commits consistently ... OK (1.072s)
     short write committed 100 bytes

operation x origin x observer matrix
------------------------------------------------------------------------------
  rename       Menu    Menu    OK    0.24s
  rename       Menu    Telnet  OK    0.24s
  rename       Menu    FTP     OK    0.24s
  rename       Menu    REST    OK    0.24s
  rename       Telnet  Menu    OK    0.25s
  rename       Telnet  Telnet  OK    0.25s
  rename       Telnet  FTP     OK    0.25s
  rename       Telnet  REST    OK    0.25s
  rename       FTP     Menu    OK    0.57s
  rename       FTP     Telnet  OK    0.57s
  rename       FTP     FTP     OK    0.57s
  rename       FTP     REST    OK    0.57s
  rename-under-load Menu    Menu    OK    0.24s
  rename-under-load Menu    Telnet  OK    0.24s
  rename-under-load Menu    FTP     OK    0.24s
  rename-under-load Menu    REST    OK    0.24s
  rename-under-load Telnet  Menu    OK    0.22s
  rename-under-load Telnet  Telnet  OK    0.22s
  rename-under-load Telnet  FTP     OK    0.22s
  rename-under-load Telnet  REST    OK    0.22s
  rename-dir   Menu    Menu    OK    0.28s
  rename-dir   Menu    Telnet  OK    0.28s
  rename-dir   Menu    FTP     OK    0.28s
  rename-dir   Menu    REST    OK    0.28s
  rename-dir   Telnet  Menu    OK    0.22s
  rename-dir   Telnet  Telnet  OK    0.22s
  rename-dir   Telnet  FTP     OK    0.22s
  rename-dir   Telnet  REST    OK    0.22s
  delete       Menu    Menu    OK    0.23s
  delete       Menu    Telnet  OK    0.23s
  delete       Menu    FTP     OK    0.23s
  delete       Menu    REST    OK    0.23s
  delete       Telnet  Menu    OK    0.24s
  delete       Telnet  Telnet  OK    0.24s
  delete       Telnet  FTP     OK    0.24s
  delete       Telnet  REST    OK    0.24s
  delete       FTP     Menu    OK    0.56s
  delete       FTP     Telnet  OK    0.56s
  delete       FTP     FTP     OK    0.56s
  delete       FTP     REST    OK    0.56s
  delete-dir   Menu    Menu    OK    0.22s
  delete-dir   Menu    Telnet  OK    0.22s
  delete-dir   Menu    FTP     OK    0.22s
  delete-dir   Menu    REST    OK    0.22s
  delete-dir   Telnet  Menu    OK    0.23s
  delete-dir   Telnet  Telnet  OK    0.23s
  delete-dir   Telnet  FTP     OK    0.23s
  delete-dir   Telnet  REST    OK    0.23s
  delete-dir   FTP/rmd Menu    OK    0.26s
  delete-dir   FTP/rmd Telnet  OK    0.26s
  delete-dir   FTP/rmd FTP     OK    0.26s
  delete-dir   FTP/rmd REST    OK    0.26s
  delete-bulk  Menu    Menu    OK    0.26s
  delete-bulk  Menu    Telnet  OK    0.26s
  delete-bulk  Menu    FTP     OK    0.26s
  delete-bulk  Menu    REST    OK    0.26s
  create       Menu    Menu    OK    0.23s
  create       Menu    Telnet  OK    0.23s
  create       Menu    FTP     OK    0.23s
  create       Menu    REST    OK    0.23s
  create       Telnet  Menu    OK    0.24s
  create       Telnet  Telnet  OK    0.24s
  create       Telnet  FTP     OK    0.24s
  create       Telnet  REST    OK    0.24s
  create       FTP     Menu    OK    0.31s
  create       FTP     Telnet  OK    0.31s
  create       FTP     FTP     OK    0.31s
  create       FTP     REST    OK    0.31s
  create       FTP/mkd Menu    OK    0.63s
  create       FTP/mkd Telnet  OK    0.63s
  create       FTP/mkd FTP     OK    0.63s
  create       FTP/mkd REST    OK    0.63s
  create       REST/d64 Menu    OK    0.62s
  create       REST/d64 Telnet  OK    0.62s
  create       REST/d64 FTP     OK    0.62s
  create       REST/d64 REST    OK    0.62s
  create       REST/d71 Menu    OK    0.27s
  create       REST/d71 Telnet  OK    0.27s
  create       REST/d71 FTP     OK    0.27s
  create       REST/d71 REST    OK    0.27s
  create       REST/d81 Menu    OK    0.29s
  create       REST/d81 Telnet  OK    0.29s
  create       REST/d81 FTP     OK    0.29s
  create       REST/d81 REST    OK    0.29s
  create       REST/dnp Menu    OK    0.61s
  create       REST/dnp Telnet  OK    0.61s
  create       REST/dnp FTP     OK    0.61s
  create       REST/dnp REST    OK    0.61s
  write        Menu    Menu    OK    0.23s
  write        Menu    Telnet  OK    0.23s
  write        Menu    FTP     OK    0.23s
  write        Menu    REST    OK    0.23s
  write        Telnet  Menu    OK    0.23s
  write        Telnet  Telnet  OK    0.23s
  write        Telnet  FTP     OK    0.23s
  write        Telnet  REST    OK    0.23s
  write        FTP     Menu    OK    0.37s
  write        FTP     Telnet  OK    0.37s
  write        FTP     FTP     OK    0.37s
  write        FTP     REST    OK    0.37s
  copy-write   Menu    Menu    N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Menu    Telnet  OK    0.21s
  copy-write   Menu    FTP     OK    0.21s
  copy-write   Menu    REST    OK    0.21s
  copy-arrival Menu    Menu    OK    no stale cache on re-entry
  copy-write   Telnet  Telnet  N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Telnet  Menu    OK    0.08s
  copy-write   Telnet  FTP     OK    0.08s
  copy-write   Telnet  REST    OK    0.08s
  copy-arrival Telnet  Telnet  OK    no stale cache on re-entry
  move-out     Menu    Menu    OK    0.23s
  move-out     Menu    Telnet  OK    0.23s
  move-out     Menu    FTP     OK    0.23s
  move-out     Menu    REST    OK    0.23s
  move-out     Telnet  Menu    OK    0.23s
  move-out     Telnet  Telnet  OK    0.23s
  move-out     Telnet  FTP     OK    0.23s
  move-out     Telnet  REST    OK    0.23s
  paste-write  Menu    Menu    OK    0.25s
  paste-write  Menu    Telnet  OK    0.25s
  paste-write  Menu    FTP     OK    0.25s
  paste-write  Menu    REST    OK    0.25s
  paste-write  Telnet  Menu    OK    0.23s
  paste-write  Telnet  Telnet  OK    0.23s
  paste-write  Telnet  FTP     OK    0.23s
  paste-write  Telnet  REST    OK    0.23s
  rename-fail  FTP     Menu    OK    0.23s
  rename-fail  FTP     Telnet  OK    0.23s
  rename-fail  FTP     FTP     OK    0.23s
  rename-fail  FTP     REST    OK    0.23s
  delete-fail  FTP     Menu    OK    0.21s
  delete-fail  FTP     Telnet  OK    0.21s
  delete-fail  FTP     FTP     OK    0.21s
  delete-fail  FTP     REST    OK    0.21s
  write-fail   FTP     Menu    OK    0.22s
  write-fail   FTP     Telnet  OK    0.22s
  write-fail   FTP     FTP     OK    0.22s
  write-fail   FTP     REST    OK    0.22s
  short-write  FTP     Menu    OK    0.30s
  short-write  FTP     Telnet  OK    0.30s
  short-write  FTP     FTP     OK    0.30s
  short-write  FTP     REST    OK    0.30s
------------------------------------------------------------------------------
  N/A=2, OK=140
browser_filesystem_refresh_test: OK (38 checks, 129s)
browser-filesystem-refresh: OK (132s)

============================================================
E2E  ftp-client  (overlay)
============================================================
     ftp-client: health: ping=13ms rest=22ms ftp=30ms telnet=40ms ident=31ms dma=24ms raster=54ms jiffy=450ms -> OK
     inferred --ftp-advertised-host 192.168.1.78
     controlled FTP server on 0.0.0.0:2121 (advertised 192.168.1.78)
[I 2026-08-11 00:02:43] concurrency model: async
[I 2026-08-11 00:02:43] masquerade (NAT) address: 192.168.1.78
[I 2026-08-11 00:02:43] passive ports: 30000->30019
[I 2026-08-11 00:02:43] >>> starting FTP server on 0.0.0.0:2121, pid=56412 <<<
     server root: /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-uz5mi_8x (marker E2E-1786420963)
[01] GET /v1/version reachable ... OK (0.1, 0.046s)
[02] menu closed -> menu_screen 404 ... OK (0.059s)
[03] menu_button opens menu ... OK (0.345s)
[04] menu_screen returns 2000-byte matrix ... OK (2000 bytes, 0.021s)
[05] input release_all works ... OK (0.028s)
[06] menu closes from anywhere ... OK (0.359s)
[07] remove any stale hosts left by a prior run ... OK (0 removed, 1.504s)

--- stage: smoke
[08] create FTP host 'E2EFTP0964eoen' through the New Host form ... OK (6.590s)
[09] new alias appears under /ftp ... OK (1.181s)
[10] enter host: server sees login + TYPE I + LIST ... [I 2026-08-11 00:02:54] 192.168.1.62:52441-[] FTP session opened (connect)
[I 2026-08-11 00:02:54] 192.168.1.62:52441-[u64e2e] USER 'u64e2e' logged in.
OK (PASS,TYPE,LIST, 1.296s)
[11] root listing shows fixture entries ... OK (README,DIRA,SMALL, 0.040s)
[12] open README.TXT -> RETR (52 bytes) ... OK (None bytes, 2.691s)
[13] remove host and confirm it disappears ... [I 2026-08-11 00:02:59] 192.168.1.62:52441-[u64e2e] RETR /private/var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-uz5mi_8x/README.TXT completed=1 bytes=52 seconds=0.0
[I 2026-08-11 00:03:00] 192.168.1.62:52441-[u64e2e] FTP session closed (disconnect).
OK (4.463s)
--- OK (6 checks, 16.3s)

--- cleanup
     preserved: nothing

--- summary
     Phase    Operation              Result             Commands       Fixture/Notes
     ------------------------------------------------------------------------------
     smoke    create host            OK                                E2EFTP0964eoen
     smoke    list host              OK                                E2EFTP0964eoen
     smoke    enter/LIST             OK                 USER/PASS/TYPE E2EFTP0964eoen
     smoke    root entries           OK                 LIST           README/DIRA/SMALL
     smoke    RETR README            OK                 RETR           README.TXT None bytes
     smoke    remove host            OK                                E2EFTP0964eoen
     ------------------------------------------------------------------------------
     Total REST requests   : 161
     Total menu snapshots  : 68
     Total keyboard events : 105
     Total FTP commands    : 24
     Created host alias    : (removed)
     Remote root path      : /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-uz5mi_8x
     Cleanup status        : clean
Exception in thread Thread-1 (serve_forever):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/servers.py", line 254, in serve_forever
    self.ioloop.loop(timeout, blocking)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 376, in loop
    poll(timeout)
    ~~~~^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 741, in poll
    kevents = self._kqueue.control(
        None, _len(self.socket_map), timeout
    )
OSError: [Errno 9] Bad file descriptor
ftp-client: OK (20.0s)

============================================================
E2E  prg-load-path-trim  (overlay)
============================================================
     prg-load-path-trim: health: ping=13ms rest=24ms ftp=14ms telnet=38ms ident=38ms dma=10ms raster=38ms jiffy=53ms -> OK

--- Ultimate 64 PRG load path trim
     host: 192.168.1.62
     PUT file path: /Temp/rest-prg-path-trim-target-example.prg
     POST upload name: rest-prg-path-trim-upload-example.prg

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configure Temp Settings
[01] set Temp Auto Cleanup to Enabled ... OK (0.015s)
[02] set Temp Subfolders to Enabled ... OK (0.035s)
--- OK (2 checks, 0.049s)

--- 3. Prepare PRG Fixture
[03] upload PUT fixture rest-prg-path-trim-target-example.prg ... OK (0.195s)
--- OK (1 checks, 0.196s)

--- 4. Validate PUT Endpoints
[04] exercise PUT runners:load_prg ... OK (0.399s)
     PUT load_prg boot-cart name: ...T-EXAMPLE
[05] exercise PUT runners:run_prg ... OK (1.784s)
     PUT run_prg boot-cart name: ...T-EXAMPLE
--- OK (2 checks, 2.344s)

--- 5. Validate POST Endpoints
[06] exercise POST runners:load_prg ... OK (0.432s)
     POST load_prg boot-cart name: ...D-EXAMPLE
[07] exercise POST runners:run_prg ... OK (1.806s)
     POST run_prg boot-cart name: ...D-EXAMPLE
--- OK (2 checks, 3.126s)
prg_load_path_trim_test: OK (7 checks, 6.386s)

--- restore User Interface Settings
[08] set Temp Auto Cleanup to Enabled ... OK (0.037s)
[09] set Temp Subfolders to Enabled ... OK (0.020s)
prg-load-path-trim: OK (7.416s)

============================================================
E2E  temp-auto-cleanup  (overlay)
============================================================
     temp-auto-cleanup: health: ping=11ms rest=38ms ftp=16ms telnet=40ms ident=16ms dma=26ms raster=41ms jiffy=57ms -> OK

--- Ultimate 64 Temp auto cleanup
     host: 192.168.1.62

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configuration Setup
[01] set Temp Auto Cleanup to Enabled ... OK (0.020s)
[02] set Temp Subfolders to Enabled ... OK (0.025s)
--- OK (2 checks, 0.046s)

--- 3. Purging /Temp
     purge complete

--- 4. Mounting D64 Images
[03] create /Temp/mount-drive-8.d64 ... OK (0.062s)
[04] download mount-drive-8.d64 for the upload mount ... OK (0.487s)
[05] remove staging source mount-drive-8.d64 ... OK (0.048s)
[06] mount drive A ... OK (1.134s)
OK (1.134s)
[07] create /Temp/mount-drive-9.d64 ... OK (0.071s)
[08] download mount-drive-9.d64 for the upload mount ... OK (0.462s)
[09] remove staging source mount-drive-9.d64 ... OK (0.066s)
[10] mount drive B ... OK (1.333s)
OK (1.333s)
--- OK (10 checks, 3.665s)

--- 5. Seeding Baseline (10 files)
[11] upload base_1.bin ... OK (1.806s)
[12] upload base_2.bin ... OK (1.825s)
[13] upload base_3.bin ... OK (1.864s)
[14] upload base_4.bin ... OK (1.866s)
[15] upload base_5.bin ... OK (1.740s)
[16] upload base_6.bin ... OK (1.815s)
[17] upload base_7.bin ... OK (1.803s)
[18] upload base_8.bin ... OK (1.784s)
[19] upload base_9.bin ... OK (1.797s)
[20] upload base_10.bin ... OK (1.743s)
--- OK (10 checks, 18.1s)

--- 6. Managed Temp File Limit (Target: 10)
[21] upload managed_1.bin over REST ... OK (4.623s)
     managed count=1 (limit=10)
[22] upload managed_2.bin over REST ... OK (4.747s)
     managed count=2 (limit=10)
[23] upload managed_3.bin over REST ... OK (4.853s)
     managed count=3 (limit=10)
[24] upload managed_4.bin over REST ... OK (4.824s)
     managed count=4 (limit=10)
[25] upload managed_5.bin over REST ... OK (4.863s)
     managed count=5 (limit=10)
[26] upload managed_6.bin over REST ... OK (4.635s)
     managed count=6 (limit=10)
[27] upload managed_7.bin over REST ... OK (4.812s)
     managed count=7 (limit=10)
[28] upload managed_8.bin over REST ... OK (4.828s)
     managed count=8 (limit=10)
[29] upload managed_9.bin over REST ... OK (4.885s)
     managed count=9 (limit=10)
[30] upload managed_10.bin over REST ... OK (4.688s)
     managed count=10 (limit=10)
[31] upload managed_11.bin over REST ... OK (4.791s)
     managed count=10 (limit=10)
[32] upload managed_12.bin over REST ... OK (4.720s)
     managed count=10 (limit=10)
OK (5.152s)
OK (5.256s)
--- OK (14 checks, 63.0s)

--- 7. Unmounted Uploads Rejoin Cleanup
[33] remove drive A ... OK (0.145s)
[34] upload post_a_1.bin over REST ... OK (4.799s)
OK (4.908s)
     removed after 1 uploads
[35] remove drive B ... OK (0.131s)
[36] upload post_b_1.bin over REST ... OK (4.701s)
     removed after 1 uploads
--- OK (5 checks, 10.4s)

--- 8. Final Integrity Check
     user files intact
temp_auto_cleanup_test: OK (36 checks, 99.4s)

--- restore User Interface Settings
[37] set Temp Auto Cleanup to Enabled ... OK (0.021s)
[38] set Temp Subfolders to Enabled ... OK (0.016s)
temp-auto-cleanup: OK (100s)

============================================================
E2E  cfg-single-group  (overlay)
============================================================
     cfg-single-group: health: ping=13ms rest=14ms ftp=44ms telnet=40ms ident=17ms dma=37ms raster=40ms jiffy=52ms -> OK
[01] load a one-group CFG file through the browser ... OK (8.854s)
[02] only the CFG group is considered after loading ... OK (0.139s)
cfg_single_group_test: OK (2 checks, 9.465s)
cfg-single-group: OK (10.2s)

============================================================
E2E  cfg-unknown-items  (overlay)
============================================================
     cfg-unknown-items: health: ping=22ms rest=101ms ftp=93ms telnet=51ms ident=29ms dma=11ms raster=65ms jiffy=30ms -> OK

--- an item this firmware does not have
[01] a CFG with an unknown item loads without being called an error ... OK (7.961s)
[02] the settings it could apply were applied ... OK (0.022s)
     Vol Master: ' 0 dB' -> 'OFF'
[03] the log names the unknown item and its value ... OK (0.115s)
--- OK (3 checks, 8.123s)

--- a store this machine does not have
[04] a CFG naming an absent store loads without being called an error ... OK (8.306s)
[05] the store that does exist was still applied ... OK (0.037s)
[06] the log names the absent store ... OK (0.123s)
--- OK (3 checks, 8.495s)
cfg_unknown_items_test: OK (6 checks, 17.1s)
cfg-unknown-items: OK (17.9s)

============================================================
E2E  printer  (overlay)
============================================================
     printer: health: ping=12ms rest=20ms ftp=16ms telnet=67ms ident=23ms dma=12ms raster=113ms jiffy=30ms -> OK
[01] REST reachable at 192.168.1.62 ... OK (0.024s)
[02] reset before run ... OK (0.168s)
[03] load printer_e2e.prg ... OK (914 bytes, 0.000s)
[04] capture original Printer Settings ... OK (0.261s)
[05] print epson/bitmap: apply settings + run PRG ... OK (phase=printer closed heartbeat=4, 3.010s)
[06] print epson/bitmap: Flush/Eject via on-screen menu ... OK (3.963s)

--- restoring original Printer Settings
     IEC printer: Disabled
     Bus ID: 4
     Output file: /Usb0/printer
     Output type: PNG B&W
     Ink density: Medium
     Page top margin (default is 5): 5
     Page height (default is 60): 60
     Emulation: Commodore MPS
     Commodore charset: USA/UK
     Epson charset: Basic
     IBM table 2: International 1

--- summary
     epson      bitmap PASS_NO_VERIFY       /USB1/printer/e2e-eb0a02
printer: OK (8.198s)

============================================================
E2E  uci-targets  (overlay)
============================================================
     uci-targets: health: ping=12ms rest=14ms ftp=18ms telnet=55ms ident=17ms dma=11ms raster=50ms jiffy=31ms -> OK
[01] reset the C64 so the command interface starts idle ... OK (3.051s)
[02] read 'C64 and Cartridge Settings' ... OK (0.024s)
     current: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}
[03] enable the Command Interface registers at $DF1B-$DF1F ... OK (0.142s)
[04] transport: an empty command returns an empty reply ... OK (0.282s)
     <empty> -> 0.04s, data b'', status b''
[05] transport: unregistered target answers IDENTIFY ... OK (1.040s)
     0f 01 -> 0.09s, data b'NO TARGET', status b'00,OK'
[06] transport: unregistered target rejects anything else ... OK (1.160s)
     0f 7f -> 0.12s, data b'', status b'21,UNKNOWN COMMAND'
[07] transport: a no-reply command returns straight to Idle ... OK (0.258s)
[08] transport: pushing while a reply is pending sets and clears ERROR ... OK (1.515s)
[09] transport: the next command is not prefixed by leftover bytes ... OK (1.299s)
     04 28 00 -> 0.12s, data b'Ultimate 64 Elite', status b'00,OK'
[10] transport: ABORT releases a pending reply back to Idle ... OK (0.206s)
[11] control-target: IDENTIFY answers with the target name ... OK (1.388s)
     04 01 -> 0.09s, data b'CONTROL TARGET V1.1', status b'00,OK'
[12] control-target: an unimplemented command is reported as unknown ... OK (1.051s)
     04 7f -> 0.10s, data b'', status b'21,UNKNOWN COMMAND'
[13] control-target: LOAD_REU without a filename is rejected, not run ... OK (0.991s)
     04 08 -> 0.07s, data b'', status b'81,INVALID PARAMS'
[14] control-target: SAVE_REU without a filename is rejected, not run ... OK (1.005s)
     04 09 -> 0.08s, data b'', status b'81,INVALID PARAMS'
[15] control-target: GET_HWINFO rejects a device number it does not have ... OK (1.045s)
     04 28 02 -> 0.11s, data b'', status b'81,INVALID PARAMS'
[16] issue-740-matrix: confirm /Temp/uci_e2e_absent.reu does not exist ... OK (0.017s)
[17] issue-740-matrix: put a 16384-byte image at /Temp/uci_e2e_present.reu ... OK (0.224s)
[18] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... OK (4.850s)
     04 08 52 45 55 2e 49 4d 47 -> 0.31s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[19] issue-740-matrix: REU Enabled, image absent, name at offset 4 ... OK (5.068s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.29s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[20] issue-740-matrix: REU Disabled, image absent, name at offset 2 ... OK (1.567s)
     04 08 52 45 55 2e 49 4d 47 -> 0.29s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[21] issue-740-matrix: REU Disabled, image absent, name at offset 4 ... OK (1.672s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.39s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[22] issue-740-matrix: REU Enabled, image present, name at offset 2 ... OK (4.380s)
     04 08 52 45 55 2e 49 4d 47 -> 0.23s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[23] issue-740-matrix: REU Enabled, image present, name at offset 4 ... OK (4.159s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.32s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[24] save-reu-offset-past-end: put the preload offset at the end of a 128 KB REU ... OK (0.076s)
[25] save-reu-offset-past-end: SAVE_REU reports the offset and saves nothing ... OK (4.427s)
     04 09 52 45 55 2e 49 4d 47 -> 0.27s, data b'\xfd\xff\xff\xffREU SAVE: OFFSET 131072 >= REU SIZE 131072, SKIPPING', status b'86,REU OFFSET > SIZE. NOT SAVED'
[26] load-reu-disabled: disable the REU ... OK (0.038s)
[27] load-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.203s)
     04 28 00 -> 0.11s, data b'Ultimate 64 Elite', status b'00,OK'
[28] load-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.324s)
     04 08 52 45 55 2e 49 4d 47 -> 0.19s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[29] save-reu-disabled: disable the REU ... OK (0.023s)
[30] save-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.153s)
     04 28 00 -> 0.10s, data b'Ultimate 64 Elite', status b'00,OK'
[31] save-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.340s)
     04 09 52 45 55 2e 49 4d 47 -> 0.22s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[32] softiec-single-part-reply: SoftIEC target answers IDENTIFY ... OK (1.420s)
     05 01 -> 0.09s, data b'SOFTWARE IEC TARGET V1.0', status b'00,OK'
[33] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... OK (0.658s)
     05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 -> 0.44s, data b'', status b'\x01'
[34] softiec-single-part-reply: GET_FATNAME reply completes in one part ... OK (0.745s)
     05 22 02 23 -> 0.15s, data b'/buffer', status b'\x00'
[35] softiec-single-part-reply: an unimplemented SoftIEC command is reported as unknown ... OK (0.298s)
     05 7f -> 0.09s, data b'', status b'\x04'
[36] interface-usable-after: the control target still answers IDENTIFY ... OK (1.455s)
     04 01 -> 0.09s, data b'CONTROL TARGET V1.1', status b'00,OK'
     restored C64 and Cartridge Settings: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}

--- summary
     transport: OK
     control-target: OK
     issue-740-matrix: OK
     save-reu-offset-past-end: OK
     load-reu-disabled: OK
     save-reu-disabled: OK
     softiec-single-part-reply: OK
     interface-usable-after: OK
     cleanup: OK
uci_targets_test: OK (36 checks, 50.9s)
uci-targets: OK (50.9s)

============================================================
E2E  machine-code-monitor  (overlay)
============================================================
     machine-code-monitor: health: ping=14ms rest=34ms ftp=16ms telnet=40ms ident=18ms dma=36ms raster=37ms jiffy=50ms -> OK
[01] initial CPU7/KERNAL monitor status ... OK (0.409s)
[02] KERNAL $E000 hex view and REST match ... OK (1.340s)
[03] paging away and back keeps memory view stable ... OK (0.622s)
[04] KERNAL disassembly formatting ... OK (1.653s)
[05] KERNAL $E010 REST match ... OK (1.050s)
[06] CPU6 RAM under BASIC write/read ... OK (4.477s)
[07] CPU5 RAM under KERNAL status ... OK (3.129s)
[08] ASCII view width and scrolling ... OK (8.062s)
[09] ASCII and Screen mapping semantics ... OK (13.2s SLOW)
[10] HEX edit writes both nibbles ... OK (3.313s)
[11] CPU bank cycling reaches CHAR and RAM mappings ... OK (3.844s)
[12] COMPARE reports differing address ... OK (4.465s)
[13] G executes finite loop and returns to monitor ... OK (2.440s)
[14] G repeated execution updates RAM sentinel ... OK (8.039s)
[15] G handoff preserves stable VIC state ... SKIP (the on-device UI owns the VIC while it is up; only comparable over telnet, 0.000s)
OK (0.000s)
[16] bookmarks recall, set, list, and label edit ... OK (7.941s)
[17] memory bookmark jump restores width 16 ... OK (6.314s)
[18] binary width cycling and bookmark jump restores width 4 ... OK (7.257s)
[19] follow and return navigation ... OK (6.337s)
[20] asm edit mnemonic validation and Return advance ... OK (9.051s)
[21] number popup arithmetic ... OK (3.100s)
[22] save/load round-trip to top-level /Temp file ... OK (10.6s SLOW)
[23] save/load round-trip to file in new /Temp D64 ... OK (20.2s SLOW)

--- Telnet transport checks
[24] telnet blocks poll mode ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
[25] telnet opcode dropdown scroll does not flood the connection ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
--- SKIP (4 checks, 0.166s)
monitor_test: OK (25 checks, 129s)
machine-code-monitor: OK (129s)

============================================================
E2E  ftp-server  (overlay)
============================================================
     ftp-server: health: ping=13ms rest=13ms ftp=31ms telnet=39ms ident=17ms dma=10ms raster=32ms jiffy=105ms -> OK

--- a name the listing reports can address the file it names
[01] a 40-character name is listed unchanged ... OK (0.110s)
[02] that file is removed by the name the listing reported ... OK (0.179s)
[03] a 100-character name is listed unchanged ... OK (0.107s)
     100 characters survived the listing
[04] SIZE answers for the long name the listing reported ... OK (0.069s)
[05] that file is removed by the name the listing reported ... OK (0.133s)
--- OK (5 checks, 0.710s)
ftp_server_test: OK (5 checks, 0.714s)
ftp-server: OK (0.761s)

============================================================
E2E  assembly64  (overlay)
============================================================
     assembly64: health: ping=13ms rest=40ms ftp=16ms telnet=39ms ident=18ms dma=30ms raster=42ms jiffy=181ms -> OK

--- the form opens from the task menu and closes again
[01] open the Assembly 64 query form ... OK (0.812s)
[02] the form leaves cleanly with RUN/STOP ... OK (0.400s)
--- OK (2 checks, 1.353s)

--- a real query is sent to the Assembly 64 service
[03] open the form and enter the first field ... OK (1.220s)
[04] the typed term lands in the Name field ... OK (0.817s)
[05] the service answers and the results match what was asked for ... OK (1.217s)
--- OK (3 checks, 3.918s)

--- the menu button must work from inside the edit field
[06] open the form and enter the edit field ... OK (1.124s)
[07] the menu button closes the menu from inside the field ... OK (0.121s)
[08] the menu opens again, so the UI task left string_edit ... OK (0.045s)
--- OK (3 checks, 1.842s)

--- an aborted edit must not wedge the form
[09] open the form, type into a field, then abort ... OK (1.644s)
[10] the form is still usable after the abort ... OK (0.081s)
--- OK (2 checks, 2.356s)

--- over-long and empty input
[11] type more than the field accepts ... OK (2.429s)
[12] an empty query is refused rather than sent ... OK (2.972s)
[13] the warning is dismissed and the form is still usable ... OK (0.352s)
--- OK (3 checks, 6.330s)

--- a user mashing keys while the form is busy
[14] submit a query and hammer keys while it runs ... OK (5.180s)
[15] the device is still answering after the mashing ... OK (0.019s)
--- OK (2 checks, 5.787s)

--- opening and abandoning the form repeatedly
[16] open and abandon the form three times ... OK (3.550s)
[17] the menu button closes and reopens the form three times ... OK (4.008s)
--- OK (2 checks, 7.918s)
assembly64_test: OK (17 checks, 30.0s)
assembly64: OK (30.0s)

============================================================
E2E  freeze-menu  (overlay)
============================================================
     freeze-menu: health: ping=13ms rest=18ms ftp=14ms telnet=66ms ident=23ms dma=10ms raster=29ms jiffy=35ms -> OK
     captured 'Interface Type'=Freeze, 'Auto Address Mirroring'=Enabled

--- menu cycle with Auto Address Mirroring Disabled
[01] select 'Freeze' interface with mirroring disabled ... OK (0.053s)
[02] C64 running before the menu is opened ... OK (1.096s)
[03] open the menu ... OK (0.352s)
[04] C64 frozen while the menu is open ... OK (0.552s)
[05] close the menu ... OK (0.302s)
[06] C64 resumed after the menu closed ... OK (0.533s)
--- OK (6 checks, 2.916s)

--- Auto Address Mirroring switched off while the menu is open
[07] select 'Freeze' interface with mirroring enabled ... OK (0.038s)
[08] C64 running before the menu is opened ... OK (0.547s)
[09] open the menu ... OK (0.303s)
[10] C64 frozen while the menu is open ... OK (0.551s)
[11] set Auto Address Mirroring to Disabled while the menu is open ... OK (0.028s)
[12] close the menu ... OK (0.285s)
[13] C64 resumed after the menu closed ... OK (0.549s)
--- OK (7 checks, 2.343s)

--- menu cycle with Auto Address Mirroring Enabled
[14] select 'Freeze' interface with mirroring enabled ... OK (0.057s)
[15] C64 running before the menu is opened ... OK (0.558s)
[16] open the menu ... OK (0.305s)
[17] C64 frozen while the menu is open ... OK (0.560s)
[18] close the menu ... OK (0.306s)
[19] C64 resumed after the menu closed ... OK (0.565s)
--- OK (6 checks, 2.365s)

--- reopen the freezer menu with a context menu left open
[20] select 'Freeze' interface with mirroring enabled ... OK (0.040s)
[21] C64 running before the menu is opened ... OK (0.540s)
[22] open the menu ... OK (0.302s)
[23] C64 frozen while the menu is open ... OK (0.546s)
[24] open the context menu on the first browser entry ... OK (7.844s)
[25] close the menu ... OK (0.307s)
[26] C64 resumed after the menu closed ... OK (0.546s)
[27] reopen the menu with the context menu still on the object stack ... OK (0.308s)
[28] dismiss the restored context menu ... OK (0.304s)
[29] close the menu ... OK (0.306s)
[30] C64 resumed after the menu closed ... OK (0.558s)
--- OK (11 checks, 11.7s)

--- the menu button works inside the Assembly 64 query form
[31] select 'Freeze' interface with mirroring enabled ... OK (0.035s)
[32] C64 running before the menu is opened ... OK (0.540s)
[33] open the menu ... OK (0.287s)
[34] C64 frozen while the menu is open ... OK (0.563s)
[35] open the task menu ... OK (0.353s)
[36] open the Assembly 64 query form ... OK (0.351s)
[37] enter the form's first edit field ... OK (0.302s)
[38] the menu button closes the menu from inside the edit field ... OK (0.293s)
[39] the menu opens again afterwards ... OK (0.290s)
[40] leave the query form ... OK (0.486s)
[41] close the menu ... OK (0.299s)
[42] C64 resumed after the menu closed ... OK (0.537s)
--- OK (12 checks, 4.469s)
freeze_menu_test: OK (42 checks, 24.9s)
freeze-menu: OK (25.0s)

TEARDOWN (overlay): release input ... OK (0.021s)
TEARDOWN (overlay): close active menu UI ... OK (0.047s)
TEARDOWN (overlay): reset machine ... OK (0.064s)

============================================================
Summary
============================================================
     OK   e2e overlay    842s (20 ok)
     slowest: prg-context-menu 172s, browser-filesystem-refresh 132s, machine-code-monitor 129s
     842s in suites, 30.2s in health checks, the UI-state gate and teardown
     872s total

OK  all 20 suite runs passed.
```
</details>
