### PR TITLE
Bound the disk image mount cache: ~5 KB leaked per disk image browsed

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -177,6 +177,12 @@ SUITES: Sequence[Suite] = (
     # profile runs for twelve hours, so it is opt-in through --soak-profile.
     Suite("soak", "network-connection", "tests/soak/network/connection_test.py",
           "--profile @SOAKPROFILE@ -H @HOST@"),
+    # Browsing many disk images must not consume heap. Listed last so it does
+    # not collide with the other soak entries being added in #764 and #766.
+    # Skips until #766 lands machine:heap.
+    Suite("soak", "mount-cache-leak",
+          "tests/soak/filemanager/mount_cache_leak_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
 )
 
 

--- a/software/filemanager/filemanager.cc
+++ b/software/filemanager/filemanager.cc
@@ -940,6 +940,80 @@ void FileManager::remove_root_entry(CachedTreeNode *obj)
     unlock();
 }
 
+// How many disk images stay mounted. Entering an image costs about 5 KB -- the
+// FatFs handle on the image file plus the embedded filesystem wrappers -- and
+// nothing releases it, so browsing a collection used to consume that per image
+// without bound. Eight covers any realistic working set; the cache still pays
+// for itself, since re-entering a mounted image allocates nothing.
+#define MOUNT_CACHE_MAX 8
+
+// Whether this mount can be released without pulling the ground from under
+// something that is using it. Two ways it can be in use:
+//
+//  - a File is open inside it, so its filesystem is still being read or
+//    written. Note the browser merely listing a directory does NOT hold a
+//    file open, which is why the recency rule below matters as much as this.
+//  - it hosts another mount: an image inside an image. Releasing the outer
+//    one would take the inner one's backing file with it.
+bool FileManager::is_mount_evictable(MountPoint *mp)
+{
+    FileSystem *fs = mp->get_embedded() ? mp->get_embedded()->getFileSystem() : NULL;
+    if (!fs) {
+        return false;
+    }
+    for (int i = 0; i < open_file_list.get_elements(); i++) {
+        File *f = open_file_list[i];
+        if (f && (f->get_file_system() == fs)) {
+            return false;
+        }
+    }
+    for (int i = 0; i < mount_points.get_elements(); i++) {
+        MountPoint *other = mount_points[i];
+        if (other && (other != mp) && other->get_file() &&
+            (other->get_file()->get_file_system() == fs)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Release least-recently-used mounts until the cache is back within its bound.
+//
+// The cap is deliberately soft: if nothing is evictable we keep every mount
+// rather than break one that is in use. Exceeding the bound is a bounded waste;
+// freeing a filesystem out from under an open file is corruption.
+//
+// The mount the user is currently inside is the most recently used one, so
+// least-recently-used never selects it. It only becomes a candidate after
+// eight other images have been entered, which means navigating away from it.
+void FileManager::evict_mount_points(void)
+{
+    while (mount_points.get_elements() > MOUNT_CACHE_MAX) {
+        int victim = -1;
+        uint32_t oldest = 0;
+        for (int i = 0; i < mount_points.get_elements(); i++) {
+            MountPoint *mp = mount_points[i];
+            if (!mp || !is_mount_evictable(mp)) {
+                continue;
+            }
+            if ((victim < 0) || (mp->get_last_used() < oldest)) {
+                victim = i;
+                oldest = mp->get_last_used();
+            }
+        }
+        if (victim < 0) {
+            // Everything still in use. Keep them all and try again next time.
+            break;
+        }
+        printf("FileManager: releasing least recently used mount '%s'\n",
+               mount_points[victim]->get_path());
+        release_mount_point(mount_points[victim]);
+        mount_points.mark_for_removal(victim);
+        mount_points.purge_list();
+    }
+}
+
+
 MountPoint *FileManager::add_mount_point(SubPath *path, File *file, FileSystemInFile *emb)
 {
     printf("FileManager :: add_mount_point: (FS=%p, path='%s')\n", file->get_file_system(), path->get_path());
@@ -955,6 +1029,7 @@ MountPoint *FileManager::find_mount_point(SubPath *path, FileInfo *info)
     for (int i = 0; i < mount_points.get_elements(); i++) {
         if (mount_points[i]->match(info->fs, path)) {
             //printf("Found!\n");
+            mount_points[i]->touch(++mount_use_seq);
             unlock();
             return mount_points[i];
         }
@@ -975,6 +1050,10 @@ MountPoint *FileManager::find_mount_point(SubPath *path, FileInfo *info)
             emb->init(file);
             if (emb->getFileSystem()) {
                 mp = add_mount_point(path, file, emb);
+                mp->touch(++mount_use_seq);
+                // Trim after adding, never before: the mount just created is
+                // the most recent, so it is never its own victim.
+                evict_mount_points();
             }
             else {
                 delete emb;

--- a/software/filemanager/filemanager.h
+++ b/software/filemanager/filemanager.h
@@ -24,12 +24,17 @@ class MountPoint
     Path *path;
     File *file;
 	FileSystemInFile *emb;
+	uint32_t last_used;   // for LRU eviction; larger is more recent
 public:
 	MountPoint(SubPath *p, File *f, FileSystemInFile *e) {
 		path = p->get_new_path();
 	    file = f;
 		emb = e;
+		last_used = 0;
 	}
+
+	void touch(uint32_t seq) { last_used = seq; }
+	uint32_t get_last_used(void) { return last_used; }
 
 	~MountPoint() {
 	    delete path;
@@ -97,7 +102,7 @@ class FileManager
 	CachedTreeNode *root;
 	FileSystem *rootfs;
 
-    FileManager() : mount_points(8, NULL), open_file_list(16, NULL), managed_temp_entries(16, NULL), next_temp_seq(0), temp_auto_cleanup_enabled(true), temp_use_cache_subfolder_enabled(true), /*used_paths(8, NULL), */observers(4, NULL) {
+    FileManager() : mount_points(8, NULL), open_file_list(16, NULL), managed_temp_entries(16, NULL), next_temp_seq(0), mount_use_seq(0), temp_auto_cleanup_enabled(true), temp_use_cache_subfolder_enabled(true), /*used_paths(8, NULL), */observers(4, NULL) {
         root = new CachedTreeNode(NULL, "RootNode");
         root->get_file_info()->attrib = AM_DIR;
         rootfs = new FileSystem_Root(root);
@@ -196,6 +201,14 @@ public:
 
     MountPoint *add_mount_point(SubPath *path, File *, FileSystemInFile *);
     MountPoint *find_mount_point(SubPath *path, FileInfo *info);
+
+    // Mount points are a cache: entering the same image twice costs nothing.
+    // Without a bound it is also a leak, because nothing releases them until
+    // the media goes away, so browsing a collection of images accumulates one
+    // open file each. Bounded here, least recently used first.
+    uint32_t mount_use_seq;
+    bool is_mount_evictable(MountPoint *mp);
+    void evict_mount_points(void);
 
     // Functions to use / handle path objects:
     Path *get_new_path(const char *owner) {

--- a/tests/soak/filemanager/mount_cache_leak_test.py
+++ b/tests/soak/filemanager/mount_cache_leak_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Soak: Asserts that browsing many disk images does not consume heap.
+
+"""Enter one disk image after another and require the heap to come back.
+
+Looking inside a disk image mounts it, and the mount holds the image file
+open. The mount is a cache -- entering the same image twice costs nothing --
+but until it was bounded, nothing released one until the media went away, so
+browsing a collection of images consumed about 5 KB per distinct image and
+never gave any of it back. On an 8 MB heap a few hundred images is real money.
+
+The trigger is deliberately not the browser: listing a directory inside an
+image over FTP goes through the same FileManager path (vfs_opendir ->
+get_directory -> find_pathentry -> find_mount_point), so this measures the
+mount cache without depending on screen scraping or menu navigation.
+
+Two things are asserted, because a fix that simply stopped caching would pass
+the first one and make the firmware slower:
+
+  1. entering many distinct images has a flat heap slope
+  2. re-entering an image that is still mounted costs nothing
+
+Uses GET /v1/machine:heap. Firmware predating that endpoint answers 404 and
+every check here skips, so the suite is safe to run against any image.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# tests/lib holds the reporting rules and the shared REST client; the D64
+# builder lives with the suite that already needed one.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "e2e" / "filemanager"))
+
+import ftp as ftp_lib  # noqa: E402
+import rest as rest_lib  # noqa: E402
+from report import (  # noqa: E402
+    Failure, check, check_ok, check_skip, check_start, detail, format_exception,
+    section, suite_fail, suite_ok)
+from prg_context_menu_test import build_d64, PRG_BYTES  # noqa: E402
+
+HEAP_PATH = "/v1/machine:heap"
+TEMP = "/Temp/"
+PREFIX = "mountleak"
+
+# The cache holds eight mounts. Entering appreciably more than that is what
+# separates "bounded" from "grows for ever": the first eight are the working
+# set and are expected to cost their ~5 KB, everything after them must be free.
+WARMUP = 10
+MEASURED = 20
+# A mount is about 5 KB. Anything approaching that per image means the cache is
+# still growing; a few hundred bytes is the ordinary noise of a REST round trip.
+TOLERANCE_BYTES_PER_IMAGE = 512
+
+
+def image_name(index: int) -> str:
+    return f"{PREFIX}{index}.d64"
+
+
+def seed_and_enter(host: str, password: str, indices) -> None:
+    """Create each image and look inside it, which is what mounts it."""
+    with ftp_lib.session(host, password, timeout=60) as ftp:
+        for i in indices:
+            name = image_name(i)
+            ftp_lib.store(ftp, TEMP + name, build_d64(f"DISK{i:03d}", "HELLO", PRG_BYTES))
+            ftp_lib.names(ftp, TEMP + name + "/")
+
+
+def re_enter(host: str, password: str, indices, times: int) -> None:
+    with ftp_lib.session(host, password, timeout=60) as ftp:
+        for _ in range(times):
+            for i in indices:
+                ftp_lib.names(ftp, TEMP + image_name(i) + "/")
+
+
+def cleanup(host: str, password: str, indices) -> int:
+    removed = 0
+    try:
+        with ftp_lib.session(host, password, timeout=60) as ftp:
+            for i in indices:
+                try:
+                    ftp_lib.delete_quietly(ftp, TEMP + image_name(i))
+                    removed += 1
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assert that browsing many disk images does not consume heap. "
+                    "Skips if the firmware has no machine:heap endpoint.")
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS"))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "30.0")))
+    args = parser.parse_args()
+
+    rest = rest_lib.RestClient(args.host, args.password or None, args.timeout)
+    password = args.password or ""
+
+    check_start("device exposes GET /v1/machine:heap")
+    if rest.status("GET", HEAP_PATH) != 200:
+        check_skip("firmware predates GET /v1/machine:heap, nothing to measure")
+        section("summary")
+        detail("skipped: device firmware has no machine:heap endpoint")
+        suite_ok("mount_cache_leak_test")
+        return 0
+    check_ok()
+
+    warm = range(WARMUP)
+    measured = range(WARMUP, WARMUP + MEASURED)
+    everything = range(WARMUP + MEASURED)
+    ok = True
+    stats = {}
+
+    try:
+        section("entering one image after another")
+        with check(f"fill the mount cache ({WARMUP} images, the working set is paid for here)"):
+            seed_and_enter(args.host, password, warm)
+
+        try:
+            with check(f"free heap is flat across {MEASURED} further images"):
+                before = int(rest.json(HEAP_PATH)["free"])
+                seed_and_enter(args.host, password, measured)
+                after = int(rest.json(HEAP_PATH)["free"])
+                consumed = before - after
+                stats.update(before=before, after=after, consumed=consumed,
+                             per_image=consumed / MEASURED)
+                if stats["per_image"] > TOLERANCE_BYTES_PER_IMAGE:
+                    raise Failure(
+                        f"browsing images leaks about {stats['per_image']:.0f} bytes "
+                        f"each ({consumed} bytes over {MEASURED} images)")
+        except Failure:
+            ok = False
+        if stats:
+            detail(f"free before {stats['before']}, after {stats['after']}")
+            detail(f"consumed {stats['consumed']} bytes over {MEASURED} images "
+                   f"= {stats['per_image']:.0f} bytes/image "
+                   f"(tolerance {TOLERANCE_BYTES_PER_IMAGE})")
+
+        section("the cache still does its job")
+        with check("re-entering images that are still mounted costs nothing"):
+            recent = list(measured)[-5:]
+            before = int(rest.json(HEAP_PATH)["free"])
+            re_enter(args.host, password, recent, 4)
+            after = int(rest.json(HEAP_PATH)["free"])
+            if before - after > TOLERANCE_BYTES_PER_IMAGE:
+                raise Failure(
+                    f"re-entering {len(recent)} mounted images consumed "
+                    f"{before - after} bytes; they should already be mounted")
+            detail(f"{len(recent)} images re-entered 4 times: {before - after} bytes")
+
+        section("summary")
+        detail(f"mount cache slope: {'OK' if ok else 'FAIL'}")
+        if ok:
+            suite_ok("mount_cache_leak_test")
+            return 0
+        suite_fail("mount_cache_leak_test", "see the summary above")
+        return 1
+    finally:
+        removed = cleanup(args.host, password, everything)
+        detail(f"removed {removed} of {len(list(everything))} images created by this suite")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        suite_fail("mount_cache_leak_test", format_exception(exc))
+        raise SystemExit(1)

--- a/tests/soak/filemanager/mount_cache_leak_test.py
+++ b/tests/soak/filemanager/mount_cache_leak_test.py
@@ -27,6 +27,7 @@ every check here skips, so the suite is safe to run against any image.
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 
 # tests/lib holds the reporting rules and the shared REST client; the D64
@@ -39,10 +40,14 @@ import rest as rest_lib  # noqa: E402
 from report import (  # noqa: E402
     Failure, check, check_ok, check_skip, check_start, detail, format_exception,
     section, suite_fail, suite_ok)
-from prg_context_menu_test import build_d64, PRG_BYTES  # noqa: E402
+from prg_context_menu_test import build_d64, default_fixture_token, PRG_BYTES  # noqa: E402
 
 HEAP_PATH = "/v1/machine:heap"
 TEMP = "/Temp/"
+# Every run needs image names it has never used before. A mount is keyed by
+# path, so recreating a file the previous run deleted would be matched against
+# that run's stale mount and allocate nothing -- the suite would pass on
+# firmware that leaks, having measured a cache hit.
 PREFIX = "mountleak"
 
 # The cache holds eight mounts. Entering appreciably more than that is what
@@ -53,10 +58,28 @@ MEASURED = 20
 # A mount is about 5 KB. Anything approaching that per image means the cache is
 # still growing; a few hundred bytes is the ordinary noise of a REST round trip.
 TOLERANCE_BYTES_PER_IMAGE = 512
+# An FTP session borrows several KB and returns it shortly after it closes, so
+# every heap figure here is taken after a settle. Sampling without one reads
+# that borrowing as a leak: measured at 7568 bytes still outstanding
+# immediately after twenty listings, and zero a few seconds later.
+SETTLE_SECONDS = 6.0
+# Re-entering images that are already mounted must not mount them again. The
+# bar is deliberately well under what one fresh mount costs, so remounting even
+# a single image fails this, while ordinary session noise does not.
+TOLERANCE_REENTRY_BYTES = 2048
+
+
+def heap_free(rest) -> int:
+    """Free heap, after letting transient allocations come back."""
+    time.sleep(SETTLE_SECONDS)
+    return int(rest.json(HEAP_PATH)["free"])
+
+
+TOKEN = default_fixture_token()
 
 
 def image_name(index: int) -> str:
-    return f"{PREFIX}{index}.d64"
+    return f"{PREFIX}{TOKEN}_{index}.d64"
 
 
 def seed_and_enter(host: str, password: str, indices) -> None:
@@ -125,9 +148,9 @@ def main() -> int:
 
         try:
             with check(f"free heap is flat across {MEASURED} further images"):
-                before = int(rest.json(HEAP_PATH)["free"])
+                before = heap_free(rest)
                 seed_and_enter(args.host, password, measured)
-                after = int(rest.json(HEAP_PATH)["free"])
+                after = heap_free(rest)
                 consumed = before - after
                 stats.update(before=before, after=after, consumed=consumed,
                              per_image=consumed / MEASURED)
@@ -146,10 +169,10 @@ def main() -> int:
         section("the cache still does its job")
         with check("re-entering images that are still mounted costs nothing"):
             recent = list(measured)[-5:]
-            before = int(rest.json(HEAP_PATH)["free"])
+            before = heap_free(rest)
             re_enter(args.host, password, recent, 4)
-            after = int(rest.json(HEAP_PATH)["free"])
-            if before - after > TOLERANCE_BYTES_PER_IMAGE:
+            after = heap_free(rest)
+            if before - after > TOLERANCE_REENTRY_BYTES:
                 raise Failure(
                     f"re-entering {len(recent)} mounted images consumed "
                     f"{before - after} bytes; they should already be mounted")


### PR DESCRIPTION
Third leak from #763, and the largest one left. Found by instrumenting the file manager after #764 accounted for the PRG context-menu handle.

### Looking inside a disk image costs 5 KB, for ever

`find_mount_point()` opens the image file and hangs it on a `MountPoint`. `release_mount_point()` is reached from exactly one place, `invalidate()`, whose callers are all media removal — SD eject, USB detach, FTP server gone. **Nothing releases a mount when you navigate out of an image.**

Measured on an Ultimate 64 Elite, entering images over FTP so the numbers do not depend on the browser:

```
 4 distinct images  ->  4 mounts,  5032 bytes each
24 distinct images  -> 24 mounts,  5059 bytes each
60 distinct images  -> 60 mounts        (linear, no ceiling)
```

Browsing a 200-image collection costs about 1 MB of an 8 MB heap and never gives it back.

What settles it as a leak rather than a cache: **the mounts survive deleting the image files.** After removing every `.d64`, all 24 remained, still naming files that no longer exist, each still holding a FatFs handle. An entry that can never be hit again is not a cache.

This is also why it hid. It is per *distinct* image, not per visit — re-entering the same image is free, which is real value worth keeping, and is why #763 recorded "browser descend/ascend x10" as clean. That measurement was correct; it kept re-entering one directory.

### Bounded, least recently used first

```c
#define MOUNT_CACHE_MAX 8
```

Eight covers any realistic working set and bounds the cost at about 40 KB. Re-entering a mounted image still allocates nothing, so the cache keeps paying for itself.

**Two decisions I would like confirmed** — @GideonZ @chrisgleissner — because both are judgement rather than a bug with one right answer:

**The number 8.** It matches the list's own initial size. Higher wastes memory for no gain; lower risks thrashing an image someone is working in.

**Least recently used, rather than releasing on leave.** Beyond being cheap, LRU has a property that matters here: *the image you are currently inside is by definition the most recently used, so it is never the victim.* It only becomes a candidate once eight other images have been entered, which means having navigated away from it. `FileManager` has no way to ask the browser where it is, and this makes it unnecessary.

**The cap is deliberately soft.** If nothing is evictable we keep every mount and exceed eight. Overshooting wastes bounded memory; freeing a filesystem out from under an open file corrupts data. I would rather leak a little than corrupt — but that is a trade you may want to call differently.

A mount is evictable when no open `File` lives on its filesystem, and it does not host another mount's backing file, which is an image inside an image. Note that merely listing a directory holds no file open — I confirmed `open_file_count` is 0 while browsing — so the recency rule carries as much weight as the explicit check.

### Result

```
                    before          after
20 images    24 mounts, 101180 B   8 mounts, 40440 B
60 images    60 mounts (linear)    8 mounts,    52 B
re-entry              0 B                  0 B
```

### Testing

**New soak suite**, `soak/mount-cache-leak`. It enters far more images than the cache holds and requires a flat heap slope once the working set is paid for, and separately requires that **re-entering a mounted image costs nothing** — without that second check, a "fix" that simply stopped caching would pass while making every image directory re-read from disk.

Red and green on the same device, firmware differing only by this commit:

```
without the bound:  5075 bytes/image over 20 images, mount_count 60   FAIL
with the bound:        3 bytes/image over 20 images, mount_count  8   OK
re-entry, both:        0 bytes                                        OK
```

The trigger is FTP rather than the browser: listing inside an image reaches the same code (`vfs_opendir` -> `get_directory` -> `find_pathentry` -> `find_mount_point`), so the measurement does not depend on screen scraping. It skips until #766 lands `machine:heap`, the same way the other leak suites do.

**Running that suite against known-broken firmware caught two faults in the suite itself**, both fixed here, and I mention them because the second is the more interesting bug:

It sampled the heap immediately after closing an FTP session, which borrows several KB and returns them shortly after — reported as 7568 bytes leaked on a run where the mount count had not moved at all.

And it reused image names between runs. Mounts are keyed by path and outlive the files they were made from, so the second run recreated files the first had deleted and was handed the previous run's **stale mounts**: nothing allocated, suite passed, on firmware leaking 5 KB an image. Names now carry a per-run token.

**Full E2E gate: all 19 suites passed**, against a build of this branch with no debug instrumentation. Log below.

### One thing I cannot explain, and would rather you heard from me

During an earlier gate — on a *different* build, based two commits behind `test-merge` — the `printer` suite took the device down hard:

```
[06] print epson/bitmap: Flush/Eject via on-screen menu ... FAIL
     (device became unresponsive during Flush/Eject (FAIL_CRASH_HARD))
```

It has not recurred: `printer` passed in two subsequent full gates, and passes in the attached run. I could not find a mechanism. I chased the two candidates I could form and both are disproven — `release_mount_point` closes the image file before deleting the embedded filesystem, which looked like a use-after-free, but `~FileSystemD64`, `~BlockDevice_File` and `~FileSystem` are all empty; and `FileSystemD64` buffers dirty sectors with no destructor flush, but `sync()` runs at the end of each write rather than lazily.

So: one unexplained hard crash, not reproduced, no mechanism found, on a build that was not this one. This change touches the filesystem layer everything else sits on, so I would rather flag it than let it surface later as a surprise. If you would like more soak time on it before merging, say so.

### Separate, not fixed here

**A stale mount is reused for a new file at the same path.** Delete an image, create a different one with the same name, look inside it, and the old mount matches by path — you get the previous image through a handle to a file that no longer exists. That is how the test bug above passed. This cap bounds how many stale mounts can exist but does not make them stale-aware. Pre-existing and orthogonal; happy to take it separately.

**`assembly64` still leaks about 31 KB per run.** I checked it against the mount instrumentation on a clean boot and `mount_count` stayed at **0**, so it is a different cause and this does not close it. #763 should stay open.

<details>
<summary><b>Full <code>./run-tests</code> output (all 19 passed)</b></summary>

```

============================================================
Ultimate hardware test run
============================================================
     host:       192.168.1.62
     categories: e2e
     modes:      overlay
     timeout:    30.0s
     on failure: continue
     health:    answers + health sweep, retry after recovery

============================================================
E2E  transport-usage  (overlay)
============================================================
UI state dirty: the root browser is not on top; a nested object still holds the UI; repairing
UI state repaired
     transport-usage: health: ping=22ms rest=15ms ftp=30ms telnet=39ms ident=22ms dma=24ms raster=30ms jiffy=49ms -> OK
check_transport_usage: OK (41 files, 0.183s)
transport-usage: OK (0.219s)

============================================================
E2E  runner-policy  (overlay)
============================================================
     runner-policy: health: ping=21ms rest=15ms ftp=15ms telnet=53ms ident=21ms dma=13ms raster=31ms jiffy=42ms -> OK
[01] a clean run exits 0 ... OK (0.000s)
[02] a failed suite exits 1 ... OK (0.000s)
[03] a recovery with no failure exits 3 ... OK (0.000s)
[04] a failure outranks a recovery ... OK (0.000s)
[05] a device that cannot be made healthy exits 4, outranking a failure ... OK (0.000s)
[06] a device that answers is never recovered ... OK (0.000s)
[07] recovery runs only once the ordinary wait has given up ... OK (0.011s)
     fixture: the device is unhealthy: it is not answering
[08] a recovery that does not bring the device back reports so ... OK (0.056s)
     fixture: the device is unhealthy: it is not answering
[09] a recovery command that exits non-zero is still followed by a probe ... OK (0.006s)
     fixture: the device is unhealthy: it is not answering
[10] a recovery command that hangs is bounded by --recover-timeout ... OK (0.207s)
     fixture: the device is unhealthy: it is not answering
[11] a recovery command the shell cannot find is a failed recovery ... OK (0.070s)
     fixture: the device is unhealthy: it is not answering
[12] no recovery command means no recovery ... OK (0.000s)
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: no --recover-command was given
[13] a suite gives up after --recover-max-per-suite recoveries ... OK (0.131s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
[14] the per-suite budget starts again at the next suite ... OK (0.070s)
     fixture: the device is unhealthy: it is not answering
[15] the run gives up after --recover-max-total recoveries ... OK (0.130s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
[16] the refusal says which ceiling was reached ... OK (0.063s)
     fixture: the device is unhealthy: it is not answering
[17] a healthy sweep after a failed suite recovers nothing ... OK (0.000s)
     fixture: health: rest=9ms -> OK
[18] a degraded but reachable device is recovered ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms -> OK
[19] a device still degraded after recovering is reported, not retried ... OK (0.005s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
[20] a degraded device is not recovered past its ceiling ... OK (0.010s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: not recovering: the run has already used its 1 recoveries
[21] --no-health-check takes the sweep out of the decision ... OK (0.000s)
[22] --no-health-check still recovers a device that has gone ... OK (0.070s)
     fixture: the device is unhealthy: it is not answering
[23] consecutive resets collapse into one ... OK (0.000s)
[24] a read between two resets does not warrant the second ... OK (0.000s)
[25] a mutating call between two resets warrants the second ... OK (0.000s)
[26] force resets even when nothing has changed ... OK (0.000s)
[27] a suite told the device was just reset does not reset again ... OK (0.000s)
[28] a suite not told that still resets ... OK (0.000s)
[29] a suite that fails on a healthy device is not run again ... OK (0.023s)
[30] a suite that fails on an unhealthy device runs again after recovery ... OK (0.065s)
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
[31] --no-retry keeps the recovery and drops the extra attempt ... OK (0.022s)
[32] a device that cannot be made healthy ends the run ... OK (0.021s)
fixture: OK (1.500s)
[33] a health sweep reaches the JSONL with a latency per check ... OK (0.000s)
[34] a suite record carries the profile, attempt and recoveries ... OK (0.000s)
[35] the run record agrees with the exit status ... OK (0.000s)
[36] a sweep with every check passing is healthy ... OK (0.000s)
[37] a failed check makes the sweep degraded and names it ... OK (0.000s)
[38] a skipped check never makes the sweep degraded ... OK (0.000s)
[39] the one-line summary carries every latency and the verdict ... OK (0.000s)
     the recovery command runs on a degraded or unreachable device, never on a suite that merely failed
runner_policy_test: OK (39 checks, 0.988s)
runner-policy: OK (1.043s)

============================================================
E2E  ui-backend-smoke  (overlay)
============================================================
     ui-backend-smoke: health: ping=22ms rest=17ms ftp=40ms telnet=41ms ident=16ms dma=12ms raster=40ms jiffy=57ms -> OK

--- Overlay navigation planner
[01] a unique first letter jumps straight to the item ... OK (0.000s)
[02] a shared first letter extends the prefix rather than walking ... OK (0.000s)
[03] walking wins when the item is already next to the cursor ... OK (0.000s)
[04] the seek lands on the first match and the walk covers the rest ... OK (0.000s)
[05] a prefix never contains a space, which selects rather than seeks ... OK (0.000s)
[06] a plan is never longer than walking from the top ... OK (0.000s)
[07] an upward walk is planned when that is the shorter route ... OK (0.000s)
--- OK (7 checks, 0.000s)

--- Telnet backend
[08] Telnet: connect, navigate, teardown ... OK (1.993s)
--- OK (1 checks, 1.993s)

--- REST backend, Interface Type = Freeze
[09] REST/Freeze: connect, navigate, teardown ... OK (2.909s)
--- OK (1 checks, 2.909s)

--- REST backend, Interface Type = Overlay on HDMI
[10] REST/Overlay: connect, navigate, teardown ... OK (3.059s)
--- OK (1 checks, 3.059s)
ui_backend_smoke_test: OK (10 checks, 7.973s)
ui-backend-smoke: OK (8.035s)

============================================================
E2E  readmem-writemem  (overlay)
============================================================
     readmem-writemem: health: ping=12ms rest=16ms ftp=37ms telnet=38ms ident=15ms dma=10ms raster=38ms jiffy=66ms -> OK
[01] reset C64 to a clean, stable state ... OK (0.025s)
[02] read User Interface Settings config ... OK (0.019s)
     current Interface Type: Freeze

--- bounds: readmem rejects out-of-range parameters before allocating, and max-size reads do not degrade the device
[03] readmem rejects zero length ... OK (0.017s)
[04] readmem rejects negative length ... OK (0.021s)
[05] readmem rejects length one past the 64KB cap ... OK (0.015s)
[06] readmem rejects length far past the cap ... OK (0.028s)
[07] readmem rejects length that overflows a long ... OK (0.017s)
[08] readmem rejects read running past $FFFF ... OK (0.016s)
[09] readmem rejects address above $FFFF ... OK (0.025s)
[10] readmem rejects negative address ... OK (0.015s)
[11] 8 back-to-back max-size reads ($0000, 65536 bytes) all succeed ... OK (2.110s)
[12] 25 unsupported machine:measure calls leave readmem working ... OK (0.750s)
[13] switch to Overlay on HDMI to probe live background activity ... OK (0.016s)
[14] probe addresses that change on their own while the C64 runs ... OK (6.208s)
     6 address(es) treated as expected live background noise: $00A1, $00A2, $00CD, $00CF, $01F2, $0287
[15] set Interface Type = Freeze ... OK (0.020s)
[16] open menu (Freeze) ... OK (0.311s)
[17] write full-range pattern (Freeze) ... OK (0.467s)
[18] read back full range (Freeze) ... OK (0.322s)
[19] menu still open after write+read (Freeze) ... OK (0.019s)
--- OK (17 checks, 10.4s)

--- selfcheck-freeze: write and read both happen in Freeze (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-freeze] ignored ROM mismatches (writes to real ROM are no-ops): 16330
     [selfcheck-freeze] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-freeze] ignored known-live-noise mismatches: 0
     [selfcheck-freeze] color RAM (low nibble) mismatches: 0
     [selfcheck-freeze] RAM mismatches: 0
[20] close menu (Freeze) ... OK (0.337s)
[21] set Interface Type = Overlay on HDMI ... OK (0.086s)
[22] open menu (Overlay on HDMI) ... OK (0.349s)
[23] pause C64 for exact round trip (Overlay on HDMI) ... OK (0.016s)
[24] write full-range pattern (Overlay on HDMI) ... OK (0.523s)
[25] read back full range (Overlay on HDMI) ... OK (0.221s)
[26] resume C64 after exact round trip (Overlay on HDMI) ... OK (0.024s)
[27] menu still open after write+read (Overlay on HDMI) ... OK (0.023s)
--- OK (8 checks, 1.603s)

--- selfcheck-overlay-on-hdmi: write and read both happen in Overlay on HDMI (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-overlay-on-hdmi] ignored ROM mismatches (writes to real ROM are no-ops): 0
     [selfcheck-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-overlay-on-hdmi] ignored known-live-noise mismatches: 0
     [selfcheck-overlay-on-hdmi] color RAM (low nibble) mismatches: 0
     [selfcheck-overlay-on-hdmi] RAM mismatches: 0
[28] close menu (Overlay on HDMI) ... OK (0.301s)
[29] close menu for the screen round trip (Overlay on HDMI) ... OK (0.056s)
[30] pause C64 for the screen round trip (Overlay on HDMI) ... OK (0.016s)
[31] write and read back $0400-$07FF (Overlay on HDMI) ... OK (0.135s)
[32] resume C64 after the screen round trip (Overlay on HDMI) ... OK (0.015s)
--- OK (5 checks, 0.545s)

--- screen-round-trip-overlay-on-hdmi: screen RAM round-trips exactly with no menu open
     [screen-round-trip-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected 0)
[33] set Interface Type = Overlay on HDMI ... OK (0.026s)
[34] open menu (Overlay on HDMI) ... OK (0.317s)
[35] write full-range pattern (Overlay on HDMI) ... OK (0.644s)
[36] capture ground truth in Overlay on HDMI mode ... OK (0.236s)
[37] close menu (Overlay on HDMI) ... OK (0.305s)
[38] set Interface Type = Freeze ... OK (0.017s)
[39] open menu (Freeze) ... OK (0.306s)
[40] read full range (Freeze) ... OK (0.211s)
[41] menu still open after cross-mode read (Freeze) ... OK (0.020s)
--- OK (9 checks, 2.087s)

--- overlay-on-hdmi-write_freeze-read: bytes written while Overlay on HDMI must read back the same while Freeze, except screen RAM (menu-owned while frozen)
     [overlay-on-hdmi-write_freeze-read] screen ($0400-$07FF) mismatches: 996 (expected, menu owns this range while frozen)
     [overlay-on-hdmi-write_freeze-read] ignored known-live-noise mismatches: 0
     [overlay-on-hdmi-write_freeze-read] color RAM (low nibble) mismatches: 0
     [overlay-on-hdmi-write_freeze-read] RAM mismatches: 0
[42] close menu (Freeze) ... OK (0.328s)
[43] set Interface Type = Freeze ... OK (0.017s)
[44] open menu (Freeze) ... OK (0.305s)
[45] write full-range pattern (Freeze) ... OK (0.588s)
[46] capture ground truth in Freeze mode ... OK (0.223s)
[47] close menu (Freeze) ... OK (0.303s)
[48] set Interface Type = Overlay on HDMI ... OK (0.017s)
[49] open menu (Overlay on HDMI) ... OK (0.319s)
[50] read full range (Overlay on HDMI) ... OK (0.237s)
[51] menu still open after cross-mode read (Overlay on HDMI) ... OK (0.023s)
--- OK (10 checks, 2.383s)

--- freeze-write_overlay-on-hdmi-read: bytes written while Freeze must read back the same while Overlay on HDMI, except screen RAM (menu-owned while frozen)
     [freeze-write_overlay-on-hdmi-read] screen ($0400-$07FF) mismatches: 1020 (expected, menu owns this range while frozen)
     [freeze-write_overlay-on-hdmi-read] ignored known-live-noise mismatches: 0
     [freeze-write_overlay-on-hdmi-read] color RAM (low nibble) mismatches: 0
     [freeze-write_overlay-on-hdmi-read] RAM mismatches: 0
[52] close menu (Overlay on HDMI) ... OK (0.314s)
     restored Interface Type to 'Freeze'
--- OK (1 checks, 2.590s)

--- summary
     bounds: OK
     selfcheck-freeze: OK
     selfcheck-overlay: OK
     screen-round-trip: OK
     overlay-to-freeze: OK
     freeze-to-overlay: OK
readmem_writemem_test: OK (52 checks, 25.8s)
readmem-writemem: OK (25.9s)

============================================================
E2E  menu-screen  (overlay)
============================================================
     menu-screen: health: ping=11ms rest=14ms ftp=28ms telnet=39ms ident=16ms dma=13ms raster=45ms jiffy=30ms -> OK
[01] open menu ... OK (0.023s)
[02] GET menu_screen contract ... OK (0.032s)
[03] menu_screen renders a real menu ... OK (0.000s)
[04] close menu ... OK (0.020s)
[05] GET menu_screen unavailable ... OK (0.016s)
[06] GET menu_screen auth ... SKIP (--password not supplied, 0.000s)
menu_screen_test: OK (6 checks, 1.324s)
menu-screen: OK (1.375s)

============================================================
E2E  input  (overlay)
============================================================
     input: health: ping=11ms rest=19ms ftp=16ms telnet=52ms ident=17ms dma=18ms raster=53ms jiffy=700ms -> OK
[01] input snapshot has stable empty response shape ... OK (0.036s)
[02] POST accepts 64 event batch ... OK (0.069s)
[03] bad content-type is rejected without mutation ... OK (0.094s)
[04] missing JSON body is rejected without mutation ... OK (0.089s)
[05] malformed JSON is rejected without mutation ... OK (0.093s)
[06] unknown root field is rejected without mutation ... OK (0.105s)
[07] late invalid event keeps whole batch atomic ... OK (0.102s)
[08] joystick port 2 fire keeps Anykey buttons 2 and 3 released ... OK (0.300s)
[09] joystick port 2 fire2 lights only Anykey button 2 ... OK (0.214s)
[10] joystick port 2 fire3 lights only Anykey button 3 ... OK (0.205s)
[11] joystick port 1 up press is visible on CIA reads ... OK (0.165s)
[12] joystick port 1 all inputs and idempotent release are visible on CIA reads ... OK (0.163s)
[13] joystick port 2 diagonal and fire are visible on CIA reads ... OK (0.179s)
[14] joystick partial release is visible on CIA reads ... OK (0.187s)
[15] joystick fire2/fire3 round-trip through REST state ... OK (0.304s)
[16] joystick release_all then press in same batch is visible on CIA reads ... OK (0.155s)
[17] joystick unusual combination is visible on CIA reads ... OK (0.154s)
[18] joystick tap does not release persistent input ... OK (0.377s)
[19] joystick tap auto releases ... OK (0.375s)
[20] invalid joystick batch does not mutate state ... OK (0.226s)
[21] joystick release_all clears both ports ... OK (0.148s)
[22] machine reset clears keyboard and joystick REST state ... OK (3.177s)
[23] keyboard single-tap batch is consumed by BASIC in order ... OK (0.913s)
[24] keyboard 10 Hz mixed alphabet echo has no missed presses ... OK (5.529s)
[25] keyboard 20 Hz alternating ab echo has no missed presses ... OK (6.295s)
[26] keyboard 5 Hz alternating ab echo has no missed presses ... OK (3.851s)
[27] keyboard single letter reaches the live C64 matrix ... OK (0.244s)
[28] keyboard shifted pair reaches the live C64 matrix ... OK (0.367s)
[29] keyboard batch applies multiple presses atomically ... OK (0.340s)
[30] keyboard ordered batch and idempotent release ... OK (0.119s)
[31] keyboard release_all can be followed by press in same batch ... OK (0.121s)
[32] keyboard accepts eight simultaneous inputs ... OK (0.153s)
[33] keyboard tap does not release persistent key ... OK (0.204s)
[34] keyboard release_all clears state ... OK (0.096s)
[35] keyboard restore tap auto releases ... OK (0.266s)
[36] keyboard special-key taps snapshot correctly and auto release ... OK (2.870s)
[37] keyboard tap is visible in the live hardware snapshot and auto releases ... OK (0.326s)
[38] keyboard cursor-left tap is visible in the live hardware snapshot and auto releases ... OK (0.306s)
[39] keyboard tap batch drains through the live matrix path ... OK (1.316s)
[40] keyboard long repeated tap train drains fully without sticky state ... OK (6.179s)
[41] invalid keyboard batch does not mutate state ... OK (0.083s)
[42] menu editor accepts an unshifted control character ... OK (1.017s)
[43] menu editor keeps separate-batch shift active across POSTs ... OK (2.870s)
[44] menu editor repeats a held printable key ... OK (3.676s)
[45] menu editor stops printable repeat after release ... OK (5.935s)
[46] menu editor accepts a single cursor-left control ... OK (4.674s)
[47] menu editor repeats a held cursor-left control ... OK (4.800s)
[48] menu editor stops cursor repeat after release ... OK (6.330s)
input_test: OK (48 checks, 82.1s)
input: OK (82.2s)

============================================================
E2E  prg-context-menu  (overlay)
============================================================
     prg-context-menu: health: ping=17ms rest=19ms ftp=17ms telnet=40ms ident=19ms dma=19ms raster=53ms jiffy=32ms -> OK
[01] reset the machine to a clean starting state ... OK (2.849s)
[02] seed /Temp with prgmenu64713.prg, prgmenu64713.d64 and a long-named PRG ... OK (0.692s)

--- every context-menu action on a plain PRG
[03] read the context menu of a plain PRG ... OK (2.503s)
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
[04] a plain PRG: every offered action is covered ... OK (0.000s)
[05] Run on a plain PRG ... OK (7.554s)
[06] Load on a plain PRG ... OK (6.253s)
[07] DMA on a plain PRG ... OK (8.310s)
[08] View on a plain PRG ... OK (3.866s)
[09] Hex View on a plain PRG ... OK (4.074s)
[10] Copy to... on a plain PRG ... OK (6.762s)
[11] Rename on a plain PRG ... OK (6.634s)
[12] Move to... on a plain PRG ... OK (7.045s)
[13] Delete on a plain PRG ... OK (4.252s)
--- OK (11 checks, 57.3s)

--- every context-menu action on a PRG inside a D64
[14] read the context menu of a PRG inside a D64 ... OK (3.597s)
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
[15] a PRG inside a D64: every offered action is covered ... OK (0.000s)
[16] Run on a PRG inside a D64 ... OK (8.650s)
[17] Load on a PRG inside a D64 ... OK (7.460s)
[18] DMA on a PRG inside a D64 ... OK (9.577s)
[19] Mount & Run on a PRG inside a D64 ... OK (9.670s)
[20] Real Run on a PRG inside a D64 ... OK (13.0s SLOW)
[21] View on a PRG inside a D64 ... OK (5.222s)
[22] Hex View on a PRG inside a D64 ... OK (5.296s)
[23] Copy to... on a PRG inside a D64 ... OK (8.290s)
[24] Rename on a PRG inside a D64 ... OK (8.629s)
[25] Move to... on a PRG inside a D64 ... OK (9.892s)
[26] Delete on a PRG inside a D64 ... OK (6.118s)
[27] Run a PRG whose name is far longer than the boot-cart display ... OK (8.232s)
--- OK (14 checks, 104s)
prg_context_menu_test: OK (23 actions, 165s)
prg-context-menu: OK (166s)

============================================================
E2E  browser-long-filename  (overlay)
============================================================
     browser-long-filename: health: ping=13ms rest=14ms ftp=16ms telnet=40ms ident=17ms dma=12ms raster=40ms jiffy=39ms -> OK
[01] reset the machine to a clean starting state ... OK (0.574s)
[02] seed long-name fixture for rename ... OK (1.093s)
[03] browser rename on long filename ... OK (8.121s)
[04] reseed long-name fixture for mount ... OK (1.301s)
[05] browser mount on long filename ... OK (5.214s)
browser_long_filename_test: OK (5 checks, 16.7s)
browser-long-filename: OK (18.2s)

============================================================
E2E  browser-filesystem-refresh  (overlay)
============================================================
     browser-filesystem-refresh: health: ping=11ms rest=15ms ftp=26ms telnet=51ms ident=19ms dma=25ms raster=30ms jiffy=47ms -> OK
[01] reset the machine to a clean starting state ... OK (0.632s)
[02] prepare fixture directories ... OK (0.188s)
[03] open Menu, Telnet and FTP on the fixture directory ... OK (4.295s)
[04] rename from the Menu ... OK (4.408s)
[05] rename from Telnet ... OK (3.106s)
[06] rename from FTP ... OK (1.369s)
[07] rename under observer-queue pressure from the Menu ... OK (5.708s)
[08] rename under observer-queue pressure from Telnet ... OK (4.912s)
[09] rename a directory from the Menu ... OK (3.811s)
[10] rename a directory from Telnet ... OK (2.975s)
[11] delete from the Menu ... OK (2.387s)
[12] delete from Telnet ... OK (2.921s)
[13] delete from FTP ... OK (1.020s)
[14] delete a non-empty directory from the Menu ... OK (2.388s)
[15] delete a non-empty directory from Telnet ... OK (2.393s)
[16] remove a directory from FTP ... OK (0.962s)
[17] select all and bulk delete from the Menu ... OK (2.499s)
[18] create from the Menu ... OK (3.499s)
[19] create from Telnet ... OK (3.233s)
[20] create from FTP ... OK (1.424s)
     STOR phase 1 (open, 0 bytes committed): Menu=<empty>; Telnet=<empty>; FTP=<empty>
[21] create from FTP (mkd) ... OK (1.216s)
[22] create from REST (d64) ... OK (0.678s)
[23] create from REST (d71) ... OK (0.754s)
[24] create from REST (d81) ... OK (1.064s)
[25] create from REST (dnp) ... OK (0.902s)
[26] write from the Menu ... OK (2.868s)
[27] write from Telnet ... OK (3.063s)
[28] write from FTP ... OK (1.998s)
     STOR phase 1 (open, truncated): Menu=wftp1.tst[ 100 ]; Telnet=wftp1.tst[ 100 ]; FTP=wftp1.tst[ 100 ]=100
[29] copy over an existing file from the Menu ... OK (11.1s SLOW)
[30] copy over an existing file from Telnet ... OK (10.8s SLOW)
[31] move an entry out of the watched directory from the Menu ... OK (6.253s)
[32] move an entry out of the watched directory from Telnet ... OK (5.035s)
[33] paste into the watched directory from the Menu ... OK (7.744s)
[34] paste into the watched directory from Telnet ... OK (7.451s)
[35] failed rename shows nothing ... OK (0.877s)
[36] failed delete removes nothing ... OK (1.056s)
[37] failed write creates nothing ... OK (1.015s)
[38] short write commits consistently ... OK (1.025s)
     short write committed 100 bytes

operation x origin x observer matrix
------------------------------------------------------------------------------
  rename       Menu    Menu    OK    0.22s
  rename       Menu    Telnet  OK    0.22s
  rename       Menu    FTP     OK    0.22s
  rename       Menu    REST    OK    0.22s
  rename       Telnet  Menu    OK    0.21s
  rename       Telnet  Telnet  OK    0.21s
  rename       Telnet  FTP     OK    0.21s
  rename       Telnet  REST    OK    0.21s
  rename       FTP     Menu    OK    0.60s
  rename       FTP     Telnet  OK    0.60s
  rename       FTP     FTP     OK    0.60s
  rename       FTP     REST    OK    0.60s
  rename-under-load Menu    Menu    OK    0.28s
  rename-under-load Menu    Telnet  OK    0.28s
  rename-under-load Menu    FTP     OK    0.28s
  rename-under-load Menu    REST    OK    0.28s
  rename-under-load Telnet  Menu    OK    0.20s
  rename-under-load Telnet  Telnet  OK    0.20s
  rename-under-load Telnet  FTP     OK    0.20s
  rename-under-load Telnet  REST    OK    0.20s
  rename-dir   Menu    Menu    OK    0.20s
  rename-dir   Menu    Telnet  OK    0.20s
  rename-dir   Menu    FTP     OK    0.20s
  rename-dir   Menu    REST    OK    0.20s
  rename-dir   Telnet  Menu    OK    0.21s
  rename-dir   Telnet  Telnet  OK    0.21s
  rename-dir   Telnet  FTP     OK    0.21s
  rename-dir   Telnet  REST    OK    0.21s
  delete       Menu    Menu    OK    0.22s
  delete       Menu    Telnet  OK    0.22s
  delete       Menu    FTP     OK    0.22s
  delete       Menu    REST    OK    0.22s
  delete       Telnet  Menu    OK    0.21s
  delete       Telnet  Telnet  OK    0.21s
  delete       Telnet  FTP     OK    0.21s
  delete       Telnet  REST    OK    0.21s
  delete       FTP     Menu    OK    0.52s
  delete       FTP     Telnet  OK    0.52s
  delete       FTP     FTP     OK    0.52s
  delete       FTP     REST    OK    0.52s
  delete-dir   Menu    Menu    OK    0.23s
  delete-dir   Menu    Telnet  OK    0.23s
  delete-dir   Menu    FTP     OK    0.23s
  delete-dir   Menu    REST    OK    0.23s
  delete-dir   Telnet  Menu    OK    0.22s
  delete-dir   Telnet  Telnet  OK    0.22s
  delete-dir   Telnet  FTP     OK    0.22s
  delete-dir   Telnet  REST    OK    0.22s
  delete-dir   FTP/rmd Menu    OK    0.28s
  delete-dir   FTP/rmd Telnet  OK    0.28s
  delete-dir   FTP/rmd FTP     OK    0.28s
  delete-dir   FTP/rmd REST    OK    0.28s
  delete-bulk  Menu    Menu    OK    0.20s
  delete-bulk  Menu    Telnet  OK    0.20s
  delete-bulk  Menu    FTP     OK    0.20s
  delete-bulk  Menu    REST    OK    0.20s
  create       Menu    Menu    OK    0.21s
  create       Menu    Telnet  OK    0.21s
  create       Menu    FTP     OK    0.21s
  create       Menu    REST    OK    0.21s
  create       Telnet  Menu    OK    0.23s
  create       Telnet  Telnet  OK    0.23s
  create       Telnet  FTP     OK    0.23s
  create       Telnet  REST    OK    0.23s
  create       FTP     Menu    OK    0.36s
  create       FTP     Telnet  OK    0.36s
  create       FTP     FTP     OK    0.36s
  create       FTP     REST    OK    0.36s
  create       FTP/mkd Menu    OK    0.56s
  create       FTP/mkd Telnet  OK    0.56s
  create       FTP/mkd FTP     OK    0.56s
  create       FTP/mkd REST    OK    0.56s
  create       REST/d64 Menu    OK    0.25s
  create       REST/d64 Telnet  OK    0.25s
  create       REST/d64 FTP     OK    0.25s
  create       REST/d64 REST    OK    0.25s
  create       REST/d71 Menu    OK    0.26s
  create       REST/d71 Telnet  OK    0.26s
  create       REST/d71 FTP     OK    0.26s
  create       REST/d71 REST    OK    0.26s
  create       REST/d81 Menu    OK    0.49s
  create       REST/d81 Telnet  OK    0.49s
  create       REST/d81 FTP     OK    0.49s
  create       REST/d81 REST    OK    0.49s
  create       REST/dnp Menu    OK    0.32s
  create       REST/dnp Telnet  OK    0.32s
  create       REST/dnp FTP     OK    0.32s
  create       REST/dnp REST    OK    0.32s
  write        Menu    Menu    OK    0.21s
  write        Menu    Telnet  OK    0.21s
  write        Menu    FTP     OK    0.21s
  write        Menu    REST    OK    0.21s
  write        Telnet  Menu    OK    0.23s
  write        Telnet  Telnet  OK    0.23s
  write        Telnet  FTP     OK    0.23s
  write        Telnet  REST    OK    0.23s
  write        FTP     Menu    OK    0.69s
  write        FTP     Telnet  OK    0.69s
  write        FTP     FTP     OK    0.69s
  write        FTP     REST    OK    0.69s
  copy-write   Menu    Menu    N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Menu    Telnet  OK    0.18s
  copy-write   Menu    FTP     OK    0.18s
  copy-write   Menu    REST    OK    0.18s
  copy-arrival Menu    Menu    OK    no stale cache on re-entry
  copy-write   Telnet  Telnet  N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Telnet  Menu    OK    0.11s
  copy-write   Telnet  FTP     OK    0.11s
  copy-write   Telnet  REST    OK    0.11s
  copy-arrival Telnet  Telnet  OK    no stale cache on re-entry
  move-out     Menu    Menu    OK    0.21s
  move-out     Menu    Telnet  OK    0.21s
  move-out     Menu    FTP     OK    0.21s
  move-out     Menu    REST    OK    0.21s
  move-out     Telnet  Menu    OK    0.25s
  move-out     Telnet  Telnet  OK    0.25s
  move-out     Telnet  FTP     OK    0.25s
  move-out     Telnet  REST    OK    0.25s
  paste-write  Menu    Menu    OK    0.21s
  paste-write  Menu    Telnet  OK    0.21s
  paste-write  Menu    FTP     OK    0.21s
  paste-write  Menu    REST    OK    0.21s
  paste-write  Telnet  Menu    OK    0.23s
  paste-write  Telnet  Telnet  OK    0.23s
  paste-write  Telnet  FTP     OK    0.23s
  paste-write  Telnet  REST    OK    0.23s
  rename-fail  FTP     Menu    OK    0.20s
  rename-fail  FTP     Telnet  OK    0.20s
  rename-fail  FTP     FTP     OK    0.20s
  rename-fail  FTP     REST    OK    0.20s
  delete-fail  FTP     Menu    OK    0.22s
  delete-fail  FTP     Telnet  OK    0.22s
  delete-fail  FTP     FTP     OK    0.22s
  delete-fail  FTP     REST    OK    0.22s
  write-fail   FTP     Menu    OK    0.24s
  write-fail   FTP     Telnet  OK    0.24s
  write-fail   FTP     FTP     OK    0.24s
  write-fail   FTP     REST    OK    0.24s
  short-write  FTP     Menu    OK    0.46s
  short-write  FTP     Telnet  OK    0.46s
  short-write  FTP     FTP     OK    0.46s
  short-write  FTP     REST    OK    0.46s
------------------------------------------------------------------------------
  N/A=2, OK=140
browser_filesystem_refresh_test: OK (38 checks, 120s)
browser-filesystem-refresh: OK (122s)

============================================================
E2E  ftp-client  (overlay)
============================================================
     ftp-client: health: ping=13ms rest=14ms ftp=23ms telnet=49ms ident=16ms dma=28ms raster=30ms jiffy=553ms -> OK
     inferred --ftp-advertised-host 192.168.1.78
     controlled FTP server on 0.0.0.0:2121 (advertised 192.168.1.78)
[I 2026-08-11 12:17:04] concurrency model: async
[I 2026-08-11 12:17:04] masquerade (NAT) address: 192.168.1.78
[I 2026-08-11 12:17:04] passive ports: 30000->30019
[I 2026-08-11 12:17:04] >>> starting FTP server on 0.0.0.0:2121, pid=68671 <<<
     server root: /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-zsp_22ig (marker E2E-1786465024)
[01] GET /v1/version reachable ... OK (0.1, 0.038s)
[02] menu closed -> menu_screen 404 ... OK (0.066s)
[03] menu_button opens menu ... OK (0.343s)
[04] menu_screen returns 2000-byte matrix ... OK (2000 bytes, 0.030s)
[05] input release_all works ... OK (0.021s)
[06] menu closes from anywhere ... OK (0.351s)
[07] remove any stale hosts left by a prior run ... OK (0 removed, 1.568s)

--- stage: smoke
[08] create FTP host 'E2EFTP50248sc6' through the New Host form ... OK (6.006s)
[09] new alias appears under /ftp ... OK (1.129s)
[10] enter host: server sees login + TYPE I + LIST ... [I 2026-08-11 12:17:14] 192.168.1.62:52432-[] FTP session opened (connect)
[I 2026-08-11 12:17:15] 192.168.1.62:52432-[u64e2e] USER 'u64e2e' logged in.
OK (PASS,TYPE,LIST, 1.233s)
[11] root listing shows fixture entries ... OK (README,DIRA,SMALL, 0.035s)
[12] open README.TXT -> RETR (52 bytes) ... [I 2026-08-11 12:17:17] 192.168.1.62:52432-[u64e2e] RETR /private/var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-zsp_22ig/README.TXT completed=1 bytes=52 seconds=0.001
OK (52 bytes, 2.402s)
[13] remove host and confirm it disappears ... [I 2026-08-11 12:17:19] 192.168.1.62:52432-[u64e2e] FTP session closed (disconnect).
OK (3.363s)
--- OK (6 checks, 14.2s)

--- cleanup
     preserved: nothing

--- summary
     Phase    Operation              Result             Commands       Fixture/Notes
     ------------------------------------------------------------------------------
     smoke    create host            OK                                E2EFTP50248sc6
     smoke    list host              OK                                E2EFTP50248sc6
     smoke    enter/LIST             OK                 USER/PASS/TYPE E2EFTP50248sc6
     smoke    root entries           OK                 LIST           README/DIRA/SMALL
     smoke    RETR README            OK                 RETR           README.TXT 52 bytes
     smoke    remove host            OK                                E2EFTP50248sc6
     ------------------------------------------------------------------------------
     Total REST requests   : 154
     Total menu snapshots  : 65
     Total keyboard events : 102
     Total FTP commands    : 24
     Created host alias    : (removed)
     Remote root path      : /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-zsp_22ig
     Cleanup status        : clean
Exception in thread Thread-1 (serve_forever):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/servers.py", line 254, in serve_forever
    self.ioloop.loop(timeout, blocking)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 376, in loop
    poll(timeout)
    ~~~~^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 741, in poll
    kevents = self._kqueue.control(
        None, _len(self.socket_map), timeout
    )
OSError: [Errno 9] Bad file descriptor
ftp-client: OK (18.0s)

============================================================
E2E  prg-load-path-trim  (overlay)
============================================================
     prg-load-path-trim: health: ping=12ms rest=15ms ftp=28ms telnet=48ms ident=18ms dma=10ms raster=38ms jiffy=28ms -> OK

--- Ultimate 64 PRG load path trim
     host: 192.168.1.62
     PUT file path: /Temp/rest-prg-path-trim-target-example.prg
     POST upload name: rest-prg-path-trim-upload-example.prg

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configure Temp Settings
[01] set Temp Auto Cleanup to Enabled ... OK (0.015s)
[02] set Temp Subfolders to Enabled ... OK (0.014s)
--- OK (2 checks, 0.029s)

--- 3. Prepare PRG Fixture
[03] upload PUT fixture rest-prg-path-trim-target-example.prg ... OK (0.161s)
--- OK (1 checks, 0.163s)

--- 4. Validate PUT Endpoints
[04] exercise PUT runners:load_prg ... OK (0.399s)
     PUT load_prg boot-cart name: ...T-EXAMPLE
[05] exercise PUT runners:run_prg ... OK (1.774s)
     PUT run_prg boot-cart name: ...T-EXAMPLE
--- OK (2 checks, 2.380s)

--- 5. Validate POST Endpoints
[06] exercise POST runners:load_prg ... OK (0.432s)
     POST load_prg boot-cart name: ...D-EXAMPLE
[07] exercise POST runners:run_prg ... OK (1.812s)
     POST run_prg boot-cart name: ...D-EXAMPLE
--- OK (2 checks, 3.124s)
prg_load_path_trim_test: OK (7 checks, 6.333s)

--- restore User Interface Settings
[08] set Temp Auto Cleanup to Enabled ... OK (0.016s)
[09] set Temp Subfolders to Enabled ... OK (0.027s)
prg-load-path-trim: OK (7.273s)

============================================================
E2E  temp-auto-cleanup  (overlay)
============================================================
     temp-auto-cleanup: health: ping=11ms rest=13ms ftp=24ms telnet=40ms ident=22ms dma=11ms raster=52ms jiffy=29ms -> OK

--- Ultimate 64 Temp auto cleanup
     host: 192.168.1.62

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configuration Setup
[01] set Temp Auto Cleanup to Enabled ... OK (0.020s)
[02] set Temp Subfolders to Enabled ... OK (0.023s)
--- OK (2 checks, 0.044s)

--- 3. Purging /Temp
     purge complete

--- 4. Mounting D64 Images
[03] create /Temp/mount-drive-8.d64 ... OK (0.059s)
[04] download mount-drive-8.d64 for the upload mount ... OK (0.407s)
[05] remove staging source mount-drive-8.d64 ... OK (0.067s)
[06] mount drive A ... OK (1.108s)
OK (1.108s)
[07] create /Temp/mount-drive-9.d64 ... OK (0.059s)
[08] download mount-drive-9.d64 for the upload mount ... OK (0.430s)
[09] remove staging source mount-drive-9.d64 ... OK (0.071s)
[10] mount drive B ... OK (1.123s)
OK (1.123s)
--- OK (10 checks, 3.326s)

--- 5. Seeding Baseline (10 files)
[11] upload base_1.bin ... OK (1.594s)
[12] upload base_2.bin ... OK (1.692s)
[13] upload base_3.bin ... OK (1.597s)
[14] upload base_4.bin ... OK (1.613s)
[15] upload base_5.bin ... OK (1.621s)
[16] upload base_6.bin ... OK (1.666s)
[17] upload base_7.bin ... OK (1.640s)
[18] upload base_8.bin ... OK (1.645s)
[19] upload base_9.bin ... OK (1.597s)
[20] upload base_10.bin ... OK (1.666s)
--- OK (10 checks, 16.4s)

--- 6. Managed Temp File Limit (Target: 10)
[21] upload managed_1.bin over REST ... OK (4.636s)
     managed count=1 (limit=10)
[22] upload managed_2.bin over REST ... OK (4.590s)
     managed count=2 (limit=10)
[23] upload managed_3.bin over REST ... OK (4.538s)
     managed count=3 (limit=10)
[24] upload managed_4.bin over REST ... OK (4.585s)
     managed count=4 (limit=10)
[25] upload managed_5.bin over REST ... OK (4.634s)
     managed count=5 (limit=10)
[26] upload managed_6.bin over REST ... OK (4.650s)
     managed count=6 (limit=10)
[27] upload managed_7.bin over REST ... OK (4.579s)
     managed count=7 (limit=10)
[28] upload managed_8.bin over REST ... OK (4.616s)
     managed count=8 (limit=10)
[29] upload managed_9.bin over REST ... OK (4.597s)
     managed count=9 (limit=10)
[30] upload managed_10.bin over REST ... OK (4.557s)
     managed count=10 (limit=10)
[31] upload managed_11.bin over REST ... OK (4.535s)
     managed count=10 (limit=10)
[32] upload managed_12.bin over REST ... OK (4.766s)
     managed count=10 (limit=10)
OK (5.168s)
OK (5.266s)
--- OK (14 checks, 60.2s)

--- 7. Unmounted Uploads Rejoin Cleanup
[33] remove drive A ... OK (0.129s)
[34] upload post_a_1.bin over REST ... OK (4.676s)
OK (4.784s)
     removed after 1 uploads
[35] remove drive B ... OK (0.128s)
[36] upload post_b_1.bin over REST ... OK (4.618s)
     removed after 1 uploads
--- OK (5 checks, 10.1s)

--- 8. Final Integrity Check
     user files intact
temp_auto_cleanup_test: OK (36 checks, 93.0s)

--- restore User Interface Settings
[37] set Temp Auto Cleanup to Enabled ... OK (0.016s)
[38] set Temp Subfolders to Enabled ... OK (0.024s)
temp-auto-cleanup: OK (93.6s)

============================================================
E2E  cfg-single-group  (overlay)
============================================================
     cfg-single-group: health: ping=12ms rest=101ms ftp=167ms telnet=79ms ident=16ms dma=13ms raster=58ms jiffy=30ms -> OK
[01] load a one-group CFG file through the browser ... OK (7.771s)
[02] only the CFG group is considered after loading ... OK (0.117s)
cfg_single_group_test: OK (2 checks, 8.354s)
cfg-single-group: OK (9.154s)

============================================================
E2E  printer  (overlay)
============================================================
     printer: health: ping=12ms rest=25ms ftp=14ms telnet=39ms ident=17ms dma=11ms raster=30ms jiffy=40ms -> OK
[01] REST reachable at 192.168.1.62 ... OK (0.018s)
[02] reset before run ... OK (0.142s)
[03] load printer_e2e.prg ... OK (914 bytes, 0.001s)
[04] capture original Printer Settings ... OK (0.221s)
[05] print epson/bitmap: apply settings + run PRG ... OK (phase=printer closed heartbeat=4, 2.894s)
[06] print epson/bitmap: Flush/Eject via on-screen menu ... OK (3.902s)

--- restoring original Printer Settings
     IEC printer: Disabled
     Bus ID: 4
     Output file: /Usb0/printer
     Output type: PNG B&W
     Ink density: Medium
     Page top margin (default is 5): 5
     Page height (default is 60): 60
     Emulation: Commodore MPS
     Commodore charset: USA/UK
     Epson charset: Basic
     IBM table 2: International 1

--- summary
     epson      bitmap PASS_NO_VERIFY       /USB1/printer/e2e-ebb602
printer: OK (8.435s)

============================================================
E2E  uci-targets  (overlay)
============================================================
     uci-targets: health: ping=12ms rest=13ms ftp=25ms telnet=38ms ident=16ms dma=10ms raster=49ms jiffy=28ms -> OK
[01] reset the C64 so the command interface starts idle ... OK (3.049s)
[02] read 'C64 and Cartridge Settings' ... OK (0.026s)
     current: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}
[03] enable the Command Interface registers at $DF1B-$DF1F ... OK (0.120s)
[04] transport: an empty command returns an empty reply ... OK (0.254s)
     <empty> -> 0.05s, data b'', status b''
[05] transport: unregistered target answers IDENTIFY ... OK (0.866s)
     0f 01 -> 0.08s, data b'NO TARGET', status b'00,OK'
[06] transport: unregistered target rejects anything else ... OK (0.909s)
     0f 7f -> 0.07s, data b'', status b'21,UNKNOWN COMMAND'
[07] transport: a no-reply command returns straight to Idle ... OK (0.154s)
[08] transport: pushing while a reply is pending sets and clears ERROR ... OK (1.264s)
[09] transport: the next command is not prefixed by leftover bytes ... OK (1.032s)
     04 28 00 -> 0.09s, data b'Ultimate 64 Elite', status b'00,OK'
[10] transport: ABORT releases a pending reply back to Idle ... OK (0.244s)
[11] control-target: IDENTIFY answers with the target name ... OK (1.285s)
     04 01 -> 0.10s, data b'CONTROL TARGET V1.1', status b'00,OK'
[12] control-target: an unimplemented command is reported as unknown ... OK (0.841s)
     04 7f -> 0.07s, data b'', status b'21,UNKNOWN COMMAND'
[13] control-target: LOAD_REU without a filename is rejected, not run ... OK (0.898s)
     04 08 -> 0.06s, data b'', status b'81,INVALID PARAMS'
[14] control-target: SAVE_REU without a filename is rejected, not run ... OK (0.922s)
     04 09 -> 0.08s, data b'', status b'81,INVALID PARAMS'
[15] control-target: GET_HWINFO rejects a device number it does not have ... OK (0.905s)
     04 28 02 -> 0.10s, data b'', status b'81,INVALID PARAMS'
[16] issue-740-matrix: confirm /Temp/uci_e2e_absent.reu does not exist ... OK (0.040s)
[17] issue-740-matrix: put a 16384-byte image at /Temp/uci_e2e_present.reu ... OK (0.246s)
[18] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... OK (4.272s)
     04 08 52 45 55 2e 49 4d 47 -> 0.21s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[19] issue-740-matrix: REU Enabled, image absent, name at offset 4 ... OK (4.146s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.25s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[20] issue-740-matrix: REU Disabled, image absent, name at offset 2 ... OK (1.363s)
     04 08 52 45 55 2e 49 4d 47 -> 0.23s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[21] issue-740-matrix: REU Disabled, image absent, name at offset 4 ... OK (1.269s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.25s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[22] issue-740-matrix: REU Enabled, image present, name at offset 2 ... OK (3.499s)
     04 08 52 45 55 2e 49 4d 47 -> 0.23s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[23] issue-740-matrix: REU Enabled, image present, name at offset 4 ... OK (3.618s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.28s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[24] save-reu-offset-past-end: put the preload offset at the end of a 128 KB REU ... OK (0.064s)
[25] save-reu-offset-past-end: SAVE_REU reports the offset and saves nothing ... OK (4.356s)
     04 09 52 45 55 2e 49 4d 47 -> 0.22s, data b'\xfd\xff\xff\xffREU SAVE: OFFSET 131072 >= REU SIZE 131072, SKIPPING', status b'86,REU OFFSET > SIZE. NOT SAVED'
[26] load-reu-disabled: disable the REU ... OK (0.018s)
[27] load-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.056s)
     04 28 00 -> 0.09s, data b'Ultimate 64 Elite', status b'00,OK'
[28] load-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.301s)
     04 08 52 45 55 2e 49 4d 47 -> 0.22s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[29] save-reu-disabled: disable the REU ... OK (0.027s)
[30] save-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.234s)
     04 28 00 -> 0.10s, data b'Ultimate 64 Elite', status b'00,OK'
[31] save-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.506s)
     04 09 52 45 55 2e 49 4d 47 -> 0.52s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[32] softiec-single-part-reply: SoftIEC target answers IDENTIFY ... OK (1.300s)
     05 01 -> 0.06s, data b'SOFTWARE IEC TARGET V1.0', status b'00,OK'
[33] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... OK (0.682s)
     05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 -> 0.50s, data b'', status b'\x01'
[34] softiec-single-part-reply: GET_FATNAME reply completes in one part ... OK (0.742s)
     05 22 02 23 -> 0.14s, data b'/buffer', status b'\x00'
[35] softiec-single-part-reply: an unimplemented SoftIEC command is reported as unknown ... OK (0.259s)
     05 7f -> 0.08s, data b'', status b'\x04'
[36] interface-usable-after: the control target still answers IDENTIFY ... OK (1.150s)
     04 01 -> 0.07s, data b'CONTROL TARGET V1.1', status b'00,OK'
     restored C64 and Cartridge Settings: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}

--- summary
     transport: OK
     control-target: OK
     issue-740-matrix: OK
     save-reu-offset-past-end: OK
     load-reu-disabled: OK
     save-reu-disabled: OK
     softiec-single-part-reply: OK
     interface-usable-after: OK
     cleanup: OK
uci_targets_test: OK (36 checks, 45.1s)
uci-targets: OK (45.2s)

============================================================
E2E  machine-code-monitor  (overlay)
============================================================
     machine-code-monitor: health: ping=12ms rest=14ms ftp=28ms telnet=49ms ident=16ms dma=10ms raster=41ms jiffy=30ms -> OK
[01] initial CPU7/KERNAL monitor status ... OK (0.027s)
[02] KERNAL $E000 hex view and REST match ... OK (0.706s)
[03] paging away and back keeps memory view stable ... OK (0.705s)
[04] KERNAL disassembly formatting ... OK (1.534s)
[05] KERNAL $E010 REST match ... OK (1.055s)
[06] CPU6 RAM under BASIC write/read ... OK (4.444s)
[07] CPU5 RAM under KERNAL status ... OK (3.017s)
[08] ASCII view width and scrolling ... OK (8.094s)
[09] ASCII and Screen mapping semantics ... OK (12.6s SLOW)
[10] HEX edit writes both nibbles ... OK (2.971s)
[11] CPU bank cycling reaches CHAR and RAM mappings ... OK (3.856s)
[12] COMPARE reports differing address ... OK (4.149s)
[13] G executes finite loop and returns to monitor ... OK (2.227s)
[14] G repeated execution updates RAM sentinel ... OK (7.903s)
[15] G handoff preserves stable VIC state ... SKIP (the on-device UI owns the VIC while it is up; only comparable over telnet, 0.000s)
OK (0.000s)
[16] bookmarks recall, set, list, and label edit ... OK (7.638s)
[17] memory bookmark jump restores width 16 ... OK (5.836s)
[18] binary width cycling and bookmark jump restores width 4 ... OK (6.698s)
[19] follow and return navigation ... OK (5.614s)
[20] asm edit mnemonic validation and Return advance ... OK (8.273s)
[21] number popup arithmetic ... OK (2.662s)
[22] save/load round-trip to top-level /Temp file ... OK (9.823s)
[23] save/load round-trip to file in new /Temp D64 ... OK (18.9s SLOW)

--- Telnet transport checks
[24] telnet blocks poll mode ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
[25] telnet opcode dropdown scroll does not flood the connection ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
--- SKIP (4 checks, 0.178s)
monitor_test: OK (25 checks, 121s)
machine-code-monitor: OK (121s)

============================================================
E2E  ftp-server  (overlay)
============================================================
     ftp-server: health: ping=12ms rest=15ms ftp=15ms telnet=41ms ident=19ms dma=12ms raster=41ms jiffy=39ms -> OK

--- a name the listing reports can address the file it names
[01] a 40-character name is listed unchanged ... OK (0.106s)
[02] that file is removed by the name the listing reported ... OK (0.101s)
[03] a 100-character name is listed unchanged ... OK (0.100s)
     100 characters survived the listing
[04] SIZE answers for the long name the listing reported ... OK (0.054s)
[05] that file is removed by the name the listing reported ... OK (0.132s)
--- OK (5 checks, 0.632s)
ftp_server_test: OK (5 checks, 0.636s)
ftp-server: OK (0.686s)

============================================================
E2E  assembly64  (overlay)
============================================================
     assembly64: health: ping=12ms rest=27ms ftp=27ms telnet=41ms ident=17ms dma=17ms raster=32ms jiffy=45ms -> OK

--- the form opens from the task menu and closes again
[01] open the Assembly 64 query form ... OK (0.841s)
[02] the form leaves cleanly with RUN/STOP ... OK (0.436s)
--- OK (2 checks, 1.439s)

--- a real query is sent to the Assembly 64 service
[03] open the form and enter the first field ... OK (1.252s)
[04] the typed term lands in the Name field ... OK (0.818s)
[05] the service answers and the results match what was asked for ... OK (1.174s)
--- OK (3 checks, 3.771s)

--- the menu button must work from inside the edit field
[06] open the form and enter the edit field ... OK (1.150s)
[07] the menu button closes the menu from inside the field ... OK (0.104s)
[08] the menu opens again, so the UI task left string_edit ... OK (0.037s)
--- OK (3 checks, 1.879s)

--- an aborted edit must not wedge the form
[09] open the form, type into a field, then abort ... OK (1.621s)
[10] the form is still usable after the abort ... OK (0.031s)
--- OK (2 checks, 2.223s)

--- over-long and empty input
[11] type more than the field accepts ... OK (2.351s)
[12] an empty query is refused rather than sent ... OK (2.820s)
[13] the warning is dismissed and the form is still usable ... OK (0.418s)
--- OK (3 checks, 6.159s)

--- a user mashing keys while the form is busy
[14] submit a query and hammer keys while it runs ... OK (5.185s)
[15] the device is still answering after the mashing ... OK (0.017s)
--- OK (2 checks, 5.751s)

--- opening and abandoning the form repeatedly
[16] open and abandon the form three times ... OK (3.409s)
[17] the menu button closes and reopens the form three times ... OK (3.689s)
--- OK (2 checks, 7.381s)
assembly64_test: OK (17 checks, 29.1s)
assembly64: OK (29.2s)

============================================================
E2E  freeze-menu  (overlay)
============================================================
     freeze-menu: health: ping=12ms rest=15ms ftp=18ms telnet=56ms ident=18ms dma=13ms raster=51ms jiffy=33ms -> OK
     captured 'Interface Type'=Freeze, 'Auto Address Mirroring'=Enabled

--- menu cycle with Auto Address Mirroring Disabled
[01] select 'Freeze' interface with mirroring disabled ... OK (0.041s)
[02] C64 running before the menu is opened ... OK (1.086s)
[03] open the menu ... OK (0.297s)
[04] C64 frozen while the menu is open ... OK (0.553s)
[05] close the menu ... OK (0.284s)
[06] C64 resumed after the menu closed ... OK (0.549s)
--- OK (6 checks, 2.828s)

--- Auto Address Mirroring switched off while the menu is open
[07] select 'Freeze' interface with mirroring enabled ... OK (0.036s)
[08] C64 running before the menu is opened ... OK (0.535s)
[09] open the menu ... OK (0.302s)
[10] C64 frozen while the menu is open ... OK (0.549s)
[11] set Auto Address Mirroring to Disabled while the menu is open ... OK (0.018s)
[12] close the menu ... OK (0.286s)
[13] C64 resumed after the menu closed ... OK (0.535s)
--- OK (7 checks, 2.307s)

--- menu cycle with Auto Address Mirroring Enabled
[14] select 'Freeze' interface with mirroring enabled ... OK (0.042s)
[15] C64 running before the menu is opened ... OK (0.562s)
[16] open the menu ... OK (0.349s)
[17] C64 frozen while the menu is open ... OK (0.535s)
[18] close the menu ... OK (0.285s)
[19] C64 resumed after the menu closed ... OK (0.533s)
--- OK (6 checks, 2.332s)

--- reopen the freezer menu with a context menu left open
[20] select 'Freeze' interface with mirroring enabled ... OK (0.062s)
[21] C64 running before the menu is opened ... OK (0.535s)
[22] open the menu ... OK (0.301s)
[23] C64 frozen while the menu is open ... OK (0.542s)
[24] open the context menu on the first browser entry ... OK (7.619s)
[25] close the menu ... OK (0.372s)
[26] C64 resumed after the menu closed ... OK (0.595s)
[27] reopen the menu with the context menu still on the object stack ... OK (0.301s)
[28] dismiss the restored context menu ... OK (0.276s)
[29] close the menu ... OK (0.280s)
[30] C64 resumed after the menu closed ... OK (0.542s)
--- OK (11 checks, 11.5s)

--- the menu button works inside the Assembly 64 query form
[31] select 'Freeze' interface with mirroring enabled ... OK (0.030s)
[32] C64 running before the menu is opened ... OK (0.554s)
[33] open the menu ... OK (0.298s)
[34] C64 frozen while the menu is open ... OK (0.557s)
[35] open the task menu ... OK (0.415s)
[36] open the Assembly 64 query form ... OK (0.319s)
[37] enter the form's first edit field ... OK (0.304s)
[38] the menu button closes the menu from inside the edit field ... OK (0.305s)
[39] the menu opens again afterwards ... OK (0.300s)
[40] leave the query form ... OK (0.396s)
[41] close the menu ... OK (0.294s)
[42] C64 resumed after the menu closed ... OK (0.539s)
--- OK (12 checks, 4.437s)
freeze_menu_test: OK (42 checks, 24.5s)
freeze-menu: OK (24.6s)

TEARDOWN (overlay): release input ... OK (0.018s)
TEARDOWN (overlay): close active menu UI ... OK (0.034s)
TEARDOWN (overlay): reset machine ... OK (0.061s)

============================================================
Summary
============================================================
     OK   e2e overlay    783s (19 ok)
     slowest: prg-context-menu 166s, browser-filesystem-refresh 122s, machine-code-monitor 121s
     783s in suites, 30.3s in health checks, the UI-state gate and teardown
     813s total

OK  all 19 suite runs passed.
```
</details>
