### PR TITLE
Free the directory listings that get_directory hands out

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -195,6 +195,14 @@ SUITES: Sequence[Suite] = (
     Suite("soak", "assembly-search-leak",
           "tests/soak/io/c64/assembly_search_leak_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
+    # Drives the filesystem-refresh matrix, the only way to reach the browser's
+    # bookkeeping for files that change underneath it: the entry it drops when a
+    # file is removed, and the listings the file manager builds to delete a
+    # directory recursively. Neither is visible over REST. Each iteration is a
+    # full matrix run, so this is the slowest suite in the soak set.
+    Suite("soak", "browser-refresh-leak",
+          "tests/soak/filemanager/browser_refresh_leak_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     # The stress profile is the bounded one, at about two minutes. The soak
     # profile runs for twelve hours, so it is opt-in through --soak-profile.
     Suite("soak", "network-connection", "tests/soak/network/connection_test.py",

--- a/software/filemanager/filemanager.cc
+++ b/software/filemanager/filemanager.cc
@@ -522,6 +522,17 @@ FRESULT FileManager::open_directory(const char *path, Directory **dir, FileInfo 
     return res;
 }
 
+// get_directory() fills the list with copies it hands to the caller, so the
+// list and its contents have to be freed separately. Deleting only the list
+// strands every FileInfo in it, each one carrying its own name buffer.
+static void delete_directory_list(IndexedList<FileInfo *> *list)
+{
+    for (int i = 0; i < list->get_elements(); i++) {
+        delete (*list)[i];
+    }
+    delete list;
+}
+
 FRESULT FileManager::get_directory(Path *p, IndexedList<FileInfo *> &target, const char *matchPattern)
 {
     lock();
@@ -1050,7 +1061,7 @@ FRESULT FileManager::delete_recursive(Path *path, const char *name)
             } else {
                 ret = get_dir_result;
             }
-            delete dirlist;
+            delete_directory_list(dirlist);
             path->cd("..");
         }
         // After recursive deletion, the dir should be empty.
@@ -1227,7 +1238,7 @@ FRESULT FileManager::fcopy(const char *path, const char *filename, const char *d
                 else {
                     ret = get_dir_result;
                 }
-                delete dirlist;
+                delete_directory_list(dirlist);
             }
             else {
                 ret = dir_create_result;

--- a/software/userinterface/system_info.cc
+++ b/software/userinterface/system_info.cc
@@ -149,6 +149,11 @@ void SystemInfo :: storage_info(StreamTextLog& b)
             b.format("%14s%s\n", inf->lfname, FileSystem :: get_error_string(fres));
         }
     }
+
+    // The list is a local, but the FileInfos in it are ours to free.
+    for(int i=0; i<dir.get_elements(); i++) {
+        delete dir[i];
+    }
 }
 
 void SystemInfo :: generate(UserInterface *ui)

--- a/tests/soak/filemanager/browser_refresh_leak_test.py
+++ b/tests/soak/filemanager/browser_refresh_leak_test.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Soak: asserts the browser gives back the heap it spends tracking file changes.
+
+"""Repeat the filesystem-refresh matrix and require the free heap to come back.
+
+Two leaks lived on this path, and neither is visible over REST -- both need a
+browser open on a directory while its contents change underneath:
+
+  1. A removed entry was unlinked from the browser's list and left. A
+     BrowsableDirEntry owns a FileInfo, a FileType, its generated FAT name and a
+     FileManager path reference, so every file that disappeared under an open
+     browser stranded all of it, about 300 bytes and one path handle.
+
+  2. FileManager::get_directory() fills the caller's list with FileInfo copies
+     the caller owns. delete_recursive() and fcopy() freed the list and not its
+     contents, so a recursively deleted directory stranded one FileInfo per
+     entry.
+
+Together they cost 16,656 bytes per run of the e2e suite this one drives.
+
+The suite is run the way the runner runs it, as a subprocess, rather than by
+importing it and re-driving its rows: it opens a Menu, a Telnet session and an
+FTP connection on the same directory and its setup is what makes those three
+agree. Reproducing that here would fork the part most likely to drift.
+
+Method: measure the steady-state slope, never a single before/after. The first
+iteration pays one-time costs -- lazy singletons, first-touch filesystem
+structures, the browser's own caches -- that never come back and are not leaks,
+so those land entirely in the warmup. Each measured block settles before its
+closing sample, because an FTP session borrows several KB and returns it
+seconds later.
+
+Uses GET /v1/machine:heap. Firmware predating that endpoint answers 404 and
+every check here skips, so the suite is safe to run against any image.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# tests/lib holds the reporting rules and the shared REST client.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+
+import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
+from report import (  # noqa: E402
+    Failure, check, check_ok, check_skip, check_start, detail, format_exception,
+    section, suite_fail, suite_ok)
+
+HEAP_PATH = "/v1/machine:heap"
+SUITE = (Path(__file__).resolve().parents[2]
+         / "e2e" / "filemanager" / "browser_filesystem_refresh_test.py")
+
+# One-time costs land here.
+WARMUP = 1
+# Each iteration is a full matrix run of about two minutes, so three is the most
+# a soak run should spend on this. It is enough: what this guards was 16.6 KB
+# per run, and the fixed firmware sits within a few dozen bytes of flat.
+MEASURED = 3
+# Comfortably above the observed noise (28, -8, -24 bytes across three runs on
+# the fixed firmware) and far below either leak. The smaller of the two was 696
+# bytes per run on its own, so this still fails if only that one comes back.
+TOLERANCE_BYTES_PER_OP = 250
+SETTLE_SECONDS = 8.0
+
+
+def heap_free(rest: rest_lib.RestClient) -> int:
+    return int(rest.json(HEAP_PATH)["free"])
+
+
+def run_suite(host: str, password: str, timeout: float) -> None:
+    """One full matrix run. A failing run is not a leak verdict, so it stops us."""
+    result = subprocess.run(
+        [sys.executable, str(SUITE), "-H", host, "-p", password or "", "-t", str(timeout)],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if result.returncode != 0:
+        tail = "\n".join(result.stdout.splitlines()[-15:])
+        raise Failure(
+            "the filesystem-refresh suite failed, so its heap figure means "
+            f"nothing:\n{tail}")
+
+
+def measure_slope(rest: rest_lib.RestClient, host: str, password: str,
+                  timeout: float) -> bool:
+    section("the browser returns the heap it spends tracking file changes")
+
+    with check(f"warm up ({WARMUP} matrix run, one-time costs land here)"):
+        for _ in range(WARMUP):
+            run_suite(host, password, timeout)
+        time.sleep(SETTLE_SECONDS)
+
+    seen = {}
+    try:
+        with check(f"free heap is flat across {MEASURED} more matrix runs"):
+            before = heap_free(rest)
+            for _ in range(MEASURED):
+                run_suite(host, password, timeout)
+            time.sleep(SETTLE_SECONDS)
+            after = heap_free(rest)
+            consumed = before - after
+            seen.update(before=before, after=after, consumed=consumed,
+                        per_op=consumed / MEASURED)
+            if seen["per_op"] > TOLERANCE_BYTES_PER_OP:
+                raise Failure(
+                    f"the browser leaks about {seen['per_op']:.0f} bytes per "
+                    f"matrix run ({consumed} bytes over {MEASURED} runs)")
+        ok = True
+    except Failure:
+        ok = False
+    if seen:
+        detail(f"free before {seen['before']}, after {seen['after']}")
+        detail(f"consumed {seen['consumed']} bytes over {MEASURED} runs "
+               f"= {seen['per_op']:.0f} bytes/run "
+               f"(tolerance {TOLERANCE_BYTES_PER_OP})")
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assert that repeated filesystem-refresh runs do not consume "
+                    "heap. Skips if the firmware has no machine:heap endpoint.")
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "30.0")))
+    args = parser.parse_args()
+
+    rest = rest_lib.RestClient(args.host, args.password or None, args.timeout)
+
+    check_start("device exposes GET /v1/machine:heap")
+    if rest.status("GET", HEAP_PATH) != 200:
+        check_skip("firmware predates GET /v1/machine:heap, nothing to measure")
+        section("summary")
+        detail("skipped: device firmware has no machine:heap endpoint")
+        suite_ok("browser_refresh_leak_test")
+        return 0
+    check_ok()
+
+    ok = measure_slope(rest, args.host, args.password, args.timeout)
+
+    section("summary")
+    detail(f"filesystem-refresh slope: {'OK' if ok else 'FAIL'}")
+    if ok:
+        suite_ok("browser_refresh_leak_test")
+        return 0
+    suite_fail("browser_refresh_leak_test", "see the summary above")
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        suite_fail("browser_refresh_leak_test", format_exception(exc))
+        raise SystemExit(1)


### PR DESCRIPTION
`FileManager::get_directory()` fills the caller's list with `new FileInfo`
copies, so the list and its contents have to be freed separately. Three callers
freed only the list:

- `FileManager::delete_recursive()`
- the directory branch of `FileManager::fcopy()`
- `SystemInfo::storage_info()`, whose list is a local, so it frees nothing at all

Every entry stranded a `FileInfo` and the name buffer it carries, about 170
bytes each.

The rule is already written down twice in the tree -- `vfs_closedir()` and the
MPS printer both delete the entries before the list, the latter with a
`// FileInfo not needed anymore` comment, and `BrowsableDirEntry::getSubItems()`
notes that it passes ownership on instead. These three just missed it, so the
two in `filemanager.cc` now share a helper that states the rule once.

`SystemInfo::storage_info()` is the one that matters outside a test run: it
leaks one `FileInfo` per root entry every time the System Information page is
opened.

## How it was isolated

An allocation tracker, reset before the run, then the `browser-filesystem-refresh`
suite run twice. The `FileInfo` copies went from 7 live to 11 while every other
allocation site stayed flat, so four per run were being stranded rather than
merely being the listing on screen. Four copies at 172 bytes is 688, and the
measured slope was 696 including one block header.

## Measurement

Ultimate 64 Elite, warm slope over `GET /v1/machine:heap`, settling before each
sample:

| build | bytes per run |
|---|---:|
| `test-merge` | 16,364 / 16,648 / 16,656 |
| with #772 | 704 / 688 / 692 |
| with #772 and this | 28 / -8 / -24 |

The first step is #772; this is the second.

## The soak suite

Nothing measured this path. The e2e suite asserts that Menu, Telnet and FTP
converge on the same file system, which it did just as happily while the
browser leaked 16.6 KB per run -- it never looks at the heap.

`browser-refresh-leak` runs the matrix as a subprocess, the way the runner does,
and requires the free heap back. Proven in both directions on hardware:

| build | verdict |
|---|---|
| #772 + this fix | 0 bytes over 3 runs, **passes** |
| #772 alone | 688 bytes/run against a 250-byte tolerance, **fails** |

**It depends on #772.** Without it the entry a browser drops on removal is
stranded and this suite fails at about 16.6 KB per run, so this PR should land
after that one.

One rough edge worth knowing: the underlying matrix suite can fail on a device
that has just booted, and a failed run yields no heap verdict, so this suite
stops rather than reporting a number. It passed on the same device once
settled. I have deliberately not added a retry inside the suite -- the runner
already owns health checks and retries, and a second mechanism inside a suite
is how the two end up disagreeing.

## Testing

Full default E2E suite set against firmware 3.15, FPGA core 123, core version
1.4B, in overlay mode. All 19 suite runs passed, exit 0, no recovery invoked.
`filemanager.cc` is on every filesystem path, and `temp-auto-cleanup`,
`ftp-client` and `prg-context-menu` all exercise the recursive delete and the
directory copy that now free these entries, so the run covers the risk of
freeing something still referenced.

**Disclosure: that gate was run on a build carrying this branch and #772
together, not on this branch alone.** The soak suite added here requires both,
so a build of this branch by itself cannot demonstrate the slope it asserts.
The E2E result is unaffected by which of the two is present -- neither changes
observable behaviour -- but the log below is not from a build of this branch in
isolation, and I would rather say so than let it be assumed.

The `ftp=FAIL` lines below are the runner's own health-check self-tests driving
a fake device, not the real one.

<details>
<summary>Full <code>./run-tests</code> output</summary>

```

============================================================
Ultimate hardware test run
============================================================
     host:       192.168.1.62
     categories: e2e
     modes:      overlay
     timeout:    30.0s
     on failure: continue
     health:    answers + health sweep, retry after recovery

============================================================
E2E  transport-usage  (overlay)
============================================================
     transport-usage: health: ping=13ms rest=14ms ftp=14ms telnet=47ms ident=19ms dma=14ms raster=42ms jiffy=100ms -> OK
check_transport_usage: OK (43 files, 0.197s)
transport-usage: OK (0.233s)

============================================================
E2E  runner-policy  (overlay)
============================================================
     runner-policy: health: ping=12ms rest=29ms ftp=14ms telnet=38ms ident=16ms dma=25ms raster=34ms jiffy=68ms -> OK
[01] a clean run exits 0 ... OK (0.000s)
[02] a failed suite exits 1 ... OK (0.000s)
[03] a recovery with no failure exits 3 ... OK (0.000s)
[04] a failure outranks a recovery ... OK (0.000s)
[05] a device that cannot be made healthy exits 4, outranking a failure ... OK (0.000s)
[06] a device that answers is never recovered ... OK (0.000s)
[07] recovery runs only once the ordinary wait has given up ... OK (0.006s)
     fixture: the device is unhealthy: it is not answering
[08] a recovery that does not bring the device back reports so ... OK (0.070s)
     fixture: the device is unhealthy: it is not answering
[09] a recovery command that exits non-zero is still followed by a probe ... OK (0.006s)
     fixture: the device is unhealthy: it is not answering
[10] a recovery command that hangs is bounded by --recover-timeout ... OK (0.203s)
     fixture: the device is unhealthy: it is not answering
[11] a recovery command the shell cannot find is a failed recovery ... OK (0.069s)
     fixture: the device is unhealthy: it is not answering
[12] no recovery command means no recovery ... OK (0.000s)
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: no --recover-command was given
[13] a suite gives up after --recover-max-per-suite recoveries ... OK (0.146s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
[14] the per-suite budget starts again at the next suite ... OK (0.063s)
     fixture: the device is unhealthy: it is not answering
[15] the run gives up after --recover-max-total recoveries ... OK (0.137s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
[16] the refusal says which ceiling was reached ... OK (0.072s)
     fixture: the device is unhealthy: it is not answering
[17] a healthy sweep after a failed suite recovers nothing ... OK (0.002s)
     fixture: health: rest=9ms -> OK
[18] a degraded but reachable device is recovered ... OK (0.014s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms -> OK
[19] a device still degraded after recovering is reported, not retried ... OK (0.010s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
[20] a degraded device is not recovered past its ceiling ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: not recovering: the run has already used its 1 recoveries
[21] --no-health-check takes the sweep out of the decision ... OK (0.000s)
[22] --no-health-check still recovers a device that has gone ... OK (0.070s)
     fixture: the device is unhealthy: it is not answering
[23] consecutive resets collapse into one ... OK (0.000s)
[24] a read between two resets does not warrant the second ... OK (0.000s)
[25] a mutating call between two resets warrants the second ... OK (0.000s)
[26] force resets even when nothing has changed ... OK (0.000s)
[27] a suite told the device was just reset does not reset again ... OK (0.000s)
[28] a suite not told that still resets ... OK (0.000s)
[29] a suite that fails on a healthy device is not run again ... OK (0.021s)
[30] a suite that fails on an unhealthy device runs again after recovery ... OK (0.064s)
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
[31] --no-retry keeps the recovery and drops the extra attempt ... OK (0.021s)
[32] a device that cannot be made healthy ends the run ... OK (0.022s)
fixture: OK (1.500s)
[33] a health sweep reaches the JSONL with a latency per check ... OK (0.000s)
[34] a suite record carries the profile, attempt and recoveries ... OK (0.000s)
[35] the run record agrees with the exit status ... OK (0.000s)
[36] a sweep with every check passing is healthy ... OK (0.000s)
[37] a failed check makes the sweep degraded and names it ... OK (0.000s)
[38] a skipped check never makes the sweep degraded ... OK (0.000s)
[39] the one-line summary carries every latency and the verdict ... OK (0.000s)
     the recovery command runs on a degraded or unreachable device, never on a suite that merely failed
runner_policy_test: OK (39 checks, 1.028s)
runner-policy: OK (1.085s)

============================================================
E2E  ui-backend-smoke  (overlay)
============================================================
     ui-backend-smoke: health: ping=12ms rest=15ms ftp=13ms telnet=41ms ident=19ms dma=12ms raster=27ms jiffy=53ms -> OK

--- Overlay navigation planner
[01] a unique first letter jumps straight to the item ... OK (0.000s)
[02] a shared first letter extends the prefix rather than walking ... OK (0.000s)
[03] walking wins when the item is already next to the cursor ... OK (0.000s)
[04] the seek lands on the first match and the walk covers the rest ... OK (0.000s)
[05] a prefix never contains a space, which selects rather than seeks ... OK (0.000s)
[06] a plan is never longer than walking from the top ... OK (0.000s)
[07] an upward walk is planned when that is the shorter route ... OK (0.000s)
--- OK (7 checks, 0.000s)

--- Telnet backend
[08] Telnet: connect, navigate, teardown ... OK (1.929s)
--- OK (1 checks, 1.929s)

--- REST backend, Interface Type = Freeze
[09] REST/Freeze: connect, navigate, teardown ... OK (3.000s)
--- OK (1 checks, 3.000s)

--- REST backend, Interface Type = Overlay on HDMI
[10] REST/Overlay: connect, navigate, teardown ... OK (3.311s)
--- OK (1 checks, 3.311s)
ui_backend_smoke_test: OK (10 checks, 8.252s)
ui-backend-smoke: OK (8.324s)

============================================================
E2E  readmem-writemem  (overlay)
============================================================
     readmem-writemem: health: ping=12ms rest=15ms ftp=44ms telnet=38ms ident=20ms dma=30ms raster=41ms jiffy=57ms -> OK
[01] reset C64 to a clean, stable state ... OK (0.026s)
[02] read User Interface Settings config ... OK (0.022s)
     current Interface Type: Freeze

--- bounds: readmem rejects out-of-range parameters before allocating, and max-size reads do not degrade the device
[03] readmem rejects zero length ... OK (0.027s)
[04] readmem rejects negative length ... OK (0.026s)
[05] readmem rejects length one past the 64KB cap ... OK (0.015s)
[06] readmem rejects length far past the cap ... OK (0.019s)
[07] readmem rejects length that overflows a long ... OK (0.018s)
[08] readmem rejects read running past $FFFF ... OK (0.027s)
[09] readmem rejects address above $FFFF ... OK (0.026s)
[10] readmem rejects negative address ... OK (0.016s)
[11] 8 back-to-back max-size reads ($0000, 65536 bytes) all succeed ... OK (1.812s)
[12] 25 unsupported machine:measure calls leave readmem working ... OK (0.715s)
[13] switch to Overlay on HDMI to probe live background activity ... OK (0.029s)
[14] probe addresses that change on their own while the C64 runs ... OK (6.442s)
     6 address(es) treated as expected live background noise: $00A1, $00A2, $00CD, $00CF, $01EC, $01F2
[15] set Interface Type = Freeze ... OK (0.015s)
[16] open menu (Freeze) ... OK (0.333s)
[17] write full-range pattern (Freeze) ... OK (0.435s)
[18] read back full range (Freeze) ... OK (0.206s)
[19] menu still open after write+read (Freeze) ... OK (0.020s)
--- OK (17 checks, 10.2s)

--- selfcheck-freeze: write and read both happen in Freeze (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-freeze] ignored ROM mismatches (writes to real ROM are no-ops): 16330
     [selfcheck-freeze] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-freeze] ignored known-live-noise mismatches: 0
     [selfcheck-freeze] color RAM (low nibble) mismatches: 0
     [selfcheck-freeze] RAM mismatches: 0
[20] close menu (Freeze) ... OK (0.332s)
[21] set Interface Type = Overlay on HDMI ... OK (0.016s)
[22] open menu (Overlay on HDMI) ... OK (0.303s)
[23] pause C64 for exact round trip (Overlay on HDMI) ... OK (0.015s)
[24] write full-range pattern (Overlay on HDMI) ... OK (0.488s)
[25] read back full range (Overlay on HDMI) ... OK (0.221s)
[26] resume C64 after exact round trip (Overlay on HDMI) ... OK (0.014s)
[27] menu still open after write+read (Overlay on HDMI) ... OK (0.019s)
--- OK (8 checks, 1.432s)

--- selfcheck-overlay-on-hdmi: write and read both happen in Overlay on HDMI (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-overlay-on-hdmi] ignored ROM mismatches (writes to real ROM are no-ops): 0
     [selfcheck-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-overlay-on-hdmi] ignored known-live-noise mismatches: 0
     [selfcheck-overlay-on-hdmi] color RAM (low nibble) mismatches: 0
     [selfcheck-overlay-on-hdmi] RAM mismatches: 0
[28] close menu (Overlay on HDMI) ... OK (0.328s)
[29] close menu for the screen round trip (Overlay on HDMI) ... OK (0.072s)
[30] pause C64 for the screen round trip (Overlay on HDMI) ... OK (0.018s)
[31] write and read back $0400-$07FF (Overlay on HDMI) ... OK (0.126s)
[32] resume C64 after the screen round trip (Overlay on HDMI) ... OK (0.014s)
--- OK (5 checks, 0.581s)

--- screen-round-trip-overlay-on-hdmi: screen RAM round-trips exactly with no menu open
     [screen-round-trip-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected 0)
[33] set Interface Type = Overlay on HDMI ... OK (0.016s)
[34] open menu (Overlay on HDMI) ... OK (0.324s)
[35] write full-range pattern (Overlay on HDMI) ... OK (0.632s)
[36] capture ground truth in Overlay on HDMI mode ... OK (0.228s)
[37] close menu (Overlay on HDMI) ... OK (0.316s)
[38] set Interface Type = Freeze ... OK (0.025s)
[39] open menu (Freeze) ... OK (0.302s)
[40] read full range (Freeze) ... OK (0.212s)
[41] menu still open after cross-mode read (Freeze) ... OK (0.020s)
--- OK (9 checks, 2.079s)

--- overlay-on-hdmi-write_freeze-read: bytes written while Overlay on HDMI must read back the same while Freeze, except screen RAM (menu-owned while frozen)
     [overlay-on-hdmi-write_freeze-read] screen ($0400-$07FF) mismatches: 996 (expected, menu owns this range while frozen)
     [overlay-on-hdmi-write_freeze-read] ignored known-live-noise mismatches: 0
     [overlay-on-hdmi-write_freeze-read] color RAM (low nibble) mismatches: 0
     [overlay-on-hdmi-write_freeze-read] RAM mismatches: 0
[42] close menu (Freeze) ... OK (0.312s)
[43] set Interface Type = Freeze ... OK (0.029s)
[44] open menu (Freeze) ... OK (0.315s)
[45] write full-range pattern (Freeze) ... OK (0.553s)
[46] capture ground truth in Freeze mode ... OK (0.247s)
[47] close menu (Freeze) ... OK (0.309s)
[48] set Interface Type = Overlay on HDMI ... OK (0.014s)
[49] open menu (Overlay on HDMI) ... OK (0.367s)
[50] read full range (Overlay on HDMI) ... OK (0.214s)
[51] menu still open after cross-mode read (Overlay on HDMI) ... OK (0.028s)
--- OK (10 checks, 2.413s)

--- freeze-write_overlay-on-hdmi-read: bytes written while Freeze must read back the same while Overlay on HDMI, except screen RAM (menu-owned while frozen)
     [freeze-write_overlay-on-hdmi-read] screen ($0400-$07FF) mismatches: 1020 (expected, menu owns this range while frozen)
     [freeze-write_overlay-on-hdmi-read] ignored known-live-noise mismatches: 0
     [freeze-write_overlay-on-hdmi-read] color RAM (low nibble) mismatches: 0
     [freeze-write_overlay-on-hdmi-read] RAM mismatches: 0
[52] close menu (Overlay on HDMI) ... OK (0.308s)
     restored Interface Type to 'Freeze'
--- OK (1 checks, 2.577s)

--- summary
     bounds: OK
     selfcheck-freeze: OK
     selfcheck-overlay: OK
     screen-round-trip: OK
     overlay-to-freeze: OK
     freeze-to-overlay: OK
readmem_writemem_test: OK (52 checks, 25.5s)
readmem-writemem: OK (25.5s)

============================================================
E2E  menu-screen  (overlay)
============================================================
     menu-screen: health: ping=12ms rest=13ms ftp=27ms telnet=35ms ident=15ms dma=10ms raster=40ms jiffy=39ms -> OK
[01] open menu ... OK (0.013s)
[02] GET menu_screen contract ... OK (0.032s)
[03] menu_screen renders a real menu ... OK (0.000s)
[04] close menu ... OK (0.014s)
[05] GET menu_screen unavailable ... OK (0.016s)
[06] GET menu_screen auth ... SKIP (--password not supplied, 0.000s)
menu_screen_test: OK (6 checks, 1.279s)
menu-screen: OK (1.329s)

============================================================
E2E  input  (overlay)
============================================================
     input: health: ping=12ms rest=14ms ftp=13ms telnet=38ms ident=24ms dma=13ms raster=30ms jiffy=788ms -> OK
[01] input snapshot has stable empty response shape ... OK (0.036s)
[02] POST accepts 64 event batch ... OK (0.062s)
[03] bad content-type is rejected without mutation ... OK (0.074s)
[04] missing JSON body is rejected without mutation ... OK (0.086s)
[05] malformed JSON is rejected without mutation ... OK (0.090s)
[06] unknown root field is rejected without mutation ... OK (0.092s)
[07] late invalid event keeps whole batch atomic ... OK (0.104s)
[08] joystick port 2 fire keeps Anykey buttons 2 and 3 released ... OK (0.294s)
[09] joystick port 2 fire2 lights only Anykey button 2 ... OK (0.211s)
[10] joystick port 2 fire3 lights only Anykey button 3 ... OK (0.230s)
[11] joystick port 1 up press is visible on CIA reads ... OK (0.148s)
[12] joystick port 1 all inputs and idempotent release are visible on CIA reads ... OK (0.179s)
[13] joystick port 2 diagonal and fire are visible on CIA reads ... OK (0.167s)
[14] joystick partial release is visible on CIA reads ... OK (0.170s)
[15] joystick fire2/fire3 round-trip through REST state ... OK (0.306s)
[16] joystick release_all then press in same batch is visible on CIA reads ... OK (0.156s)
[17] joystick unusual combination is visible on CIA reads ... OK (0.133s)
[18] joystick tap does not release persistent input ... OK (0.355s)
[19] joystick tap auto releases ... OK (0.358s)
[20] invalid joystick batch does not mutate state ... OK (0.225s)
[21] joystick release_all clears both ports ... OK (0.126s)
[22] machine reset clears keyboard and joystick REST state ... OK (3.174s)
[23] keyboard single-tap batch is consumed by BASIC in order ... OK (0.960s)
[24] keyboard 10 Hz mixed alphabet echo has no missed presses ... OK (5.475s)
[25] keyboard 20 Hz alternating ab echo has no missed presses ... OK (6.259s)
[26] keyboard 5 Hz alternating ab echo has no missed presses ... OK (3.876s)
[27] keyboard single letter reaches the live C64 matrix ... OK (0.245s)
[28] keyboard shifted pair reaches the live C64 matrix ... OK (0.347s)
[29] keyboard batch applies multiple presses atomically ... OK (0.411s)
[30] keyboard ordered batch and idempotent release ... OK (0.103s)
[31] keyboard release_all can be followed by press in same batch ... OK (0.095s)
[32] keyboard accepts eight simultaneous inputs ... OK (0.131s)
[33] keyboard tap does not release persistent key ... OK (0.197s)
[34] keyboard release_all clears state ... OK (0.102s)
[35] keyboard restore tap auto releases ... OK (0.262s)
[36] keyboard special-key taps snapshot correctly and auto release ... OK (2.690s)
[37] keyboard tap is visible in the live hardware snapshot and auto releases ... OK (0.328s)
[38] keyboard cursor-left tap is visible in the live hardware snapshot and auto releases ... OK (0.293s)
[39] keyboard tap batch drains through the live matrix path ... OK (1.311s)
[40] keyboard long repeated tap train drains fully without sticky state ... OK (6.223s)
[41] invalid keyboard batch does not mutate state ... OK (0.061s)
[42] menu editor accepts an unshifted control character ... OK (1.052s)
[43] menu editor keeps separate-batch shift active across POSTs ... OK (2.828s)
[44] menu editor repeats a held printable key ... OK (3.675s)
[45] menu editor stops printable repeat after release ... OK (5.777s)
[46] menu editor accepts a single cursor-left control ... OK (4.604s)
[47] menu editor repeats a held cursor-left control ... OK (4.745s)
[48] menu editor stops cursor repeat after release ... OK (6.335s)
input_test: OK (48 checks, 81.6s)
input: OK (81.8s)

============================================================
E2E  prg-context-menu  (overlay)
============================================================
     prg-context-menu: health: ping=12ms rest=14ms ftp=16ms telnet=38ms ident=18ms dma=12ms raster=31ms jiffy=48ms -> OK
[01] reset the machine to a clean starting state ... OK (2.909s)
[02] seed /Temp with prgmenu69795.prg, prgmenu69795.d64 and a long-named PRG ... OK (0.700s)

--- every context-menu action on a plain PRG
[03] read the context menu of a plain PRG ... OK (2.416s)
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
[04] a plain PRG: every offered action is covered ... OK (0.000s)
[05] Run on a plain PRG ... OK (7.388s)
[06] Load on a plain PRG ... OK (6.087s)
[07] DMA on a plain PRG ... OK (8.123s)
[08] View on a plain PRG ... OK (3.905s)
[09] Hex View on a plain PRG ... OK (3.990s)
[10] Copy to... on a plain PRG ... OK (6.901s)
[11] Rename on a plain PRG ... OK (6.492s)
[12] Move to... on a plain PRG ... OK (7.183s)
[13] Delete on a plain PRG ... OK (3.872s)
--- OK (11 checks, 56.4s)

--- every context-menu action on a PRG inside a D64
[14] read the context menu of a PRG inside a D64 ... OK (3.566s)
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
[15] a PRG inside a D64: every offered action is covered ... OK (0.000s)
[16] Run on a PRG inside a D64 ... OK (8.982s)
[17] Load on a PRG inside a D64 ... OK (7.419s)
[18] DMA on a PRG inside a D64 ... OK (9.143s)
[19] Mount & Run on a PRG inside a D64 ... OK (9.486s)
[20] Real Run on a PRG inside a D64 ... OK (12.9s SLOW)
[21] View on a PRG inside a D64 ... OK (5.294s)
[22] Hex View on a PRG inside a D64 ... OK (4.861s)
[23] Copy to... on a PRG inside a D64 ... OK (8.139s)
[24] Rename on a PRG inside a D64 ... OK (8.631s)
[25] Move to... on a PRG inside a D64 ... OK (10.000s)
[26] Delete on a PRG inside a D64 ... OK (5.931s)
[27] Run a PRG whose name is far longer than the boot-cart display ... OK (7.956s)
--- OK (14 checks, 102s)
prg_context_menu_test: OK (23 actions, 163s)
prg-context-menu: OK (164s)

============================================================
E2E  browser-long-filename  (overlay)
============================================================
     browser-long-filename: health: ping=12ms rest=14ms ftp=13ms telnet=35ms ident=24ms dma=22ms raster=27ms jiffy=53ms -> OK
[01] reset the machine to a clean starting state ... OK (0.583s)
[02] seed long-name fixture for rename ... OK (1.087s)
[03] browser rename on long filename ... OK (8.032s)
[04] reseed long-name fixture for mount ... OK (1.153s)
[05] browser mount on long filename ... OK (5.144s)
browser_long_filename_test: OK (5 checks, 16.4s)
browser-long-filename: OK (17.5s)

============================================================
E2E  browser-filesystem-refresh  (overlay)
============================================================
     browser-filesystem-refresh: health: ping=12ms rest=15ms ftp=13ms telnet=47ms ident=31ms dma=12ms raster=30ms jiffy=41ms -> OK
[01] reset the machine to a clean starting state ... OK (0.631s)
[02] prepare fixture directories ... OK (0.127s)
[03] open Menu, Telnet and FTP on the fixture directory ... OK (4.355s)
[04] rename from the Menu ... OK (3.892s)
[05] rename from Telnet ... OK (3.301s)
[06] rename from FTP ... OK (1.271s)
[07] rename under observer-queue pressure from the Menu ... OK (5.603s)
[08] rename under observer-queue pressure from Telnet ... OK (4.974s)
[09] rename a directory from the Menu ... OK (3.576s)
[10] rename a directory from Telnet ... OK (2.982s)
[11] delete from the Menu ... OK (2.561s)
[12] delete from Telnet ... OK (3.262s)
[13] delete from FTP ... OK (1.429s)
[14] delete a non-empty directory from the Menu ... OK (2.182s)
[15] delete a non-empty directory from Telnet ... OK (2.471s)
[16] remove a directory from FTP ... OK (1.107s)
[17] select all and bulk delete from the Menu ... OK (2.391s)
[18] create from the Menu ... OK (3.782s)
[19] create from Telnet ... OK (3.157s)
[20] create from FTP ... OK (1.380s)
     STOR phase 1 (open, 0 bytes committed): Menu=<empty>; Telnet=<empty>; FTP=<empty>
[21] create from FTP (mkd) ... OK (0.889s)
[22] create from REST (d64) ... OK (0.860s)
[23] create from REST (d71) ... OK (0.864s)
[24] create from REST (d81) ... OK (0.771s)
[25] create from REST (dnp) ... OK (1.199s)
[26] write from the Menu ... OK (2.667s)
[27] write from Telnet ... OK (3.005s)
[28] write from FTP ... OK (1.929s)
     STOR phase 1 (open, truncated): Menu=wftp1.tst[ 100 ]; Telnet=wftp1.tst[ 100 ]; FTP=wftp1.tst[ 100 ]=100
[29] copy over an existing file from the Menu ... OK (12.1s SLOW)
[30] copy over an existing file from Telnet ... OK (10.6s SLOW)
[31] move an entry out of the watched directory from the Menu ... OK (5.584s)
[32] move an entry out of the watched directory from Telnet ... OK (5.301s)
[33] paste into the watched directory from the Menu ... OK (8.103s)
[34] paste into the watched directory from Telnet ... OK (7.583s)
[35] failed rename shows nothing ... OK (0.939s)
[36] failed delete removes nothing ... OK (0.864s)
[37] failed write creates nothing ... OK (0.957s)
[38] short write commits consistently ... OK (0.981s)
     short write committed 100 bytes

operation x origin x observer matrix
------------------------------------------------------------------------------
  rename       Menu    Menu    OK    0.22s
  rename       Menu    Telnet  OK    0.22s
  rename       Menu    FTP     OK    0.22s
  rename       Menu    REST    OK    0.22s
  rename       Telnet  Menu    OK    0.23s
  rename       Telnet  Telnet  OK    0.23s
  rename       Telnet  FTP     OK    0.23s
  rename       Telnet  REST    OK    0.23s
  rename       FTP     Menu    OK    0.67s
  rename       FTP     Telnet  OK    0.67s
  rename       FTP     FTP     OK    0.67s
  rename       FTP     REST    OK    0.67s
  rename-under-load Menu    Menu    OK    0.22s
  rename-under-load Menu    Telnet  OK    0.22s
  rename-under-load Menu    FTP     OK    0.22s
  rename-under-load Menu    REST    OK    0.22s
  rename-under-load Telnet  Menu    OK    0.22s
  rename-under-load Telnet  Telnet  OK    0.22s
  rename-under-load Telnet  FTP     OK    0.22s
  rename-under-load Telnet  REST    OK    0.22s
  rename-dir   Menu    Menu    OK    0.23s
  rename-dir   Menu    Telnet  OK    0.23s
  rename-dir   Menu    FTP     OK    0.23s
  rename-dir   Menu    REST    OK    0.23s
  rename-dir   Telnet  Menu    OK    0.22s
  rename-dir   Telnet  Telnet  OK    0.22s
  rename-dir   Telnet  FTP     OK    0.22s
  rename-dir   Telnet  REST    OK    0.22s
  delete       Menu    Menu    OK    0.29s
  delete       Menu    Telnet  OK    0.29s
  delete       Menu    FTP     OK    0.29s
  delete       Menu    REST    OK    0.29s
  delete       Telnet  Menu    OK    0.21s
  delete       Telnet  Telnet  OK    0.21s
  delete       Telnet  FTP     OK    0.21s
  delete       Telnet  REST    OK    0.21s
  delete       FTP     Menu    OK    0.63s
  delete       FTP     Telnet  OK    0.63s
  delete       FTP     FTP     OK    0.63s
  delete       FTP     REST    OK    0.63s
  delete-dir   Menu    Menu    OK    0.20s
  delete-dir   Menu    Telnet  OK    0.20s
  delete-dir   Menu    FTP     OK    0.20s
  delete-dir   Menu    REST    OK    0.20s
  delete-dir   Telnet  Menu    OK    0.24s
  delete-dir   Telnet  Telnet  OK    0.24s
  delete-dir   Telnet  FTP     OK    0.24s
  delete-dir   Telnet  REST    OK    0.24s
  delete-dir   FTP/rmd Menu    OK    0.29s
  delete-dir   FTP/rmd Telnet  OK    0.29s
  delete-dir   FTP/rmd FTP     OK    0.29s
  delete-dir   FTP/rmd REST    OK    0.29s
  delete-bulk  Menu    Menu    OK    0.25s
  delete-bulk  Menu    Telnet  OK    0.25s
  delete-bulk  Menu    FTP     OK    0.25s
  delete-bulk  Menu    REST    OK    0.25s
  create       Menu    Menu    OK    0.24s
  create       Menu    Telnet  OK    0.24s
  create       Menu    FTP     OK    0.24s
  create       Menu    REST    OK    0.24s
  create       Telnet  Menu    OK    0.23s
  create       Telnet  Telnet  OK    0.23s
  create       Telnet  FTP     OK    0.23s
  create       Telnet  REST    OK    0.23s
  create       FTP     Menu    OK    0.33s
  create       FTP     Telnet  OK    0.33s
  create       FTP     FTP     OK    0.33s
  create       FTP     REST    OK    0.33s
  create       FTP/mkd Menu    OK    0.28s
  create       FTP/mkd Telnet  OK    0.28s
  create       FTP/mkd FTP     OK    0.28s
  create       FTP/mkd REST    OK    0.28s
  create       REST/d64 Menu    OK    0.33s
  create       REST/d64 Telnet  OK    0.33s
  create       REST/d64 FTP     OK    0.33s
  create       REST/d64 REST    OK    0.33s
  create       REST/d71 Menu    OK    0.25s
  create       REST/d71 Telnet  OK    0.25s
  create       REST/d71 FTP     OK    0.25s
  create       REST/d71 REST    OK    0.25s
  create       REST/d81 Menu    OK    0.25s
  create       REST/d81 Telnet  OK    0.25s
  create       REST/d81 FTP     OK    0.25s
  create       REST/d81 REST    OK    0.25s
  create       REST/dnp Menu    OK    0.59s
  create       REST/dnp Telnet  OK    0.59s
  create       REST/dnp FTP     OK    0.59s
  create       REST/dnp REST    OK    0.59s
  write        Menu    Menu    OK    0.21s
  write        Menu    Telnet  OK    0.21s
  write        Menu    FTP     OK    0.21s
  write        Menu    REST    OK    0.21s
  write        Telnet  Menu    OK    0.21s
  write        Telnet  Telnet  OK    0.21s
  write        Telnet  FTP     OK    0.21s
  write        Telnet  REST    OK    0.21s
  write        FTP     Menu    OK    0.24s
  write        FTP     Telnet  OK    0.24s
  write        FTP     FTP     OK    0.24s
  write        FTP     REST    OK    0.24s
  copy-write   Menu    Menu    N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Menu    Telnet  OK    0.21s
  copy-write   Menu    FTP     OK    0.21s
  copy-write   Menu    REST    OK    0.21s
  copy-arrival Menu    Menu    OK    no stale cache on re-entry
  copy-write   Telnet  Telnet  N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Telnet  Menu    OK    0.05s
  copy-write   Telnet  FTP     OK    0.05s
  copy-write   Telnet  REST    OK    0.05s
  copy-arrival Telnet  Telnet  OK    no stale cache on re-entry
  move-out     Menu    Menu    OK    0.20s
  move-out     Menu    Telnet  OK    0.20s
  move-out     Menu    FTP     OK    0.20s
  move-out     Menu    REST    OK    0.20s
  move-out     Telnet  Menu    OK    0.23s
  move-out     Telnet  Telnet  OK    0.23s
  move-out     Telnet  FTP     OK    0.23s
  move-out     Telnet  REST    OK    0.23s
  paste-write  Menu    Menu    OK    0.22s
  paste-write  Menu    Telnet  OK    0.22s
  paste-write  Menu    FTP     OK    0.22s
  paste-write  Menu    REST    OK    0.22s
  paste-write  Telnet  Menu    OK    0.21s
  paste-write  Telnet  Telnet  OK    0.21s
  paste-write  Telnet  FTP     OK    0.21s
  paste-write  Telnet  REST    OK    0.21s
  rename-fail  FTP     Menu    OK    0.23s
  rename-fail  FTP     Telnet  OK    0.23s
  rename-fail  FTP     FTP     OK    0.23s
  rename-fail  FTP     REST    OK    0.23s
  delete-fail  FTP     Menu    OK    0.21s
  delete-fail  FTP     Telnet  OK    0.21s
  delete-fail  FTP     FTP     OK    0.21s
  delete-fail  FTP     REST    OK    0.21s
  write-fail   FTP     Menu    OK    0.22s
  write-fail   FTP     Telnet  OK    0.22s
  write-fail   FTP     FTP     OK    0.22s
  write-fail   FTP     REST    OK    0.22s
  short-write  FTP     Menu    OK    0.30s
  short-write  FTP     Telnet  OK    0.30s
  short-write  FTP     FTP     OK    0.30s
  short-write  FTP     REST    OK    0.30s
------------------------------------------------------------------------------
  N/A=2, OK=140
browser_filesystem_refresh_test: OK (38 checks, 121s)
browser-filesystem-refresh: OK (123s)

============================================================
E2E  ftp-client  (overlay)
============================================================
     ftp-client: health: ping=22ms rest=14ms ftp=25ms telnet=37ms ident=29ms dma=25ms raster=30ms jiffy=462ms -> OK
     inferred --ftp-advertised-host 192.168.1.78
     controlled FTP server on 0.0.0.0:2121 (advertised 192.168.1.78)
[I 2026-08-12 17:28:24] concurrency model: async
[I 2026-08-12 17:28:24] masquerade (NAT) address: 192.168.1.78
[I 2026-08-12 17:28:24] passive ports: 30000->30019
[I 2026-08-12 17:28:24] >>> starting FTP server on 0.0.0.0:2121, pid=79190 <<<
     server root: /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-iwbxhc8u (marker E2E-1786570104)
[01] GET /v1/version reachable ... OK (0.1, 0.028s)
[02] menu closed -> menu_screen 404 ... OK (0.050s)
[03] menu_button opens menu ... OK (0.338s)
[04] menu_screen returns 2000-byte matrix ... OK (2000 bytes, 0.020s)
[05] input release_all works ... OK (0.018s)
[06] menu closes from anywhere ... OK (0.335s)
[07] remove any stale hosts left by a prior run ... OK (0 removed, 1.470s)

--- stage: smoke
[08] create FTP host 'E2EFTP0104iybk' through the New Host form ... OK (6.371s)
[09] new alias appears under /ftp ... OK (1.106s)
[10] enter host: server sees login + TYPE I + LIST ... [I 2026-08-12 17:28:35] 192.168.1.62:52432-[] FTP session opened (connect)
[I 2026-08-12 17:28:35] 192.168.1.62:52432-[u64e2e] USER 'u64e2e' logged in.
OK (PASS,TYPE,LIST, 1.239s)
[11] root listing shows fixture entries ... OK (README,DIRA,SMALL, 0.020s)
[12] open README.TXT -> RETR (52 bytes) ... [I 2026-08-12 17:28:37] 192.168.1.62:52432-[u64e2e] RETR /private/var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-iwbxhc8u/README.TXT completed=1 bytes=52 seconds=0.0
OK (52 bytes, 2.445s)
[13] remove host and confirm it disappears ... [I 2026-08-12 17:28:39] 192.168.1.62:52432-[u64e2e] FTP session closed (disconnect).
OK (3.411s)
--- OK (6 checks, 14.6s)

--- cleanup
     preserved: nothing

--- summary
     Phase    Operation              Result             Commands       Fixture/Notes
     ------------------------------------------------------------------------------
     smoke    create host            OK                                E2EFTP0104iybk
     smoke    list host              OK                                E2EFTP0104iybk
     smoke    enter/LIST             OK                 USER/PASS/TYPE E2EFTP0104iybk
     smoke    root entries           OK                 LIST           README/DIRA/SMALL
     smoke    RETR README            OK                 RETR           README.TXT 52 bytes
     smoke    remove host            OK                                E2EFTP0104iybk
     ------------------------------------------------------------------------------
     Total REST requests   : 155
     Total menu snapshots  : 65
     Total keyboard events : 102
     Total FTP commands    : 24
     Created host alias    : (removed)
     Remote root path      : /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-iwbxhc8u
     Cleanup status        : clean
Exception in thread Thread-1 (serve_forever):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/servers.py", line 254, in serve_forever
    self.ioloop.loop(timeout, blocking)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 376, in loop
    poll(timeout)
    ~~~~^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 741, in poll
    kevents = self._kqueue.control(
        None, _len(self.socket_map), timeout
    )
OSError: [Errno 9] Bad file descriptor
ftp-client: OK (18.2s)

============================================================
E2E  prg-load-path-trim  (overlay)
============================================================
     prg-load-path-trim: health: ping=12ms rest=13ms ftp=13ms telnet=47ms ident=16ms dma=12ms raster=48ms jiffy=31ms -> OK

--- Ultimate 64 PRG load path trim
     host: 192.168.1.62
     PUT file path: /Temp/rest-prg-path-trim-target-example.prg
     POST upload name: rest-prg-path-trim-upload-example.prg

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configure Temp Settings
[01] set Temp Auto Cleanup to Enabled ... OK (0.027s)
[02] set Temp Subfolders to Enabled ... OK (0.024s)
--- OK (2 checks, 0.050s)

--- 3. Prepare PRG Fixture
[03] upload PUT fixture rest-prg-path-trim-target-example.prg ... OK (0.181s)
--- OK (1 checks, 0.182s)

--- 4. Validate PUT Endpoints
[04] exercise PUT runners:load_prg ... OK (0.410s)
     PUT load_prg boot-cart name: ...T-EXAMPLE
[05] exercise PUT runners:run_prg ... OK (1.763s)
     PUT run_prg boot-cart name: ...T-EXAMPLE
--- OK (2 checks, 2.332s)

--- 5. Validate POST Endpoints
[06] exercise POST runners:load_prg ... OK (0.425s)
     POST load_prg boot-cart name: ...D-EXAMPLE
[07] exercise POST runners:run_prg ... OK (1.793s)
     POST run_prg boot-cart name: ...D-EXAMPLE
--- OK (2 checks, 3.061s)
prg_load_path_trim_test: OK (7 checks, 6.408s)

--- restore User Interface Settings
[08] set Temp Auto Cleanup to Enabled ... OK (0.017s)
[09] set Temp Subfolders to Enabled ... OK (0.027s)
prg-load-path-trim: OK (7.352s)

============================================================
E2E  temp-auto-cleanup  (overlay)
============================================================
     temp-auto-cleanup: health: ping=41ms rest=14ms ftp=14ms telnet=47ms ident=18ms dma=12ms raster=31ms jiffy=58ms -> OK

--- Ultimate 64 Temp auto cleanup
     host: 192.168.1.62

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configuration Setup
[01] set Temp Auto Cleanup to Enabled ... OK (0.026s)
[02] set Temp Subfolders to Enabled ... OK (0.034s)
--- OK (2 checks, 0.060s)

--- 3. Purging /Temp
     purge complete

--- 4. Mounting D64 Images
[03] create /Temp/mount-drive-8.d64 ... OK (0.056s)
[04] download mount-drive-8.d64 for the upload mount ... OK (0.439s)
[05] remove staging source mount-drive-8.d64 ... OK (0.053s)
[06] mount drive A ... OK (1.085s)
OK (1.085s)
[07] create /Temp/mount-drive-9.d64 ... OK (0.055s)
[08] download mount-drive-9.d64 for the upload mount ... OK (0.427s)
[09] remove staging source mount-drive-9.d64 ... OK (0.046s)
[10] mount drive B ... OK (1.096s)
OK (1.096s)
--- OK (10 checks, 3.257s)

--- 5. Seeding Baseline (10 files)
[11] upload base_1.bin ... OK (1.660s)
[12] upload base_2.bin ... OK (1.704s)
[13] upload base_3.bin ... OK (1.690s)
[14] upload base_4.bin ... OK (1.602s)
[15] upload base_5.bin ... OK (1.626s)
[16] upload base_6.bin ... OK (1.862s)
[17] upload base_7.bin ... OK (1.604s)
[18] upload base_8.bin ... OK (1.584s)
[19] upload base_9.bin ... OK (1.767s)
[20] upload base_10.bin ... OK (1.576s)
--- OK (10 checks, 16.7s)

--- 6. Managed Temp File Limit (Target: 10)
[21] upload managed_1.bin over REST ... OK (4.533s)
     managed count=1 (limit=10)
[22] upload managed_2.bin over REST ... OK (4.725s)
     managed count=2 (limit=10)
[23] upload managed_3.bin over REST ... OK (4.616s)
     managed count=3 (limit=10)
[24] upload managed_4.bin over REST ... OK (4.602s)
     managed count=4 (limit=10)
[25] upload managed_5.bin over REST ... OK (4.596s)
     managed count=5 (limit=10)
[26] upload managed_6.bin over REST ... OK (4.509s)
     managed count=6 (limit=10)
[27] upload managed_7.bin over REST ... OK (4.628s)
     managed count=7 (limit=10)
[28] upload managed_8.bin over REST ... OK (4.542s)
     managed count=8 (limit=10)
[29] upload managed_9.bin over REST ... OK (4.546s)
     managed count=9 (limit=10)
[30] upload managed_10.bin over REST ... OK (4.692s)
     managed count=10 (limit=10)
[31] upload managed_11.bin over REST ... OK (4.627s)
     managed count=10 (limit=10)
[32] upload managed_12.bin over REST ... OK (4.580s)
     managed count=10 (limit=10)
OK (4.945s)
OK (5.064s)
--- OK (14 checks, 60.3s)

--- 7. Unmounted Uploads Rejoin Cleanup
[33] remove drive A ... OK (0.123s)
[34] upload post_a_1.bin over REST ... OK (4.560s)
OK (4.647s)
     removed after 1 uploads
[35] remove drive B ... OK (0.125s)
[36] upload post_b_1.bin over REST ... OK (4.806s)
     removed after 1 uploads
--- OK (5 checks, 10.2s)

--- 8. Final Integrity Check
     user files intact
temp_auto_cleanup_test: OK (36 checks, 93.4s)

--- restore User Interface Settings
[37] set Temp Auto Cleanup to Enabled ... OK (0.028s)
[38] set Temp Subfolders to Enabled ... OK (0.016s)
temp-auto-cleanup: OK (94.0s)

============================================================
E2E  cfg-single-group  (overlay)
============================================================
     cfg-single-group: health: ping=23ms rest=14ms ftp=14ms telnet=38ms ident=17ms dma=17ms raster=40ms jiffy=42ms -> OK
[01] load a one-group CFG file through the browser ... OK (7.805s)
[02] only the CFG group is considered after loading ... OK (0.111s)
cfg_single_group_test: OK (2 checks, 8.398s)
cfg-single-group: OK (9.050s)

============================================================
E2E  printer  (overlay)
============================================================
     printer: health: ping=12ms rest=13ms ftp=25ms telnet=35ms ident=14ms dma=10ms raster=38ms jiffy=29ms -> OK
[01] REST reachable at 192.168.1.62 ... OK (0.018s)
[02] reset before run ... OK (0.142s)
[03] load printer_e2e.prg ... OK (914 bytes, 0.000s)
[04] capture original Printer Settings ... OK (0.322s)
[05] print epson/bitmap: apply settings + run PRG ... OK (phase=printer closed heartbeat=4, 2.923s)
[06] print epson/bitmap: Flush/Eject via on-screen menu ... OK (3.896s)

--- restoring original Printer Settings
     IEC printer: Disabled
     Bus ID: 4
     Output file: /Usb0/printer
     Output type: PNG B&W
     Ink density: Medium
     Page top margin (default is 5): 5
     Page height (default is 60): 60
     Emulation: Commodore MPS
     Commodore charset: USA/UK
     Epson charset: Basic
     IBM table 2: International 1

--- summary
     epson      bitmap PASS_NO_VERIFY       /USB1/printer/e2e-eb507b
printer: OK (8.325s)

============================================================
E2E  uci-targets  (overlay)
============================================================
     uci-targets: health: ping=12ms rest=13ms ftp=12ms telnet=59ms ident=15ms dma=10ms raster=51ms jiffy=30ms -> OK
[01] reset the C64 so the command interface starts idle ... OK (3.062s)
[02] read 'C64 and Cartridge Settings' ... OK (0.034s)
     current: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}
[03] enable the Command Interface registers at $DF1B-$DF1F ... OK (0.159s)
[04] transport: an empty command returns an empty reply ... OK (0.168s)
     <empty> -> 0.03s, data b'', status b''
[05] transport: unregistered target answers IDENTIFY ... OK (0.645s)
     0f 01 -> 0.06s, data b'NO TARGET', status b'00,OK'
[06] transport: unregistered target rejects anything else ... OK (0.872s)
     0f 7f -> 0.08s, data b'', status b'21,UNKNOWN COMMAND'
[07] transport: a no-reply command returns straight to Idle ... OK (0.173s)
[08] transport: pushing while a reply is pending sets and clears ERROR ... OK (1.139s)
[09] transport: the next command is not prefixed by leftover bytes ... OK (0.989s)
     04 28 00 -> 0.09s, data b'Ultimate 64 Elite', status b'00,OK'
[10] transport: ABORT releases a pending reply back to Idle ... OK (0.179s)
[11] control-target: IDENTIFY answers with the target name ... OK (1.095s)
     04 01 -> 0.07s, data b'CONTROL TARGET V1.1', status b'00,OK'
[12] control-target: an unimplemented command is reported as unknown ... OK (0.852s)
     04 7f -> 0.08s, data b'', status b'21,UNKNOWN COMMAND'
[13] control-target: LOAD_REU without a filename is rejected, not run ... OK (0.832s)
     04 08 -> 0.08s, data b'', status b'81,INVALID PARAMS'
[14] control-target: SAVE_REU without a filename is rejected, not run ... OK (0.778s)
     04 09 -> 0.08s, data b'', status b'81,INVALID PARAMS'
[15] control-target: GET_HWINFO rejects a device number it does not have ... OK (0.874s)
     04 28 02 -> 0.08s, data b'', status b'81,INVALID PARAMS'
[16] issue-740-matrix: confirm /Temp/uci_e2e_absent.reu does not exist ... OK (0.020s)
[17] issue-740-matrix: put a 16384-byte image at /Temp/uci_e2e_present.reu ... OK (0.168s)
[18] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... OK (4.234s)
     04 08 52 45 55 2e 49 4d 47 -> 0.19s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[19] issue-740-matrix: REU Enabled, image absent, name at offset 4 ... OK (4.404s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.23s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[20] issue-740-matrix: REU Disabled, image absent, name at offset 2 ... OK (1.078s)
     04 08 52 45 55 2e 49 4d 47 -> 0.20s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[21] issue-740-matrix: REU Disabled, image absent, name at offset 4 ... OK (1.276s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.32s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[22] issue-740-matrix: REU Enabled, image present, name at offset 2 ... OK (3.216s)
     04 08 52 45 55 2e 49 4d 47 -> 0.21s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[23] issue-740-matrix: REU Enabled, image present, name at offset 4 ... OK (3.262s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.23s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[24] save-reu-offset-past-end: put the preload offset at the end of a 128 KB REU ... OK (0.046s)
[25] save-reu-offset-past-end: SAVE_REU reports the offset and saves nothing ... OK (3.477s)
     04 09 52 45 55 2e 49 4d 47 -> 0.21s, data b'\xfd\xff\xff\xffREU SAVE: OFFSET 131072 >= REU SIZE 131072, SKIPPING', status b'86,REU OFFSET > SIZE. NOT SAVED'
[26] load-reu-disabled: disable the REU ... OK (0.014s)
[27] load-reu-disabled: leave text in the reply buffer from a previous command ... OK (1.012s)
     04 28 00 -> 0.10s, data b'Ultimate 64 Elite', status b'00,OK'
[28] load-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.025s)
     04 08 52 45 55 2e 49 4d 47 -> 0.18s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[29] save-reu-disabled: disable the REU ... OK (0.014s)
[30] save-reu-disabled: leave text in the reply buffer from a previous command ... OK (0.980s)
     04 28 00 -> 0.10s, data b'Ultimate 64 Elite', status b'00,OK'
[31] save-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (1.242s)
     04 09 52 45 55 2e 49 4d 47 -> 0.22s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[32] softiec-single-part-reply: SoftIEC target answers IDENTIFY ... OK (1.362s)
     05 01 -> 0.08s, data b'SOFTWARE IEC TARGET V1.0', status b'00,OK'
[33] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... OK (0.642s)
     05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 -> 0.38s, data b'', status b'\x01'
[34] softiec-single-part-reply: GET_FATNAME reply completes in one part ... OK (0.546s)
     05 22 02 23 -> 0.10s, data b'/buffer', status b'\x00'
[35] softiec-single-part-reply: an unimplemented SoftIEC command is reported as unknown ... OK (0.293s)
     05 7f -> 0.09s, data b'', status b'\x04'
[36] interface-usable-after: the control target still answers IDENTIFY ... OK (1.206s)
     04 01 -> 0.08s, data b'CONTROL TARGET V1.1', status b'00,OK'
     restored C64 and Cartridge Settings: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}

--- summary
     transport: OK
     control-target: OK
     issue-740-matrix: OK
     save-reu-offset-past-end: OK
     load-reu-disabled: OK
     save-reu-disabled: OK
     softiec-single-part-reply: OK
     interface-usable-after: OK
     cleanup: OK
uci_targets_test: OK (36 checks, 41.7s)
uci-targets: OK (41.7s)

============================================================
E2E  machine-code-monitor  (overlay)
============================================================
     machine-code-monitor: health: ping=12ms rest=13ms ftp=14ms telnet=60ms ident=18ms dma=12ms raster=45ms jiffy=30ms -> OK
[01] initial CPU7/KERNAL monitor status ... OK (0.028s)
[02] KERNAL $E000 hex view and REST match ... OK (0.658s)
[03] paging away and back keeps memory view stable ... OK (0.620s)
[04] KERNAL disassembly formatting ... OK (1.540s)
[05] KERNAL $E010 REST match ... OK (0.928s)
[06] CPU6 RAM under BASIC write/read ... OK (4.424s)
[07] CPU5 RAM under KERNAL status ... OK (2.858s)
[08] ASCII view width and scrolling ... OK (7.319s)
[09] ASCII and Screen mapping semantics ... OK (12.2s SLOW)
[10] HEX edit writes both nibbles ... OK (2.964s)
[11] CPU bank cycling reaches CHAR and RAM mappings ... OK (3.730s)
[12] COMPARE reports differing address ... OK (4.244s)
[13] G executes finite loop and returns to monitor ... OK (2.258s)
[14] G repeated execution updates RAM sentinel ... OK (7.297s)
[15] G handoff preserves stable VIC state ... SKIP (the on-device UI owns the VIC while it is up; only comparable over telnet, 0.000s)
OK (0.000s)
[16] bookmarks recall, set, list, and label edit ... OK (7.757s)
[17] memory bookmark jump restores width 16 ... OK (5.636s)
[18] binary width cycling and bookmark jump restores width 4 ... OK (6.523s)
[19] follow and return navigation ... OK (5.608s)
[20] asm edit mnemonic validation and Return advance ... OK (8.234s)
[21] number popup arithmetic ... OK (2.661s)
[22] save/load round-trip to top-level /Temp file ... OK (10.1s SLOW)
[23] save/load round-trip to file in new /Temp D64 ... OK (18.1s SLOW)

--- Telnet transport checks
[24] telnet blocks poll mode ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
[25] telnet opcode dropdown scroll does not flood the connection ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
--- SKIP (4 checks, 0.178s)
monitor_test: OK (25 checks, 118s)
machine-code-monitor: OK (118s)

============================================================
E2E  ftp-server  (overlay)
============================================================
     ftp-server: health: ping=12ms rest=14ms ftp=24ms telnet=48ms ident=16ms dma=12ms raster=50ms jiffy=40ms -> OK

--- a name the listing reports can address the file it names
[01] a 40-character name is listed unchanged ... OK (0.117s)
[02] that file is removed by the name the listing reported ... OK (0.117s)
[03] a 100-character name is listed unchanged ... OK (0.100s)
     100 characters survived the listing
[04] SIZE answers for the long name the listing reported ... OK (0.052s)
[05] that file is removed by the name the listing reported ... OK (0.106s)
--- OK (5 checks, 0.616s)
ftp_server_test: OK (5 checks, 0.619s)
ftp-server: OK (0.667s)

============================================================
E2E  assembly64  (overlay)
============================================================
     assembly64: health: ping=12ms rest=15ms ftp=14ms telnet=49ms ident=78ms dma=116ms raster=32ms jiffy=41ms -> OK

--- the form opens from the task menu and closes again
[01] open the Assembly 64 query form ... OK (0.907s)
[02] the form leaves cleanly with RUN/STOP ... OK (0.391s)
--- OK (2 checks, 1.453s)

--- a real query is sent to the Assembly 64 service
[03] open the form and enter the first field ... OK (1.179s)
[04] the typed term lands in the Name field ... OK (0.850s)
[05] the service answers and the results match what was asked for ... OK (1.128s)
--- OK (3 checks, 3.744s)

--- the menu button must work from inside the edit field
[06] open the form and enter the edit field ... OK (1.070s)
[07] the menu button closes the menu from inside the field ... OK (0.137s)
[08] the menu opens again, so the UI task left string_edit ... OK (0.079s)
--- OK (3 checks, 1.799s)

--- an aborted edit must not wedge the form
[09] open the form, type into a field, then abort ... OK (1.804s)
[10] the form is still usable after the abort ... OK (0.031s)
--- OK (2 checks, 2.354s)

--- over-long and empty input
[11] type more than the field accepts ... OK (2.153s)
[12] an empty query is refused rather than sent ... OK (2.815s)
[13] the warning is dismissed and the form is still usable ... OK (0.323s)
--- OK (3 checks, 5.808s)

--- a user mashing keys while the form is busy
[14] submit a query and hammer keys while it runs ... OK (5.239s)
[15] the device is still answering after the mashing ... OK (0.015s)
--- OK (2 checks, 5.746s)

--- opening and abandoning the form repeatedly
[16] open and abandon the form three times ... OK (3.182s)
[17] the menu button closes and reopens the form three times ... OK (3.426s)
--- OK (2 checks, 6.906s)
assembly64_test: OK (17 checks, 28.2s)
assembly64: OK (28.3s)

============================================================
E2E  freeze-menu  (overlay)
============================================================
     freeze-menu: health: ping=12ms rest=13ms ftp=12ms telnet=55ms ident=15ms dma=9ms raster=43ms jiffy=27ms -> OK
     captured 'Interface Type'=Freeze, 'Auto Address Mirroring'=Enabled

--- menu cycle with Auto Address Mirroring Disabled
[01] select 'Freeze' interface with mirroring disabled ... OK (0.034s)
[02] C64 running before the menu is opened ... OK (1.102s)
[03] open the menu ... OK (0.292s)
[04] C64 frozen while the menu is open ... OK (0.538s)
[05] close the menu ... OK (0.281s)
[06] C64 resumed after the menu closed ... OK (0.533s)
--- OK (6 checks, 2.807s)

--- Auto Address Mirroring switched off while the menu is open
[07] select 'Freeze' interface with mirroring enabled ... OK (0.042s)
[08] C64 running before the menu is opened ... OK (0.541s)
[09] open the menu ... OK (0.294s)
[10] C64 frozen while the menu is open ... OK (0.534s)
[11] set Auto Address Mirroring to Disabled while the menu is open ... OK (0.031s)
[12] close the menu ... OK (0.297s)
[13] C64 resumed after the menu closed ... OK (0.568s)
--- OK (7 checks, 2.332s)

--- menu cycle with Auto Address Mirroring Enabled
[14] select 'Freeze' interface with mirroring enabled ... OK (0.272s)
[15] C64 running before the menu is opened ... OK (0.546s)
[16] open the menu ... OK (0.298s)
[17] C64 frozen while the menu is open ... OK (0.534s)
[18] close the menu ... OK (0.283s)
[19] C64 resumed after the menu closed ... OK (0.533s)
--- OK (6 checks, 2.481s)

--- reopen the freezer menu with a context menu left open
[20] select 'Freeze' interface with mirroring enabled ... OK (0.041s)
[21] C64 running before the menu is opened ... OK (0.532s)
[22] open the menu ... OK (0.288s)
[23] C64 frozen while the menu is open ... OK (0.534s)
[24] open the context menu on the first browser entry ... OK (7.675s)
[25] close the menu ... OK (0.293s)
[26] C64 resumed after the menu closed ... OK (0.530s)
[27] reopen the menu with the context menu still on the object stack ... OK (0.286s)
[28] dismiss the restored context menu ... OK (0.271s)
[29] close the menu ... OK (0.283s)
[30] C64 resumed after the menu closed ... OK (0.611s)
--- OK (11 checks, 11.4s)

--- the menu button works inside the Assembly 64 query form
[31] select 'Freeze' interface with mirroring enabled ... OK (0.054s)
[32] C64 running before the menu is opened ... OK (0.538s)
[33] open the menu ... OK (0.292s)
[34] C64 frozen while the menu is open ... OK (0.531s)
[35] open the task menu ... OK (0.347s)
[36] open the Assembly 64 query form ... OK (0.302s)
[37] enter the form's first edit field ... OK (0.305s)
[38] the menu button closes the menu from inside the edit field ... OK (0.333s)
[39] the menu opens again afterwards ... OK (0.289s)
[40] leave the query form ... OK (0.415s)
[41] close the menu ... OK (0.289s)
[42] C64 resumed after the menu closed ... OK (0.546s)
--- OK (12 checks, 4.388s)
freeze_menu_test: OK (42 checks, 24.5s)
freeze-menu: OK (24.6s)

TEARDOWN (overlay): release input ... OK (0.027s)
TEARDOWN (overlay): close active menu UI ... OK (0.047s)
TEARDOWN (overlay): reset machine ... OK (0.067s)

============================================================
Summary
============================================================
     OK   e2e overlay    773s (19 ok)
     slowest: prg-context-menu 164s, browser-filesystem-refresh 123s, machine-code-monitor 118s
     773s in suites, 26.5s in health checks, the UI-state gate and teardown
     799s total

OK  all 19 suite runs passed.
```

</details>
