### PR TITLE
Reload the listing when a browsed entry is removed

### DIFF
--- a/software/userinterface/tree_browser.cc
+++ b/software/userinterface/tree_browser.cc
@@ -275,7 +275,6 @@ void TreeBrowser :: checkFileManagerEvent(void)
         }
 
         // printf("DIR %sMATCHED, ENTRY %sMATCHED, st = %s, %p, %p, %d\n", match_dir?"":"NOT ", match_entry?"":"NOT ", st->node->getName(), st, this->state, match_exact_path);
-        Browsable *b;
 
         switch (event->eventType) {
         case eNodeAdded:
@@ -301,11 +300,19 @@ void TreeBrowser :: checkFileManagerEvent(void)
                 state->refresh = true;
             }
             if (match_dir) {
-                b = st->node->findChild(event->newName.c_str());
-                if (b) {
-                    printf("Removing %s\n", b->getName());
-                    st->node->children.remove(b);
-                }
+                // Reload rather than unlinking the entry. IndexedList::remove()
+                // only drops the pointer, and a BrowsableDirEntry owns a
+                // FileInfo, a FileType, its generated FAT name and a
+                // FileManager path reference, so unlinking stranded all of it --
+                // about 300 bytes and one path handle for every file that
+                // disappeared under an open browser. Deleting it here instead
+                // is not safe either: this state's under_cursor, and on some
+                // paths a deeper state's node, still point at it. reload()
+                // already frees the children through killChildren() and
+                // rebuilds the list from the filesystem, and do_refresh() runs
+                // it before anything reads under_cursor again. It is also what
+                // eNodeAdded above does with the same list.
+                st->needs_reload = true;
             }
             break;
 


### PR DESCRIPTION
`TreeBrowser::checkFileManagerEvent()` unlinked the `Browsable` for a removed
node and left it:

```c
b = st->node->findChild(event->newName.c_str());
if (b) {
    printf("Removing %s\n", b->getName());
    st->node->children.remove(b);
}
```

`IndexedList::remove()` only drops the pointer out of the array. A
`BrowsableDirEntry` owns a `FileInfo`, a `FileType`, its generated FAT name and
a `FileManager` path reference, so every file that disappeared under an open
browser stranded all of it -- around 300 bytes, and one path handle from a
bounded pool, which is the part that worries me more than the bytes.

This is not test-only: deleting files over FTP, from a C64 program or from a
second Telnet session while a browser sits on that directory is ordinary use.

## Why not just delete it

Deleting the `Browsable` at that point trades a leak for a use-after-free. This
state's `under_cursor` still names it, and on the path where the event names the
browser's own directory a deeper state can still hold it as its `node`.
`level_up()` unwinds those states only on the other branch.

Marking the state for reload frees the children through the existing
`killChildren()` path and rebuilds the list from the filesystem, and
`do_refresh()` runs the reload before anything reads `under_cursor` again. It is
also exactly what `eNodeAdded` and `eRefreshDirectory` do with the same list
twenty lines above, so the event paths now behave the same way.

## Measurement

Ultimate 64 Elite, warm slope over `GET /v1/machine:heap`, settling six seconds
before each sample. The `browser-filesystem-refresh` suite deletes files over
FTP and checks the menu notices, so it is the one that provokes this.

| build | bytes per run |
|---|---:|
| before | 16,364 / 16,648 / 16,656 |
| after | 704 / 688 / 692 |

An allocation tracker on the before build attributed it to 56 `FileInfo`
copy-constructions, 55 `BrowsableDirEntry` allocations from
`BrowsableDirEntry::getSubItems()` and their strings, for 56 removals in a run,
with no other site accounting for it.

The same bug showed up in `prg-context-menu`, which removes its fixtures and
drives at teardown: with the disk image mount cache bounded (#769) that suite
sat at 3,020 bytes per run, and with this fix as well it reads 80 and 40.

A residual of about 695 bytes per run remains in `browser-filesystem-refresh`
after this change. It is consistent across runs, so it is a real and separate
thing rather than noise, and it is not this bug; it is being chased separately.

## Testing

Full default E2E suite set against firmware 3.15, FPGA core 123, core version
1.4B, in overlay mode, on a build of this branch alone. All 19 suite runs
passed, exit 0, no recovery invoked. `browser-filesystem-refresh` is the suite
that verifies the browser notices deletions, which is the mechanism changed
here, and it passes.

The `ftp=FAIL` lines below are the runner's own health-check self-tests driving
a fake device, not the real one.

<details>
<summary>Full <code>./run-tests</code> output</summary>

```

============================================================
Ultimate hardware test run
============================================================
     host:       192.168.1.62
     categories: e2e
     modes:      overlay
     timeout:    30.0s
     on failure: continue
     health:    answers + health sweep, retry after recovery

============================================================
E2E  transport-usage  (overlay)
============================================================
UI state dirty: the root browser is not on top; a nested object still holds the UI; repairing
UI state repaired
     transport-usage: health: ping=22ms rest=27ms ftp=12ms telnet=45ms ident=15ms dma=21ms raster=35ms jiffy=66ms -> OK
check_transport_usage: OK (43 files, 0.188s)
transport-usage: OK (0.222s)

============================================================
E2E  runner-policy  (overlay)
============================================================
     runner-policy: health: ping=12ms rest=12ms ftp=13ms telnet=42ms ident=15ms dma=23ms raster=28ms jiffy=40ms -> OK
[01] a clean run exits 0 ... OK (0.000s)
[02] a failed suite exits 1 ... OK (0.000s)
[03] a recovery with no failure exits 3 ... OK (0.000s)
[04] a failure outranks a recovery ... OK (0.000s)
[05] a device that cannot be made healthy exits 4, outranking a failure ... OK (0.000s)
[06] a device that answers is never recovered ... OK (0.000s)
[07] recovery runs only once the ordinary wait has given up ... OK (0.006s)
     fixture: the device is unhealthy: it is not answering
[08] a recovery that does not bring the device back reports so ... OK (0.066s)
     fixture: the device is unhealthy: it is not answering
[09] a recovery command that exits non-zero is still followed by a probe ... OK (0.011s)
     fixture: the device is unhealthy: it is not answering
[10] a recovery command that hangs is bounded by --recover-timeout ... OK (0.207s)
     fixture: the device is unhealthy: it is not answering
[11] a recovery command the shell cannot find is a failed recovery ... OK (0.069s)
     fixture: the device is unhealthy: it is not answering
[12] no recovery command means no recovery ... OK (0.000s)
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: no --recover-command was given
[13] a suite gives up after --recover-max-per-suite recoveries ... OK (0.128s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
[14] the per-suite budget starts again at the next suite ... OK (0.070s)
     fixture: the device is unhealthy: it is not answering
[15] the run gives up after --recover-max-total recoveries ... OK (0.140s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
[16] the refusal says which ceiling was reached ... OK (0.061s)
     fixture: the device is unhealthy: it is not answering
[17] a healthy sweep after a failed suite recovers nothing ... OK (0.000s)
     fixture: health: rest=9ms -> OK
[18] a degraded but reachable device is recovered ... OK (0.011s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms -> OK
[19] a device still degraded after recovering is reported, not retried ... OK (0.010s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
[20] a degraded device is not recovered past its ceiling ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: not recovering: the run has already used its 1 recoveries
[21] --no-health-check takes the sweep out of the decision ... OK (0.000s)
[22] --no-health-check still recovers a device that has gone ... OK (0.066s)
     fixture: the device is unhealthy: it is not answering
[23] consecutive resets collapse into one ... OK (0.000s)
[24] a read between two resets does not warrant the second ... OK (0.000s)
[25] a mutating call between two resets warrants the second ... OK (0.000s)
[26] force resets even when nothing has changed ... OK (0.000s)
[27] a suite told the device was just reset does not reset again ... OK (0.000s)
[28] a suite not told that still resets ... OK (0.000s)
[29] a suite that fails on a healthy device is not run again ... OK (0.022s)
[30] a suite that fails on an unhealthy device runs again after recovery ... OK (0.065s)
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
[31] --no-retry keeps the recovery and drops the extra attempt ... OK (0.028s)
[32] a device that cannot be made healthy ends the run ... OK (0.022s)
fixture: OK (1.500s)
[33] a health sweep reaches the JSONL with a latency per check ... OK (0.000s)
[34] a suite record carries the profile, attempt and recoveries ... OK (0.000s)
[35] the run record agrees with the exit status ... OK (0.000s)
[36] a sweep with every check passing is healthy ... OK (0.000s)
[37] a failed check makes the sweep degraded and names it ... OK (0.000s)
[38] a skipped check never makes the sweep degraded ... OK (0.000s)
[39] the one-line summary carries every latency and the verdict ... OK (0.000s)
     the recovery command runs on a degraded or unreachable device, never on a suite that merely failed
runner_policy_test: OK (39 checks, 1.016s)
runner-policy: OK (1.077s)

============================================================
E2E  ui-backend-smoke  (overlay)
============================================================
     ui-backend-smoke: health: ping=11ms rest=18ms ftp=12ms telnet=38ms ident=15ms dma=21ms raster=27ms jiffy=29ms -> OK

--- Overlay navigation planner
[01] a unique first letter jumps straight to the item ... OK (0.000s)
[02] a shared first letter extends the prefix rather than walking ... OK (0.000s)
[03] walking wins when the item is already next to the cursor ... OK (0.000s)
[04] the seek lands on the first match and the walk covers the rest ... OK (0.000s)
[05] a prefix never contains a space, which selects rather than seeks ... OK (0.000s)
[06] a plan is never longer than walking from the top ... OK (0.000s)
[07] an upward walk is planned when that is the shorter route ... OK (0.000s)
--- OK (7 checks, 0.000s)

--- Telnet backend
[08] Telnet: connect, navigate, teardown ... OK (1.923s)
--- OK (1 checks, 1.923s)

--- REST backend, Interface Type = Freeze
[09] REST/Freeze: connect, navigate, teardown ... OK (2.779s)
--- OK (1 checks, 2.779s)

--- REST backend, Interface Type = Overlay on HDMI
[10] REST/Overlay: connect, navigate, teardown ... OK (3.156s)
--- OK (1 checks, 3.156s)
ui_backend_smoke_test: OK (10 checks, 7.871s)
ui-backend-smoke: OK (7.946s)

============================================================
E2E  readmem-writemem  (overlay)
============================================================
     readmem-writemem: health: ping=12ms rest=15ms ftp=25ms telnet=37ms ident=18ms dma=10ms raster=48ms jiffy=29ms -> OK
[01] reset C64 to a clean, stable state ... OK (0.036s)
[02] read User Interface Settings config ... OK (0.027s)
     current Interface Type: Freeze

--- bounds: readmem rejects out-of-range parameters before allocating, and max-size reads do not degrade the device
[03] readmem rejects zero length ... OK (0.017s)
[04] readmem rejects negative length ... OK (0.021s)
[05] readmem rejects length one past the 64KB cap ... OK (0.015s)
[06] readmem rejects length far past the cap ... OK (0.015s)
[07] readmem rejects length that overflows a long ... OK (0.015s)
[08] readmem rejects read running past $FFFF ... OK (0.019s)
[09] readmem rejects address above $FFFF ... OK (0.030s)
[10] readmem rejects negative address ... OK (0.015s)
[11] 8 back-to-back max-size reads ($0000, 65536 bytes) all succeed ... OK (1.902s)
[12] 25 unsupported machine:measure calls leave readmem working ... OK (0.770s)
[13] switch to Overlay on HDMI to probe live background activity ... OK (0.017s)
[14] probe addresses that change on their own while the C64 runs ... OK (6.223s)
     5 address(es) treated as expected live background noise: $00A1, $00A2, $00CD, $00CF, $01F2
[15] set Interface Type = Freeze ... OK (0.014s)
[16] open menu (Freeze) ... OK (0.331s)
[17] write full-range pattern (Freeze) ... OK (0.445s)
[18] read back full range (Freeze) ... OK (0.210s)
[19] menu still open after write+read (Freeze) ... OK (0.020s)
--- OK (17 checks, 10.1s)

--- selfcheck-freeze: write and read both happen in Freeze (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-freeze] ignored ROM mismatches (writes to real ROM are no-ops): 16330
     [selfcheck-freeze] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-freeze] ignored known-live-noise mismatches: 0
     [selfcheck-freeze] color RAM (low nibble) mismatches: 0
     [selfcheck-freeze] RAM mismatches: 0
[20] close menu (Freeze) ... OK (0.335s)
[21] set Interface Type = Overlay on HDMI ... OK (0.015s)
[22] open menu (Overlay on HDMI) ... OK (0.300s)
[23] pause C64 for exact round trip (Overlay on HDMI) ... OK (0.014s)
[24] write full-range pattern (Overlay on HDMI) ... OK (0.492s)
[25] read back full range (Overlay on HDMI) ... OK (0.222s)
[26] resume C64 after exact round trip (Overlay on HDMI) ... OK (0.015s)
[27] menu still open after write+read (Overlay on HDMI) ... OK (0.030s)
--- OK (8 checks, 1.447s)

--- selfcheck-overlay-on-hdmi: write and read both happen in Overlay on HDMI (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-overlay-on-hdmi] ignored ROM mismatches (writes to real ROM are no-ops): 0
     [selfcheck-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-overlay-on-hdmi] ignored known-live-noise mismatches: 0
     [selfcheck-overlay-on-hdmi] color RAM (low nibble) mismatches: 0
     [selfcheck-overlay-on-hdmi] RAM mismatches: 0
[28] close menu (Overlay on HDMI) ... OK (0.301s)
[29] close menu for the screen round trip (Overlay on HDMI) ... OK (0.041s)
[30] pause C64 for the screen round trip (Overlay on HDMI) ... OK (0.015s)
[31] write and read back $0400-$07FF (Overlay on HDMI) ... OK (0.127s)
[32] resume C64 after the screen round trip (Overlay on HDMI) ... OK (0.014s)
--- OK (5 checks, 0.521s)

--- screen-round-trip-overlay-on-hdmi: screen RAM round-trips exactly with no menu open
     [screen-round-trip-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected 0)
[33] set Interface Type = Overlay on HDMI ... OK (0.026s)
[34] open menu (Overlay on HDMI) ... OK (0.312s)
[35] write full-range pattern (Overlay on HDMI) ... OK (0.596s)
[36] capture ground truth in Overlay on HDMI mode ... OK (0.225s)
[37] close menu (Overlay on HDMI) ... OK (0.318s)
[38] set Interface Type = Freeze ... OK (0.015s)
[39] open menu (Freeze) ... OK (0.300s)
[40] read full range (Freeze) ... OK (0.210s)
[41] menu still open after cross-mode read (Freeze) ... OK (0.020s)
--- OK (9 checks, 2.026s)

--- overlay-on-hdmi-write_freeze-read: bytes written while Overlay on HDMI must read back the same while Freeze, except screen RAM (menu-owned while frozen)
     [overlay-on-hdmi-write_freeze-read] screen ($0400-$07FF) mismatches: 996 (expected, menu owns this range while frozen)
     [overlay-on-hdmi-write_freeze-read] ignored known-live-noise mismatches: 0
     [overlay-on-hdmi-write_freeze-read] color RAM (low nibble) mismatches: 0
     [overlay-on-hdmi-write_freeze-read] RAM mismatches: 0
[42] close menu (Freeze) ... OK (0.307s)
[43] set Interface Type = Freeze ... OK (0.025s)
[44] open menu (Freeze) ... OK (0.316s)
[45] write full-range pattern (Freeze) ... OK (0.550s)
[46] capture ground truth in Freeze mode ... OK (0.215s)
[47] close menu (Freeze) ... OK (0.321s)
[48] set Interface Type = Overlay on HDMI ... OK (0.022s)
[49] open menu (Overlay on HDMI) ... OK (0.323s)
[50] read full range (Overlay on HDMI) ... OK (0.217s)
[51] menu still open after cross-mode read (Overlay on HDMI) ... OK (0.019s)
--- OK (10 checks, 2.337s)

--- freeze-write_overlay-on-hdmi-read: bytes written while Freeze must read back the same while Overlay on HDMI, except screen RAM (menu-owned while frozen)
     [freeze-write_overlay-on-hdmi-read] screen ($0400-$07FF) mismatches: 1020 (expected, menu owns this range while frozen)
     [freeze-write_overlay-on-hdmi-read] ignored known-live-noise mismatches: 0
     [freeze-write_overlay-on-hdmi-read] color RAM (low nibble) mismatches: 0
     [freeze-write_overlay-on-hdmi-read] RAM mismatches: 0
[52] close menu (Overlay on HDMI) ... OK (0.319s)
     restored Interface Type to 'Freeze'
--- OK (1 checks, 2.592s)

--- summary
     bounds: OK
     selfcheck-freeze: OK
     selfcheck-overlay: OK
     screen-round-trip: OK
     overlay-to-freeze: OK
     freeze-to-overlay: OK
readmem_writemem_test: OK (52 checks, 25.2s)
readmem-writemem: OK (25.2s)

============================================================
E2E  menu-screen  (overlay)
============================================================
     menu-screen: health: ping=12ms rest=13ms ftp=26ms telnet=35ms ident=15ms dma=11ms raster=50ms jiffy=31ms -> OK
[01] open menu ... OK (0.013s)
[02] GET menu_screen contract ... OK (0.031s)
[03] menu_screen renders a real menu ... OK (0.000s)
[04] close menu ... OK (0.014s)
[05] GET menu_screen unavailable ... OK (0.014s)
[06] GET menu_screen auth ... SKIP (--password not supplied, 0.000s)
menu_screen_test: OK (6 checks, 1.270s)
menu-screen: OK (1.320s)

============================================================
E2E  input  (overlay)
============================================================
     input: health: ping=12ms rest=14ms ftp=20ms telnet=52ms ident=17ms dma=12ms raster=52ms jiffy=737ms -> OK
[01] input snapshot has stable empty response shape ... OK (0.046s)
[02] POST accepts 64 event batch ... OK (0.079s)
[03] bad content-type is rejected without mutation ... OK (0.101s)
[04] missing JSON body is rejected without mutation ... OK (0.079s)
[05] malformed JSON is rejected without mutation ... OK (0.079s)
[06] unknown root field is rejected without mutation ... OK (0.106s)
[07] late invalid event keeps whole batch atomic ... OK (0.091s)
[08] joystick port 2 fire keeps Anykey buttons 2 and 3 released ... OK (0.291s)
[09] joystick port 2 fire2 lights only Anykey button 2 ... OK (0.235s)
[10] joystick port 2 fire3 lights only Anykey button 3 ... OK (0.220s)
[11] joystick port 1 up press is visible on CIA reads ... OK (0.174s)
[12] joystick port 1 all inputs and idempotent release are visible on CIA reads ... OK (0.175s)
[13] joystick port 2 diagonal and fire are visible on CIA reads ... OK (0.186s)
[14] joystick partial release is visible on CIA reads ... OK (0.192s)
[15] joystick fire2/fire3 round-trip through REST state ... OK (0.347s)
[16] joystick release_all then press in same batch is visible on CIA reads ... OK (0.155s)
[17] joystick unusual combination is visible on CIA reads ... OK (0.158s)
[18] joystick tap does not release persistent input ... OK (0.393s)
[19] joystick tap auto releases ... OK (0.369s)
[20] invalid joystick batch does not mutate state ... OK (0.259s)
[21] joystick release_all clears both ports ... OK (0.175s)
[22] machine reset clears keyboard and joystick REST state ... OK (3.195s)
[23] keyboard single-tap batch is consumed by BASIC in order ... OK (0.932s)
[24] keyboard 10 Hz mixed alphabet echo has no missed presses ... OK (5.489s)
[25] keyboard 20 Hz alternating ab echo has no missed presses ... OK (6.288s)
[26] keyboard 5 Hz alternating ab echo has no missed presses ... OK (3.905s)
[27] keyboard single letter reaches the live C64 matrix ... OK (0.241s)
[28] keyboard shifted pair reaches the live C64 matrix ... OK (0.354s)
[29] keyboard batch applies multiple presses atomically ... OK (0.375s)
[30] keyboard ordered batch and idempotent release ... OK (0.106s)
[31] keyboard release_all can be followed by press in same batch ... OK (0.103s)
[32] keyboard accepts eight simultaneous inputs ... OK (0.121s)
[33] keyboard tap does not release persistent key ... OK (0.194s)
[34] keyboard release_all clears state ... OK (0.087s)
[35] keyboard restore tap auto releases ... OK (0.260s)
[36] keyboard special-key taps snapshot correctly and auto release ... OK (2.696s)
[37] keyboard tap is visible in the live hardware snapshot and auto releases ... OK (0.292s)
[38] keyboard cursor-left tap is visible in the live hardware snapshot and auto releases ... OK (0.291s)
[39] keyboard tap batch drains through the live matrix path ... OK (1.311s)
[40] keyboard long repeated tap train drains fully without sticky state ... OK (6.156s)
[41] invalid keyboard batch does not mutate state ... OK (0.062s)
[42] menu editor accepts an unshifted control character ... OK (1.038s)
[43] menu editor keeps separate-batch shift active across POSTs ... OK (2.810s)
[44] menu editor repeats a held printable key ... OK (3.671s)
[45] menu editor stops printable repeat after release ... OK (5.790s)
[46] menu editor accepts a single cursor-left control ... OK (4.601s)
[47] menu editor repeats a held cursor-left control ... OK (4.722s)
[48] menu editor stops cursor repeat after release ... OK (6.232s)
input_test: OK (48 checks, 81.5s)
input: OK (81.6s)

============================================================
E2E  prg-context-menu  (overlay)
============================================================
     prg-context-menu: health: ping=11ms rest=15ms ftp=19ms telnet=49ms ident=14ms dma=10ms raster=51ms jiffy=31ms -> OK
[01] reset the machine to a clean starting state ... OK (2.807s)
[02] seed /Temp with prgmenu65806.prg, prgmenu65806.d64 and a long-named PRG ... OK (0.640s)

--- every context-menu action on a plain PRG
[03] read the context menu of a plain PRG ... OK (2.380s)
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
[04] a plain PRG: every offered action is covered ... OK (0.000s)
[05] Run on a plain PRG ... OK (7.382s)
[06] Load on a plain PRG ... OK (6.102s)
[07] DMA on a plain PRG ... OK (8.137s)
[08] View on a plain PRG ... OK (3.830s)
[09] Hex View on a plain PRG ... OK (3.949s)
[10] Copy to... on a plain PRG ... OK (6.451s)
[11] Rename on a plain PRG ... OK (6.410s)
[12] Move to... on a plain PRG ... OK (6.901s)
[13] Delete on a plain PRG ... OK (3.837s)
--- OK (11 checks, 55.4s)

--- every context-menu action on a PRG inside a D64
[14] read the context menu of a PRG inside a D64 ... OK (3.512s)
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
[15] a PRG inside a D64: every offered action is covered ... OK (0.000s)
[16] Run on a PRG inside a D64 ... OK (8.403s)
[17] Load on a PRG inside a D64 ... OK (7.360s)
[18] DMA on a PRG inside a D64 ... OK (9.204s)
[19] Mount & Run on a PRG inside a D64 ... OK (9.603s)
[20] Real Run on a PRG inside a D64 ... OK (12.8s SLOW)
[21] View on a PRG inside a D64 ... OK (5.143s)
[22] Hex View on a PRG inside a D64 ... OK (5.199s)
[23] Copy to... on a PRG inside a D64 ... OK (8.291s)
[24] Rename on a PRG inside a D64 ... OK (8.099s)
[25] Move to... on a PRG inside a D64 ... OK (9.940s)
[26] Delete on a PRG inside a D64 ... OK (5.723s)
[27] Run a PRG whose name is far longer than the boot-cart display ... OK (8.389s)
--- OK (14 checks, 102s)
prg_context_menu_test: OK (23 actions, 161s)
prg-context-menu: OK (162s)

============================================================
E2E  browser-long-filename  (overlay)
============================================================
     browser-long-filename: health: ping=12ms rest=14ms ftp=14ms telnet=49ms ident=16ms dma=12ms raster=51ms jiffy=30ms -> OK
[01] reset the machine to a clean starting state ... OK (0.581s)
[02] seed long-name fixture for rename ... OK (1.063s)
[03] browser rename on long filename ... OK (7.780s)
[04] reseed long-name fixture for mount ... OK (1.170s)
[05] browser mount on long filename ... OK (5.004s)
browser_long_filename_test: OK (5 checks, 16.0s)
browser-long-filename: OK (17.2s)

============================================================
E2E  browser-filesystem-refresh  (overlay)
============================================================
     browser-filesystem-refresh: health: ping=12ms rest=14ms ftp=12ms telnet=35ms ident=15ms dma=12ms raster=28ms jiffy=41ms -> OK
[01] reset the machine to a clean starting state ... OK (0.616s)
[02] prepare fixture directories ... OK (0.115s)
[03] open Menu, Telnet and FTP on the fixture directory ... OK (4.037s)
[04] rename from the Menu ... OK (3.671s)
[05] rename from Telnet ... OK (3.267s)
[06] rename from FTP ... OK (1.020s)
[07] rename under observer-queue pressure from the Menu ... OK (6.011s)
[08] rename under observer-queue pressure from Telnet ... OK (4.876s)
[09] rename a directory from the Menu ... OK (3.762s)
[10] rename a directory from Telnet ... OK (2.931s)
[11] delete from the Menu ... OK (2.577s)
[12] delete from Telnet ... OK (3.248s)
[13] delete from FTP ... OK (1.023s)
[14] delete a non-empty directory from the Menu ... OK (2.270s)
[15] delete a non-empty directory from Telnet ... OK (2.384s)
[16] remove a directory from FTP ... OK (0.919s)
[17] select all and bulk delete from the Menu ... OK (2.294s)
[18] create from the Menu ... OK (3.431s)
[19] create from Telnet ... OK (3.227s)
[20] create from FTP ... OK (1.401s)
     STOR phase 1 (open, 0 bytes committed): Menu=<empty>; Telnet=<empty>; FTP=<empty>
[21] create from FTP (mkd) ... OK (1.052s)
[22] create from REST (d64) ... OK (0.755s)
[23] create from REST (d71) ... OK (0.960s)
[24] create from REST (d81) ... OK (0.788s)
[25] create from REST (dnp) ... OK (0.779s)
[26] write from the Menu ... OK (2.620s)
[27] write from Telnet ... OK (3.162s)
[28] write from FTP ... OK (1.926s)
     STOR phase 1 (open, truncated): Menu=wftp1.tst[ 100 ]; Telnet=wftp1.tst[ 100 ]; FTP=wftp1.tst[ 100 ]=100
[29] copy over an existing file from the Menu ... OK (11.2s SLOW)
[30] copy over an existing file from Telnet ... OK (10.7s SLOW)
[31] move an entry out of the watched directory from the Menu ... OK (5.732s)
[32] move an entry out of the watched directory from Telnet ... OK (5.279s)
[33] paste into the watched directory from the Menu ... OK (7.990s)
[34] paste into the watched directory from Telnet ... OK (7.240s)
[35] failed rename shows nothing ... OK (0.881s)
[36] failed delete removes nothing ... OK (1.039s)
[37] failed write creates nothing ... OK (0.940s)
[38] short write commits consistently ... OK (1.011s)
     short write committed 100 bytes

operation x origin x observer matrix
------------------------------------------------------------------------------
  rename       Menu    Menu    OK    0.20s
  rename       Menu    Telnet  OK    0.20s
  rename       Menu    FTP     OK    0.20s
  rename       Menu    REST    OK    0.20s
  rename       Telnet  Menu    OK    0.23s
  rename       Telnet  Telnet  OK    0.23s
  rename       Telnet  FTP     OK    0.23s
  rename       Telnet  REST    OK    0.23s
  rename       FTP     Menu    OK    0.32s
  rename       FTP     Telnet  OK    0.32s
  rename       FTP     FTP     OK    0.32s
  rename       FTP     REST    OK    0.32s
  rename-under-load Menu    Menu    OK    0.21s
  rename-under-load Menu    Telnet  OK    0.21s
  rename-under-load Menu    FTP     OK    0.21s
  rename-under-load Menu    REST    OK    0.21s
  rename-under-load Telnet  Menu    OK    0.24s
  rename-under-load Telnet  Telnet  OK    0.24s
  rename-under-load Telnet  FTP     OK    0.24s
  rename-under-load Telnet  REST    OK    0.24s
  rename-dir   Menu    Menu    OK    0.22s
  rename-dir   Menu    Telnet  OK    0.22s
  rename-dir   Menu    FTP     OK    0.22s
  rename-dir   Menu    REST    OK    0.22s
  rename-dir   Telnet  Menu    OK    0.23s
  rename-dir   Telnet  Telnet  OK    0.23s
  rename-dir   Telnet  FTP     OK    0.23s
  rename-dir   Telnet  REST    OK    0.23s
  delete       Menu    Menu    OK    0.29s
  delete       Menu    Telnet  OK    0.29s
  delete       Menu    FTP     OK    0.29s
  delete       Menu    REST    OK    0.29s
  delete       Telnet  Menu    OK    0.23s
  delete       Telnet  Telnet  OK    0.23s
  delete       Telnet  FTP     OK    0.23s
  delete       Telnet  REST    OK    0.23s
  delete       FTP     Menu    OK    0.54s
  delete       FTP     Telnet  OK    0.54s
  delete       FTP     FTP     OK    0.54s
  delete       FTP     REST    OK    0.54s
  delete-dir   Menu    Menu    OK    0.22s
  delete-dir   Menu    Telnet  OK    0.22s
  delete-dir   Menu    FTP     OK    0.22s
  delete-dir   Menu    REST    OK    0.22s
  delete-dir   Telnet  Menu    OK    0.22s
  delete-dir   Telnet  Telnet  OK    0.22s
  delete-dir   Telnet  FTP     OK    0.22s
  delete-dir   Telnet  REST    OK    0.22s
  delete-dir   FTP/rmd Menu    OK    0.27s
  delete-dir   FTP/rmd Telnet  OK    0.27s
  delete-dir   FTP/rmd FTP     OK    0.27s
  delete-dir   FTP/rmd REST    OK    0.27s
  delete-bulk  Menu    Menu    OK    0.20s
  delete-bulk  Menu    Telnet  OK    0.20s
  delete-bulk  Menu    FTP     OK    0.20s
  delete-bulk  Menu    REST    OK    0.20s
  create       Menu    Menu    OK    0.20s
  create       Menu    Telnet  OK    0.20s
  create       Menu    FTP     OK    0.20s
  create       Menu    REST    OK    0.20s
  create       Telnet  Menu    OK    0.22s
  create       Telnet  Telnet  OK    0.22s
  create       Telnet  FTP     OK    0.22s
  create       Telnet  REST    OK    0.22s
  create       FTP     Menu    OK    0.36s
  create       FTP     Telnet  OK    0.36s
  create       FTP     FTP     OK    0.36s
  create       FTP     REST    OK    0.36s
  create       FTP/mkd Menu    OK    0.54s
  create       FTP/mkd Telnet  OK    0.54s
  create       FTP/mkd FTP     OK    0.54s
  create       FTP/mkd REST    OK    0.54s
  create       REST/d64 Menu    OK    0.30s
  create       REST/d64 Telnet  OK    0.30s
  create       REST/d64 FTP     OK    0.30s
  create       REST/d64 REST    OK    0.30s
  create       REST/d71 Menu    OK    0.25s
  create       REST/d71 Telnet  OK    0.25s
  create       REST/d71 FTP     OK    0.25s
  create       REST/d71 REST    OK    0.25s
  create       REST/d81 Menu    OK    0.24s
  create       REST/d81 Telnet  OK    0.24s
  create       REST/d81 FTP     OK    0.24s
  create       REST/d81 REST    OK    0.24s
  create       REST/dnp Menu    OK    0.33s
  create       REST/dnp Telnet  OK    0.33s
  create       REST/dnp FTP     OK    0.33s
  create       REST/dnp REST    OK    0.33s
  write        Menu    Menu    OK    0.22s
  write        Menu    Telnet  OK    0.22s
  write        Menu    FTP     OK    0.22s
  write        Menu    REST    OK    0.22s
  write        Telnet  Menu    OK    0.21s
  write        Telnet  Telnet  OK    0.21s
  write        Telnet  FTP     OK    0.21s
  write        Telnet  REST    OK    0.21s
  write        FTP     Menu    OK    0.56s
  write        FTP     Telnet  OK    0.56s
  write        FTP     FTP     OK    0.56s
  write        FTP     REST    OK    0.56s
  copy-write   Menu    Menu    N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Menu    Telnet  OK    0.18s
  copy-write   Menu    FTP     OK    0.18s
  copy-write   Menu    REST    OK    0.18s
  copy-arrival Menu    Menu    OK    no stale cache on re-entry
  copy-write   Telnet  Telnet  N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Telnet  Menu    OK    0.08s
  copy-write   Telnet  FTP     OK    0.08s
  copy-write   Telnet  REST    OK    0.08s
  copy-arrival Telnet  Telnet  OK    no stale cache on re-entry
  move-out     Menu    Menu    OK    0.24s
  move-out     Menu    Telnet  OK    0.24s
  move-out     Menu    FTP     OK    0.24s
  move-out     Menu    REST    OK    0.24s
  move-out     Telnet  Menu    OK    0.21s
  move-out     Telnet  Telnet  OK    0.21s
  move-out     Telnet  FTP     OK    0.21s
  move-out     Telnet  REST    OK    0.21s
  paste-write  Menu    Menu    OK    0.25s
  paste-write  Menu    Telnet  OK    0.25s
  paste-write  Menu    FTP     OK    0.25s
  paste-write  Menu    REST    OK    0.25s
  paste-write  Telnet  Menu    OK    0.21s
  paste-write  Telnet  Telnet  OK    0.21s
  paste-write  Telnet  FTP     OK    0.21s
  paste-write  Telnet  REST    OK    0.21s
  rename-fail  FTP     Menu    OK    0.20s
  rename-fail  FTP     Telnet  OK    0.20s
  rename-fail  FTP     FTP     OK    0.20s
  rename-fail  FTP     REST    OK    0.20s
  delete-fail  FTP     Menu    OK    0.21s
  delete-fail  FTP     Telnet  OK    0.21s
  delete-fail  FTP     FTP     OK    0.21s
  delete-fail  FTP     REST    OK    0.21s
  write-fail   FTP     Menu    OK    0.20s
  write-fail   FTP     Telnet  OK    0.20s
  write-fail   FTP     FTP     OK    0.20s
  write-fail   FTP     REST    OK    0.20s
  short-write  FTP     Menu    OK    0.26s
  short-write  FTP     Telnet  OK    0.26s
  short-write  FTP     FTP     OK    0.26s
  short-write  FTP     REST    OK    0.26s
------------------------------------------------------------------------------
  N/A=2, OK=140
browser_filesystem_refresh_test: OK (38 checks, 118s)
browser-filesystem-refresh: OK (120s)

============================================================
E2E  ftp-client  (overlay)
============================================================
     ftp-client: health: ping=11ms rest=15ms ftp=27ms telnet=38ms ident=16ms dma=13ms raster=38ms jiffy=667ms -> OK
     inferred --ftp-advertised-host 192.168.1.78
     controlled FTP server on 0.0.0.0:2121 (advertised 192.168.1.78)
[I 2026-08-12 16:21:51] concurrency model: async
[I 2026-08-12 16:21:51] masquerade (NAT) address: 192.168.1.78
[I 2026-08-12 16:21:51] passive ports: 30000->30019
[I 2026-08-12 16:21:51] >>> starting FTP server on 0.0.0.0:2121, pid=29319 <<<
     server root: /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-t1maqobu (marker E2E-1786566111)
[01] GET /v1/version reachable ... OK (0.1, 0.032s)
[02] menu closed -> menu_screen 404 ... OK (0.074s)
[03] menu_button opens menu ... OK (0.328s)
[04] menu_screen returns 2000-byte matrix ... OK (2000 bytes, 0.020s)
[05] input release_all works ... OK (0.040s)
[06] menu closes from anywhere ... OK (0.331s)
[07] remove any stale hosts left by a prior run ... OK (0 removed, 1.345s)

--- stage: smoke
[08] create FTP host 'E2EFTP6111e5a6' through the New Host form ... OK (6.301s)
[09] new alias appears under /ftp ... OK (1.134s)
[10] enter host: server sees login + TYPE I + LIST ... [I 2026-08-12 16:22:01] 192.168.1.62:52432-[] FTP session opened (connect)
[I 2026-08-12 16:22:01] 192.168.1.62:52432-[u64e2e] USER 'u64e2e' logged in.
OK (PASS,TYPE,LIST, 1.219s)
[11] root listing shows fixture entries ... OK (README,DIRA,SMALL, 0.021s)
[12] open README.TXT -> RETR (52 bytes) ... [I 2026-08-12 16:22:04] 192.168.1.62:52432-[u64e2e] RETR /private/var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-t1maqobu/README.TXT completed=1 bytes=52 seconds=0.001
OK (52 bytes, 2.538s)
[13] remove host and confirm it disappears ... [I 2026-08-12 16:22:06] 192.168.1.62:52432-[u64e2e] FTP session closed (disconnect).
OK (3.528s)
--- OK (6 checks, 14.7s)

--- cleanup
     preserved: nothing

--- summary
     Phase    Operation              Result             Commands       Fixture/Notes
     ------------------------------------------------------------------------------
     smoke    create host            OK                                E2EFTP6111e5a6
     smoke    list host              OK                                E2EFTP6111e5a6
     smoke    enter/LIST             OK                 USER/PASS/TYPE E2EFTP6111e5a6
     smoke    root entries           OK                 LIST           README/DIRA/SMALL
     smoke    RETR README            OK                 RETR           README.TXT 52 bytes
     smoke    remove host            OK                                E2EFTP6111e5a6
     ------------------------------------------------------------------------------
     Total REST requests   : 155
     Total menu snapshots  : 65
     Total keyboard events : 102
     Total FTP commands    : 24
     Created host alias    : (removed)
     Remote root path      : /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-t1maqobu
     Cleanup status        : clean
Exception in thread Thread-1 (serve_forever):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/servers.py", line 254, in serve_forever
    self.ioloop.loop(timeout, blocking)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 376, in loop
    poll(timeout)
    ~~~~^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 741, in poll
    kevents = self._kqueue.control(
        None, _len(self.socket_map), timeout
    )
OSError: [Errno 9] Bad file descriptor
ftp-client: OK (18.3s)

============================================================
E2E  prg-load-path-trim  (overlay)
============================================================
     prg-load-path-trim: health: ping=12ms rest=14ms ftp=13ms telnet=37ms ident=28ms dma=11ms raster=43ms jiffy=30ms -> OK

--- Ultimate 64 PRG load path trim
     host: 192.168.1.62
     PUT file path: /Temp/rest-prg-path-trim-target-example.prg
     POST upload name: rest-prg-path-trim-upload-example.prg

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configure Temp Settings
[01] set Temp Auto Cleanup to Enabled ... OK (0.033s)
[02] set Temp Subfolders to Enabled ... OK (0.017s)
--- OK (2 checks, 0.051s)

--- 3. Prepare PRG Fixture
[03] upload PUT fixture rest-prg-path-trim-target-example.prg ... OK (0.196s)
--- OK (1 checks, 0.198s)

--- 4. Validate PUT Endpoints
[04] exercise PUT runners:load_prg ... OK (0.422s)
     PUT load_prg boot-cart name: ...T-EXAMPLE
[05] exercise PUT runners:run_prg ... OK (1.763s)
     PUT run_prg boot-cart name: ...T-EXAMPLE
--- OK (2 checks, 2.376s)

--- 5. Validate POST Endpoints
[06] exercise POST runners:load_prg ... OK (0.448s)
     POST load_prg boot-cart name: ...D-EXAMPLE
[07] exercise POST runners:run_prg ... OK (1.790s)
     POST run_prg boot-cart name: ...D-EXAMPLE
--- OK (2 checks, 3.002s)
prg_load_path_trim_test: OK (7 checks, 6.328s)

--- restore User Interface Settings
[08] set Temp Auto Cleanup to Enabled ... OK (0.014s)
[09] set Temp Subfolders to Enabled ... OK (0.096s)
prg-load-path-trim: OK (7.320s)

============================================================
E2E  temp-auto-cleanup  (overlay)
============================================================
     temp-auto-cleanup: health: ping=12ms rest=13ms ftp=12ms telnet=36ms ident=15ms dma=11ms raster=31ms jiffy=35ms -> OK

--- Ultimate 64 Temp auto cleanup
     host: 192.168.1.62

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configuration Setup
[01] set Temp Auto Cleanup to Enabled ... OK (0.050s)
[02] set Temp Subfolders to Enabled ... OK (0.015s)
--- OK (2 checks, 0.066s)

--- 3. Purging /Temp
     purge complete

--- 4. Mounting D64 Images
[03] create /Temp/mount-drive-8.d64 ... OK (0.055s)
[04] download mount-drive-8.d64 for the upload mount ... OK (0.413s)
[05] remove staging source mount-drive-8.d64 ... OK (0.047s)
[06] mount drive A ... OK (1.083s)
OK (1.083s)
[07] create /Temp/mount-drive-9.d64 ... OK (0.054s)
[08] download mount-drive-9.d64 for the upload mount ... OK (0.420s)
[09] remove staging source mount-drive-9.d64 ... OK (0.042s)
[10] mount drive B ... OK (1.061s)
OK (1.061s)
--- OK (10 checks, 3.174s)

--- 5. Seeding Baseline (10 files)
[11] upload base_1.bin ... OK (1.640s)
[12] upload base_2.bin ... OK (1.607s)
[13] upload base_3.bin ... OK (1.560s)
[14] upload base_4.bin ... OK (1.575s)
[15] upload base_5.bin ... OK (1.689s)
[16] upload base_6.bin ... OK (1.638s)
[17] upload base_7.bin ... OK (1.736s)
[18] upload base_8.bin ... OK (1.640s)
[19] upload base_9.bin ... OK (1.590s)
[20] upload base_10.bin ... OK (1.966s)
--- OK (10 checks, 16.7s)

--- 6. Managed Temp File Limit (Target: 10)
[21] upload managed_1.bin over REST ... OK (4.539s)
     managed count=1 (limit=10)
[22] upload managed_2.bin over REST ... OK (4.545s)
     managed count=2 (limit=10)
[23] upload managed_3.bin over REST ... OK (4.669s)
     managed count=3 (limit=10)
[24] upload managed_4.bin over REST ... OK (4.618s)
     managed count=4 (limit=10)
[25] upload managed_5.bin over REST ... OK (4.603s)
     managed count=5 (limit=10)
[26] upload managed_6.bin over REST ... OK (4.821s)
     managed count=6 (limit=10)
[27] upload managed_7.bin over REST ... OK (4.531s)
     managed count=7 (limit=10)
[28] upload managed_8.bin over REST ... OK (4.579s)
     managed count=8 (limit=10)
[29] upload managed_9.bin over REST ... OK (4.540s)
     managed count=9 (limit=10)
[30] upload managed_10.bin over REST ... OK (4.565s)
     managed count=10 (limit=10)
[31] upload managed_11.bin over REST ... OK (4.582s)
     managed count=10 (limit=10)
[32] upload managed_12.bin over REST ... OK (4.600s)
     managed count=10 (limit=10)
OK (4.967s)
OK (5.065s)
--- OK (14 checks, 60.1s)

--- 7. Unmounted Uploads Rejoin Cleanup
[33] remove drive A ... OK (0.159s)
[34] upload post_a_1.bin over REST ... OK (4.710s)
OK (4.804s)
     removed after 1 uploads
[35] remove drive B ... OK (0.147s)
[36] upload post_b_1.bin over REST ... OK (4.585s)
     removed after 1 uploads
--- OK (5 checks, 10.1s)

--- 8. Final Integrity Check
     user files intact
temp_auto_cleanup_test: OK (36 checks, 93.1s)

--- restore User Interface Settings
[37] set Temp Auto Cleanup to Enabled ... OK (0.014s)
[38] set Temp Subfolders to Enabled ... OK (0.014s)
temp-auto-cleanup: OK (93.7s)

============================================================
E2E  cfg-single-group  (overlay)
============================================================
     cfg-single-group: health: ping=12ms rest=13ms ftp=27ms telnet=35ms ident=15ms dma=12ms raster=38ms jiffy=39ms -> OK
[01] load a one-group CFG file through the browser ... OK (7.679s)
[02] only the CFG group is considered after loading ... OK (0.103s)
cfg_single_group_test: OK (2 checks, 8.245s)
cfg-single-group: OK (8.904s)

============================================================
E2E  printer  (overlay)
============================================================
     printer: health: ping=11ms rest=13ms ftp=13ms telnet=48ms ident=17ms dma=10ms raster=41ms jiffy=43ms -> OK
[01] REST reachable at 192.168.1.62 ... OK (0.017s)
[02] reset before run ... OK (0.150s)
[03] load printer_e2e.prg ... OK (914 bytes, 0.000s)
[04] capture original Printer Settings ... OK (0.220s)
[05] print epson/bitmap: apply settings + run PRG ... OK (phase=printer closed heartbeat=4, 3.024s)
[06] print epson/bitmap: Flush/Eject via on-screen menu ... OK (3.834s)

--- restoring original Printer Settings
     IEC printer: Disabled
     Bus ID: 4
     Output file: /Usb0/printer
     Output type: PNG B&W
     Ink density: Medium
     Page top margin (default is 5): 5
     Page height (default is 60): 60
     Emulation: Commodore MPS
     Commodore charset: USA/UK
     Epson charset: Basic
     IBM table 2: International 1

--- summary
     epson      bitmap PASS_NO_VERIFY       /USB1/printer/e2e-eb40e2
printer: OK (8.458s)

============================================================
E2E  uci-targets  (overlay)
============================================================
     uci-targets: health: ping=11ms rest=13ms ftp=13ms telnet=36ms ident=16ms dma=11ms raster=29ms jiffy=41ms -> OK
[01] reset the C64 so the command interface starts idle ... OK (3.094s)
[02] read 'C64 and Cartridge Settings' ... OK (0.026s)
     current: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}
[03] enable the Command Interface registers at $DF1B-$DF1F ... OK (0.120s)
[04] transport: an empty command returns an empty reply ... OK (0.204s)
     <empty> -> 0.04s, data b'', status b''
[05] transport: unregistered target answers IDENTIFY ... OK (0.802s)
     0f 01 -> 0.08s, data b'NO TARGET', status b'00,OK'
[06] transport: unregistered target rejects anything else ... OK (0.837s)
     0f 7f -> 0.08s, data b'', status b'21,UNKNOWN COMMAND'
[07] transport: a no-reply command returns straight to Idle ... OK (0.163s)
[08] transport: pushing while a reply is pending sets and clears ERROR ... OK (1.317s)
[09] transport: the next command is not prefixed by leftover bytes ... OK (1.129s)
     04 28 00 -> 0.10s, data b'Ultimate 64 Elite', status b'00,OK'
[10] transport: ABORT releases a pending reply back to Idle ... OK (0.185s)
[11] control-target: IDENTIFY answers with the target name ... OK (1.068s)
     04 01 -> 0.07s, data b'CONTROL TARGET V1.1', status b'00,OK'
[12] control-target: an unimplemented command is reported as unknown ... OK (0.881s)
     04 7f -> 0.07s, data b'', status b'21,UNKNOWN COMMAND'
[13] control-target: LOAD_REU without a filename is rejected, not run ... OK (0.979s)
     04 08 -> 0.08s, data b'', status b'81,INVALID PARAMS'
[14] control-target: SAVE_REU without a filename is rejected, not run ... OK (0.876s)
     04 09 -> 0.07s, data b'', status b'81,INVALID PARAMS'
[15] control-target: GET_HWINFO rejects a device number it does not have ... OK (0.907s)
     04 28 02 -> 0.09s, data b'', status b'81,INVALID PARAMS'
[16] issue-740-matrix: confirm /Temp/uci_e2e_absent.reu does not exist ... OK (0.018s)
[17] issue-740-matrix: put a 16384-byte image at /Temp/uci_e2e_present.reu ... OK (0.198s)
[18] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... OK (4.507s)
     04 08 52 45 55 2e 49 4d 47 -> 0.25s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[19] issue-740-matrix: REU Enabled, image absent, name at offset 4 ... OK (4.503s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.26s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[20] issue-740-matrix: REU Disabled, image absent, name at offset 2 ... OK (1.306s)
     04 08 52 45 55 2e 49 4d 47 -> 0.22s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[21] issue-740-matrix: REU Disabled, image absent, name at offset 4 ... OK (1.336s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.29s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[22] issue-740-matrix: REU Enabled, image present, name at offset 2 ... OK (3.448s)
     04 08 52 45 55 2e 49 4d 47 -> 0.20s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[23] issue-740-matrix: REU Enabled, image present, name at offset 4 ... OK (3.466s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.30s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[24] save-reu-offset-past-end: put the preload offset at the end of a 128 KB REU ... OK (0.045s)
[25] save-reu-offset-past-end: SAVE_REU reports the offset and saves nothing ... OK (3.472s)
     04 09 52 45 55 2e 49 4d 47 -> 0.20s, data b'\xfd\xff\xff\xffREU SAVE: OFFSET 131072 >= REU SIZE 131072, SKIPPING', status b'86,REU OFFSET > SIZE. NOT SAVED'
[26] load-reu-disabled: disable the REU ... OK (0.015s)
[27] load-reu-disabled: leave text in the reply buffer from a previous command ... OK (0.986s)
     04 28 00 -> 0.09s, data b'Ultimate 64 Elite', status b'00,OK'
[28] load-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.243s)
     04 08 52 45 55 2e 49 4d 47 -> 0.19s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[29] save-reu-disabled: disable the REU ... OK (0.016s)
[30] save-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.027s)
     04 28 00 -> 0.09s, data b'Ultimate 64 Elite', status b'00,OK'
[31] save-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.125s)
     04 09 52 45 55 2e 49 4d 47 -> 0.20s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[32] softiec-single-part-reply: SoftIEC target answers IDENTIFY ... OK (1.446s)
     05 01 -> 0.07s, data b'SOFTWARE IEC TARGET V1.0', status b'00,OK'
[33] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... OK (0.585s)
     05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 -> 0.40s, data b'', status b'\x01'
[34] softiec-single-part-reply: GET_FATNAME reply completes in one part ... OK (0.581s)
     05 22 02 23 -> 0.10s, data b'/buffer', status b'\x00'
[35] softiec-single-part-reply: an unimplemented SoftIEC command is reported as unknown ... OK (0.270s)
     05 7f -> 0.09s, data b'', status b'\x04'
[36] interface-usable-after: the control target still answers IDENTIFY ... OK (1.097s)
     04 01 -> 0.07s, data b'CONTROL TARGET V1.1', status b'00,OK'
     restored C64 and Cartridge Settings: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}

--- summary
     transport: OK
     control-target: OK
     issue-740-matrix: OK
     save-reu-offset-past-end: OK
     load-reu-disabled: OK
     save-reu-disabled: OK
     softiec-single-part-reply: OK
     interface-usable-after: OK
     cleanup: OK
uci_targets_test: OK (36 checks, 43.7s)
uci-targets: OK (43.7s)

============================================================
E2E  machine-code-monitor  (overlay)
============================================================
     machine-code-monitor: health: ping=12ms rest=14ms ftp=13ms telnet=50ms ident=20ms dma=16ms raster=48ms jiffy=31ms -> OK
[01] initial CPU7/KERNAL monitor status ... OK (0.037s)
[02] KERNAL $E000 hex view and REST match ... OK (0.631s)
[03] paging away and back keeps memory view stable ... OK (0.680s)
[04] KERNAL disassembly formatting ... OK (1.484s)
[05] KERNAL $E010 REST match ... OK (0.969s)
[06] CPU6 RAM under BASIC write/read ... OK (4.632s)
[07] CPU5 RAM under KERNAL status ... OK (2.916s)
[08] ASCII view width and scrolling ... OK (7.224s)
[09] ASCII and Screen mapping semantics ... OK (11.9s SLOW)
[10] HEX edit writes both nibbles ... OK (2.856s)
[11] CPU bank cycling reaches CHAR and RAM mappings ... OK (3.529s)
[12] COMPARE reports differing address ... OK (4.141s)
[13] G executes finite loop and returns to monitor ... OK (2.357s)
[14] G repeated execution updates RAM sentinel ... OK (7.499s)
[15] G handoff preserves stable VIC state ... SKIP (the on-device UI owns the VIC while it is up; only comparable over telnet, 0.000s)
OK (0.000s)
[16] bookmarks recall, set, list, and label edit ... OK (7.557s)
[17] memory bookmark jump restores width 16 ... OK (5.689s)
[18] binary width cycling and bookmark jump restores width 4 ... OK (6.479s)
[19] follow and return navigation ... OK (5.373s)
[20] asm edit mnemonic validation and Return advance ... OK (7.972s)
[21] number popup arithmetic ... OK (2.752s)
[22] save/load round-trip to top-level /Temp file ... OK (9.226s)
[23] save/load round-trip to file in new /Temp D64 ... OK (18.2s SLOW)

--- Telnet transport checks
[24] telnet blocks poll mode ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
[25] telnet opcode dropdown scroll does not flood the connection ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
--- SKIP (4 checks, 0.180s)
monitor_test: OK (25 checks, 116s)
machine-code-monitor: OK (116s)

============================================================
E2E  ftp-server  (overlay)
============================================================
     ftp-server: health: ping=12ms rest=13ms ftp=23ms telnet=35ms ident=15ms dma=11ms raster=35ms jiffy=41ms -> OK

--- a name the listing reports can address the file it names
[01] a 40-character name is listed unchanged ... OK (0.086s)
[02] that file is removed by the name the listing reported ... OK (0.100s)
[03] a 100-character name is listed unchanged ... OK (0.101s)
     100 characters survived the listing
[04] SIZE answers for the long name the listing reported ... OK (0.048s)
[05] that file is removed by the name the listing reported ... OK (0.086s)
--- OK (5 checks, 0.534s)
ftp_server_test: OK (5 checks, 0.537s)
ftp-server: OK (0.587s)

============================================================
E2E  assembly64  (overlay)
============================================================
     assembly64: health: ping=13ms rest=13ms ftp=17ms telnet=55ms ident=17ms dma=10ms raster=48ms jiffy=29ms -> OK

--- the form opens from the task menu and closes again
[01] open the Assembly 64 query form ... OK (0.855s)
[02] the form leaves cleanly with RUN/STOP ... OK (0.524s)
--- OK (2 checks, 1.579s)

--- a real query is sent to the Assembly 64 service
[03] open the form and enter the first field ... OK (1.205s)
[04] the typed term lands in the Name field ... OK (0.716s)
[05] the service answers and the results match what was asked for ... OK (1.108s)
--- OK (3 checks, 3.523s)

--- the menu button must work from inside the edit field
[06] open the form and enter the edit field ... OK (1.086s)
[07] the menu button closes the menu from inside the field ... OK (0.107s)
[08] the menu opens again, so the UI task left string_edit ... OK (0.036s)
--- OK (3 checks, 1.800s)

--- an aborted edit must not wedge the form
[09] open the form, type into a field, then abort ... OK (1.777s)
[10] the form is still usable after the abort ... OK (0.017s)
--- OK (2 checks, 2.297s)

--- over-long and empty input
[11] type more than the field accepts ... OK (2.294s)
[12] an empty query is refused rather than sent ... OK (2.986s)
[13] the warning is dismissed and the form is still usable ... OK (0.313s)
--- OK (3 checks, 6.075s)

--- a user mashing keys while the form is busy
[14] submit a query and hammer keys while it runs ... OK (5.104s)
[15] the device is still answering after the mashing ... OK (0.013s)
--- OK (2 checks, 5.772s)

--- opening and abandoning the form repeatedly
[16] open and abandon the form three times ... OK (3.374s)
[17] the menu button closes and reopens the form three times ... OK (3.630s)
--- OK (2 checks, 7.291s)
assembly64_test: OK (17 checks, 28.8s)
assembly64: OK (28.8s)

============================================================
E2E  freeze-menu  (overlay)
============================================================
     freeze-menu: health: ping=12ms rest=28ms ftp=73ms telnet=43ms ident=24ms dma=12ms raster=31ms jiffy=57ms -> OK
     captured 'Interface Type'=Freeze, 'Auto Address Mirroring'=Enabled

--- menu cycle with Auto Address Mirroring Disabled
[01] select 'Freeze' interface with mirroring disabled ... OK (0.028s)
[02] C64 running before the menu is opened ... OK (1.058s)
[03] open the menu ... OK (0.290s)
[04] C64 frozen while the menu is open ... OK (0.545s)
[05] close the menu ... OK (0.295s)
[06] C64 resumed after the menu closed ... OK (0.532s)
--- OK (6 checks, 2.780s)

--- Auto Address Mirroring switched off while the menu is open
[07] select 'Freeze' interface with mirroring enabled ... OK (0.028s)
[08] C64 running before the menu is opened ... OK (0.537s)
[09] open the menu ... OK (0.289s)
[10] C64 frozen while the menu is open ... OK (0.535s)
[11] set Auto Address Mirroring to Disabled while the menu is open ... OK (0.015s)
[12] close the menu ... OK (0.277s)
[13] C64 resumed after the menu closed ... OK (0.529s)
--- OK (7 checks, 2.235s)

--- menu cycle with Auto Address Mirroring Enabled
[14] select 'Freeze' interface with mirroring enabled ... OK (0.042s)
[15] C64 running before the menu is opened ... OK (0.532s)
[16] open the menu ... OK (0.300s)
[17] C64 frozen while the menu is open ... OK (0.549s)
[18] close the menu ... OK (0.295s)
[19] C64 resumed after the menu closed ... OK (0.531s)
--- OK (6 checks, 2.270s)

--- reopen the freezer menu with a context menu left open
[20] select 'Freeze' interface with mirroring enabled ... OK (0.029s)
[21] C64 running before the menu is opened ... OK (0.536s)
[22] open the menu ... OK (0.291s)
[23] C64 frozen while the menu is open ... OK (0.534s)
[24] open the context menu on the first browser entry ... OK (7.573s)
[25] close the menu ... OK (0.291s)
[26] C64 resumed after the menu closed ... OK (0.541s)
[27] reopen the menu with the context menu still on the object stack ... OK (0.283s)
[28] dismiss the restored context menu ... OK (0.271s)
[29] close the menu ... OK (0.290s)
[30] C64 resumed after the menu closed ... OK (0.544s)
--- OK (11 checks, 11.2s)

--- the menu button works inside the Assembly 64 query form
[31] select 'Freeze' interface with mirroring enabled ... OK (0.031s)
[32] C64 running before the menu is opened ... OK (0.546s)
[33] open the menu ... OK (0.287s)
[34] C64 frozen while the menu is open ... OK (0.543s)
[35] open the task menu ... OK (0.329s)
[36] open the Assembly 64 query form ... OK (0.300s)
[37] enter the form's first edit field ... OK (0.300s)
[38] the menu button closes the menu from inside the edit field ... OK (0.314s)
[39] the menu opens again afterwards ... OK (0.289s)
[40] leave the query form ... OK (0.395s)
[41] close the menu ... OK (0.283s)
[42] C64 resumed after the menu closed ... OK (0.533s)
--- OK (12 checks, 4.297s)
freeze_menu_test: OK (42 checks, 24.0s)
freeze-menu: OK (24.0s)

TEARDOWN (overlay): release input ... OK (0.019s)
TEARDOWN (overlay): close active menu UI ... OK (0.043s)
TEARDOWN (overlay): reset machine ... OK (0.066s)

============================================================
Summary
============================================================
     OK   e2e overlay    767s (19 ok)
     slowest: prg-context-menu 162s, browser-filesystem-refresh 120s, machine-code-monitor 116s
     767s in suites, 29.2s in health checks, the UI-state gate and teardown
     797s total

OK  all 19 suite runs passed.
```

</details>
