### PR TITLE
Fix four heap leaks in the Assembly 64 search and the tree browser

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -185,6 +185,12 @@ SUITES: Sequence[Suite] = (
     Suite("soak", "prg-context-menu-leak",
           "tests/soak/filemanager/prg_context_menu_leak_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
+    # Drives the Assembly 64 search browser, for the same reason: its query
+    # path is not reachable over REST. Skips when the Assembly 64 service is
+    # unreachable from the device, since the form cannot open without it.
+    Suite("soak", "assembly-search-leak",
+          "tests/soak/io/c64/assembly_search_leak_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
     # The stress profile is the bounded one, at about two minutes. The soak
     # profile runs for twelve hours, so it is opt-in through --soak-profile.
     Suite("soak", "network-connection", "tests/soak/network/connection_test.py",

--- a/software/network/assembly.cc
+++ b/software/network/assembly.cc
@@ -62,6 +62,7 @@ int Assembly :: connect_to_server(void)
 
     if (connect(sock_fd, (struct sockaddr *)&serv_addr,sizeof(serv_addr)) < 0) {
         printf("Connection failed.\n");
+        close(sock_fd);
         return -1;
     }
     // printf("Connection succeeded.\n");
@@ -96,11 +97,25 @@ JSON *Assembly :: get_presets(void)
         get_response(this->socket_fd, collect_in_buffer, response);
         close_connection();
 
-        body = (t_BufferedBody *) response.userContext;
-        presets = convert_buffer_to_json(body);
+        presets = take_response_json();
         return presets;
     }
     return NULL;
+}
+
+// The JSON tree copies every key and value out of the response buffer, so the
+// 16 KB body has no owner once the tree is built. Freeing it here keeps that
+// out of every caller; only request_binary() hands its user context onwards.
+JSON *Assembly :: take_response_json(void)
+{
+    t_BufferedBody *body = (t_BufferedBody *) response.userContext;
+    if (!body) {
+        return NULL;
+    }
+    JSON *json = convert_buffer_to_json(body);
+    response.userContext = NULL;
+    delete body;
+    return json;
 }
 
 JSON *Assembly :: send_query(const char *query)
@@ -123,9 +138,7 @@ JSON *Assembly :: send_query(const char *query)
         get_response(socket_fd, collect_in_buffer, response);
         close_connection();
 
-        t_BufferedBody *body = (t_BufferedBody *) response.userContext;
-        JSON *json = convert_buffer_to_json(body);
-        return json;
+        return take_response_json();
     }
     return NULL;
 }
@@ -175,9 +188,7 @@ JSON *Assembly :: request_entries(const char *id, int cat)
         get_response(this->socket_fd, collect_in_buffer, response);
         close_connection();
 
-        t_BufferedBody *body = (t_BufferedBody *) response.userContext;
-        JSON *json = convert_buffer_to_json(body);
-        return json;
+        return take_response_json();
     }
     return NULL;
 }
@@ -239,29 +250,16 @@ int main(int argc, char **argv)
         delete results;
     }
 
-    t_BufferedBody *body2 = (t_BufferedBody *) assembly.get_user_context();
-    if (body2) {
-        delete body2;
-    }
-
     JSON *json = assembly.request_entries("237033", 0);
     if (json) {
         puts(json->render());
         delete json;
-    }
-    t_BufferedBody *body = (t_BufferedBody *) assembly.get_user_context();
-    if (body) {
-        delete body;
     }
 
     JSON *json3 = assembly.request_entries("145050", 3);
     if (json3) {
         puts(json3->render());
         delete json3;
-    }
-    t_BufferedBody *body3 = (t_BufferedBody *) assembly.get_user_context();
-    if (body3) {
-        delete body3;
     }
 
     assembly.request_binary("237033", 0, 0);

--- a/software/network/assembly.h
+++ b/software/network/assembly.h
@@ -6,24 +6,21 @@
 
 class Assembly
 {
-    t_BufferedBody *body;
     JSON *presets;
     int socket_fd;
     HTTPReqMessage response;
 
     int   connect_to_server(void);
     void  close_connection(void);
+    JSON *take_response_json(void);
 public:
     Assembly() {
-        body = NULL;
         presets = NULL;
         socket_fd = -1;
     }
     ~Assembly() {
         if (presets)
             delete presets;
-        if (body)
-            delete body;
     }
     void *get_user_context() { return response.userContext; }
     JSON *get_presets(void);

--- a/software/userinterface/assembly_search.cc
+++ b/software/userinterface/assembly_search.cc
@@ -37,7 +37,7 @@
 AssemblySearch :: AssemblySearch(UserInterface *ui, Browsable *root) : TreeBrowser(ui, root)
 {
     setCleanup();
-    state = new AssemblySearchForm(root, this, 0);
+    replace_root_state(new AssemblySearchForm(root, this, 0));
     state->reload();
 }
 

--- a/software/userinterface/assembly_search.cc
+++ b/software/userinterface/assembly_search.cc
@@ -190,11 +190,16 @@ int AssemblySearch :: handle_key(int c)
 AssemblySearchForm :: AssemblySearchForm(Browsable *node, TreeBrowser *tb, int level) : TreeBrowserState(node, tb, level)
 {
     //default_color = 7;
+    results = NULL;
 }
 
 AssemblySearchForm :: ~AssemblySearchForm()
 {
-
+    // Runs after ~TreeBrowserState has torn the results view down, because the
+    // view deletes its 'previous' (this form) last.
+    if (results) {
+        delete results;
+    }
 }
 
 
@@ -248,7 +253,13 @@ void AssemblySearchForm :: send_query(void)
     if (response) {
         if (response->type() == eList) {
             printf("Creating results view...\n");
+            // The previous query's results view is already gone by the time the
+            // form can be used again, so its results object is ours to drop.
+            if (results) {
+                delete results;
+            }
             BrowsableQueryResults *rb = new BrowsableQueryResults((JSON_List *)response);
+            results = rb;
             deeper = new AssemblyResultsView(rb, browser, 1);
             deeper->previous = this;
             int error;
@@ -261,9 +272,6 @@ void AssemblySearchForm :: send_query(void)
     } else {
         browser->window->getScreen()->set_status("** Connection FAILED **", 10);
     }
-    t_BufferedBody *body = (t_BufferedBody *)assembly.get_user_context();
-    if (body)
-        delete body;
 }
 
 // The form mixes unselectable spacers in with the query fields, and the cast is
@@ -393,6 +401,11 @@ IndexedList<Browsable *> *BrowsableQueryResult :: getSubItems(int &error)
             }
         } else {
             error = 1;
+        }
+        // Each entry copied what it needs out of the tree, so nothing below
+        // points into it once the loop is done.
+        if (j) {
+            delete j;
         }
     }
     return &children;

--- a/software/userinterface/assembly_search.h
+++ b/software/userinterface/assembly_search.h
@@ -11,8 +11,15 @@
 #include "action.h"
 #include "network_interface.h"
 
+class BrowsableQueryResults;
+
 class AssemblySearchForm: public TreeBrowserState
 {
+    // The results object built for the last query. The results view holds it as
+    // its node but never owns it, and TreeBrowserState does not delete nodes, so
+    // the form outlives the view and frees it.
+    BrowsableQueryResults *results;
+
     void send_query(void);
 public:
     AssemblySearchForm(Browsable *node, TreeBrowser *tb, int level);
@@ -215,7 +222,13 @@ public:
             }
         }
     }
-    ~BrowsableQueryResults() { }
+    ~BrowsableQueryResults()
+    {
+        for (int i = 0; i < items.get_elements(); i++) {
+            delete items[i];
+        }
+        items.clear_list();
+    }
 
     IndexedList<Browsable *> *getSubItems(int &error)
     {

--- a/software/userinterface/config_menu.cc
+++ b/software/userinterface/config_menu.cc
@@ -19,7 +19,7 @@ ConfigBrowser :: ConfigBrowser(UserInterface *ui, Browsable *root, int level) : 
     setCleanup();
     has_path = false;
     start_level = level;
-    state = new ConfigBrowserState(root, this, level);
+    replace_root_state(new ConfigBrowserState(root, this, level));
 }
 
 ConfigBrowser :: ~ConfigBrowser()

--- a/software/userinterface/form.cc
+++ b/software/userinterface/form.cc
@@ -21,9 +21,12 @@
 
 
 FormUI :: FormUI(UserInterface *ui, int size_x, int size_y, const char *title, JSON_Object *fields)
-    : form(title, fields), size_x(size_x), size_y(size_y), TreeBrowser(ui, root)
+    : form(title, fields), size_x(size_x), size_y(size_y), TreeBrowser(ui, &form)
 {
-    state = new FormUIState(&form, this, 0);
+    // &form is passed to the base before form is constructed, which is fine:
+    // the base only stores the pointer. By the time anything dereferences it,
+    // here or in ~TreeBrowserState, the member exists.
+    replace_root_state(new FormUIState(&form, this, 0));
     state->reload();
 }
 

--- a/software/userinterface/tree_browser.cc
+++ b/software/userinterface/tree_browser.cc
@@ -64,6 +64,15 @@ TreeBrowser :: TreeBrowser(UserInterface *ui, Browsable *root) : UIObject(ui)
     }
 }
 
+void TreeBrowser :: replace_root_state(TreeBrowserState *s)
+{
+    if (state) {
+        delete state;
+    }
+    state = s;
+    state_root = s;
+}
+
 TreeBrowser :: ~TreeBrowser()
 {
 	if(state)

--- a/software/userinterface/tree_browser.h
+++ b/software/userinterface/tree_browser.h
@@ -116,6 +116,12 @@ public:
     virtual void redraw(void);
     virtual void deinit(void);
 
+    // For a subclass whose root screen is not a plain TreeBrowserState. The
+    // constructor here has already made one by then, and it has to go: it is
+    // what state_root still points at otherwise, so cd() would compare state
+    // against a state the browser can never be in.
+    void replace_root_state(TreeBrowserState *s);
+
     virtual int poll(int);
     virtual int poll_inactive(void);
     virtual int handle_key(int);

--- a/tests/soak/io/c64/assembly_search_leak_test.py
+++ b/tests/soak/io/c64/assembly_search_leak_test.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# Soak: asserts the Assembly 64 search returns the heap it borrows.
+
+"""Repeat the search browser's two costly paths and require the free heap back.
+
+Two independent leaks lived here, and neither is visible over REST: the query
+path is only reachable by driving the menu.
+
+  1. Opening the browser. TreeBrowser's constructor makes a plain
+     TreeBrowserState, and AssemblySearch assigns over it with a form state of
+     its own, orphaning 60 bytes per open. That bug is not specific to this
+     browser -- ConfigBrowser and FormUI replace the same state the same way,
+     so every config menu open paid it too. The search form is what this suite
+     can drive in a tight loop, so it is what guards the fix.
+
+  2. Running a query and stepping into a result. Each HTTP response is
+     collected into a 16,392-byte t_BufferedBody, which the JSON tree copies
+     out of and nobody then owned on the entries path; the results object and
+     its entries had no owner either.
+
+Method: measure the steady-state slope, never a single before/after. The first
+iteration of anything pays one-time costs -- the preset list this browser
+fetches once and caches for the life of the box, lazy singletons -- that never
+come back and are not leaks, so those land entirely in the warmup. Each
+measured block settles before its closing sample: an FTP or HTTP session
+borrows several KB and returns it seconds later, and sampling immediately reads
+that as a leak.
+
+The open/close slope needs many iterations because what it guards is small: 60
+bytes against a noise floor of a few dozen. The query slope needs few, because
+a single leaked response body is 16 KB -- and each iteration is a request to a
+third-party service, which is not something to make a habit of.
+
+Uses GET /v1/machine:heap. Firmware predating that endpoint answers 404 and
+every check here skips, so the suite is safe to run against any image. It also
+talks to the live Assembly 64 service through the device: when that is
+unreachable the form never opens, and the suite skips rather than reporting a
+third-party outage as a firmware defect.
+"""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+# tests/lib holds the reporting rules and the shared REST client; tests/e2e
+# holds the UI backend and this fixture's own e2e suite, which already knows
+# how to open the form, fill a field and submit a query.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "e2e" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "e2e" / "io" / "c64"))
+
+import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
+from report import (  # noqa: E402
+    Failure, check, check_ok, check_skip, check_start, detail, format_exception,
+    section, suite_fail, suite_ok, suite_skip)
+from menu import wait_until  # noqa: E402
+from ui_backend import add_mode_argument, make_backend  # noqa: E402
+import assembly64_test as a64  # noqa: E402
+
+HEAP_PATH = "/v1/machine:heap"
+
+# One-time costs land here. The very first open also fetches the preset list,
+# which is cached for the life of the box and must not be counted.
+OPEN_WARMUP = 3
+# 40 opens put a 60-byte-per-open leak at 2,400 bytes, well clear of the few
+# dozen bytes of allocator noise seen across a whole suite run.
+OPEN_MEASURED = 40
+OPEN_TOLERANCE_BYTES_PER_OP = 25
+
+# One warmup is enough: nothing about a query is cached, and every iteration
+# costs the Assembly 64 service two requests.
+QUERY_WARMUP = 1
+QUERY_MEASURED = 5
+# A leaked response body alone is 16,392 bytes. This tolerance is loose on
+# purpose: what it has to catch is thousands of bytes per query, and a result
+# list whose size depends on what the service returns is not worth tightening
+# against.
+QUERY_TOLERANCE_BYTES_PER_OP = 2000
+
+SETTLE_SECONDS = 6.0
+
+
+def heap_free(rest: rest_lib.RestClient) -> int:
+    return int(rest.json(HEAP_PATH)["free"])
+
+
+def open_and_leave(device) -> None:
+    """One full open and close of the search browser."""
+    a64.open_query_form(device)
+    a64.leave_form(device)
+
+
+def query_and_open_entry(device) -> bool:
+    """One query, then step into the first result. True if an entry was opened.
+
+    Stepping in is the part that calls request_entries(), so a run where the
+    service returns nothing to step into still exercises the query itself but
+    not the entries path. That is reported rather than failed: an empty corpus
+    is the service's business, not the firmware's.
+    """
+    a64.open_query_form(device)
+    a64.enter_field(device, a64.NAME_FIELD)
+    device.type_text(a64.SEARCH_TERM)
+    device.send_key("ENTER")
+    a64.submit_query(device)
+
+    opened = False
+    if wait_until(lambda: device.menu_is_open() and not device.form_visible(),
+                  a64.QUERY_TIMEOUT):
+        rows = device.rows() or []
+        if any(a64.SEARCH_TERM in text.lower() for text in rows):
+            before = device.screen()
+            device.send_key("ENTER")
+            # The entry list is fetched over the network, so the press is given
+            # time to produce it. Leaving before it lands would measure a fetch
+            # still in flight.
+            if before is not None:
+                wait_until(lambda: device.screen_changed(before), a64.QUERY_TIMEOUT)
+            opened = True
+
+    a64.recover(device, "after a query")
+    return opened
+
+
+def measure(rest: rest_lib.RestClient, title: str, once, warmup: int,
+            measured: int, tolerance: int, unit: str) -> bool:
+    """Warm up, then require the free heap to be flat over `measured` runs."""
+    section(title)
+
+    with check(f"warm up ({warmup} {unit}, one-time costs land here)"):
+        for _ in range(warmup):
+            once()
+        time.sleep(SETTLE_SECONDS)
+
+    seen = {}
+    try:
+        with check(f"free heap is flat across {measured} more {unit}"):
+            before = heap_free(rest)
+            for _ in range(measured):
+                once()
+            time.sleep(SETTLE_SECONDS)
+            after = heap_free(rest)
+            consumed = before - after
+            seen.update(before=before, after=after, consumed=consumed,
+                        per_op=consumed / measured)
+            if seen["per_op"] > tolerance:
+                raise Failure(
+                    f"{title} leaks about {seen['per_op']:.0f} bytes per "
+                    f"iteration ({consumed} bytes over {measured})")
+        ok = True
+    except Failure:
+        ok = False
+    if seen:
+        detail(f"free before {seen['before']}, after {seen['after']}")
+        detail(f"consumed {seen['consumed']} bytes over {measured} {unit} "
+               f"= {seen['per_op']:.0f} bytes each (tolerance {tolerance})")
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assert that repeated Assembly 64 searches do not consume "
+                    "heap. Skips if the firmware has no machine:heap endpoint, "
+                    "or if the Assembly 64 service is unreachable.")
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS"))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "30.0")))
+    parser.add_argument("--telnet-port", type=int,
+                        default=int(os.environ.get("U64_TELNET_PORT", "23")))
+    add_mode_argument(parser, default=os.environ.get("U64_MODE", "overlay"))
+    args = parser.parse_args()
+
+    password = args.password or None
+    rest = rest_lib.RestClient(args.host, password, args.timeout)
+
+    check_start("device exposes GET /v1/machine:heap")
+    if rest.status("GET", HEAP_PATH) != 200:
+        check_skip("firmware predates GET /v1/machine:heap, nothing to measure")
+        section("summary")
+        detail("skipped: device firmware has no machine:heap endpoint")
+        suite_ok("assembly_search_leak_test")
+        return 0
+    check_ok()
+
+    # The same wider Telnet session the e2e suite needs: at the standard width
+    # the form box's own title renders truncated.
+    backend = make_backend(args.mode, args.host, password, args.timeout,
+                           telnet_port=args.telnet_port, telnet_width=60)
+    device = a64.Device(backend, args.mode, args.host, password, args.timeout)
+
+    entries_opened = 0
+
+    def one_query() -> None:
+        nonlocal entries_opened
+        if query_and_open_entry(device):
+            entries_opened += 1
+
+    try:
+        opens_ok = measure(rest, "opening and closing the search browser",
+                           lambda: open_and_leave(device), OPEN_WARMUP,
+                           OPEN_MEASURED, OPEN_TOLERANCE_BYTES_PER_OP, "opens")
+        query_ok = measure(rest, "running a query and opening a result",
+                           one_query, QUERY_WARMUP, QUERY_MEASURED,
+                           QUERY_TOLERANCE_BYTES_PER_OP, "queries")
+
+        section("summary")
+        detail(f"open/close slope: {'OK' if opens_ok else 'FAIL'}")
+        detail(f"query slope: {'OK' if query_ok else 'FAIL'}")
+        detail(f"stepped into a result on {entries_opened} of "
+               f"{QUERY_WARMUP + QUERY_MEASURED} queries")
+        if entries_opened == 0:
+            detail("the service returned no matches, so the entries path was "
+                   "never exercised")
+        if opens_ok and query_ok:
+            suite_ok("assembly_search_leak_test")
+            return 0
+        suite_fail("assembly_search_leak_test", "see the summary above")
+        return 1
+    except a64.Skip as exc:
+        suite_skip("assembly_search_leak_test", str(exc))
+        return 0
+    finally:
+        try:
+            a64.recover(device, "tearing down")
+        except Exception:
+            pass
+        backend.close()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        suite_fail("assembly_search_leak_test", format_exception(exc))
+        raise SystemExit(1)


### PR DESCRIPTION
Running the Assembly 64 search leaked about 31.4 KB of heap per pass through
its E2E suite. Chasing that down found four causes; the last one is not
Assembly 64 code at all and costs every config menu open 60 bytes.

Measured on an Ultimate 64 Elite, warm slope over `GET /v1/machine:heap`,
settling six seconds before each sample:

| stage | bytes per `assembly64` run |
|---|---|
| before | 31,440 / 31,520 |
| after the query-path fixes | ~780 |
| after the browser-state fix | 0 / 64 / -20 |

What is left oscillates in both directions around a fixed free-heap figure, so
it is allocator fit rather than accumulation.

## The response buffers

`collect_in_buffer()` allocates a 16,392-byte `t_BufferedBody` per request and
parks it in the request's user context. `convert_buffer_to_json()` copies every
key and value into the JSON tree -- the parser builds `JSON_Object(true)`, so
keys are owned, and `JSON_String` holds an `mstring` -- so the buffer has no
owner once the tree exists.

Only the query path deleted it. `request_entries()` dropped one on every entry
opened, along with the whole entries JSON tree, and `get_presets()` held one
for the lifetime of the box. `Assembly::take_response_json()` now frees the
body itself, which puts it in one place instead of asking each caller to
remember. `request_binary()` is unaffected: its user context is a
`TempfileWriter` the caller still owns.

An outstanding-allocation tracker confirmed this before the fix: one live
block of 16,400 bytes after a single suite run.

## The query results

`BrowsableQueryResults` had no owner either. It is handed to
`AssemblyResultsView` as its node, and `TreeBrowserState` only ever kills a
node's children, never the node, so both it and the `BrowsableQueryResult`
entries inside it leaked per query. The search form holds it now: it outlives
the results view, which deletes its `previous` last, so freeing it from
`~AssemblySearchForm` is ordered safely against the base destructor's use of
`node`. Its own destructor frees the entries, which live in a list of their own
rather than in `Browsable::children`.

## The browser state, which is the general one

`TreeBrowser`'s constructor makes a plain `TreeBrowserState`, and three
subclasses then assign over it with a state of their own: `AssemblySearch`,
`ConfigBrowser` and `FormUI`. The one the constructor made is never freed. That
is 60 bytes every time one of these browsers opens -- measured at 61 bytes per
Assembly 64 form open, and the same on every config menu.

`state_root` is the worse half. It still points at the orphan, so `cd()`'s walk
back up to root, `while (state != state_root) state->level_up()`, compares
`state` against a state the browser can never be in; at the root level
`level_up()` is a no-op and the loop does not terminate. `handleEvent()` walks
from the same stale pointer.

`replace_root_state()` frees the old state and sets both pointers, which is the
part every caller was getting wrong.

`FormUI` needed one thing first: it passed the base class its own `root`
member, uninitialised at that point, so the state the base constructed held a
garbage node and destroying it would have dereferenced it. Its root is `&form`,
which its own state already uses. `&form` is passed before `form` is
constructed, which is fine -- the base only stores the pointer, and by the time
anything dereferences it the member exists.

## Also

`Assembly::connect_to_server()` dropped the socket when `connect()` failed. The
identical bug is still in `HttpRequest::connect_to_server()` and is left alone
here as out of scope.

## Testing

Full default E2E suite set against firmware 3.15, FPGA core 123, core version
1.4B, in overlay mode. All 19 suite runs passed, exit 0, no recovery invoked.
`freeze-menu` ran and passed.

The `ftp=FAIL` lines below are the runner's own health-check self-tests driving
a fake device, not the real one.

<details>
<summary>Full <code>./run-tests</code> output</summary>

```

============================================================
Ultimate hardware test run
============================================================
     host:       192.168.1.62
     categories: e2e
     modes:      overlay
     timeout:    30.0s
     on failure: continue
     health:    answers + health sweep, retry after recovery

============================================================
E2E  transport-usage  (overlay)
============================================================
     transport-usage: health: ping=12ms rest=13ms ftp=21ms telnet=45ms ident=15ms dma=12ms raster=57ms jiffy=29ms -> OK
check_transport_usage: OK (43 files, 0.187s)
transport-usage: OK (0.240s)

============================================================
E2E  runner-policy  (overlay)
============================================================
     runner-policy: health: ping=13ms rest=13ms ftp=12ms telnet=39ms ident=21ms dma=12ms raster=43ms jiffy=79ms -> OK
[01] a clean run exits 0 ... OK (0.000s)
[02] a failed suite exits 1 ... OK (0.000s)
[03] a recovery with no failure exits 3 ... OK (0.000s)
[04] a failure outranks a recovery ... OK (0.000s)
[05] a device that cannot be made healthy exits 4, outranking a failure ... OK (0.000s)
[06] a device that answers is never recovered ... OK (0.000s)
[07] recovery runs only once the ordinary wait has given up ... OK (0.011s)
     fixture: the device is unhealthy: it is not answering
[08] a recovery that does not bring the device back reports so ... OK (0.065s)
     fixture: the device is unhealthy: it is not answering
[09] a recovery command that exits non-zero is still followed by a probe ... OK (0.006s)
     fixture: the device is unhealthy: it is not answering
[10] a recovery command that hangs is bounded by --recover-timeout ... OK (0.205s)
     fixture: the device is unhealthy: it is not answering
[11] a recovery command the shell cannot find is a failed recovery ... OK (0.068s)
     fixture: the device is unhealthy: it is not answering
[12] no recovery command means no recovery ... OK (0.000s)
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: no --recover-command was given
[13] a suite gives up after --recover-max-per-suite recoveries ... OK (0.127s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
[14] the per-suite budget starts again at the next suite ... OK (0.061s)
     fixture: the device is unhealthy: it is not answering
[15] the run gives up after --recover-max-total recoveries ... OK (0.120s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
[16] the refusal says which ceiling was reached ... OK (0.092s)
     fixture: the device is unhealthy: it is not answering
[17] a healthy sweep after a failed suite recovers nothing ... OK (0.000s)
     fixture: health: rest=9ms -> OK
[18] a degraded but reachable device is recovered ... OK (0.011s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms -> OK
[19] a device still degraded after recovering is reported, not retried ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
[20] a degraded device is not recovered past its ceiling ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: not recovering: the run has already used its 1 recoveries
[21] --no-health-check takes the sweep out of the decision ... OK (0.000s)
[22] --no-health-check still recovers a device that has gone ... OK (0.065s)
     fixture: the device is unhealthy: it is not answering
[23] consecutive resets collapse into one ... OK (0.000s)
[24] a read between two resets does not warrant the second ... OK (0.000s)
[25] a mutating call between two resets warrants the second ... OK (0.000s)
[26] force resets even when nothing has changed ... OK (0.000s)
[27] a suite told the device was just reset does not reset again ... OK (0.000s)
[28] a suite not told that still resets ... OK (0.000s)
[29] a suite that fails on a healthy device is not run again ... OK (0.024s)
[30] a suite that fails on an unhealthy device runs again after recovery ... OK (0.070s)
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
[31] --no-retry keeps the recovery and drops the extra attempt ... OK (0.023s)
[32] a device that cannot be made healthy ends the run ... OK (0.021s)
fixture: OK (1.500s)
[33] a health sweep reaches the JSONL with a latency per check ... OK (0.000s)
[34] a suite record carries the profile, attempt and recoveries ... OK (0.000s)
[35] the run record agrees with the exit status ... OK (0.000s)
[36] a sweep with every check passing is healthy ... OK (0.000s)
[37] a failed check makes the sweep degraded and names it ... OK (0.000s)
[38] a skipped check never makes the sweep degraded ... OK (0.000s)
[39] the one-line summary carries every latency and the verdict ... OK (0.000s)
     the recovery command runs on a degraded or unreachable device, never on a suite that merely failed
runner_policy_test: OK (39 checks, 1.002s)
runner-policy: OK (1.063s)

============================================================
E2E  ui-backend-smoke  (overlay)
============================================================
     ui-backend-smoke: health: ping=11ms rest=16ms ftp=14ms telnet=62ms ident=16ms dma=11ms raster=44ms jiffy=32ms -> OK

--- Overlay navigation planner
[01] a unique first letter jumps straight to the item ... OK (0.000s)
[02] a shared first letter extends the prefix rather than walking ... OK (0.000s)
[03] walking wins when the item is already next to the cursor ... OK (0.000s)
[04] the seek lands on the first match and the walk covers the rest ... OK (0.000s)
[05] a prefix never contains a space, which selects rather than seeks ... OK (0.000s)
[06] a plan is never longer than walking from the top ... OK (0.000s)
[07] an upward walk is planned when that is the shorter route ... OK (0.000s)
--- OK (7 checks, 0.000s)

--- Telnet backend
[08] Telnet: connect, navigate, teardown ... OK (1.928s)
--- OK (1 checks, 1.928s)

--- REST backend, Interface Type = Freeze
[09] REST/Freeze: connect, navigate, teardown ... OK (3.113s)
--- OK (1 checks, 3.113s)

--- REST backend, Interface Type = Overlay on HDMI
[10] REST/Overlay: connect, navigate, teardown ... OK (3.323s)
--- OK (1 checks, 3.323s)
ui_backend_smoke_test: OK (10 checks, 8.378s)
ui-backend-smoke: OK (8.439s)

============================================================
E2E  readmem-writemem  (overlay)
============================================================
     readmem-writemem: health: ping=19ms rest=14ms ftp=18ms telnet=38ms ident=18ms dma=21ms raster=38ms jiffy=54ms -> OK
[01] reset C64 to a clean, stable state ... OK (0.047s)
[02] read User Interface Settings config ... OK (0.031s)
     current Interface Type: Freeze

--- bounds: readmem rejects out-of-range parameters before allocating, and max-size reads do not degrade the device
[03] readmem rejects zero length ... OK (0.022s)
[04] readmem rejects negative length ... OK (0.026s)
[05] readmem rejects length one past the 64KB cap ... OK (0.017s)
[06] readmem rejects length far past the cap ... OK (0.036s)
[07] readmem rejects length that overflows a long ... OK (0.017s)
[08] readmem rejects read running past $FFFF ... OK (0.028s)
[09] readmem rejects address above $FFFF ... OK (0.018s)
[10] readmem rejects negative address ... OK (0.023s)
[11] 8 back-to-back max-size reads ($0000, 65536 bytes) all succeed ... OK (1.823s)
[12] 25 unsupported machine:measure calls leave readmem working ... OK (0.704s)
[13] switch to Overlay on HDMI to probe live background activity ... OK (0.019s)
[14] probe addresses that change on their own while the C64 runs ... OK (6.346s)
     6 address(es) treated as expected live background noise: $00A1, $00A2, $00CD, $00CF, $01F2, $0287
[15] set Interface Type = Freeze ... OK (0.016s)
[16] open menu (Freeze) ... OK (0.326s)
[17] write full-range pattern (Freeze) ... OK (0.447s)
[18] read back full range (Freeze) ... OK (0.237s)
[19] menu still open after write+read (Freeze) ... OK (0.020s)
--- OK (17 checks, 10.2s)

--- selfcheck-freeze: write and read both happen in Freeze (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-freeze] ignored ROM mismatches (writes to real ROM are no-ops): 16330
     [selfcheck-freeze] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-freeze] ignored known-live-noise mismatches: 0
     [selfcheck-freeze] color RAM (low nibble) mismatches: 0
     [selfcheck-freeze] RAM mismatches: 0
[20] close menu (Freeze) ... OK (0.344s)
[21] set Interface Type = Overlay on HDMI ... OK (0.018s)
[22] open menu (Overlay on HDMI) ... OK (0.314s)
[23] pause C64 for exact round trip (Overlay on HDMI) ... OK (0.013s)
[24] write full-range pattern (Overlay on HDMI) ... OK (0.536s)
[25] read back full range (Overlay on HDMI) ... OK (0.217s)
[26] resume C64 after exact round trip (Overlay on HDMI) ... OK (0.021s)
[27] menu still open after write+read (Overlay on HDMI) ... OK (0.020s)
--- OK (8 checks, 1.538s)

--- selfcheck-overlay-on-hdmi: write and read both happen in Overlay on HDMI (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-overlay-on-hdmi] ignored ROM mismatches (writes to real ROM are no-ops): 0
     [selfcheck-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-overlay-on-hdmi] ignored known-live-noise mismatches: 0
     [selfcheck-overlay-on-hdmi] color RAM (low nibble) mismatches: 0
     [selfcheck-overlay-on-hdmi] RAM mismatches: 0
[28] close menu (Overlay on HDMI) ... OK (0.311s)
[29] close menu for the screen round trip (Overlay on HDMI) ... OK (0.032s)
[30] pause C64 for the screen round trip (Overlay on HDMI) ... OK (0.015s)
[31] write and read back $0400-$07FF (Overlay on HDMI) ... OK (0.129s)
[32] resume C64 after the screen round trip (Overlay on HDMI) ... OK (0.027s)
--- OK (5 checks, 0.593s)

--- screen-round-trip-overlay-on-hdmi: screen RAM round-trips exactly with no menu open
     [screen-round-trip-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected 0)
[33] set Interface Type = Overlay on HDMI ... OK (0.015s)
[34] open menu (Overlay on HDMI) ... OK (0.334s)
[35] write full-range pattern (Overlay on HDMI) ... OK (0.626s)
[36] capture ground truth in Overlay on HDMI mode ... OK (0.220s)
[37] close menu (Overlay on HDMI) ... OK (0.306s)
[38] set Interface Type = Freeze ... OK (0.030s)
[39] open menu (Freeze) ... OK (0.352s)
[40] read full range (Freeze) ... OK (0.262s)
[41] menu still open after cross-mode read (Freeze) ... OK (0.029s)
--- OK (9 checks, 2.188s)

--- overlay-on-hdmi-write_freeze-read: bytes written while Overlay on HDMI must read back the same while Freeze, except screen RAM (menu-owned while frozen)
     [overlay-on-hdmi-write_freeze-read] screen ($0400-$07FF) mismatches: 996 (expected, menu owns this range while frozen)
     [overlay-on-hdmi-write_freeze-read] ignored known-live-noise mismatches: 0
     [overlay-on-hdmi-write_freeze-read] color RAM (low nibble) mismatches: 0
     [overlay-on-hdmi-write_freeze-read] RAM mismatches: 0
[42] close menu (Freeze) ... OK (0.314s)
[43] set Interface Type = Freeze ... OK (0.031s)
[44] open menu (Freeze) ... OK (0.308s)
[45] write full-range pattern (Freeze) ... OK (0.546s)
[46] capture ground truth in Freeze mode ... OK (0.257s)
[47] close menu (Freeze) ... OK (0.300s)
[48] set Interface Type = Overlay on HDMI ... OK (0.019s)
[49] open menu (Overlay on HDMI) ... OK (0.373s)
[50] read full range (Overlay on HDMI) ... OK (0.224s)
[51] menu still open after cross-mode read (Overlay on HDMI) ... OK (0.023s)
--- OK (10 checks, 2.424s)

--- freeze-write_overlay-on-hdmi-read: bytes written while Freeze must read back the same while Overlay on HDMI, except screen RAM (menu-owned while frozen)
     [freeze-write_overlay-on-hdmi-read] screen ($0400-$07FF) mismatches: 1020 (expected, menu owns this range while frozen)
     [freeze-write_overlay-on-hdmi-read] ignored known-live-noise mismatches: 0
     [freeze-write_overlay-on-hdmi-read] color RAM (low nibble) mismatches: 0
     [freeze-write_overlay-on-hdmi-read] RAM mismatches: 0
[52] close menu (Overlay on HDMI) ... OK (0.305s)
     restored Interface Type to 'Freeze'
--- OK (1 checks, 2.595s)

--- summary
     bounds: OK
     selfcheck-freeze: OK
     selfcheck-overlay: OK
     screen-round-trip: OK
     overlay-to-freeze: OK
     freeze-to-overlay: OK
readmem_writemem_test: OK (52 checks, 25.8s)
readmem-writemem: OK (25.9s)

============================================================
E2E  menu-screen  (overlay)
============================================================
     menu-screen: health: ping=39ms rest=21ms ftp=14ms telnet=36ms ident=31ms dma=11ms raster=28ms jiffy=51ms -> OK
[01] open menu ... OK (0.016s)
[02] GET menu_screen contract ... OK (0.019s)
[03] menu_screen renders a real menu ... OK (0.000s)
[04] close menu ... OK (0.048s)
[05] GET menu_screen unavailable ... OK (0.015s)
[06] GET menu_screen auth ... SKIP (--password not supplied, 0.000s)
menu_screen_test: OK (6 checks, 1.324s)
menu-screen: OK (1.418s)

============================================================
E2E  input  (overlay)
============================================================
     input: health: ping=22ms rest=21ms ftp=13ms telnet=36ms ident=28ms dma=21ms raster=33ms jiffy=642ms -> OK
[01] input snapshot has stable empty response shape ... OK (0.094s)
[02] POST accepts 64 event batch ... OK (0.087s)
[03] bad content-type is rejected without mutation ... OK (0.095s)
[04] missing JSON body is rejected without mutation ... OK (0.105s)
[05] malformed JSON is rejected without mutation ... OK (0.123s)
[06] unknown root field is rejected without mutation ... OK (0.104s)
[07] late invalid event keeps whole batch atomic ... OK (0.114s)
[08] joystick port 2 fire keeps Anykey buttons 2 and 3 released ... OK (0.327s)
[09] joystick port 2 fire2 lights only Anykey button 2 ... OK (0.227s)
[10] joystick port 2 fire3 lights only Anykey button 3 ... OK (0.237s)
[11] joystick port 1 up press is visible on CIA reads ... OK (0.165s)
[12] joystick port 1 all inputs and idempotent release are visible on CIA reads ... OK (0.166s)
[13] joystick port 2 diagonal and fire are visible on CIA reads ... OK (0.193s)
[14] joystick partial release is visible on CIA reads ... OK (0.188s)
[15] joystick fire2/fire3 round-trip through REST state ... OK (0.414s)
[16] joystick release_all then press in same batch is visible on CIA reads ... OK (0.152s)
[17] joystick unusual combination is visible on CIA reads ... OK (0.164s)
[18] joystick tap does not release persistent input ... OK (0.406s)
[19] joystick tap auto releases ... OK (0.374s)
[20] invalid joystick batch does not mutate state ... OK (0.232s)
[21] joystick release_all clears both ports ... OK (0.156s)
[22] machine reset clears keyboard and joystick REST state ... OK (3.186s)
[23] keyboard single-tap batch is consumed by BASIC in order ... OK (0.959s)
[24] keyboard 10 Hz mixed alphabet echo has no missed presses ... OK (5.523s)
[25] keyboard 20 Hz alternating ab echo has no missed presses ... OK (6.262s)
[26] keyboard 5 Hz alternating ab echo has no missed presses ... OK (3.914s)
[27] keyboard single letter reaches the live C64 matrix ... OK (0.220s)
[28] keyboard shifted pair reaches the live C64 matrix ... OK (0.306s)
[29] keyboard batch applies multiple presses atomically ... OK (0.496s)
[30] keyboard ordered batch and idempotent release ... OK (0.119s)
[31] keyboard release_all can be followed by press in same batch ... OK (0.115s)
[32] keyboard accepts eight simultaneous inputs ... OK (0.220s)
[33] keyboard tap does not release persistent key ... OK (0.200s)
[34] keyboard release_all clears state ... OK (0.089s)
[35] keyboard restore tap auto releases ... OK (0.279s)
[36] keyboard special-key taps snapshot correctly and auto release ... OK (2.807s)
[37] keyboard tap is visible in the live hardware snapshot and auto releases ... OK (0.341s)
[38] keyboard cursor-left tap is visible in the live hardware snapshot and auto releases ... OK (0.282s)
[39] keyboard tap batch drains through the live matrix path ... OK (1.309s)
[40] keyboard long repeated tap train drains fully without sticky state ... OK (6.164s)
[41] invalid keyboard batch does not mutate state ... OK (0.086s)
[42] menu editor accepts an unshifted control character ... OK (1.058s)
[43] menu editor keeps separate-batch shift active across POSTs ... OK (2.824s)
[44] menu editor repeats a held printable key ... OK (3.680s)
[45] menu editor stops printable repeat after release ... OK (5.837s)
[46] menu editor accepts a single cursor-left control ... OK (4.672s)
[47] menu editor repeats a held cursor-left control ... OK (4.744s)
[48] menu editor stops cursor repeat after release ... OK (6.320s)
input_test: OK (48 checks, 82.7s)
input: OK (82.9s)

============================================================
E2E  prg-context-menu  (overlay)
============================================================
     prg-context-menu: health: ping=44ms rest=24ms ftp=13ms telnet=42ms ident=19ms dma=11ms raster=31ms jiffy=49ms -> OK
[01] reset the machine to a clean starting state ... OK (2.964s)
[02] seed /Temp with prgmenu48074.prg, prgmenu48074.d64 and a long-named PRG ... OK (0.652s)

--- every context-menu action on a plain PRG
[03] read the context menu of a plain PRG ... OK (2.706s)
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
[04] a plain PRG: every offered action is covered ... OK (0.000s)
[05] Run on a plain PRG ... OK (7.511s)
[06] Load on a plain PRG ... OK (6.310s)
[07] DMA on a plain PRG ... OK (8.314s)
[08] View on a plain PRG ... OK (3.499s)
[09] Hex View on a plain PRG ... OK (4.361s)
[10] Copy to... on a plain PRG ... OK (7.133s)
[11] Rename on a plain PRG ... OK (6.954s)
[12] Move to... on a plain PRG ... OK (7.007s)
[13] Delete on a plain PRG ... OK (4.072s)
--- OK (11 checks, 57.9s)

--- every context-menu action on a PRG inside a D64
[14] read the context menu of a PRG inside a D64 ... OK (3.769s)
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
[15] a PRG inside a D64: every offered action is covered ... OK (0.000s)
[16] Run on a PRG inside a D64 ... OK (8.933s)
[17] Load on a PRG inside a D64 ... OK (7.472s)
[18] DMA on a PRG inside a D64 ... OK (9.759s)
[19] Mount & Run on a PRG inside a D64 ... OK (9.535s)
[20] Real Run on a PRG inside a D64 ... OK (13.0s SLOW)
[21] View on a PRG inside a D64 ... OK (5.360s)
[22] Hex View on a PRG inside a D64 ... OK (5.227s)
[23] Copy to... on a PRG inside a D64 ... OK (8.936s)
[24] Rename on a PRG inside a D64 ... OK (8.985s)
[25] Move to... on a PRG inside a D64 ... OK (10.9s SLOW)
[26] Delete on a PRG inside a D64 ... OK (6.506s)
[27] Run a PRG whose name is far longer than the boot-cart display ... OK (8.608s)
--- OK (14 checks, 107s)
prg_context_menu_test: OK (23 actions, 169s)
prg-context-menu: OK (170s)

============================================================
E2E  browser-long-filename  (overlay)
============================================================
     browser-long-filename: health: ping=14ms rest=15ms ftp=15ms telnet=46ms ident=15ms dma=20ms raster=54ms jiffy=33ms -> OK
[01] reset the machine to a clean starting state ... OK (0.599s)
[02] seed long-name fixture for rename ... OK (1.373s)
[03] browser rename on long filename ... OK (8.610s)
[04] reseed long-name fixture for mount ... OK (1.240s)
[05] browser mount on long filename ... OK (5.183s)
browser_long_filename_test: OK (5 checks, 17.5s)
browser-long-filename: OK (18.8s)

============================================================
E2E  browser-filesystem-refresh  (overlay)
============================================================
     browser-filesystem-refresh: health: ping=24ms rest=25ms ftp=14ms telnet=48ms ident=27ms dma=11ms raster=43ms jiffy=33ms -> OK
[01] reset the machine to a clean starting state ... OK (0.626s)
[02] prepare fixture directories ... OK (0.123s)
[03] open Menu, Telnet and FTP on the fixture directory ... OK (4.329s)
[04] rename from the Menu ... OK (4.234s)
[05] rename from Telnet ... OK (3.095s)
[06] rename from FTP ... OK (1.319s)
[07] rename under observer-queue pressure from the Menu ... OK (6.098s)
[08] rename under observer-queue pressure from Telnet ... OK (4.939s)
[09] rename a directory from the Menu ... OK (3.967s)
[10] rename a directory from Telnet ... OK (3.099s)
[11] delete from the Menu ... OK (3.385s)
[12] delete from Telnet ... OK (3.077s)
[13] delete from FTP ... OK (1.077s)
[14] delete a non-empty directory from the Menu ... OK (2.707s)
[15] delete a non-empty directory from Telnet ... OK (2.492s)
[16] remove a directory from FTP ... OK (1.315s)
[17] select all and bulk delete from the Menu ... OK (2.754s)
[18] create from the Menu ... OK (4.124s)
[19] create from Telnet ... OK (3.256s)
[20] create from FTP ... OK (1.408s)
     STOR phase 1 (open, 0 bytes committed): Menu=<empty>; Telnet=<empty>; FTP=<empty>
[21] create from FTP (mkd) ... OK (1.155s)
[22] create from REST (d64) ... OK (0.763s)
[23] create from REST (d71) ... OK (0.891s)
[24] create from REST (d81) ... OK (1.237s)
[25] create from REST (dnp) ... OK (0.841s)
[26] write from the Menu ... OK (3.208s)
[27] write from Telnet ... OK (3.141s)
[28] write from FTP ... OK (1.675s)
     STOR phase 1 (open, truncated): Menu=wftp1.tst[ 100 ]; Telnet=wftp1.tst[ 100 ]; FTP=wftp1.tst[ 100 ]=100
[29] copy over an existing file from the Menu ... OK (13.1s SLOW)
[30] copy over an existing file from Telnet ... OK (11.1s SLOW)
[31] move an entry out of the watched directory from the Menu ... OK (6.565s)
[32] move an entry out of the watched directory from Telnet ... OK (5.465s)
[33] paste into the watched directory from the Menu ... OK (8.562s)
[34] paste into the watched directory from Telnet ... OK (7.450s)
[35] failed rename shows nothing ... OK (1.493s)
[36] failed delete removes nothing ... OK (0.900s)
[37] failed write creates nothing ... OK (1.000s)
[38] short write commits consistently ... OK (1.061s)
     short write committed 100 bytes

operation x origin x observer matrix
------------------------------------------------------------------------------
  rename       Menu    Menu    OK    0.24s
  rename       Menu    Telnet  OK    0.24s
  rename       Menu    FTP     OK    0.24s
  rename       Menu    REST    OK    0.24s
  rename       Telnet  Menu    OK    0.24s
  rename       Telnet  Telnet  OK    0.24s
  rename       Telnet  FTP     OK    0.24s
  rename       Telnet  REST    OK    0.24s
  rename       FTP     Menu    OK    0.64s
  rename       FTP     Telnet  OK    0.64s
  rename       FTP     FTP     OK    0.64s
  rename       FTP     REST    OK    0.64s
  rename-under-load Menu    Menu    OK    0.23s
  rename-under-load Menu    Telnet  OK    0.23s
  rename-under-load Menu    FTP     OK    0.23s
  rename-under-load Menu    REST    OK    0.23s
  rename-under-load Telnet  Menu    OK    0.22s
  rename-under-load Telnet  Telnet  OK    0.22s
  rename-under-load Telnet  FTP     OK    0.22s
  rename-under-load Telnet  REST    OK    0.22s
  rename-dir   Menu    Menu    OK    0.22s
  rename-dir   Menu    Telnet  OK    0.22s
  rename-dir   Menu    FTP     OK    0.22s
  rename-dir   Menu    REST    OK    0.22s
  rename-dir   Telnet  Menu    OK    0.24s
  rename-dir   Telnet  Telnet  OK    0.24s
  rename-dir   Telnet  FTP     OK    0.24s
  rename-dir   Telnet  REST    OK    0.24s
  delete       Menu    Menu    OK    0.25s
  delete       Menu    Telnet  OK    0.25s
  delete       Menu    FTP     OK    0.25s
  delete       Menu    REST    OK    0.25s
  delete       Telnet  Menu    OK    0.23s
  delete       Telnet  Telnet  OK    0.23s
  delete       Telnet  FTP     OK    0.23s
  delete       Telnet  REST    OK    0.23s
  delete       FTP     Menu    OK    0.25s
  delete       FTP     Telnet  OK    0.25s
  delete       FTP     FTP     OK    0.25s
  delete       FTP     REST    OK    0.25s
  delete-dir   Menu    Menu    OK    0.22s
  delete-dir   Menu    Telnet  OK    0.22s
  delete-dir   Menu    FTP     OK    0.22s
  delete-dir   Menu    REST    OK    0.22s
  delete-dir   Telnet  Menu    OK    0.23s
  delete-dir   Telnet  Telnet  OK    0.23s
  delete-dir   Telnet  FTP     OK    0.23s
  delete-dir   Telnet  REST    OK    0.23s
  delete-dir   FTP/rmd Menu    OK    0.36s
  delete-dir   FTP/rmd Telnet  OK    0.36s
  delete-dir   FTP/rmd FTP     OK    0.36s
  delete-dir   FTP/rmd REST    OK    0.36s
  delete-bulk  Menu    Menu    OK    0.22s
  delete-bulk  Menu    Telnet  OK    0.22s
  delete-bulk  Menu    FTP     OK    0.22s
  delete-bulk  Menu    REST    OK    0.22s
  create       Menu    Menu    OK    0.24s
  create       Menu    Telnet  OK    0.24s
  create       Menu    FTP     OK    0.24s
  create       Menu    REST    OK    0.24s
  create       Telnet  Menu    OK    0.24s
  create       Telnet  Telnet  OK    0.24s
  create       Telnet  FTP     OK    0.24s
  create       Telnet  REST    OK    0.24s
  create       FTP     Menu    OK    0.31s
  create       FTP     Telnet  OK    0.31s
  create       FTP     FTP     OK    0.31s
  create       FTP     REST    OK    0.31s
  create       FTP/mkd Menu    OK    0.63s
  create       FTP/mkd Telnet  OK    0.63s
  create       FTP/mkd FTP     OK    0.63s
  create       FTP/mkd REST    OK    0.63s
  create       REST/d64 Menu    OK    0.29s
  create       REST/d64 Telnet  OK    0.29s
  create       REST/d64 FTP     OK    0.29s
  create       REST/d64 REST    OK    0.29s
  create       REST/d71 Menu    OK    0.25s
  create       REST/d71 Telnet  OK    0.25s
  create       REST/d71 FTP     OK    0.25s
  create       REST/d71 REST    OK    0.25s
  create       REST/d81 Menu    OK    0.50s
  create       REST/d81 Telnet  OK    0.50s
  create       REST/d81 FTP     OK    0.50s
  create       REST/d81 REST    OK    0.50s
  create       REST/dnp Menu    OK    0.26s
  create       REST/dnp Telnet  OK    0.26s
  create       REST/dnp FTP     OK    0.26s
  create       REST/dnp REST    OK    0.26s
  write        Menu    Menu    OK    0.21s
  write        Menu    Telnet  OK    0.21s
  write        Menu    FTP     OK    0.21s
  write        Menu    REST    OK    0.21s
  write        Telnet  Menu    OK    0.26s
  write        Telnet  Telnet  OK    0.26s
  write        Telnet  FTP     OK    0.26s
  write        Telnet  REST    OK    0.26s
  write        FTP     Menu    OK    0.38s
  write        FTP     Telnet  OK    0.38s
  write        FTP     FTP     OK    0.38s
  write        FTP     REST    OK    0.38s
  copy-write   Menu    Menu    N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Menu    Telnet  OK    0.23s
  copy-write   Menu    FTP     OK    0.23s
  copy-write   Menu    REST    OK    0.23s
  copy-arrival Menu    Menu    OK    no stale cache on re-entry
  copy-write   Telnet  Telnet  N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Telnet  Menu    OK    0.07s
  copy-write   Telnet  FTP     OK    0.07s
  copy-write   Telnet  REST    OK    0.07s
  copy-arrival Telnet  Telnet  OK    no stale cache on re-entry
  move-out     Menu    Menu    OK    0.22s
  move-out     Menu    Telnet  OK    0.22s
  move-out     Menu    FTP     OK    0.22s
  move-out     Menu    REST    OK    0.22s
  move-out     Telnet  Menu    OK    0.24s
  move-out     Telnet  Telnet  OK    0.24s
  move-out     Telnet  FTP     OK    0.24s
  move-out     Telnet  REST    OK    0.24s
  paste-write  Menu    Menu    OK    0.23s
  paste-write  Menu    Telnet  OK    0.23s
  paste-write  Menu    FTP     OK    0.23s
  paste-write  Menu    REST    OK    0.23s
  paste-write  Telnet  Menu    OK    0.27s
  paste-write  Telnet  Telnet  OK    0.27s
  paste-write  Telnet  FTP     OK    0.27s
  paste-write  Telnet  REST    OK    0.27s
  rename-fail  FTP     Menu    OK    0.39s
  rename-fail  FTP     Telnet  OK    0.39s
  rename-fail  FTP     FTP     OK    0.39s
  rename-fail  FTP     REST    OK    0.39s
  delete-fail  FTP     Menu    OK    0.25s
  delete-fail  FTP     Telnet  OK    0.25s
  delete-fail  FTP     FTP     OK    0.25s
  delete-fail  FTP     REST    OK    0.25s
  write-fail   FTP     Menu    OK    0.21s
  write-fail   FTP     Telnet  OK    0.21s
  write-fail   FTP     FTP     OK    0.21s
  write-fail   FTP     REST    OK    0.21s
  short-write  FTP     Menu    OK    0.28s
  short-write  FTP     Telnet  OK    0.28s
  short-write  FTP     FTP     OK    0.28s
  short-write  FTP     REST    OK    0.28s
------------------------------------------------------------------------------
  N/A=2, OK=140
browser_filesystem_refresh_test: OK (38 checks, 128s)
browser-filesystem-refresh: OK (130s)

============================================================
E2E  ftp-client  (overlay)
============================================================
     ftp-client: health: ping=12ms rest=27ms ftp=24ms telnet=39ms ident=28ms dma=107ms raster=26ms jiffy=65ms -> OK
     inferred --ftp-advertised-host 192.168.1.78
     controlled FTP server on 0.0.0.0:2121 (advertised 192.168.1.78)
[I 2026-08-12 11:26:38] concurrency model: async
[I 2026-08-12 11:26:38] masquerade (NAT) address: 192.168.1.78
[I 2026-08-12 11:26:38] passive ports: 30000->30019
[I 2026-08-12 11:26:38] >>> starting FTP server on 0.0.0.0:2121, pid=43353 <<<
     server root: /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-36zdwhbn (marker E2E-1786548398)
[01] GET /v1/version reachable ... OK (0.1, 0.029s)
[02] menu closed -> menu_screen 404 ... OK (0.077s)
[03] menu_button opens menu ... OK (0.365s)
[04] menu_screen returns 2000-byte matrix ... OK (2000 bytes, 0.022s)
[05] input release_all works ... OK (0.026s)
[06] menu closes from anywhere ... OK (0.356s)
[07] remove any stale hosts left by a prior run ... OK (0 removed, 1.239s)

--- stage: smoke
[08] create FTP host 'E2EFTP8398ac4t' through the New Host form ... OK (6.490s)
[09] new alias appears under /ftp ... OK (0.927s)
[10] enter host: server sees login + TYPE I + LIST ... [I 2026-08-12 11:26:49] 192.168.1.62:52454-[] FTP session opened (connect)
[I 2026-08-12 11:26:49] 192.168.1.62:52454-[u64e2e] USER 'u64e2e' logged in.
OK (PASS,TYPE,LIST, 1.249s)
[11] root listing shows fixture entries ... OK (README,DIRA,SMALL, 0.037s)
[12] open README.TXT -> RETR (52 bytes) ... [I 2026-08-12 11:26:51] 192.168.1.62:52454-[u64e2e] RETR /private/var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-36zdwhbn/README.TXT completed=1 bytes=52 seconds=0.0
OK (52 bytes, 2.509s)
[13] remove host and confirm it disappears ... [I 2026-08-12 11:26:53] 192.168.1.62:52454-[u64e2e] FTP session closed (disconnect).
OK (3.518s)
--- OK (6 checks, 14.7s)

--- cleanup
     preserved: nothing

--- summary
     Phase    Operation              Result             Commands       Fixture/Notes
     ------------------------------------------------------------------------------
     smoke    create host            OK                                E2EFTP8398ac4t
     smoke    list host              OK                                E2EFTP8398ac4t
     smoke    enter/LIST             OK                 USER/PASS/TYPE E2EFTP8398ac4t
     smoke    root entries           OK                 LIST           README/DIRA/SMALL
     smoke    RETR README            OK                 RETR           README.TXT 52 bytes
     smoke    remove host            OK                                E2EFTP8398ac4t
     ------------------------------------------------------------------------------
     Total REST requests   : 153
     Total menu snapshots  : 65
     Total keyboard events : 102
     Total FTP commands    : 24
     Created host alias    : (removed)
     Remote root path      : /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-36zdwhbn
     Cleanup status        : clean
Exception in thread Thread-1 (serve_forever):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/servers.py", line 254, in serve_forever
    self.ioloop.loop(timeout, blocking)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 376, in loop
    poll(timeout)
    ~~~~^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 741, in poll
    kevents = self._kqueue.control(
        None, _len(self.socket_map), timeout
    )
OSError: [Errno 9] Bad file descriptor
ftp-client: OK (18.2s)

============================================================
E2E  prg-load-path-trim  (overlay)
============================================================
     prg-load-path-trim: health: ping=12ms rest=13ms ftp=30ms telnet=38ms ident=20ms dma=12ms raster=31ms jiffy=32ms -> OK

--- Ultimate 64 PRG load path trim
     host: 192.168.1.62
     PUT file path: /Temp/rest-prg-path-trim-target-example.prg
     POST upload name: rest-prg-path-trim-upload-example.prg

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configure Temp Settings
[01] set Temp Auto Cleanup to Enabled ... OK (0.014s)
[02] set Temp Subfolders to Enabled ... OK (0.028s)
--- OK (2 checks, 0.042s)

--- 3. Prepare PRG Fixture
[03] upload PUT fixture rest-prg-path-trim-target-example.prg ... OK (0.167s)
--- OK (1 checks, 0.167s)

--- 4. Validate PUT Endpoints
[04] exercise PUT runners:load_prg ... OK (0.390s)
     PUT load_prg boot-cart name: ...T-EXAMPLE
[05] exercise PUT runners:run_prg ... OK (1.762s)
     PUT run_prg boot-cart name: ...T-EXAMPLE
--- OK (2 checks, 2.344s)

--- 5. Validate POST Endpoints
[06] exercise POST runners:load_prg ... OK (0.440s)
     POST load_prg boot-cart name: ...D-EXAMPLE
[07] exercise POST runners:run_prg ... OK (1.796s)
     POST run_prg boot-cart name: ...D-EXAMPLE
--- OK (2 checks, 3.119s)
prg_load_path_trim_test: OK (7 checks, 6.417s)

--- restore User Interface Settings
[08] set Temp Auto Cleanup to Enabled ... OK (0.015s)
[09] set Temp Subfolders to Enabled ... OK (0.031s)
prg-load-path-trim: OK (7.412s)

============================================================
E2E  temp-auto-cleanup  (overlay)
============================================================
     temp-auto-cleanup: health: ping=13ms rest=13ms ftp=12ms telnet=37ms ident=34ms dma=22ms raster=37ms jiffy=51ms -> OK

--- Ultimate 64 Temp auto cleanup
     host: 192.168.1.62

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configuration Setup
[01] set Temp Auto Cleanup to Enabled ... OK (0.026s)
[02] set Temp Subfolders to Enabled ... OK (0.027s)
--- OK (2 checks, 0.052s)

--- 3. Purging /Temp
     purge complete

--- 4. Mounting D64 Images
[03] create /Temp/mount-drive-8.d64 ... OK (0.082s)
[04] download mount-drive-8.d64 for the upload mount ... OK (0.422s)
[05] remove staging source mount-drive-8.d64 ... OK (0.060s)
[06] mount drive A ... OK (1.101s)
OK (1.101s)
[07] create /Temp/mount-drive-9.d64 ... OK (0.066s)
[08] download mount-drive-9.d64 for the upload mount ... OK (0.445s)
[09] remove staging source mount-drive-9.d64 ... OK (0.089s)
[10] mount drive B ... OK (1.196s)
OK (1.196s)
--- OK (10 checks, 3.462s)

--- 5. Seeding Baseline (10 files)
[11] upload base_1.bin ... OK (1.604s)
[12] upload base_2.bin ... OK (1.685s)
[13] upload base_3.bin ... OK (1.644s)
[14] upload base_4.bin ... OK (1.744s)
[15] upload base_5.bin ... OK (1.710s)
[16] upload base_6.bin ... OK (1.586s)
[17] upload base_7.bin ... OK (1.689s)
[18] upload base_8.bin ... OK (1.603s)
[19] upload base_9.bin ... OK (1.575s)
[20] upload base_10.bin ... OK (1.589s)
--- OK (10 checks, 16.5s)

--- 6. Managed Temp File Limit (Target: 10)
[21] upload managed_1.bin over REST ... OK (4.533s)
     managed count=1 (limit=10)
[22] upload managed_2.bin over REST ... OK (4.607s)
     managed count=2 (limit=10)
[23] upload managed_3.bin over REST ... OK (4.575s)
     managed count=3 (limit=10)
[24] upload managed_4.bin over REST ... OK (4.744s)
     managed count=4 (limit=10)
[25] upload managed_5.bin over REST ... OK (8.355s)
     managed count=5 (limit=10)
[26] upload managed_6.bin over REST ... OK (4.642s)
     managed count=6 (limit=10)
[27] upload managed_7.bin over REST ... OK (4.567s)
     managed count=7 (limit=10)
[28] upload managed_8.bin over REST ... OK (4.603s)
     managed count=8 (limit=10)
[29] upload managed_9.bin over REST ... OK (4.606s)
     managed count=9 (limit=10)
[30] upload managed_10.bin over REST ... OK (4.609s)
     managed count=10 (limit=10)
[31] upload managed_11.bin over REST ... OK (4.561s)
     managed count=10 (limit=10)
[32] upload managed_12.bin over REST ... OK (4.598s)
     managed count=10 (limit=10)
OK (5.045s)
OK (5.164s)
--- OK (14 checks, 64.6s)

--- 7. Unmounted Uploads Rejoin Cleanup
[33] remove drive A ... OK (0.162s)
[34] upload post_a_1.bin over REST ... OK (4.613s)
OK (4.722s)
     removed after 1 uploads
[35] remove drive B ... OK (0.135s)
[36] upload post_b_1.bin over REST ... OK (4.662s)
     removed after 1 uploads
--- OK (5 checks, 10.2s)

--- 8. Final Integrity Check
     user files intact
temp_auto_cleanup_test: OK (36 checks, 97.9s)

--- restore User Interface Settings
[37] set Temp Auto Cleanup to Enabled ... OK (0.018s)
[38] set Temp Subfolders to Enabled ... OK (0.021s)
temp-auto-cleanup: OK (98.5s)

============================================================
E2E  cfg-single-group  (overlay)
============================================================
     cfg-single-group: health: ping=12ms rest=13ms ftp=23ms telnet=46ms ident=15ms dma=11ms raster=67ms jiffy=153ms -> OK
[01] load a one-group CFG file through the browser ... OK (7.904s)
[02] only the CFG group is considered after loading ... OK (0.111s)
cfg_single_group_test: OK (2 checks, 8.485s)
cfg-single-group: OK (9.128s)

============================================================
E2E  printer  (overlay)
============================================================
     printer: health: ping=41ms rest=14ms ftp=13ms telnet=37ms ident=33ms dma=10ms raster=39ms jiffy=41ms -> OK
[01] REST reachable at 192.168.1.62 ... OK (0.023s)
[02] reset before run ... OK (0.124s)
[03] load printer_e2e.prg ... OK (914 bytes, 0.000s)
[04] capture original Printer Settings ... OK (0.200s)
[05] print epson/bitmap: apply settings + run PRG ... OK (phase=printer closed heartbeat=4, 2.995s)
[06] print epson/bitmap: Flush/Eject via on-screen menu ... OK (3.672s)

--- restoring original Printer Settings
     IEC printer: Disabled
     Bus ID: 4
     Output file: /Usb0/printer
     Output type: PNG B&W
     Ink density: Medium
     Page top margin (default is 5): 5
     Page height (default is 60): 60
     Emulation: Commodore MPS
     Commodore charset: USA/UK
     Epson charset: Basic
     IBM table 2: International 1

--- summary
     epson      bitmap PASS_NO_VERIFY       /USB1/printer/e2e-ebfbb6
printer: OK (8.099s)

============================================================
E2E  uci-targets  (overlay)
============================================================
     uci-targets: health: ping=12ms rest=13ms ftp=22ms telnet=49ms ident=21ms dma=12ms raster=31ms jiffy=27ms -> OK
[01] reset the C64 so the command interface starts idle ... OK (3.052s)
[02] read 'C64 and Cartridge Settings' ... OK (0.027s)
     current: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}
[03] enable the Command Interface registers at $DF1B-$DF1F ... OK (0.188s)
[04] transport: an empty command returns an empty reply ... OK (0.199s)
     <empty> -> 0.04s, data b'', status b''
[05] transport: unregistered target answers IDENTIFY ... OK (0.836s)
     0f 01 -> 0.08s, data b'NO TARGET', status b'00,OK'
[06] transport: unregistered target rejects anything else ... OK (1.012s)
     0f 7f -> 0.14s, data b'', status b'21,UNKNOWN COMMAND'
[07] transport: a no-reply command returns straight to Idle ... OK (0.198s)
[08] transport: pushing while a reply is pending sets and clears ERROR ... OK (1.245s)
[09] transport: the next command is not prefixed by leftover bytes ... OK (1.300s)
     04 28 00 -> 0.10s, data b'Ultimate 64 Elite', status b'00,OK'
[10] transport: ABORT releases a pending reply back to Idle ... OK (0.204s)
[11] control-target: IDENTIFY answers with the target name ... OK (1.193s)
     04 01 -> 0.10s, data b'CONTROL TARGET V1.1', status b'00,OK'
[12] control-target: an unimplemented command is reported as unknown ... OK (0.895s)
     04 7f -> 0.07s, data b'', status b'21,UNKNOWN COMMAND'
[13] control-target: LOAD_REU without a filename is rejected, not run ... OK (0.910s)
     04 08 -> 0.09s, data b'', status b'81,INVALID PARAMS'
[14] control-target: SAVE_REU without a filename is rejected, not run ... OK (0.942s)
     04 09 -> 0.10s, data b'', status b'81,INVALID PARAMS'
[15] control-target: GET_HWINFO rejects a device number it does not have ... OK (0.913s)
     04 28 02 -> 0.11s, data b'', status b'81,INVALID PARAMS'
[16] issue-740-matrix: confirm /Temp/uci_e2e_absent.reu does not exist ... OK (0.017s)
[17] issue-740-matrix: put a 16384-byte image at /Temp/uci_e2e_present.reu ... OK (0.187s)
[18] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... OK (4.381s)
     04 08 52 45 55 2e 49 4d 47 -> 0.23s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[19] issue-740-matrix: REU Enabled, image absent, name at offset 4 ... OK (4.479s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.27s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[20] issue-740-matrix: REU Disabled, image absent, name at offset 2 ... OK (1.241s)
     04 08 52 45 55 2e 49 4d 47 -> 0.20s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[21] issue-740-matrix: REU Disabled, image absent, name at offset 4 ... OK (1.330s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.25s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[22] issue-740-matrix: REU Enabled, image present, name at offset 2 ... OK (3.473s)
     04 08 52 45 55 2e 49 4d 47 -> 0.22s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[23] issue-740-matrix: REU Enabled, image present, name at offset 4 ... OK (3.454s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.28s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[24] save-reu-offset-past-end: put the preload offset at the end of a 128 KB REU ... OK (0.064s)
[25] save-reu-offset-past-end: SAVE_REU reports the offset and saves nothing ... OK (3.955s)
     04 09 52 45 55 2e 49 4d 47 -> 0.20s, data b'\xfd\xff\xff\xffREU SAVE: OFFSET 131072 >= REU SIZE 131072, SKIPPING', status b'86,REU OFFSET > SIZE. NOT SAVED'
[26] load-reu-disabled: disable the REU ... OK (0.034s)
[27] load-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.049s)
     04 28 00 -> 0.13s, data b'Ultimate 64 Elite', status b'00,OK'
[28] load-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.441s)
     04 08 52 45 55 2e 49 4d 47 -> 0.22s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[29] save-reu-disabled: disable the REU ... OK (0.015s)
[30] save-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.137s)
     04 28 00 -> 0.09s, data b'Ultimate 64 Elite', status b'00,OK'
[31] save-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.163s)
     04 09 52 45 55 2e 49 4d 47 -> 0.22s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[32] softiec-single-part-reply: SoftIEC target answers IDENTIFY ... OK (1.324s)
     05 01 -> 0.07s, data b'SOFTWARE IEC TARGET V1.0', status b'00,OK'
[33] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... OK (0.580s)
     05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 -> 0.39s, data b'', status b'\x01'
[34] softiec-single-part-reply: GET_FATNAME reply completes in one part ... OK (0.589s)
     05 22 02 23 -> 0.12s, data b'/buffer', status b'\x00'
[35] softiec-single-part-reply: an unimplemented SoftIEC command is reported as unknown ... OK (0.299s)
     05 7f -> 0.07s, data b'', status b'\x04'
[36] interface-usable-after: the control target still answers IDENTIFY ... OK (1.313s)
     04 01 -> 0.08s, data b'CONTROL TARGET V1.1', status b'00,OK'
     restored C64 and Cartridge Settings: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}

--- summary
     transport: OK
     control-target: OK
     issue-740-matrix: OK
     save-reu-offset-past-end: OK
     load-reu-disabled: OK
     save-reu-disabled: OK
     softiec-single-part-reply: OK
     interface-usable-after: OK
     cleanup: OK
uci_targets_test: OK (36 checks, 44.9s)
uci-targets: OK (45.0s)

============================================================
E2E  machine-code-monitor  (overlay)
============================================================
     machine-code-monitor: health: ping=12ms rest=13ms ftp=31ms telnet=40ms ident=17ms dma=10ms raster=31ms jiffy=76ms -> OK
[01] initial CPU7/KERNAL monitor status ... OK (0.018s)
[02] KERNAL $E000 hex view and REST match ... OK (0.702s)
[03] paging away and back keeps memory view stable ... OK (0.613s)
[04] KERNAL disassembly formatting ... OK (1.605s)
[05] KERNAL $E010 REST match ... OK (0.910s)
[06] CPU6 RAM under BASIC write/read ... OK (4.606s)
[07] CPU5 RAM under KERNAL status ... OK (2.908s)
[08] ASCII view width and scrolling ... OK (7.781s)
[09] ASCII and Screen mapping semantics ... OK (12.8s SLOW)
[10] HEX edit writes both nibbles ... OK (3.079s)
[11] CPU bank cycling reaches CHAR and RAM mappings ... OK (3.571s)
[12] COMPARE reports differing address ... OK (4.208s)
[13] G executes finite loop and returns to monitor ... OK (2.286s)
[14] G repeated execution updates RAM sentinel ... OK (7.447s)
[15] G handoff preserves stable VIC state ... SKIP (the on-device UI owns the VIC while it is up; only comparable over telnet, 0.000s)
OK (0.000s)
[16] bookmarks recall, set, list, and label edit ... OK (7.635s)
[17] memory bookmark jump restores width 16 ... OK (5.907s)
[18] binary width cycling and bookmark jump restores width 4 ... OK (6.835s)
[19] follow and return navigation ... OK (5.773s)
[20] asm edit mnemonic validation and Return advance ... OK (8.171s)
[21] number popup arithmetic ... OK (2.844s)
[22] save/load round-trip to top-level /Temp file ... OK (9.471s)
[23] save/load round-trip to file in new /Temp D64 ... OK (18.5s SLOW)

--- Telnet transport checks
[24] telnet blocks poll mode ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
[25] telnet opcode dropdown scroll does not flood the connection ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
--- SKIP (4 checks, 0.167s)
monitor_test: OK (25 checks, 120s)
machine-code-monitor: OK (120s)

============================================================
E2E  ftp-server  (overlay)
============================================================
     ftp-server: health: ping=22ms rest=15ms ftp=16ms telnet=36ms ident=15ms dma=21ms raster=65ms jiffy=27ms -> OK

--- a name the listing reports can address the file it names
[01] a 40-character name is listed unchanged ... OK (0.095s)
[02] that file is removed by the name the listing reported ... OK (0.096s)
[03] a 100-character name is listed unchanged ... OK (0.107s)
     100 characters survived the listing
[04] SIZE answers for the long name the listing reported ... OK (0.054s)
[05] that file is removed by the name the listing reported ... OK (0.123s)
--- OK (5 checks, 0.580s)
ftp_server_test: OK (5 checks, 0.583s)
ftp-server: OK (0.631s)

============================================================
E2E  assembly64  (overlay)
============================================================
     assembly64: health: ping=12ms rest=13ms ftp=36ms telnet=36ms ident=17ms dma=12ms raster=26ms jiffy=27ms -> OK

--- the form opens from the task menu and closes again
[01] open the Assembly 64 query form ... OK (0.689s)
[02] the form leaves cleanly with RUN/STOP ... OK (0.364s)
--- OK (2 checks, 1.175s)

--- a real query is sent to the Assembly 64 service
[03] open the form and enter the first field ... OK (1.025s)
[04] the typed term lands in the Name field ... OK (0.775s)
[05] the service answers and the results match what was asked for ... OK (1.140s)
--- OK (3 checks, 3.546s)

--- the menu button must work from inside the edit field
[06] open the form and enter the edit field ... OK (1.141s)
[07] the menu button closes the menu from inside the field ... OK (0.105s)
[08] the menu opens again, so the UI task left string_edit ... OK (0.035s)
--- OK (3 checks, 1.879s)

--- an aborted edit must not wedge the form
[09] open the form, type into a field, then abort ... OK (1.626s)
[10] the form is still usable after the abort ... OK (0.039s)
--- OK (2 checks, 2.136s)

--- over-long and empty input
[11] type more than the field accepts ... OK (2.529s)
[12] an empty query is refused rather than sent ... OK (2.855s)
[13] the warning is dismissed and the form is still usable ... OK (0.444s)
--- OK (3 checks, 6.349s)

--- a user mashing keys while the form is busy
[14] submit a query and hammer keys while it runs ... OK (5.102s)
[15] the device is still answering after the mashing ... OK (0.013s)
--- OK (2 checks, 5.723s)

--- opening and abandoning the form repeatedly
[16] open and abandon the form three times ... OK (3.388s)
[17] the menu button closes and reopens the form three times ... OK (3.647s)
--- OK (2 checks, 7.320s)
assembly64_test: OK (17 checks, 28.6s)
assembly64: OK (28.6s)

============================================================
E2E  freeze-menu  (overlay)
============================================================
     freeze-menu: health: ping=11ms rest=13ms ftp=13ms telnet=62ms ident=19ms dma=10ms raster=48ms jiffy=75ms -> OK
     captured 'Interface Type'=Freeze, 'Auto Address Mirroring'=Enabled

--- menu cycle with Auto Address Mirroring Disabled
[01] select 'Freeze' interface with mirroring disabled ... OK (0.033s)
[02] C64 running before the menu is opened ... OK (1.094s)
[03] open the menu ... OK (0.289s)
[04] C64 frozen while the menu is open ... OK (0.539s)
[05] close the menu ... OK (0.289s)
[06] C64 resumed after the menu closed ... OK (0.551s)
--- OK (6 checks, 2.807s)

--- Auto Address Mirroring switched off while the menu is open
[07] select 'Freeze' interface with mirroring enabled ... OK (0.030s)
[08] C64 running before the menu is opened ... OK (0.551s)
[09] open the menu ... OK (0.285s)
[10] C64 frozen while the menu is open ... OK (0.533s)
[11] set Auto Address Mirroring to Disabled while the menu is open ... OK (0.016s)
[12] close the menu ... OK (0.280s)
[13] C64 resumed after the menu closed ... OK (0.538s)
--- OK (7 checks, 2.255s)

--- menu cycle with Auto Address Mirroring Enabled
[14] select 'Freeze' interface with mirroring enabled ... OK (0.049s)
[15] C64 running before the menu is opened ... OK (0.532s)
[16] open the menu ... OK (0.300s)
[17] C64 frozen while the menu is open ... OK (0.544s)
[18] close the menu ... OK (0.288s)
[19] C64 resumed after the menu closed ... OK (0.533s)
--- OK (6 checks, 2.262s)

--- reopen the freezer menu with a context menu left open
[20] select 'Freeze' interface with mirroring enabled ... OK (0.040s)
[21] C64 running before the menu is opened ... OK (0.533s)
[22] open the menu ... OK (0.288s)
[23] C64 frozen while the menu is open ... OK (0.536s)
[24] open the context menu on the first browser entry ... OK (7.503s)
[25] close the menu ... OK (0.287s)
[26] C64 resumed after the menu closed ... OK (0.566s)
[27] reopen the menu with the context menu still on the object stack ... OK (0.308s)
[28] dismiss the restored context menu ... OK (0.278s)
[29] close the menu ... OK (0.294s)
[30] C64 resumed after the menu closed ... OK (0.532s)
--- OK (11 checks, 11.2s)

--- the menu button works inside the Assembly 64 query form
[31] select 'Freeze' interface with mirroring enabled ... OK (0.030s)
[32] C64 running before the menu is opened ... OK (0.529s)
[33] open the menu ... OK (0.298s)
[34] C64 frozen while the menu is open ... OK (0.545s)
[35] open the task menu ... OK (0.335s)
[36] open the Assembly 64 query form ... OK (0.316s)
[37] enter the form's first edit field ... OK (0.294s)
[38] the menu button closes the menu from inside the edit field ... OK (0.288s)
[39] the menu opens again afterwards ... OK (0.296s)
[40] leave the query form ... OK (0.395s)
[41] close the menu ... OK (0.300s)
[42] C64 resumed after the menu closed ... OK (0.540s)
--- OK (12 checks, 4.325s)
freeze_menu_test: OK (42 checks, 24.0s)
freeze-menu: OK (24.1s)

TEARDOWN (overlay): release input ... OK (0.018s)
TEARDOWN (overlay): close active menu UI ... OK (0.046s)
TEARDOWN (overlay): reset machine ... OK (0.060s)

============================================================
Summary
============================================================
     OK   e2e overlay    799s (19 ok)
     slowest: prg-context-menu 170s, browser-filesystem-refresh 130s, machine-code-monitor 120s
     799s in suites, 27.1s in health checks, the UI-state gate and teardown
     826s total

OK  all 19 suite runs passed.
```

</details>
