### PR TITLE
Outstanding-allocation tracker behind a build flag

### DIFF
--- a/software/FreeRTOS/Source/MemMang/heap_4.c
+++ b/software/FreeRTOS/Source/MemMang/heap_4.c
@@ -84,6 +84,7 @@ task.h is included from an application file. */
 
 #include "FreeRTOS.h"
 #include "task.h"
+#include "heap_track.h"
 
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
@@ -294,6 +295,7 @@ void *pvReturn = NULL;
 	#endif
 
 	configASSERT( ( ( ( uint32_t ) pvReturn ) & portBYTE_ALIGNMENT_MASK ) == 0 );
+	heap_track_record( pvReturn, xWantedSize, __builtin_return_address( 0 ) );
 	return pvReturn;
 }
 /*-----------------------------------------------------------*/
@@ -305,6 +307,8 @@ BlockLink_t *pxLink;
 
 	if( pv != NULL )
 	{
+		heap_track_forget( pv );
+
 		/* The memory being freed will have an BlockLink_t structure immediately
 		before it. */
 		puc -= xHeapStructSize;

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -654,11 +654,13 @@ API_CALL(GET, machine, heap_allocations, NULL, ARRAY( {  }))
     char buf[64];
 
     int n = heap_track_report(callers, HEAP_TRACK_REPORT_CALLERS, &totals);
+    JSON_List *caller_list = JSON::List();
+    resp->json->add("caller", caller_list);
     for (int i = 0; i < n; i++) {
         // small_printf has no %lu, so every field is printed as %d or %p.
         sprintf(buf, "%d allocations %d bytes ra %p", (int)callers[i].blocks,
                 (int)callers[i].bytes, callers[i].caller);
-        resp->json->add("caller", buf);
+        caller_list->add(buf);
     }
     resp->json->add("live_allocations", (int)totals.live_blocks);
     resp->json->add("live_bytes", (int)totals.live_bytes);

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -635,19 +635,19 @@ API_CALL(GET, machine, heap, NULL, ARRAY( {  }))
 // build made with EXTRA_DEFINES=-DHEAP_TRACK=1; see software/system/heap_track.h.
 //
 // Read these differentially: reset, exercise the device, read, exercise it
-// again, read again. A block that is live is not a block that is leaked, and
+// again, read again. An allocation that is live is not one that is leaked, and
 // only the growth between two identical rounds separates them.
 #include "heap_track.h"
 
 #define HEAP_TRACK_REPORT_CALLERS 48
 
-API_CALL(PUT, machine, heapblocks_reset, NULL, ARRAY( {  }))
+API_CALL(PUT, machine, heap_allocations_reset, NULL, ARRAY( {  }))
 {
     heap_track_reset();
     resp->json_response(HTTP_OK);
 }
 
-API_CALL(GET, machine, heapblocks, NULL, ARRAY( {  }))
+API_CALL(GET, machine, heap_allocations, NULL, ARRAY( {  }))
 {
     static HeapTrackCaller_t callers[HEAP_TRACK_REPORT_CALLERS];
     HeapTrackTotals_t totals;
@@ -656,11 +656,11 @@ API_CALL(GET, machine, heapblocks, NULL, ARRAY( {  }))
     int n = heap_track_report(callers, HEAP_TRACK_REPORT_CALLERS, &totals);
     for (int i = 0; i < n; i++) {
         // small_printf has no %lu, so every field is printed as %d or %p.
-        sprintf(buf, "%d blocks %d bytes ra %p", (int)callers[i].blocks,
+        sprintf(buf, "%d allocations %d bytes ra %p", (int)callers[i].blocks,
                 (int)callers[i].bytes, callers[i].caller);
         resp->json->add("caller", buf);
     }
-    resp->json->add("live_blocks", (int)totals.live_blocks);
+    resp->json->add("live_allocations", (int)totals.live_blocks);
     resp->json->add("live_bytes", (int)totals.live_bytes);
     resp->json->add("distinct_callers", n);
     // Non-zero means the table dropped records and is under-reporting.

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -629,3 +629,42 @@ API_CALL(GET, machine, heap, NULL, ARRAY( {  }))
     resp->json->add("total", (int)configTOTAL_HEAP_SIZE);
     resp->json_response(HTTP_OK);
 }
+
+#ifdef HEAP_TRACK
+// Where the leak is, as opposed to whether there is one. Present only in a
+// build made with EXTRA_DEFINES=-DHEAP_TRACK=1; see software/system/heap_track.h.
+//
+// Read these differentially: reset, exercise the device, read, exercise it
+// again, read again. A block that is live is not a block that is leaked, and
+// only the growth between two identical rounds separates them.
+#include "heap_track.h"
+
+#define HEAP_TRACK_REPORT_CALLERS 48
+
+API_CALL(PUT, machine, heapblocks_reset, NULL, ARRAY( {  }))
+{
+    heap_track_reset();
+    resp->json_response(HTTP_OK);
+}
+
+API_CALL(GET, machine, heapblocks, NULL, ARRAY( {  }))
+{
+    static HeapTrackCaller_t callers[HEAP_TRACK_REPORT_CALLERS];
+    HeapTrackTotals_t totals;
+    char buf[64];
+
+    int n = heap_track_report(callers, HEAP_TRACK_REPORT_CALLERS, &totals);
+    for (int i = 0; i < n; i++) {
+        // small_printf has no %lu, so every field is printed as %d or %p.
+        sprintf(buf, "%d blocks %d bytes ra %p", (int)callers[i].blocks,
+                (int)callers[i].bytes, callers[i].caller);
+        resp->json->add("caller", buf);
+    }
+    resp->json->add("live_blocks", (int)totals.live_blocks);
+    resp->json->add("live_bytes", (int)totals.live_bytes);
+    resp->json->add("distinct_callers", n);
+    // Non-zero means the table dropped records and is under-reporting.
+    resp->json->add("evicted", (int)totals.evicted);
+    resp->json_response(HTTP_OK);
+}
+#endif

--- a/software/system/heap_track.c
+++ b/software/system/heap_track.c
@@ -1,0 +1,183 @@
+/*
+ * Outstanding-allocation tracker. See heap_track.h for what it is for.
+ *
+ * Not built at all unless HEAP_TRACK is defined.
+ */
+
+#include "heap_track.h"
+
+#ifdef HEAP_TRACK
+
+#include <string.h>
+
+/*
+ * Sizing. 8192 slots at 16 bytes is 128 KB of BSS, which is affordable on a
+ * diagnostic build and holds far more than a single run leaves live. Both are
+ * overridable from the build:
+ *
+ *     EXTRA_DEFINES="-DHEAP_TRACK=1 -DHEAP_TRACK_SLOTS=16384"
+ */
+#ifndef HEAP_TRACK_SLOTS
+#define HEAP_TRACK_SLOTS 8192
+#endif
+
+/* Smallest allocation worth recording. Zero tracks everything, which is what
+   a hunt for many small objects needs; raise it to ignore the noise when
+   chasing one big buffer. */
+#ifndef HEAP_TRACK_MIN
+#define HEAP_TRACK_MIN 0
+#endif
+
+/*
+ * Slots are addressed directly from the pointer rather than searched, so
+ * record and forget stay constant-time: they sit in the allocator path and a
+ * linear scan there is not affordable once every allocation is tracked.
+ *
+ * Four ways per set, because a plain direct-mapped table lost a noticeable
+ * number of records to collisions on real runs -- two live blocks landing in
+ * one slot cost the older one. Four ways made that rare without making the
+ * lookup a search. When a set is genuinely full the oldest way is dropped and
+ * counted in `evicted`, so an under-reporting table says so rather than
+ * quietly lying.
+ */
+#define HEAP_TRACK_WAYS 4
+#define HEAP_TRACK_SETS (HEAP_TRACK_SLOTS / HEAP_TRACK_WAYS)
+
+typedef struct {
+    void *ptr;
+    void *caller;
+    uint32_t size;
+    uint32_t seq;       // insertion order, so the oldest way can be identified
+} Slot_t;
+
+static Slot_t slots[HEAP_TRACK_SETS][HEAP_TRACK_WAYS];
+static uint32_t evicted;
+static uint32_t seq_counter;
+
+static inline uint32_t set_of(void *p)
+{
+    uint32_t a = (uint32_t)p;
+    // Allocations are aligned, so the low bits carry nothing; mixing in a
+    // higher slice keeps neighbouring blocks from crowding one set.
+    return ((a >> 3) ^ (a >> 15)) & (HEAP_TRACK_SETS - 1);
+}
+
+void heap_track_record(void *p, size_t size, void *caller)
+{
+    if (!p || size < HEAP_TRACK_MIN) {
+        return;
+    }
+    Slot_t *set = slots[set_of(p)];
+    int victim = 0;
+    uint32_t oldest = 0xFFFFFFFFu;
+
+    for (int i = 0; i < HEAP_TRACK_WAYS; i++) {
+        if (set[i].ptr == NULL) {
+            victim = i;
+            goto claim;
+        }
+        if (set[i].seq < oldest) {
+            oldest = set[i].seq;
+            victim = i;
+        }
+    }
+    evicted++;
+
+claim:
+    set[victim].ptr = p;
+    set[victim].caller = caller;
+    set[victim].size = (uint32_t)size;
+    set[victim].seq = ++seq_counter;
+}
+
+void heap_track_forget(void *p)
+{
+    if (!p) {
+        return;
+    }
+    Slot_t *set = slots[set_of(p)];
+    for (int i = 0; i < HEAP_TRACK_WAYS; i++) {
+        if (set[i].ptr == p) {
+            set[i].ptr = NULL;
+            return;
+        }
+    }
+}
+
+void heap_track_note_caller(void *p, void *caller)
+{
+    if (!p) {
+        return;
+    }
+    Slot_t *set = slots[set_of(p)];
+    for (int i = 0; i < HEAP_TRACK_WAYS; i++) {
+        if (set[i].ptr == p) {
+            set[i].caller = caller;
+            return;
+        }
+    }
+}
+
+void heap_track_reset(void)
+{
+    memset(slots, 0, sizeof(slots));
+    evicted = 0;
+    seq_counter = 0;
+}
+
+int heap_track_report(HeapTrackCaller_t *out, int max, HeapTrackTotals_t *totals)
+{
+    int used = 0;
+    uint32_t blocks = 0;
+    uint32_t bytes = 0;
+
+    for (int s = 0; s < HEAP_TRACK_SETS; s++) {
+        for (int w = 0; w < HEAP_TRACK_WAYS; w++) {
+            Slot_t *slot = &slots[s][w];
+            if (!slot->ptr) {
+                continue;
+            }
+            blocks++;
+            bytes += slot->size;
+
+            int i;
+            for (i = 0; i < used; i++) {
+                if (out[i].caller == slot->caller) {
+                    break;
+                }
+            }
+            if (i == used) {
+                if (used == max) {
+                    continue;   // totals still count it; the list is full
+                }
+                out[used].caller = slot->caller;
+                out[used].blocks = 0;
+                out[used].bytes = 0;
+                used++;
+            }
+            out[i].blocks++;
+            out[i].bytes += slot->size;
+        }
+    }
+
+    // Largest first: the caller that matters is almost always at the top, and
+    // the report is read by eye as often as by script.
+    for (int i = 1; i < used; i++) {
+        HeapTrackCaller_t key = out[i];
+        int j = i - 1;
+        while (j >= 0 && out[j].bytes < key.bytes) {
+            out[j + 1] = out[j];
+            j--;
+        }
+        out[j + 1] = key;
+    }
+
+    if (totals) {
+        totals->live_blocks = blocks;
+        totals->live_bytes = bytes;
+        totals->evicted = evicted;
+    }
+    return used;
+}
+
+#endif /* HEAP_TRACK */

--- a/software/system/heap_track.h
+++ b/software/system/heap_track.h
@@ -1,0 +1,71 @@
+#ifndef HEAP_TRACK_H
+#define HEAP_TRACK_H
+
+/*
+ * Outstanding-allocation tracker.
+ *
+ * Built only when HEAP_TRACK is defined; without it every entry point below
+ * compiles to nothing and the object carries no table, so a release image is
+ * unaffected. Enable with:
+ *
+ *     make u64_no_esp EXTRA_DEFINES=-DHEAP_TRACK=1
+ *
+ * What it answers: "which allocations made since I reset it are still live?"
+ * GET /v1/machine:heap gives the free-bytes figure that says a leak exists;
+ * this says where it came from.
+ *
+ * The intended workflow is differential, because a live block is not a leaked
+ * block: reset, exercise the device once, read; exercise it again, read again.
+ * Allocations that are genuinely in use hold steady across the two, while
+ * leaked ones grow by the same amount each time. tests/tools/heap_diff.py
+ * does this.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    void *caller;
+    uint32_t blocks;
+    uint32_t bytes;
+} HeapTrackCaller_t;
+
+typedef struct {
+    uint32_t live_blocks;
+    uint32_t live_bytes;
+    uint32_t evicted;   // records lost because a set was full; see heap_track.c
+} HeapTrackTotals_t;
+
+#ifdef HEAP_TRACK
+
+void heap_track_record(void *p, size_t size, void *caller);
+void heap_track_forget(void *p);
+// operator new and malloc both funnel through one wrapper, so without this
+// every block would be attributed to that wrapper rather than to its caller.
+void heap_track_note_caller(void *p, void *caller);
+void heap_track_reset(void);
+
+// Fills `out` with one entry per distinct caller, largest byte total first,
+// and returns how many were written. Totals cover every live block, including
+// callers beyond `max`.
+int heap_track_report(HeapTrackCaller_t *out, int max, HeapTrackTotals_t *totals);
+
+#else
+
+#define heap_track_record(p, size, caller)   ((void)0)
+#define heap_track_forget(p)                 ((void)0)
+#define heap_track_note_caller(p, caller)    ((void)0)
+#define heap_track_reset()                   ((void)0)
+#define heap_track_report(out, max, totals)  (0)
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HEAP_TRACK_H */

--- a/software/system/memory_wrap.cc
+++ b/software/system/memory_wrap.cc
@@ -1,4 +1,5 @@
 #include "FreeRTOS.h"
+#include "heap_track.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -32,6 +33,10 @@ void * get_mem(size_t size)
     //printf("New operator for size = %d, returned: \n", size);
     void *ret;
 	ret = pvPortMalloc(size ? size : 1);
+	// Every C++ allocation arrives here, so without this the tracker would
+	// attribute all of them to this function instead of to the code that
+	// asked.
+	heap_track_note_caller(ret, __builtin_return_address(0));
 
 	if (!ret) {
         printf("** PANIC **: Error allocating %p..\n", __builtin_return_address(0));

--- a/target/u2/riscv/ultimate/Makefile
+++ b/target/u2/riscv/ultimate/Makefile
@@ -12,6 +12,7 @@ PRJ      =  ultimate
 FINAL    =  $(RESULT)/$(PRJ).app $(RESULT)/$(PRJ).elf $(OUTPUT)/$(PRJ).sim
 
 SRCS_C   =	itu.c \
+			heap_track.c \
 			dump_hex.c \
 			assert.c \
 			profiler.c \
@@ -192,7 +193,7 @@ SRCS_IEC = iec_code.iec
 SRCS_NANO = nano_minimal.nan
 
 PATH_INC =  $(addprefix -I, $(VPATH))
-OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-div -msave-restore
+OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-div -msave-restore $(EXTRA_DEFINES)
 OPTIONS += -gdwarf-2 -Os -DRISCV -DU2 -DOS -DIOBASE=0x10000000 -DU2P_IO_BASE=0x10100000 -DCLOCK_FREQ=50000000 -Wno-write-strings
 COPTIONS = $(OPTIONS) -std=gnu99
 CPPOPT   = $(OPTIONS) -std=gnu++11 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive

--- a/target/u2plus/nios/ultimate/Makefile
+++ b/target/u2plus/nios/ultimate/Makefile
@@ -9,6 +9,7 @@ PRJ      =  ultimate
 FINAL    =  $(RESULT)/$(PRJ).app $(RESULT)/$(PRJ).elf $(OUTPUT)/$(PRJ).sim
 
 SRCS_C   =	itu.c \
+			heap_track.c \
 			dump_hex.c \
 			assert.c \
 			profiler.c \
@@ -217,7 +218,7 @@ SRCS_IEC = iec_code.iec
 SRCS_NANO = nano_minimal.nan
 
 PATH_INC =  $(addprefix -I, $(VPATH))
-OPTIONS  = -g -ffunction-sections -Os -DOS -DU2P=1 -DNIOS=1 -DCLOCK_FREQ=62500000 -Wno-write-strings -mno-hw-div -mno-hw-mul -mno-hw-mulx
+OPTIONS  = -g -ffunction-sections -Os -DOS -DU2P=1 -DNIOS=1 -DCLOCK_FREQ=62500000 -Wno-write-strings -mno-hw-div -mno-hw-mul -mno-hw-mulx $(EXTRA_DEFINES)
 # OPTIONS  = -g -ffunction-sections -O0 -DOS -DNIOS=1 -DCLOCK_FREQ=62500000 -Wno-write-strings -mno-hw-div -mno-hw-mul -mno-hw-mulx
 COPTIONS = $(OPTIONS) -std=gnu99
 CPPOPT   = $(OPTIONS) -std=gnu++11 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive

--- a/target/u2plus_L/riscv/ultimate/Makefile
+++ b/target/u2plus_L/riscv/ultimate/Makefile
@@ -13,6 +13,7 @@ PRJ      =  ultimate
 FINAL    =  $(RESULT)/$(PRJ).app $(RESULT)/$(PRJ).elf $(OUTPUT)/$(PRJ).sim
 
 SRCS_C   =	itu.c \
+			heap_track.c \
 			dump_hex.c \
 			assert.c \
 			profiler.c \
@@ -224,7 +225,7 @@ SRCS_IEC = iec_code.iec
 SRCS_NANO = nano_minimal.nan
 
 PATH_INC =  $(addprefix -I, $(VPATH))
-OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-div
+OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-div $(EXTRA_DEFINES)
 OPTIONS += -gdwarf-2 -Os -DU2P=2 -DRISCV -DUSB2503 -DOS -DIOBASE=0x10000000 -DU2P_IO_BASE=0x10100000 -DCLOCK_FREQ=50000000 -Wno-write-strings
 COPTIONS = $(OPTIONS) -std=gnu99
 CPPOPT   = $(OPTIONS) -std=gnu++11 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive

--- a/target/u64/nios2/ultimate/Makefile
+++ b/target/u64/nios2/ultimate/Makefile
@@ -11,6 +11,7 @@ FINAL    =  $(RESULT)/$(PRJ).app $(RESULT)/$(PRJ).elf $(OUTPUT)/$(PRJ).sim
 BSP      = $(PATH_SW)/nios_appl_bsp
 
 SRCS_C   =	itu.c \
+			heap_track.c \
 			dump_hex.c \
 			assert.c \
 			profiler.c \
@@ -248,7 +249,7 @@ SRCS_IEC = iec_code.iec
 SRCS_NANO = nano_minimal.nan
 
 PATH_INC =  $(addprefix -I, $(VPATH))
-OPTIONS  = -g -ffunction-sections -Os -DOS -DDEVELOPER=0 -DNIOS=1 -DCLOCK_FREQ=66666667 -DU64=1 -Wno-write-strings -mno-hw-div -mno-hw-mul -mno-hw-mulx
+OPTIONS  = -g -ffunction-sections -Os -DOS -DDEVELOPER=0 -DNIOS=1 -DCLOCK_FREQ=66666667 -DU64=1 -Wno-write-strings -mno-hw-div -mno-hw-mul -mno-hw-mulx $(EXTRA_DEFINES)
 COPTIONS = $(OPTIONS) -std=gnu99
 CPPOPT   = $(OPTIONS) -std=gnu++11 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive
 LINK 	 = $(BSP)/linker.x

--- a/target/u64/riscv/ultimate/Makefile
+++ b/target/u64/riscv/ultimate/Makefile
@@ -12,6 +12,7 @@ PRJ      =  ultimate
 FINAL    =  $(RESULT)/$(PRJ).app $(RESULT)/$(PRJ).elf $(OUTPUT)/$(PRJ).sim
 
 SRCS_C   =	itu.c \
+			heap_track.c \
 			dump_hex.c \
 			assert.c \
 			profiler.c \
@@ -198,7 +199,7 @@ SRCS_IEC = iec_code_pr.iec iec_code_dr_pr.iec iec_code_dr.iec
 SRCS_NANO = nano_minimal.nan
 
 PATH_INC =  $(addprefix -I, $(VPATH))
-OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-fdiv
+OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-fdiv $(EXTRA_DEFINES)
 OPTIONS += -gdwarf-2 -O0 -DRISCV -DOS -DIOBASE=0x10000000 -DU2P_IO_BASE=0x10100000 -DCLOCK_FREQ=66666667 -DU64=1 -Wno-write-strings
 COPTIONS = $(OPTIONS) -std=gnu99
 CPPOPT   = $(OPTIONS) -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive

--- a/target/u64ii/riscv/ultimate/Makefile
+++ b/target/u64ii/riscv/ultimate/Makefile
@@ -12,6 +12,7 @@ PRJ      =  ultimate
 FINAL    =  $(RESULT)/$(PRJ).app $(RESULT)/$(PRJ).elf $(OUTPUT)/$(PRJ).sim
 
 SRCS_C   =	itu.c \
+			heap_track.c \
 			dump_hex.c \
 			assert.c \
 			profiler.c \
@@ -240,7 +241,7 @@ SRCS_IEC = iec_code.iec
 SRCS_NANO = nano_minimal.nan
 
 PATH_INC =  $(addprefix -I, $(VPATH))
-OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-div
+OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-div $(EXTRA_DEFINES)
 OPTIONS += -gdwarf-2 -Os -DRISCV -DU64=2 -DUSB2513 -DOS -DIOBASE=0x10000000 -DU2P_IO_BASE=0x10100000 -DCLOCK_FREQ=100000000 -Wno-write-strings -DFP_SUPPORT=1
 COPTIONS = $(OPTIONS) -std=gnu99
 CPPOPT   = $(OPTIONS) -std=gnu++11 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive

--- a/tests/tools/heap_diff.py
+++ b/tests/tools/heap_diff.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Find which allocation sites leak, by running the same work twice.
+
+A live block is not a leaked block. The device's own report says what is
+outstanding right now, which on any real firmware is mostly legitimate: the
+directory on screen, the current session, cached structures. Reading it once
+and treating the big entries as leaks is how you end up fixing the wrong thing.
+
+So run the work twice and compare. A caller whose block count is the same after
+one round and after two is holding live objects. A caller whose count grows by
+the same amount each round is leaking that much per round. That difference is
+the whole tool.
+
+Needs firmware built with EXTRA_DEFINES=-DHEAP_TRACK=1; without it the
+endpoints are absent and this exits saying so.
+
+    tests/tools/heap_diff.py -H 192.168.1.64 -- ./run-tests -H 192.168.1.64 -s prg-context-menu
+
+Whatever follows -- is run once per round. Give it something that does the same
+work every time, or the comparison means nothing.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+
+# tests/lib holds the one shared REST client; every suite and tool goes through
+# it so the retry policy lives in exactly one place.
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "lib"))
+import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
+
+BLOCKS = "/v1/machine:heapblocks"
+RESET = "/v1/machine:heapblocks_reset"
+HEAP = "/v1/machine:heap"
+
+
+def callers(rest):
+    """Map caller address -> (blocks, bytes), plus the raw report."""
+    data = rest.json(BLOCKS)
+    out = {}
+    entries = data.get("caller", [])
+    if isinstance(entries, str):
+        entries = [entries]
+    for line in entries:
+        m = re.match(r"(\d+) blocks (\d+) bytes ra ([0-9A-Fa-f]+)", line)
+        if m:
+            out[m.group(3)] = (int(m.group(1)), int(m.group(2)))
+    return out, data
+
+
+def free_heap(rest):
+    return int(rest.json(HEAP)["free"])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("-H", "--host", required=True)
+    ap.add_argument("-p", "--password", default=os.environ.get("U64_PASS"))
+    ap.add_argument("-t", "--timeout", type=float, default=30.0)
+    ap.add_argument("-n", "--rounds", type=int, default=2,
+                    help="rounds to run; 2 is enough to separate live from leaked (default: 2)")
+    ap.add_argument("-s", "--settle", type=float, default=8.0,
+                    help="seconds to settle before each sample (default: 8.0)")
+    ap.add_argument("--warmup", action="store_true",
+                    help="run the command once before measuring, so one-time "
+                         "costs are not counted as leaks")
+    ap.add_argument("command", nargs=argparse.REMAINDER,
+                    help="after --, the command to run each round")
+    args = ap.parse_args()
+
+    cmd = args.command[1:] if args.command and args.command[0] == "--" else args.command
+    if not cmd:
+        ap.error("give a command to run after --")
+
+    rest = rest_lib.RestClient(args.host, args.password or None, args.timeout)
+
+    if rest.status("GET", BLOCKS) != 200:
+        print("This firmware has no machine:heapblocks. Rebuild with "
+              "EXTRA_DEFINES=-DHEAP_TRACK=1", file=sys.stderr)
+        return 2
+
+    if args.warmup:
+        print("warmup round (not measured)")
+        subprocess.run(cmd, check=False)
+        time.sleep(args.settle)
+
+    rest.expect("PUT", RESET)
+    before_free = free_heap(rest)
+    rounds = []
+    for i in range(args.rounds):
+        print(f"round {i + 1}/{args.rounds}: {' '.join(cmd)}")
+        result = subprocess.run(cmd, check=False)
+        if result.returncode != 0:
+            print(f"  command exited {result.returncode}; a failed round makes "
+                  f"the comparison meaningless", file=sys.stderr)
+            return 1
+        time.sleep(args.settle)
+        rounds.append(callers(rest)[0])
+
+    after_free = free_heap(rest)
+    first, last = rounds[0], rounds[-1]
+    spent = before_free - after_free
+    span = len(rounds) - 1 or 1
+
+    print(f"\nfree heap: {before_free} -> {after_free} = {spent} bytes over "
+          f"{args.rounds} rounds")
+    print(f"\n{'caller':>10}  {'blocks/round':>13}  {'bytes/round':>12}  verdict")
+    growing = []
+    for ra in sorted(set(first) | set(last)):
+        b0, y0 = first.get(ra, (0, 0))
+        b1, y1 = last.get(ra, (0, 0))
+        db, dy = (b1 - b0) / span, (y1 - y0) / span
+        if db > 0:
+            growing.append((dy, ra, db))
+        verdict = "GROWING" if db > 0 else "steady"
+        if db > 0 or b1:
+            print(f"{ra:>10}  {db:13.1f}  {dy:12.1f}  {verdict}")
+
+    if growing:
+        growing.sort(reverse=True)
+        print("\nLeaking, largest first. Resolve with:")
+        print("  nios2-elf-addr2line -f -C -e <ultimate.elf> 0x<addr>")
+        for dy, ra, db in growing:
+            print(f"  0x{ra}  {dy:.0f} bytes/round in {db:.1f} blocks")
+    else:
+        print("\nNothing grew between rounds.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/heap_diff.py
+++ b/tests/tools/heap_diff.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Find which allocation sites leak, by running the same work twice.
 
-A live block is not a leaked block. The device's own report says what is
+A live allocation is not a leaked one. The device's own report says what is
 outstanding right now, which on any real firmware is mostly legitimate: the
 directory on screen, the current session, cached structures. Reading it once
 and treating the big entries as leaks is how you end up fixing the wrong thing.
 
-So run the work twice and compare. A caller whose block count is the same after
+So run the work twice and compare. A caller whose allocation count is the same after
 one round and after two is holding live objects. A caller whose count grows by
 the same amount each round is leaking that much per round. That difference is
 the whole tool.
@@ -33,20 +33,20 @@ sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "lib"))
 import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
 
-BLOCKS = "/v1/machine:heapblocks"
-RESET = "/v1/machine:heapblocks_reset"
+ALLOCATIONS = "/v1/machine:heap_allocations"
+RESET = "/v1/machine:heap_allocations_reset"
 HEAP = "/v1/machine:heap"
 
 
 def callers(rest):
-    """Map caller address -> (blocks, bytes), plus the raw report."""
-    data = rest.json(BLOCKS)
+    """Map caller address -> (allocations, bytes), plus the raw report."""
+    data = rest.json(ALLOCATIONS)
     out = {}
     entries = data.get("caller", [])
     if isinstance(entries, str):
         entries = [entries]
     for line in entries:
-        m = re.match(r"(\d+) blocks (\d+) bytes ra ([0-9A-Fa-f]+)", line)
+        m = re.match(r"(\d+) allocations (\d+) bytes ra ([0-9A-Fa-f]+)", line)
         if m:
             out[m.group(3)] = (int(m.group(1)), int(m.group(2)))
     return out, data
@@ -78,8 +78,8 @@ def main():
 
     rest = rest_lib.RestClient(args.host, args.password or None, args.timeout)
 
-    if rest.status("GET", BLOCKS) != 200:
-        print("This firmware has no machine:heapblocks. Rebuild with "
+    if rest.status("GET", ALLOCATIONS) != 200:
+        print("This firmware has no machine:heap_allocations. Rebuild with "
               "EXTRA_DEFINES=-DHEAP_TRACK=1", file=sys.stderr)
         return 2
 
@@ -108,7 +108,7 @@ def main():
 
     print(f"\nfree heap: {before_free} -> {after_free} = {spent} bytes over "
           f"{args.rounds} rounds")
-    print(f"\n{'caller':>10}  {'blocks/round':>13}  {'bytes/round':>12}  verdict")
+    print(f"\n{'caller':>10}  {'allocs/round':>13}  {'bytes/round':>12}  verdict")
     growing = []
     for ra in sorted(set(first) | set(last)):
         b0, y0 = first.get(ra, (0, 0))
@@ -125,7 +125,7 @@ def main():
         print("\nLeaking, largest first. Resolve with:")
         print("  nios2-elf-addr2line -f -C -e <ultimate.elf> 0x<addr>")
         for dy, ra, db in growing:
-            print(f"  0x{ra}  {dy:.0f} bytes/round in {db:.1f} blocks")
+            print(f"  0x{ra}  {dy:.0f} bytes/round in {db:.1f} allocations")
     else:
         print("\nNothing grew between rounds.")
     return 0


### PR DESCRIPTION
`machine:heap` (#766) says a leak exists. This says where. It found four of the
five leaks in #770, #772 and #773, none of which were reachable by reading
code -- each had correct-looking ownership on every path around it.

## Shape

- `software/system/heap_track.{c,h}` -- the table and the report. All of it
  behind `HEAP_TRACK`; with the flag undefined the entry points are macros that
  expand to nothing, no table is reserved and the allocator does no extra work.
- `heap_4.c` -- four guarded lines, no logic. I put the implementation in its
  own file specifically so the FreeRTOS vendor diff stays trivial.
- `memory_wrap.cc` -- one call. `operator new` and `malloc` both funnel through
  `get_mem()`, so without re-attributing there, every allocation reads as that
  wrapper rather than as the code that asked.
- `route_machine.cc` -- `GET /v1/machine:heap_allocations` and
  `PUT /v1/machine:heap_allocations_reset`, compiled only with the flag.
- Makefiles -- `$(EXTRA_DEFINES)` appended to `OPTIONS` (the hook #763 proposed,
  which did not land with #766) plus `heap_track.c` in the source list, for the
  six actively built targets.

Slots are addressed directly from the pointer rather than searched: record and
forget sit in the allocator path and a linear scan there is not affordable once
every allocation is tracked. Four ways per set, because a plain direct-mapped
table lost a noticeable number of records to collisions on real runs. A full
set drops its oldest entry and counts it in `evicted`, so a table that is
under-reporting says so rather than quietly lying.

## Gating, demonstrated

```
flag off:  update.u64 5,374,124 bytes,  no machine:heap_allocations in the image
flag on:   update.u64 5,375,552 bytes,  both endpoints present
```

The 128 KB table is BSS, so it does not appear in the image either way. Both
configurations build clean on the CI-matched Quartus 18.1 nios2 toolchain.

## The part that actually finds leaks

`tests/tools/heap_diff.py`. A live block is not a leaked block, and on real
firmware most outstanding blocks are legitimate -- the directory on screen, the
current session, cached structures. Reading the endpoint once and treating the
big entries as leaks is how you fix the wrong thing.

So it runs the same work twice and reports which callers grew between rounds.
Steady callers are holding live objects; growing ones are leaking, by the
amount they grow. That is what separated four stranded `FileInfo` copies per
run from the seven that were merely the listing on screen in #773 -- and what
stopped me attributing that leak to the disk image mount cache, whose totals
looked right for it and were not.

```
tests/tools/heap_diff.py -H <device> -- ./run-tests -H <device> -s prg-context-menu
```

It goes through `tests/lib/rest.py` like everything else; `transport-usage`
passes.

## Status and what I want to hear

**Not yet verified on hardware in this form.** The tracker it descends from has
been in daily use all week, but this is a rewrite -- four-way sets, sorted
report, compiled-out gating -- and I have not yet run *this* code on a device.
Happy to do that before it leaves draft; I did not want to build on a shape
nobody has agreed to.

The open questions are in #775, and the two that matter:

1. **Vendor hooks or not.** Completeness argues for `pvPortMalloc`/`vPortFree`
   as here. Hooking only `memory_wrap.cc` would touch no FreeRTOS code and
   would still have caught every leak found so far, at the cost of missing task
   stacks, queues and direct `pvPortMalloc` callers.
2. **Whether you want a debugging tool in the shipping tree at all**, gated but
   present. If the answer is that it should stay on a branch, that is a fine
   answer and nothing is wasted -- it lives on one today.

@chrisgleissner -- this touches no part of the e2e runner, and `heap_diff.py`
is standalone, so it should not collide with your multi-device work.

