### PR TITLE
Accept whitespace around names and enum values in a .cfg

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -135,6 +135,11 @@ SUITES: Sequence[Suite] = (
     # anyway: that is what a file from another Ultimate looks like.
     Suite("e2e", "cfg-unknown-items", "tests/e2e/filemanager/cfg_unknown_items_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
+    # A hand-edited .cfg spaces things the way a person would, which the padded
+    # enum labels in the Audio Mixer make a real case rather than a contrived
+    # one: nobody types "Vol Master= 0 dB" with the leading space.
+    Suite("e2e", "cfg-whitespace", "tests/e2e/filemanager/cfg_whitespace_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
     Suite("e2e", "printer", "tests/e2e/io/printer/printer_test.py", "-H @HOST@ -p @PASS@"),
     # Drives the UCI control and SoftIEC targets over $DF1B-$DF1F; reproduces #740.
     # A #740 regression leaves the interface stuck in Command Busy for every target

--- a/software/test/configio/configio_test.cc
+++ b/software/test/configio/configio_test.cc
@@ -162,8 +162,8 @@ int main(int argc, char **argv)
 
     printf("-- enum labels with spaces survive a round trip\n");
     /* An ARMSID writes "8580 Lowest Filt Freq= ~45" into a .cfg, padding and
-       all. Nothing trims either side, so the value has to match exactly the
-       way it was written -- including a label whose own name contains spaces. */
+       all. The padding is written verbatim and read back as the same choice,
+       including a label whose own name contains spaces. */
     sid->set_value(0x02, 1);   // " ~45"
     sid->set_value(0x03, 0);   // "12 kHz"
     MemFile pad;
@@ -184,6 +184,37 @@ int main(int argc, char **argv)
           "reading those values back is not an error");
     check(sid->get_value(0x02) == 1, "the padded label is matched exactly");
     check(sid->get_value(0x03) == 0, "the label with an inner space is matched");
+
+    printf("-- a hand-edited file may space things how it likes\n");
+    /* Nobody types the menu's alignment padding. "8580 Lowest Filt Freq=30" is
+       what a person writes for the choice the firmware spells "  30", and it
+       used to be rejected as an invalid choice. */
+    sid->set_value(0x02, 3);
+    sid->set_value(0x03, 2);
+    sid->set_value(0x01, 0);
+    MemFile hand;
+    IndexedList<ConfigStore *> loaded_hand(8, NULL);
+    StreamTextLog log_hand(4096);
+    hand.load("[SID Socket 1: PDsid]\n"
+              "8580 Lowest Filt Freq=30\n"          /* label is "  30" */
+              "8580 Highest Filt Freq=  12 kHz  \n" /* inner space kept */
+              "  Emulation Mode  =  8580  \n"       /* spaces around both */
+              "\n");
+    check(ConfigIO::S_read_from_file(&hand, &log_hand, loaded_hand),
+          "a hand-spaced file loads without error");
+    check(sid->get_value(0x02) == 0, "an unpadded value matches a padded label");
+    check(sid->get_value(0x03) == 0, "outer spaces are ignored, the inner one is not");
+    check(sid->get_value(0x01) == 1, "a padded item name finds its item");
+
+    printf("-- tolerance is not laxity\n");
+    sid->set_value(0x02, 1);
+    MemFile bogus;
+    IndexedList<ConfigStore *> loaded_bogus(8, NULL);
+    StreamTextLog log_bogus(4096);
+    bogus.load("[SID Socket 1: PDsid]\n8580 Lowest Filt Freq=31\n\n");
+    check(!ConfigIO::S_read_from_file(&bogus, &log_bogus, loaded_bogus),
+          "a value that is not a choice is still an error");
+    check(sid->get_value(0x02) == 1, "and the store keeps its previous value");
 
     printf("-- an unknown item is a warning, not a failure\n");
     MemFile unknown_item;

--- a/software/userinterface/configio.cc
+++ b/software/userinterface/configio.cc
@@ -308,6 +308,39 @@ bool ConfigIO :: S_read_from_file(File *f, StreamTextLog *log, IndexedList<Confi
     return allOK;
 }
 
+// A .cfg written by this firmware never puts spaces around '=', so a file that
+// has been round-tripped is unaffected by any of this. A hand-edited one is
+// another matter, and enum labels make it worse: several are padded so the menu
+// can right align them ("  30", " ~45"), which means writing the obvious thing
+// by hand produces a value that used to be rejected outright.
+static const char *skip_leading_space(const char *s)
+{
+    while ((*s == ' ') || (*s == '\t')) {
+        s++;
+    }
+    return s;
+}
+
+static int length_without_trailing_space(const char *s)
+{
+    int n = (int)strlen(s);
+    while ((n > 0) && ((s[n - 1] == ' ') || (s[n - 1] == '\t'))) {
+        n--;
+    }
+    return n;
+}
+
+// Compares what is between the spaces, so " ~45" and "~45" are the same choice
+// while "12 kHz" keeps the space that belongs to it.
+static bool equal_ignoring_outer_space(const char *a, const char *b)
+{
+    a = skip_leading_space(a);
+    b = skip_leading_space(b);
+    int la = length_without_trailing_space(a);
+    int lb = length_without_trailing_space(b);
+    return (la == lb) && (strncasecmp(a, b, la) == 0);
+}
+
 t_cfg_line_result ConfigIO :: S_read_store_element(ConfigStore *st, const char *line, int linenr, StreamTextLog *log)
 {
     char itemname[40];
@@ -323,23 +356,28 @@ t_cfg_line_result ConfigIO :: S_read_store_element(ConfigStore *st, const char *
         }
         itemname[i] = line[i];
     }
-    if (strlen(itemname) == 0) {
+    // No config item is defined with padding around its name, so trimming the
+    // name can only help: it makes "Item = value" find the same item as
+    // "Item=value".
+    itemname[length_without_trailing_space(itemname)] = 0;
+    const char *name = skip_leading_space(itemname);
+    if (strlen(name) == 0) {
         log->format("Line %d: No item name.\n", linenr);
         return CFG_LINE_MALFORMED;
     }
     if (!valuestr) {
-        log->format("Line %d: No value given for item '%s'.\n", linenr, itemname);
+        log->format("Line %d: No value given for item '%s'.\n", linenr, name);
         return CFG_LINE_MALFORMED;
     }
     // now look for the store element with the itemname
-    ConfigItem *item = st->find_item(itemname);
+    ConfigItem *item = st->find_item(name);
     if (!item) {
         // Not an error: a .cfg from a machine with other hardware, or from
         // another firmware version, legitimately names items this one lacks.
         // printf goes to the syslog when one is configured.
         printf("Config: [%s] has no item '%s' (value '%s'); ignored.\n",
-               st->store_name.c_str(), itemname, valuestr);
-        log->format("Line %d: Item '%s' not found in this store [%s]; ignored.\n", linenr, itemname, st->store_name.c_str());
+               st->store_name.c_str(), name, valuestr);
+        log->format("Line %d: Item '%s' not found in this store [%s]; ignored.\n", linenr, name, st->store_name.c_str());
         return CFG_LINE_UNKNOWN;
     }
 
@@ -354,6 +392,10 @@ t_cfg_line_result ConfigIO :: S_read_store_element(ConfigStore *st, const char *
             st->staleFlash = true;
         }
     } else if ((item->definition->type == CFG_TYPE_STRING) || (item->definition->type == CFG_TYPE_STRFUNC) || (item->definition->type == CFG_TYPE_STRPASS)) {
+        // Taken exactly as written, unlike an enum choice: a space in a string
+        // value can be deliberate, and a password is a string. Trimming here
+        // would silently change data rather than accept a different spelling of
+        // the same choice.
         if (strncmp(item->string, valuestr, item->definition->max) != 0) {
             strncpy(item->string, valuestr, item->definition->max);
             st->staleEffect = true;
@@ -362,7 +404,7 @@ t_cfg_line_result ConfigIO :: S_read_store_element(ConfigStore *st, const char *
     } else if (item->definition->type == CFG_TYPE_ENUM) {
         // this is the most nasty one. Let's just iterate over the possibilities and compare the resulting strings
         for(int n = item->definition->min; n <= item->definition->max; n++) {
-            if (strcasecmp(valuestr, item->definition->items[n]) == 0) {
+            if (equal_ignoring_outer_space(valuestr, item->definition->items[n])) {
                 if (n != item->value) {
                     item->value = n;
                     st->staleEffect = true;

--- a/tests/e2e/filemanager/cfg_whitespace_test.py
+++ b/tests/e2e/filemanager/cfg_whitespace_test.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""E2E: a hand-edited CFG may space its names and values how a person would.
+
+Enum labels are padded so the menu can right align them, and the Audio Mixer is
+the plainest example on any machine: its values are " 0 dB", "-6 dB", "+3 dB".
+A .cfg the firmware wrote carries that padding verbatim, but nobody typing one
+by hand writes "Vol Master= 0 dB" with the leading space, and before this change
+"Vol Master=0 dB" was answered with "not a valid choice" and the load failed.
+
+Two checks, both through the real loader on real hardware:
+
+  - an unpadded value matches its padded label
+  - spaces around the item name, and around the value, are ignored
+
+The inner space is the interesting part of both: every value here contains one,
+so a fix that merely stripped all whitespace would match nothing and these would
+fail.
+
+What is deliberately *not* here: that a value which is not a choice is still an
+error, and that a string value keeps its spaces. Both are decided in
+S_read_store_element and are covered by the host unit tests, which can assert
+them without driving a popup and an editor. This suite exists to prove the path
+works end to end, not to re-test the parser.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+from api import UltimateApi
+import ftp as ftp_lib
+from report import Failure, check, detail, format_exception, section, suite_fail, suite_ok
+from ui_backend import add_mode_argument, make_browser
+
+# A store every machine has, whose enum labels are padded and contain a space.
+STORE = "Audio Mixer"
+ITEM = "Vol Master"
+
+CFG_NAME = "cfg-space-e2e.cfg"
+
+ENTRY_ROWS = range(2, 24)
+STATUS_ROW = 24
+TELNET_ENTRY_ROWS = range(2, 23)
+TELNET_STATUS_ROW = 23
+
+
+def padded_value(api: UltimateApi) -> str:
+    """The value carrying leading padding, which is what makes this test mean
+    something. On the Audio Mixer that is " 0 dB", padded to the width of the
+    negative values beside it."""
+    values = api.configs.item(STORE, ITEM).get("values", [])
+    for value in values:
+        if isinstance(value, str) and value != value.strip() and " " in value.strip():
+            return value
+    raise Failure(f"{STORE}/{ITEM} has no padded value to test with: {values!r}")
+
+
+def plain_value(api: UltimateApi, avoid: str) -> str:
+    """A value with no padding but an inner space, e.g. "-6 dB"."""
+    values = api.configs.item(STORE, ITEM).get("values", [])
+    for value in values:
+        if isinstance(value, str) and value != avoid and value == value.strip() and " " in value:
+            return value
+    raise Failure(f"{STORE}/{ITEM} has no unpadded value to test with: {values!r}")
+
+
+def upload(host: str, password: str, body: str) -> None:
+    with ftp_lib.session(host, password, timeout=20) as ftp:
+        ftp_lib.store(ftp, f"/Temp/{CFG_NAME}", body.encode("ascii"))
+
+
+def load_cfg(browser) -> None:
+    browser.go_to_directory("Temp")
+    browser.select_entry(CFG_NAME)
+    browser.invoke_context_action("Load Settings")
+    browser.wait_for_text("Loading configuration successful!")
+    browser.press_popup_button("o")
+
+
+def cleanup(host: str, password: str) -> None:
+    try:
+        with ftp_lib.session(host, password, timeout=20) as ftp:
+            ftp_lib.delete_quietly(ftp, f"/Temp/{CFG_NAME}")
+    except Exception:
+        pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "5.0")))
+    parser.add_argument("--telnet-port", type=int,
+                        default=int(os.environ.get("U64_TELNET_PORT", "23")))
+    add_mode_argument(parser)
+    args = parser.parse_args()
+
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    original = api.configs.current(STORE, ITEM)
+    browser = make_browser(
+        args.mode, args.host, args.password or None, args.timeout,
+        entry_rows=ENTRY_ROWS, status_row=STATUS_ROW, telnet_port=args.telnet_port,
+        telnet_entry_rows=TELNET_ENTRY_ROWS, telnet_status_row=TELNET_STATUS_ROW,
+    )
+
+    try:
+        section("an unpadded value matches its padded label")
+        wanted = padded_value(api)
+        # Start somewhere else, so applying the file is what moves it.
+        api.configs.set(STORE, ITEM, plain_value(api, wanted))
+        with check(f"a CFG saying {ITEM}={wanted.strip()!r} loads and applies"):
+            # Written the way a person would: no leading padding, but the space
+            # inside the label kept, because that one is part of the value.
+            upload(args.host, args.password, f"[{STORE}]\n{ITEM}={wanted.strip()}\n")
+            load_cfg(browser)
+            now = api.configs.current(STORE, ITEM)
+            if now != wanted:
+                raise Failure(
+                    f"{STORE}/{ITEM} is {now!r}, expected the padded label {wanted!r}")
+            detail(f"file said {wanted.strip()!r}, device holds {now!r}")
+
+        section("spaces around the name and the value are ignored")
+        spaced = plain_value(api, wanted)
+        api.configs.set(STORE, ITEM, wanted)
+        with check("a CFG with spaces around both loads and applies"):
+            upload(args.host, args.password, f"[{STORE}]\n  {ITEM}  =  {spaced}  \n")
+            load_cfg(browser)
+            now = api.configs.current(STORE, ITEM)
+            if now != spaced:
+                raise Failure(f"{STORE}/{ITEM} is {now!r}, expected {spaced!r}")
+            detail(f"file said '  {ITEM}  =  {spaced}  ', device holds {now!r}")
+
+        suite_ok("cfg_whitespace_test")
+        return 0
+    except Failure as exc:
+        suite_fail("cfg_whitespace_test", str(exc))
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        suite_fail("cfg_whitespace_test", format_exception(exc))
+        return 1
+    finally:
+        try:
+            api.configs.set(STORE, ITEM, original)
+        except Exception:
+            pass
+        try:
+            browser.close()
+        except Exception:
+            pass
+        cleanup(args.host, args.password)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
@chrisgleissner asked for this on #768, which merged before it was written, so
it comes as its own PR. Follows on from #755.

A `.cfg` written by this firmware never puts spaces around `=`, so a
round-tripped file was never affected by any of this. A hand-edited one is
another matter, and enum labels make it worse: several are padded so the menu
can right align them, which your ARM2SID screenshots showed nicely --
`8580 Lowest Filt Freq` is stored as `"  30"`, `" ~45"`, `" ~70"`. Writing the
obvious thing by hand produced:

```
Line 4: Value '30' is not a valid choice for item 8580 Lowest Filt Freq
```

and failed the load.

## What changes

| line in a .cfg | before | after |
|---|---|---|
| `8580 Lowest Filt Freq=30` | rejected | matches `"  30"` |
| `8580 Highest Filt Freq=  12 kHz  ` | rejected | matches `"12 kHz"` |
| `  Emulation Mode  =  8580  ` | item not found, ignored | matches |
| `8580 Lowest Filt Freq=31` | error | **still an error** |
| anything this firmware wrote | works | unchanged |

Enum choices are compared ignoring what surrounds them, and a padded item name
finds its item. The space inside `12 kHz` is untouched -- only the outside is
ignored. No config item is defined with padding around its *name*, so trimming
that side can only help.

**String values are deliberately left exactly as written.** Trimming an enum
accepts a different spelling of the same choice; trimming a string would
silently change data, and a password is a string. The asymmetry is commented in
place, because it looks like an oversight otherwise.

## Testing

Host tests: **25 checks, 0 failed**. Reverting `configio.cc` alone fails
exactly the four new ones:

```
FAIL a hand-spaced file loads without error
FAIL an unpadded value matches a padded label
FAIL outer spaces are ignored, the inner one is not
FAIL a padded item name finds its item
25 checks, 4 failed
```

The two checks under "tolerance is not laxity" pass either way by design --
they guard that a value which is not a choice is still an error, and that the
store keeps its previous value when one is rejected.

Full default E2E suite set against firmware 3.15, FPGA core 123, core version
1.4B, overlay mode: **all 20 suite runs passed**, exit 0, no recovery invoked.
`cfg-single-group` and `cfg-unknown-items` both green, which are the suites on
the path this touches.

## Two harness notes, neither fixed here

@chrisgleissner, both are pre-existing and relevant to your zero-flakiness aim:

1. **Host tests cannot cover `CFG_TYPE_STRING` at all.** I wrote a test
   asserting that a string keeps its spaces, and it segfaulted the harness:
   `definition->def` is an `int`, and `config.cc:664` casts it back to
   `const char *`. Fine on the 32-bit targets, fatal on a 64-bit host. I
   withdrew the test rather than ship a broken one, so the string half of this
   change rests on inspection -- it is a comment and no code.
2. **`make host_tests` fails from a clean checkout** until
   `target/pc/linux/configiotest/output` and `result` exist:
   `Fatal error: can't create output/dump_hex.o: No such file or directory`.
   Creating them by hand fixes it. Worth a `mkdir -p` in the rule, but that is
   the runner area you asked me to leave alone until Thursday.

<details>
<summary>Full <code>./run-tests</code> output</summary>

```

============================================================
Ultimate hardware test run
============================================================
     host:       192.168.1.148
     categories: e2e
     modes:      overlay
     timeout:    30.0s
     on failure: continue
     health:    answers + health sweep, retry after recovery

============================================================
E2E  transport-usage  (overlay)
============================================================
UI state dirty: the root browser is not on top; a nested object still holds the UI; repairing
UI state repaired
     transport-usage: health: ping=7ms rest=10ms ftp=10ms telnet=33ms ident=15ms dma=7ms raster=21ms jiffy=21ms -> OK
check_transport_usage: OK (45 files, 0.191s)
transport-usage: OK (0.226s)

============================================================
E2E  runner-policy  (overlay)
============================================================
     runner-policy: health: ping=7ms rest=10ms ftp=10ms telnet=34ms ident=12ms dma=7ms raster=23ms jiffy=57ms -> OK
[01] a clean run exits 0 ... OK (0.000s)
[02] a failed suite exits 1 ... OK (0.000s)
[03] a recovery with no failure exits 3 ... OK (0.000s)
[04] a failure outranks a recovery ... OK (0.000s)
[05] a device that cannot be made healthy exits 4, outranking a failure ... OK (0.000s)
[06] a device that answers is never recovered ... OK (0.000s)
[07] recovery runs only once the ordinary wait has given up ... OK (0.011s)
     fixture: the device is unhealthy: it is not answering
[08] a recovery that does not bring the device back reports so ... OK (0.070s)
     fixture: the device is unhealthy: it is not answering
[09] a recovery command that exits non-zero is still followed by a probe ... OK (0.006s)
     fixture: the device is unhealthy: it is not answering
[10] a recovery command that hangs is bounded by --recover-timeout ... OK (0.203s)
     fixture: the device is unhealthy: it is not answering
[11] a recovery command the shell cannot find is a failed recovery ... OK (0.072s)
     fixture: the device is unhealthy: it is not answering
[12] no recovery command means no recovery ... OK (0.000s)
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: no --recover-command was given
[13] a suite gives up after --recover-max-per-suite recoveries ... OK (0.141s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
[14] the per-suite budget starts again at the next suite ... OK (0.061s)
     fixture: the device is unhealthy: it is not answering
[15] the run gives up after --recover-max-total recoveries ... OK (0.128s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
[16] the refusal says which ceiling was reached ... OK (0.066s)
     fixture: the device is unhealthy: it is not answering
[17] a healthy sweep after a failed suite recovers nothing ... OK (0.000s)
     fixture: health: rest=9ms -> OK
[18] a degraded but reachable device is recovered ... OK (0.015s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms -> OK
[19] a device still degraded after recovering is reported, not retried ... OK (0.011s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
[20] a degraded device is not recovered past its ceiling ... OK (0.011s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: not recovering: the run has already used its 1 recoveries
[21] --no-health-check takes the sweep out of the decision ... OK (0.000s)
[22] --no-health-check still recovers a device that has gone ... OK (0.067s)
     fixture: the device is unhealthy: it is not answering
[23] consecutive resets collapse into one ... OK (0.000s)
[24] a read between two resets does not warrant the second ... OK (0.000s)
[25] a mutating call between two resets warrants the second ... OK (0.000s)
[26] force resets even when nothing has changed ... OK (0.000s)
[27] a suite told the device was just reset does not reset again ... OK (0.000s)
[28] a suite not told that still resets ... OK (0.000s)
[29] a suite that fails on a healthy device is not run again ... OK (0.023s)
[30] a suite that fails on an unhealthy device runs again after recovery ... OK (0.067s)
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
[31] --no-retry keeps the recovery and drops the extra attempt ... OK (0.027s)
[32] a device that cannot be made healthy ends the run ... OK (0.023s)
fixture: OK (1.500s)
[33] a health sweep reaches the JSONL with a latency per check ... OK (0.000s)
[34] a suite record carries the profile, attempt and recoveries ... OK (0.000s)
[35] the run record agrees with the exit status ... OK (0.000s)
[36] a sweep with every check passing is healthy ... OK (0.000s)
[37] a failed check makes the sweep degraded and names it ... OK (0.000s)
[38] a skipped check never makes the sweep degraded ... OK (0.000s)
[39] the one-line summary carries every latency and the verdict ... OK (0.000s)
     the recovery command runs on a degraded or unreachable device, never on a suite that merely failed
runner_policy_test: OK (39 checks, 1.031s)
runner-policy: OK (1.089s)

============================================================
E2E  ui-backend-smoke  (overlay)
============================================================
     ui-backend-smoke: health: ping=7ms rest=10ms ftp=10ms telnet=33ms ident=12ms dma=8ms raster=22ms jiffy=21ms -> OK

--- Overlay navigation planner
[01] a unique first letter jumps straight to the item ... OK (0.000s)
[02] a shared first letter extends the prefix rather than walking ... OK (0.000s)
[03] walking wins when the item is already next to the cursor ... OK (0.000s)
[04] the seek lands on the first match and the walk covers the rest ... OK (0.000s)
[05] a prefix never contains a space, which selects rather than seeks ... OK (0.000s)
[06] a plan is never longer than walking from the top ... OK (0.000s)
[07] an upward walk is planned when that is the shorter route ... OK (0.000s)
--- OK (7 checks, 0.000s)

--- Telnet backend
[08] Telnet: connect, navigate, teardown ... OK (1.901s)
--- OK (1 checks, 1.901s)

--- REST backend, Interface Type = Freeze
[09] REST/Freeze: connect, navigate, teardown ... OK (2.571s)
--- OK (1 checks, 2.571s)

--- REST backend, Interface Type = Overlay on HDMI
[10] REST/Overlay: connect, navigate, teardown ... OK (2.704s)
--- OK (1 checks, 2.704s)
ui_backend_smoke_test: OK (10 checks, 7.194s)
ui-backend-smoke: OK (7.257s)

============================================================
E2E  readmem-writemem  (overlay)
============================================================
     readmem-writemem: health: ping=6ms rest=10ms ftp=10ms telnet=33ms ident=12ms dma=19ms raster=21ms jiffy=22ms -> OK
[01] reset C64 to a clean, stable state ... OK (0.024s)
[02] read User Interface Settings config ... OK (0.014s)
     current Interface Type: Freeze

--- bounds: readmem rejects out-of-range parameters before allocating, and max-size reads do not degrade the device
[03] readmem rejects zero length ... OK (0.012s)
[04] readmem rejects negative length ... OK (0.011s)
[05] readmem rejects length one past the 64KB cap ... OK (0.010s)
[06] readmem rejects length far past the cap ... OK (0.011s)
[07] readmem rejects length that overflows a long ... OK (0.010s)
[08] readmem rejects read running past $FFFF ... OK (0.014s)
[09] readmem rejects address above $FFFF ... OK (0.021s)
[10] readmem rejects negative address ... OK (0.010s)
[11] 8 back-to-back max-size reads ($0000, 65536 bytes) all succeed ... OK (1.621s)
[12] 25 unsupported machine:measure calls leave readmem working ... OK (0.533s)
[13] switch to Overlay on HDMI to probe live background activity ... OK (0.011s)
[14] probe addresses that change on their own while the C64 runs ... OK (5.939s)
     6 address(es) treated as expected live background noise: $00A1, $00A2, $00CD, $00CF, $01F2, $0287
[15] set Interface Type = Freeze ... OK (0.010s)
[16] open menu (Freeze) ... OK (0.327s)
[17] write full-range pattern (Freeze) ... OK (0.410s)
[18] read back full range (Freeze) ... OK (0.193s)
[19] menu still open after write+read (Freeze) ... OK (0.015s)
--- OK (17 checks, 9.176s)

--- selfcheck-freeze: write and read both happen in Freeze (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-freeze] ignored ROM mismatches (writes to real ROM are no-ops): 16330
     [selfcheck-freeze] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-freeze] ignored known-live-noise mismatches: 0
     [selfcheck-freeze] color RAM (low nibble) mismatches: 0
     [selfcheck-freeze] RAM mismatches: 0
[20] close menu (Freeze) ... OK (0.291s)
[21] set Interface Type = Overlay on HDMI ... OK (0.014s)
[22] open menu (Overlay on HDMI) ... OK (0.289s)
[23] pause C64 for exact round trip (Overlay on HDMI) ... OK (0.015s)
[24] write full-range pattern (Overlay on HDMI) ... OK (0.464s)
[25] read back full range (Overlay on HDMI) ... OK (0.202s)
[26] resume C64 after exact round trip (Overlay on HDMI) ... OK (0.011s)
[27] menu still open after write+read (Overlay on HDMI) ... OK (0.015s)
--- OK (8 checks, 1.324s)

--- selfcheck-overlay-on-hdmi: write and read both happen in Overlay on HDMI (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-overlay-on-hdmi] ignored ROM mismatches (writes to real ROM are no-ops): 0
     [selfcheck-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-overlay-on-hdmi] ignored known-live-noise mismatches: 0
     [selfcheck-overlay-on-hdmi] color RAM (low nibble) mismatches: 0
     [selfcheck-overlay-on-hdmi] RAM mismatches: 0
[28] close menu (Overlay on HDMI) ... OK (0.293s)
[29] close menu for the screen round trip (Overlay on HDMI) ... OK (0.033s)
[30] pause C64 for the screen round trip (Overlay on HDMI) ... OK (0.010s)
[31] write and read back $0400-$07FF (Overlay on HDMI) ... OK (0.099s)
[32] resume C64 after the screen round trip (Overlay on HDMI) ... OK (0.010s)
--- OK (5 checks, 0.468s)

--- screen-round-trip-overlay-on-hdmi: screen RAM round-trips exactly with no menu open
     [screen-round-trip-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected 0)
[33] set Interface Type = Overlay on HDMI ... OK (0.011s)
[34] open menu (Overlay on HDMI) ... OK (0.289s)
[35] write full-range pattern (Overlay on HDMI) ... OK (0.566s)
[36] capture ground truth in Overlay on HDMI mode ... OK (0.198s)
[37] close menu (Overlay on HDMI) ... OK (0.301s)
[38] set Interface Type = Freeze ... OK (0.011s)
[39] open menu (Freeze) ... OK (0.297s)
[40] read full range (Freeze) ... OK (0.198s)
[41] menu still open after cross-mode read (Freeze) ... OK (0.037s)
--- OK (9 checks, 1.913s)

--- overlay-on-hdmi-write_freeze-read: bytes written while Overlay on HDMI must read back the same while Freeze, except screen RAM (menu-owned while frozen)
     [overlay-on-hdmi-write_freeze-read] screen ($0400-$07FF) mismatches: 996 (expected, menu owns this range while frozen)
     [overlay-on-hdmi-write_freeze-read] ignored known-live-noise mismatches: 0
     [overlay-on-hdmi-write_freeze-read] color RAM (low nibble) mismatches: 0
     [overlay-on-hdmi-write_freeze-read] RAM mismatches: 0
[42] close menu (Freeze) ... OK (0.294s)
[43] set Interface Type = Freeze ... OK (0.011s)
[44] open menu (Freeze) ... OK (0.289s)
[45] write full-range pattern (Freeze) ... OK (0.508s)
[46] capture ground truth in Freeze mode ... OK (0.205s)
[47] close menu (Freeze) ... OK (0.294s)
[48] set Interface Type = Overlay on HDMI ... OK (0.022s)
[49] open menu (Overlay on HDMI) ... OK (0.298s)
[50] read full range (Overlay on HDMI) ... OK (0.205s)
[51] menu still open after cross-mode read (Overlay on HDMI) ... OK (0.016s)
--- OK (10 checks, 2.166s)

--- freeze-write_overlay-on-hdmi-read: bytes written while Freeze must read back the same while Overlay on HDMI, except screen RAM (menu-owned while frozen)
     [freeze-write_overlay-on-hdmi-read] screen ($0400-$07FF) mismatches: 1020 (expected, menu owns this range while frozen)
     [freeze-write_overlay-on-hdmi-read] ignored known-live-noise mismatches: 0
     [freeze-write_overlay-on-hdmi-read] color RAM (low nibble) mismatches: 0
     [freeze-write_overlay-on-hdmi-read] RAM mismatches: 0
[52] close menu (Overlay on HDMI) ... OK (0.285s)
     restored Interface Type to 'Freeze'
--- OK (1 checks, 2.555s)

--- summary
     bounds: OK
     selfcheck-freeze: OK
     selfcheck-overlay: OK
     screen-round-trip: OK
     overlay-to-freeze: OK
     freeze-to-overlay: OK
readmem_writemem_test: OK (52 checks, 23.8s)
readmem-writemem: OK (23.8s)

============================================================
E2E  menu-screen  (overlay)
============================================================
     menu-screen: health: ping=7ms rest=10ms ftp=18ms telnet=33ms ident=12ms dma=7ms raster=26ms jiffy=32ms -> OK
[01] open menu ... OK (0.010s)
[02] GET menu_screen contract ... OK (0.016s)
[03] menu_screen renders a real menu ... OK (0.000s)
[04] close menu ... OK (0.010s)
[05] GET menu_screen unavailable ... OK (0.011s)
[06] GET menu_screen auth ... SKIP (--password not supplied, 0.000s)
menu_screen_test: OK (6 checks, 1.202s)
menu-screen: OK (1.252s)

============================================================
E2E  input  (overlay)
============================================================
     input: health: ping=7ms rest=16ms ftp=10ms telnet=33ms ident=12ms dma=7ms raster=34ms jiffy=887ms -> OK
[01] input snapshot has stable empty response shape ... OK (0.026s)
[02] POST accepts 64 event batch ... OK (0.063s)
[03] bad content-type is rejected without mutation ... OK (0.056s)
[04] missing JSON body is rejected without mutation ... OK (0.064s)
[05] malformed JSON is rejected without mutation ... OK (0.056s)
[06] unknown root field is rejected without mutation ... OK (0.061s)
[07] late invalid event keeps whole batch atomic ... OK (0.062s)
[08] joystick port 2 fire keeps Anykey buttons 2 and 3 released ... OK (0.231s)
[09] joystick port 2 fire2 lights only Anykey button 2 ... OK (0.173s)
[10] joystick port 2 fire3 lights only Anykey button 3 ... OK (0.167s)
[11] joystick port 1 up press is visible on CIA reads ... OK (0.106s)
[12] joystick port 1 all inputs and idempotent release are visible on CIA reads ... OK (0.108s)
[13] joystick port 2 diagonal and fire are visible on CIA reads ... OK (0.104s)
[14] joystick partial release is visible on CIA reads ... OK (0.101s)
[15] joystick fire2/fire3 round-trip through REST state ... OK (0.187s)
[16] joystick release_all then press in same batch is visible on CIA reads ... OK (0.092s)
[17] joystick unusual combination is visible on CIA reads ... OK (0.088s)
[18] joystick tap does not release persistent input ... OK (0.309s)
[19] joystick tap auto releases ... OK (0.309s)
[20] invalid joystick batch does not mutate state ... OK (0.135s)
[21] joystick release_all clears both ports ... OK (0.088s)
[22] machine reset clears keyboard and joystick REST state ... OK (3.123s)
[23] keyboard single-tap batch is consumed by BASIC in order ... OK (0.864s)
[24] keyboard 10 Hz mixed alphabet echo has no missed presses ... OK (5.443s)
[25] keyboard 20 Hz alternating ab echo has no missed presses ... OK (6.283s)
[26] keyboard 5 Hz alternating ab echo has no missed presses ... OK (3.837s)
[27] keyboard single letter reaches the live C64 matrix ... OK (0.132s)
[28] keyboard shifted pair reaches the live C64 matrix ... OK (0.205s)
[29] keyboard batch applies multiple presses atomically ... OK (0.233s)
[30] keyboard ordered batch and idempotent release ... OK (0.061s)
[31] keyboard release_all can be followed by press in same batch ... OK (0.070s)
[32] keyboard accepts eight simultaneous inputs ... OK (0.084s)
[33] keyboard tap does not release persistent key ... OK (0.167s)
[34] keyboard release_all clears state ... OK (0.058s)
[35] keyboard restore tap auto releases ... OK (0.255s)
[36] keyboard special-key taps snapshot correctly and auto release ... OK (2.489s)
[37] keyboard tap is visible in the live hardware snapshot and auto releases ... OK (0.279s)
[38] keyboard cursor-left tap is visible in the live hardware snapshot and auto releases ... OK (0.262s)
[39] keyboard tap batch drains through the live matrix path ... OK (1.279s)
[40] keyboard long repeated tap train drains fully without sticky state ... OK (6.128s)
[41] invalid keyboard batch does not mutate state ... OK (0.040s)
[42] menu editor accepts an unshifted control character ... OK (0.992s)
[43] menu editor keeps separate-batch shift active across POSTs ... OK (2.785s)
[44] menu editor repeats a held printable key ... OK (3.606s)
[45] menu editor stops printable repeat after release ... OK (5.713s)
[46] menu editor accepts a single cursor-left control ... OK (4.518s)
[47] menu editor repeats a held cursor-left control ... OK (4.673s)
[48] menu editor stops cursor repeat after release ... OK (6.201s)
input_test: OK (48 checks, 78.0s)
input: OK (78.2s)

============================================================
E2E  prg-context-menu  (overlay)
============================================================
     prg-context-menu: health: ping=7ms rest=17ms ftp=10ms telnet=33ms ident=13ms dma=7ms raster=32ms jiffy=58ms -> OK
[01] reset the machine to a clean starting state ... OK (2.824s)
[02] seed /Temp with prgmenu78112.prg, prgmenu78112.d64 and a long-named PRG ... OK (0.411s)

--- every context-menu action on a plain PRG
[03] read the context menu of a plain PRG ... OK (2.293s)
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
[04] a plain PRG: every offered action is covered ... OK (0.000s)
[05] Run on a plain PRG ... OK (7.125s)
[06] Load on a plain PRG ... OK (6.261s)
[07] DMA on a plain PRG ... OK (8.118s)
[08] View on a plain PRG ... OK (3.701s)
[09] Hex View on a plain PRG ... OK (3.650s)
[10] Copy to... on a plain PRG ... OK (6.140s)
[11] Rename on a plain PRG ... OK (5.944s)
[12] Move to... on a plain PRG ... OK (6.341s)
[13] Delete on a plain PRG ... OK (3.588s)
--- OK (11 checks, 53.2s)

--- every context-menu action on a PRG inside a D64
[14] read the context menu of a PRG inside a D64 ... OK (3.200s)
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
[15] a PRG inside a D64: every offered action is covered ... OK (0.000s)
[16] Run on a PRG inside a D64 ... OK (8.434s)
[17] Load on a PRG inside a D64 ... OK (7.726s)
[18] DMA on a PRG inside a D64 ... OK (9.177s)
[19] Mount & Run on a PRG inside a D64 ... OK (9.393s)
[20] Real Run on a PRG inside a D64 ... OK (12.5s SLOW)
[21] View on a PRG inside a D64 ... OK (4.793s)
[22] Hex View on a PRG inside a D64 ... OK (4.593s)
[23] Copy to... on a PRG inside a D64 ... OK (7.589s)
[24] Rename on a PRG inside a D64 ... OK (7.511s)
[25] Move to... on a PRG inside a D64 ... OK (8.708s)
[26] Delete on a PRG inside a D64 ... OK (5.226s)
[27] Run a PRG whose name is far longer than the boot-cart display ... OK (7.863s)
--- OK (14 checks, 96.8s)
prg_context_menu_test: OK (23 actions, 154s)
prg-context-menu: OK (155s)

============================================================
E2E  browser-long-filename  (overlay)
============================================================
     browser-long-filename: health: ping=19ms rest=12ms ftp=10ms telnet=33ms ident=21ms dma=7ms raster=22ms jiffy=60ms -> OK
[01] reset the machine to a clean starting state ... OK (0.589s)
[02] seed long-name fixture for rename ... OK (0.759s)
[03] browser rename on long filename ... OK (7.336s)
[04] reseed long-name fixture for mount ... OK (0.881s)
[05] browser mount on long filename ... OK (4.715s)
browser_long_filename_test: OK (5 checks, 14.7s)
browser-long-filename: OK (15.9s)

============================================================
E2E  browser-filesystem-refresh  (overlay)
============================================================
     browser-filesystem-refresh: health: ping=7ms rest=10ms ftp=10ms telnet=38ms ident=12ms dma=19ms raster=21ms jiffy=22ms -> OK
[01] reset the machine to a clean starting state ... OK (0.612s)
[02] prepare fixture directories ... OK (0.096s)
[03] open Menu, Telnet and FTP on the fixture directory ... OK (4.030s)
[04] rename from the Menu ... OK (3.412s)
[05] rename from Telnet ... OK (3.092s)
[06] rename from FTP ... OK (1.346s)
[07] rename under observer-queue pressure from the Menu ... OK (5.366s)
[08] rename under observer-queue pressure from Telnet ... OK (4.922s)
[09] rename a directory from the Menu ... OK (3.329s)
[10] rename a directory from Telnet ... OK (2.821s)
[11] delete from the Menu ... OK (2.346s)
[12] delete from Telnet ... OK (3.018s)
[13] delete from FTP ... OK (1.113s)
[14] delete a non-empty directory from the Menu ... OK (2.235s)
[15] delete a non-empty directory from Telnet ... OK (2.387s)
[16] remove a directory from FTP ... OK (1.243s)
[17] select all and bulk delete from the Menu ... OK (2.143s)
[18] create from the Menu ... OK (3.184s)
[19] create from Telnet ... OK (3.170s)
[20] create from FTP ... OK (1.539s)
     STOR phase 1 (open, 0 bytes committed): Menu=<empty>; Telnet=<empty>; FTP=<empty>
[21] create from FTP (mkd) ... OK (0.919s)
[22] create from REST (d64) ... OK (1.157s)
[23] create from REST (d71) ... OK (0.728s)
[24] create from REST (d81) ... OK (1.013s)
[25] create from REST (dnp) ... OK (1.117s)
[26] write from the Menu ... OK (2.689s)
[27] write from Telnet ... OK (2.937s)
[28] write from FTP ... OK (1.486s)
     STOR phase 1 (open, truncated): Menu=wftp1.tst[ 100 ]; Telnet=wftp1.tst[ 100 ]; FTP=wftp1.tst[ 100 ]=100
[29] copy over an existing file from the Menu ... OK (10.5s SLOW)
[30] copy over an existing file from Telnet ... OK (10.7s SLOW)
[31] move an entry out of the watched directory from the Menu ... OK (5.668s)
[32] move an entry out of the watched directory from Telnet ... OK (4.911s)
[33] paste into the watched directory from the Menu ... OK (7.269s)
[34] paste into the watched directory from Telnet ... OK (7.239s)
[35] failed rename shows nothing ... OK (1.122s)
[36] failed delete removes nothing ... OK (0.948s)
[37] failed write creates nothing ... OK (0.858s)
[38] short write commits consistently ... OK (1.143s)
     short write committed 100 bytes

operation x origin x observer matrix
------------------------------------------------------------------------------
  rename       Menu    Menu    OK    0.19s
  rename       Menu    Telnet  OK    0.19s
  rename       Menu    FTP     OK    0.19s
  rename       Menu    REST    OK    0.19s
  rename       Telnet  Menu    OK    0.20s
  rename       Telnet  Telnet  OK    0.20s
  rename       Telnet  FTP     OK    0.20s
  rename       Telnet  REST    OK    0.20s
  rename       FTP     Menu    OK    0.57s
  rename       FTP     Telnet  OK    0.57s
  rename       FTP     FTP     OK    0.57s
  rename       FTP     REST    OK    0.57s
  rename-under-load Menu    Menu    OK    0.20s
  rename-under-load Menu    Telnet  OK    0.20s
  rename-under-load Menu    FTP     OK    0.20s
  rename-under-load Menu    REST    OK    0.20s
  rename-under-load Telnet  Menu    OK    0.19s
  rename-under-load Telnet  Telnet  OK    0.19s
  rename-under-load Telnet  FTP     OK    0.19s
  rename-under-load Telnet  REST    OK    0.19s
  rename-dir   Menu    Menu    OK    0.19s
  rename-dir   Menu    Telnet  OK    0.19s
  rename-dir   Menu    FTP     OK    0.19s
  rename-dir   Menu    REST    OK    0.19s
  rename-dir   Telnet  Menu    OK    0.19s
  rename-dir   Telnet  Telnet  OK    0.19s
  rename-dir   Telnet  FTP     OK    0.19s
  rename-dir   Telnet  REST    OK    0.19s
  delete       Menu    Menu    OK    0.20s
  delete       Menu    Telnet  OK    0.20s
  delete       Menu    FTP     OK    0.20s
  delete       Menu    REST    OK    0.20s
  delete       Telnet  Menu    OK    0.20s
  delete       Telnet  Telnet  OK    0.20s
  delete       Telnet  FTP     OK    0.20s
  delete       Telnet  REST    OK    0.20s
  delete       FTP     Menu    OK    0.31s
  delete       FTP     Telnet  OK    0.31s
  delete       FTP     FTP     OK    0.31s
  delete       FTP     REST    OK    0.31s
  delete-dir   Menu    Menu    OK    0.22s
  delete-dir   Menu    Telnet  OK    0.22s
  delete-dir   Menu    FTP     OK    0.22s
  delete-dir   Menu    REST    OK    0.22s
  delete-dir   Telnet  Menu    OK    0.19s
  delete-dir   Telnet  Telnet  OK    0.19s
  delete-dir   Telnet  FTP     OK    0.19s
  delete-dir   Telnet  REST    OK    0.19s
  delete-dir   FTP/rmd Menu    OK    0.62s
  delete-dir   FTP/rmd Telnet  OK    0.62s
  delete-dir   FTP/rmd FTP     OK    0.62s
  delete-dir   FTP/rmd REST    OK    0.62s
  delete-bulk  Menu    Menu    OK    0.19s
  delete-bulk  Menu    Telnet  OK    0.19s
  delete-bulk  Menu    FTP     OK    0.19s
  delete-bulk  Menu    REST    OK    0.19s
  create       Menu    Menu    OK    0.19s
  create       Menu    Telnet  OK    0.19s
  create       Menu    FTP     OK    0.19s
  create       Menu    REST    OK    0.19s
  create       Telnet  Menu    OK    0.19s
  create       Telnet  Telnet  OK    0.19s
  create       Telnet  FTP     OK    0.19s
  create       Telnet  REST    OK    0.19s
  create       FTP     Menu    OK    0.50s
  create       FTP     Telnet  OK    0.50s
  create       FTP     FTP     OK    0.50s
  create       FTP     REST    OK    0.50s
  create       FTP/mkd Menu    OK    0.50s
  create       FTP/mkd Telnet  OK    0.50s
  create       FTP/mkd FTP     OK    0.50s
  create       FTP/mkd REST    OK    0.50s
  create       REST/d64 Menu    OK    0.71s
  create       REST/d64 Telnet  OK    0.71s
  create       REST/d64 FTP     OK    0.71s
  create       REST/d64 REST    OK    0.71s
  create       REST/d71 Menu    OK    0.29s
  create       REST/d71 Telnet  OK    0.29s
  create       REST/d71 FTP     OK    0.29s
  create       REST/d71 REST    OK    0.29s
  create       REST/d81 Menu    OK    0.53s
  create       REST/d81 Telnet  OK    0.53s
  create       REST/d81 FTP     OK    0.53s
  create       REST/d81 REST    OK    0.53s
  create       REST/dnp Menu    OK    0.63s
  create       REST/dnp Telnet  OK    0.63s
  create       REST/dnp FTP     OK    0.63s
  create       REST/dnp REST    OK    0.63s
  write        Menu    Menu    OK    0.20s
  write        Menu    Telnet  OK    0.20s
  write        Menu    FTP     OK    0.20s
  write        Menu    REST    OK    0.20s
  write        Telnet  Menu    OK    0.20s
  write        Telnet  Telnet  OK    0.20s
  write        Telnet  FTP     OK    0.20s
  write        Telnet  REST    OK    0.20s
  write        FTP     Menu    OK    0.27s
  write        FTP     Telnet  OK    0.27s
  write        FTP     FTP     OK    0.27s
  write        FTP     REST    OK    0.27s
  copy-write   Menu    Menu    N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Menu    Telnet  OK    0.18s
  copy-write   Menu    FTP     OK    0.18s
  copy-write   Menu    REST    OK    0.18s
  copy-arrival Menu    Menu    OK    no stale cache on re-entry
  copy-write   Telnet  Telnet  N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Telnet  Menu    OK    0.04s
  copy-write   Telnet  FTP     OK    0.04s
  copy-write   Telnet  REST    OK    0.04s
  copy-arrival Telnet  Telnet  OK    no stale cache on re-entry
  move-out     Menu    Menu    OK    0.21s
  move-out     Menu    Telnet  OK    0.21s
  move-out     Menu    FTP     OK    0.21s
  move-out     Menu    REST    OK    0.21s
  move-out     Telnet  Menu    OK    0.19s
  move-out     Telnet  Telnet  OK    0.19s
  move-out     Telnet  FTP     OK    0.19s
  move-out     Telnet  REST    OK    0.19s
  paste-write  Menu    Menu    OK    0.20s
  paste-write  Menu    Telnet  OK    0.20s
  paste-write  Menu    FTP     OK    0.20s
  paste-write  Menu    REST    OK    0.20s
  paste-write  Telnet  Menu    OK    0.20s
  paste-write  Telnet  Telnet  OK    0.20s
  paste-write  Telnet  FTP     OK    0.20s
  paste-write  Telnet  REST    OK    0.20s
  rename-fail  FTP     Menu    OK    0.20s
  rename-fail  FTP     Telnet  OK    0.20s
  rename-fail  FTP     FTP     OK    0.20s
  rename-fail  FTP     REST    OK    0.20s
  delete-fail  FTP     Menu    OK    0.20s
  delete-fail  FTP     Telnet  OK    0.20s
  delete-fail  FTP     FTP     OK    0.20s
  delete-fail  FTP     REST    OK    0.20s
  write-fail   FTP     Menu    OK    0.22s
  write-fail   FTP     Telnet  OK    0.22s
  write-fail   FTP     FTP     OK    0.22s
  write-fail   FTP     REST    OK    0.22s
  short-write  FTP     Menu    OK    0.51s
  short-write  FTP     Telnet  OK    0.51s
  short-write  FTP     FTP     OK    0.51s
  short-write  FTP     REST    OK    0.51s
------------------------------------------------------------------------------
  N/A=2, OK=140
browser_filesystem_refresh_test: OK (38 checks, 115s)
browser-filesystem-refresh: OK (117s)

============================================================
E2E  ftp-client  (overlay)
============================================================
     ftp-client: health: ping=39ms rest=18ms ftp=26ms telnet=34ms ident=19ms dma=8ms raster=44ms jiffy=567ms -> OK
     inferred --ftp-advertised-host 192.168.1.78
     controlled FTP server on 0.0.0.0:2121 (advertised 192.168.1.78)
[I 2026-08-12 19:46:44] concurrency model: async
[I 2026-08-12 19:46:44] masquerade (NAT) address: 192.168.1.78
[I 2026-08-12 19:46:44] passive ports: 30000->30019
[I 2026-08-12 19:46:44] >>> starting FTP server on 0.0.0.0:2121, pid=3037 <<<
     server root: /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-3jy2u43z (marker E2E-1786578404)
[01] GET /v1/version reachable ... OK (0.1, 0.025s)
[02] menu closed -> menu_screen 404 ... OK (0.045s)
[03] menu_button opens menu ... OK (0.301s)
[04] menu_screen returns 2000-byte matrix ... OK (2000 bytes, 0.017s)
[05] input release_all works ... OK (0.015s)
[06] menu closes from anywhere ... OK (0.320s)
[07] remove any stale hosts left by a prior run ... OK (0 removed, 1.289s)

--- stage: smoke
[08] create FTP host 'E2EFTP8405v000' through the New Host form ... OK (6.040s)
[09] new alias appears under /ftp ... OK (1.059s)
[10] enter host: server sees login + TYPE I + LIST ... [I 2026-08-12 19:46:55] 192.168.1.62:52432-[] FTP session opened (connect)
[I 2026-08-12 19:46:55] 192.168.1.62:52432-[u64e2e] USER 'u64e2e' logged in.
OK (PASS,TYPE,LIST, 1.212s)
[11] root listing shows fixture entries ... OK (README,DIRA,SMALL, 0.017s)
[12] open README.TXT -> RETR (52 bytes) ... [I 2026-08-12 19:46:57] 192.168.1.62:52432-[u64e2e] RETR /private/var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-3jy2u43z/README.TXT completed=1 bytes=52 seconds=0.0
OK (52 bytes, 2.205s)
[13] remove host and confirm it disappears ... [I 2026-08-12 19:46:59] 192.168.1.62:52432-[u64e2e] FTP session closed (disconnect).
OK (3.196s)
--- OK (6 checks, 13.7s)

--- cleanup
     preserved: nothing

--- summary
     Phase    Operation              Result             Commands       Fixture/Notes
     ------------------------------------------------------------------------------
     smoke    create host            OK                                E2EFTP8405v000
     smoke    list host              OK                                E2EFTP8405v000
     smoke    enter/LIST             OK                 USER/PASS/TYPE E2EFTP8405v000
     smoke    root entries           OK                 LIST           README/DIRA/SMALL
     smoke    RETR README            OK                 RETR           README.TXT 52 bytes
     smoke    remove host            OK                                E2EFTP8405v000
     ------------------------------------------------------------------------------
     Total REST requests   : 155
     Total menu snapshots  : 65
     Total keyboard events : 102
     Total FTP commands    : 24
     Created host alias    : (removed)
     Remote root path      : /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-3jy2u43z
     Cleanup status        : clean
Exception in thread Thread-1 (serve_forever):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/servers.py", line 254, in serve_forever
    self.ioloop.loop(timeout, blocking)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 376, in loop
    poll(timeout)
    ~~~~^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 741, in poll
    kevents = self._kqueue.control(
        None, _len(self.socket_map), timeout
    )
OSError: [Errno 9] Bad file descriptor
ftp-client: OK (17.1s)

============================================================
E2E  prg-load-path-trim  (overlay)
============================================================
     prg-load-path-trim: health: ping=7ms rest=11ms ftp=10ms telnet=33ms ident=22ms dma=8ms raster=21ms jiffy=22ms -> OK

--- Ultimate 64 PRG load path trim
     host: 192.168.1.148
     PUT file path: /Temp/rest-prg-path-trim-target-example.prg
     POST upload name: rest-prg-path-trim-upload-example.prg

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configure Temp Settings
[01] set Temp Auto Cleanup to Enabled ... OK (0.012s)
[02] set Temp Subfolders to Enabled ... OK (0.012s)
--- OK (2 checks, 0.024s)

--- 3. Prepare PRG Fixture
[03] upload PUT fixture rest-prg-path-trim-target-example.prg ... OK (0.114s)
--- OK (1 checks, 0.115s)

--- 4. Validate PUT Endpoints
[04] exercise PUT runners:load_prg ... OK (0.399s)
     PUT load_prg boot-cart name: ...T-EXAMPLE
[05] exercise PUT runners:run_prg ... OK (1.777s)
     PUT run_prg boot-cart name: ...T-EXAMPLE
--- OK (2 checks, 2.317s)

--- 5. Validate POST Endpoints
[06] exercise POST runners:load_prg ... OK (0.422s)
     POST load_prg boot-cart name: ...D-EXAMPLE
[07] exercise POST runners:run_prg ... OK (1.796s)
     POST run_prg boot-cart name: ...D-EXAMPLE
--- OK (2 checks, 3.040s)
prg_load_path_trim_test: OK (7 checks, 6.109s)

--- restore User Interface Settings
[08] set Temp Auto Cleanup to Enabled ... OK (0.013s)
[09] set Temp Subfolders to Enabled ... OK (0.011s)
prg-load-path-trim: OK (6.841s)

============================================================
E2E  temp-auto-cleanup  (overlay)
============================================================
     temp-auto-cleanup: health: ping=7ms rest=10ms ftp=10ms telnet=37ms ident=21ms dma=12ms raster=22ms jiffy=22ms -> OK

--- Ultimate 64 Temp auto cleanup
     host: 192.168.1.148

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configuration Setup
[01] set Temp Auto Cleanup to Enabled ... OK (0.012s)
[02] set Temp Subfolders to Enabled ... OK (0.020s)
--- OK (2 checks, 0.032s)

--- 3. Purging /Temp
     purge complete

--- 4. Mounting D64 Images
[03] create /Temp/mount-drive-8.d64 ... OK (0.052s)
[04] download mount-drive-8.d64 for the upload mount ... OK (0.374s)
[05] remove staging source mount-drive-8.d64 ... OK (0.033s)
[06] mount drive A ... OK (0.996s)
OK (0.996s)
[07] create /Temp/mount-drive-9.d64 ... OK (0.053s)
[08] download mount-drive-9.d64 for the upload mount ... OK (0.368s)
[09] remove staging source mount-drive-9.d64 ... OK (0.032s)
[10] mount drive B ... OK (0.991s)
OK (0.991s)
--- OK (10 checks, 2.900s)

--- 5. Seeding Baseline (10 files)
[11] upload base_1.bin ... OK (0.937s)
[12] upload base_2.bin ... OK (0.936s)
[13] upload base_3.bin ... OK (0.922s)
[14] upload base_4.bin ... OK (0.917s)
[15] upload base_5.bin ... OK (0.999s)
[16] upload base_6.bin ... OK (0.974s)
[17] upload base_7.bin ... OK (0.935s)
[18] upload base_8.bin ... OK (0.968s)
[19] upload base_9.bin ... OK (0.944s)
[20] upload base_10.bin ... OK (0.980s)
--- OK (10 checks, 9.560s)

--- 6. Managed Temp File Limit (Target: 10)
[21] upload managed_1.bin over REST ... OK (4.232s)
     managed count=1 (limit=10)
[22] upload managed_2.bin over REST ... OK (4.194s)
     managed count=2 (limit=10)
[23] upload managed_3.bin over REST ... OK (4.223s)
     managed count=3 (limit=10)
[24] upload managed_4.bin over REST ... OK (4.275s)
     managed count=4 (limit=10)
[25] upload managed_5.bin over REST ... OK (4.205s)
     managed count=5 (limit=10)
[26] upload managed_6.bin over REST ... OK (4.250s)
     managed count=6 (limit=10)
[27] upload managed_7.bin over REST ... OK (4.203s)
     managed count=7 (limit=10)
[28] upload managed_8.bin over REST ... OK (4.271s)
     managed count=8 (limit=10)
[29] upload managed_9.bin over REST ... OK (4.234s)
     managed count=9 (limit=10)
[30] upload managed_10.bin over REST ... OK (4.253s)
     managed count=10 (limit=10)
[31] upload managed_11.bin over REST ... OK (4.221s)
     managed count=10 (limit=10)
[32] upload managed_12.bin over REST ... OK (4.206s)
     managed count=10 (limit=10)
OK (4.485s)
OK (4.555s)
--- OK (14 checks, 54.2s)

--- 7. Unmounted Uploads Rejoin Cleanup
[33] remove drive A ... OK (0.127s)
[34] upload post_a_1.bin over REST ... OK (4.310s)
OK (4.382s)
     removed after 1 uploads
[35] remove drive B ... OK (0.122s)
[36] upload post_b_1.bin over REST ... OK (4.350s)
     removed after 1 uploads
--- OK (5 checks, 9.245s)

--- 8. Final Integrity Check
     user files intact
temp_auto_cleanup_test: OK (36 checks, 78.0s)

--- restore User Interface Settings
[37] set Temp Auto Cleanup to Enabled ... OK (0.011s)
[38] set Temp Subfolders to Enabled ... OK (0.012s)
temp-auto-cleanup: OK (78.6s)

============================================================
E2E  cfg-single-group  (overlay)
============================================================
     cfg-single-group: health: ping=9ms rest=11ms ftp=9ms telnet=34ms ident=12ms dma=24ms raster=96ms jiffy=59ms -> OK
[01] load a one-group CFG file through the browser ... OK (6.784s)
[02] only the CFG group is considered after loading ... OK (0.067s)
cfg_single_group_test: OK (2 checks, 7.273s)
cfg-single-group: OK (7.803s)

============================================================
E2E  cfg-unknown-items  (overlay)
============================================================
     cfg-unknown-items: health: ping=10ms rest=21ms ftp=9ms telnet=34ms ident=12ms dma=8ms raster=35ms jiffy=22ms -> OK

--- an item this firmware does not have
[01] a CFG with an unknown item loads without being called an error ... OK (6.679s)
[02] the settings it could apply were applied ... OK (0.017s)
     Vol Master: ' 0 dB' -> 'OFF'
[03] the log names the unknown item and its value ... OK (0.077s)
--- OK (3 checks, 6.791s)

--- a store this machine does not have
[04] a CFG naming an absent store loads without being called an error ... OK (7.127s)
[05] the store that does exist was still applied ... OK (0.017s)
[06] the log names the absent store ... OK (0.077s)
--- OK (3 checks, 7.235s)
cfg_unknown_items_test: OK (6 checks, 14.5s)
cfg-unknown-items: OK (15.0s)

============================================================
E2E  printer  (overlay)
============================================================
     printer: health: ping=10ms rest=11ms ftp=10ms telnet=39ms ident=12ms dma=7ms raster=24ms jiffy=23ms -> OK
[01] REST reachable at 192.168.1.148 ... OK (0.019s)
[02] reset before run ... OK (0.110s)
[03] load printer_e2e.prg ... OK (914 bytes, 0.000s)
[04] capture original Printer Settings ... OK (0.156s)
[05] print epson/bitmap: apply settings + run PRG ... OK (phase=printer closed heartbeat=4, 2.757s)
[06] print epson/bitmap: Flush/Eject via on-screen menu ... OK (3.785s)

--- restoring original Printer Settings
     IEC printer: Disabled
     Bus ID: 4
     Output file: /Usb0/printer
     Output type: PNG B&W
     Ink density: Medium
     Page top margin (default is 5): 5
     Page height (default is 60): 60
     Emulation: Commodore MPS
     Commodore charset: USA/UK
     Epson charset: Basic
     IBM table 2: International 1

--- summary
     epson      bitmap PASS_NO_VERIFY       /USB1/printer/e2e-eb70e6
printer: OK (8.292s)

============================================================
E2E  uci-targets  (overlay)
============================================================
     uci-targets: health: ping=8ms rest=11ms ftp=10ms telnet=34ms ident=21ms dma=7ms raster=23ms jiffy=24ms -> OK
[01] reset the C64 so the command interface starts idle ... OK (3.062s)
[02] read 'C64 and Cartridge Settings' ... OK (0.017s)
     current: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}
[03] enable the Command Interface registers at $DF1B-$DF1F ... OK (0.089s)
[04] transport: an empty command returns an empty reply ... OK (0.119s)
     <empty> -> 0.03s, data b'', status b''
[05] transport: unregistered target answers IDENTIFY ... OK (0.523s)
     0f 01 -> 0.05s, data b'NO TARGET', status b'00,OK'
[06] transport: unregistered target rejects anything else ... OK (0.683s)
     0f 7f -> 0.06s, data b'', status b'21,UNKNOWN COMMAND'
[07] transport: a no-reply command returns straight to Idle ... OK (0.128s)
[08] transport: pushing while a reply is pending sets and clears ERROR ... OK (0.925s)
[09] transport: the next command is not prefixed by leftover bytes ... OK (0.790s)
     04 28 00 -> 0.06s, data b'Ultimate 64 Elite', status b'00,OK'
[10] transport: ABORT releases a pending reply back to Idle ... OK (0.143s)
[11] control-target: IDENTIFY answers with the target name ... OK (0.857s)
     04 01 -> 0.05s, data b'CONTROL TARGET V1.1', status b'00,OK'
[12] control-target: an unimplemented command is reported as unknown ... OK (0.707s)
     04 7f -> 0.06s, data b'', status b'21,UNKNOWN COMMAND'
[13] control-target: LOAD_REU without a filename is rejected, not run ... OK (0.638s)
     04 08 -> 0.06s, data b'', status b'81,INVALID PARAMS'
[14] control-target: SAVE_REU without a filename is rejected, not run ... OK (0.651s)
     04 09 -> 0.06s, data b'', status b'81,INVALID PARAMS'
[15] control-target: GET_HWINFO rejects a device number it does not have ... OK (0.681s)
     04 28 02 -> 0.06s, data b'', status b'81,INVALID PARAMS'
[16] issue-740-matrix: confirm /Temp/uci_e2e_absent.reu does not exist ... OK (0.014s)
[17] issue-740-matrix: put a 16384-byte image at /Temp/uci_e2e_present.reu ... OK (0.117s)
[18] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... OK (3.150s)
     04 08 52 45 55 2e 49 4d 47 -> 0.15s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[19] issue-740-matrix: REU Enabled, image absent, name at offset 4 ... OK (3.231s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.20s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[20] issue-740-matrix: REU Disabled, image absent, name at offset 2 ... OK (0.955s)
     04 08 52 45 55 2e 49 4d 47 -> 0.15s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[21] issue-740-matrix: REU Disabled, image absent, name at offset 4 ... OK (0.974s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.19s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[22] issue-740-matrix: REU Enabled, image present, name at offset 2 ... OK (2.575s)
     04 08 52 45 55 2e 49 4d 47 -> 0.17s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[23] issue-740-matrix: REU Enabled, image present, name at offset 4 ... OK (2.699s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.18s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[24] save-reu-offset-past-end: put the preload offset at the end of a 128 KB REU ... OK (0.060s)
[25] save-reu-offset-past-end: SAVE_REU reports the offset and saves nothing ... OK (2.765s)
     04 09 52 45 55 2e 49 4d 47 -> 0.17s, data b'\xfd\xff\xff\xffREU SAVE: OFFSET 131072 >= REU SIZE 131072, SKIPPING', status b'86,REU OFFSET > SIZE. NOT SAVED'
[26] load-reu-disabled: disable the REU ... OK (0.025s)
[27] load-reu-disabled: leave text in the reply buffer from a previous command ... OK (0.823s)
     04 28 00 -> 0.07s, data b'Ultimate 64 Elite', status b'00,OK'
[28] load-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (0.889s)
     04 08 52 45 55 2e 49 4d 47 -> 0.16s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[29] save-reu-disabled: disable the REU ... OK (0.025s)
[30] save-reu-disabled: leave text in the reply buffer from a previous command ... OK (0.820s)
     04 28 00 -> 0.08s, data b'Ultimate 64 Elite', status b'00,OK'
[31] save-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (0.890s)
     04 09 52 45 55 2e 49 4d 47 -> 0.18s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[32] softiec-single-part-reply: SoftIEC target answers IDENTIFY ... OK (0.999s)
     05 01 -> 0.06s, data b'SOFTWARE IEC TARGET V1.0', status b'00,OK'
[33] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... OK (0.435s)
     05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 -> 0.30s, data b'', status b'\x01'
[34] softiec-single-part-reply: GET_FATNAME reply completes in one part ... OK (0.493s)
     05 22 02 23 -> 0.08s, data b'/buffer', status b'\x00'
[35] softiec-single-part-reply: an unimplemented SoftIEC command is reported as unknown ... OK (0.192s)
     05 7f -> 0.04s, data b'', status b'\x04'
[36] interface-usable-after: the control target still answers IDENTIFY ... OK (0.801s)
     04 01 -> 0.06s, data b'CONTROL TARGET V1.1', status b'00,OK'
     restored C64 and Cartridge Settings: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}

--- summary
     transport: OK
     control-target: OK
     issue-740-matrix: OK
     save-reu-offset-past-end: OK
     load-reu-disabled: OK
     save-reu-disabled: OK
     softiec-single-part-reply: OK
     interface-usable-after: OK
     cleanup: OK
uci_targets_test: OK (36 checks, 33.2s)
uci-targets: OK (33.3s)

============================================================
E2E  machine-code-monitor  (overlay)
============================================================
     machine-code-monitor: health: ping=9ms rest=10ms ftp=10ms telnet=33ms ident=21ms dma=7ms raster=21ms jiffy=22ms -> OK
[01] initial CPU7/KERNAL monitor status ... OK (0.014s)
[02] KERNAL $E000 hex view and REST match ... OK (0.682s)
[03] paging away and back keeps memory view stable ... OK (0.468s)
[04] KERNAL disassembly formatting ... OK (1.564s)
[05] KERNAL $E010 REST match ... OK (0.851s)
[06] CPU6 RAM under BASIC write/read ... OK (4.017s)
[07] CPU5 RAM under KERNAL status ... OK (2.750s)
[08] ASCII view width and scrolling ... OK (6.839s)
[09] ASCII and Screen mapping semantics ... OK (10.7s SLOW)
[10] HEX edit writes both nibbles ... OK (2.539s)
[11] CPU bank cycling reaches CHAR and RAM mappings ... OK (3.348s)
[12] COMPARE reports differing address ... OK (3.788s)
[13] G executes finite loop and returns to monitor ... OK (2.095s)
[14] G repeated execution updates RAM sentinel ... OK (6.781s)
[15] G handoff preserves stable VIC state ... SKIP (the on-device UI owns the VIC while it is up; only comparable over telnet, 0.000s)
OK (0.000s)
[16] bookmarks recall, set, list, and label edit ... OK (6.652s)
[17] memory bookmark jump restores width 16 ... OK (5.218s)
[18] binary width cycling and bookmark jump restores width 4 ... OK (5.707s)
[19] follow and return navigation ... OK (5.051s)
[20] asm edit mnemonic validation and Return advance ... OK (7.349s)
[21] number popup arithmetic ... OK (2.788s)
[22] save/load round-trip to top-level /Temp file ... OK (8.286s)
[23] save/load round-trip to file in new /Temp D64 ... OK (15.5s SLOW)

--- Telnet transport checks
[24] telnet blocks poll mode ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
[25] telnet opcode dropdown scroll does not flood the connection ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
--- SKIP (4 checks, 0.143s)
monitor_test: OK (25 checks, 105s)
machine-code-monitor: OK (105s)

============================================================
E2E  ftp-server  (overlay)
============================================================
     ftp-server: health: ping=7ms rest=10ms ftp=10ms telnet=34ms ident=12ms dma=9ms raster=22ms jiffy=22ms -> OK

--- a name the listing reports can address the file it names
[01] a 40-character name is listed unchanged ... OK (0.062s)
[02] that file is removed by the name the listing reported ... OK (0.087s)
[03] a 100-character name is listed unchanged ... OK (0.078s)
     100 characters survived the listing
[04] SIZE answers for the long name the listing reported ... OK (0.056s)
[05] that file is removed by the name the listing reported ... OK (0.080s)
--- OK (5 checks, 0.455s)
ftp_server_test: OK (5 checks, 0.459s)
ftp-server: OK (0.510s)

============================================================
E2E  assembly64  (overlay)
============================================================
     assembly64: health: ping=8ms rest=10ms ftp=9ms telnet=34ms ident=12ms dma=7ms raster=21ms jiffy=21ms -> OK

--- the form opens from the task menu and closes again
[01] open the Assembly 64 query form ... OK (0.834s)
[02] the form leaves cleanly with RUN/STOP ... OK (0.311s)
--- OK (2 checks, 1.242s)

--- a real query is sent to the Assembly 64 service
[03] open the form and enter the first field ... OK (0.911s)
[04] the typed term lands in the Name field ... OK (0.654s)
[05] the service answers and the results match what was asked for ... OK (0.999s)
--- OK (3 checks, 3.045s)

--- the menu button must work from inside the edit field
[06] open the form and enter the edit field ... OK (0.868s)
[07] the menu button closes the menu from inside the field ... OK (0.088s)
[08] the menu opens again, so the UI task left string_edit ... OK (0.090s)
--- OK (3 checks, 1.508s)

--- an aborted edit must not wedge the form
[09] open the form, type into a field, then abort ... OK (1.534s)
[10] the form is still usable after the abort ... OK (0.015s)
--- OK (2 checks, 2.035s)

--- over-long and empty input
[11] type more than the field accepts ... OK (2.013s)
[12] an empty query is refused rather than sent ... OK (2.650s)
[13] the warning is dismissed and the form is still usable ... OK (0.338s)
--- OK (3 checks, 5.471s)

--- a user mashing keys while the form is busy
[14] submit a query and hammer keys while it runs ... OK (4.668s)
[15] the device is still answering after the mashing ... OK (0.011s)
--- OK (2 checks, 5.143s)

--- opening and abandoning the form repeatedly
[16] open and abandon the form three times ... OK (3.102s)
[17] the menu button closes and reopens the form three times ... OK (3.236s)
--- OK (2 checks, 6.594s)
assembly64_test: OK (17 checks, 25.4s)
assembly64: OK (25.5s)

============================================================
E2E  freeze-menu  (overlay)
============================================================
     freeze-menu: health: ping=7ms rest=10ms ftp=10ms telnet=33ms ident=25ms dma=7ms raster=20ms jiffy=22ms -> OK
     captured 'Interface Type'=Freeze, 'Auto Address Mirroring'=Enabled

--- menu cycle with Auto Address Mirroring Disabled
[01] select 'Freeze' interface with mirroring disabled ... OK (0.022s)
[02] C64 running before the menu is opened ... OK (1.592s)
[03] open the menu ... OK (0.289s)
[04] C64 frozen while the menu is open ... OK (0.529s)
[05] close the menu ... OK (0.285s)
[06] C64 resumed after the menu closed ... OK (0.530s)
--- OK (6 checks, 3.260s)

--- Auto Address Mirroring switched off while the menu is open
[07] select 'Freeze' interface with mirroring enabled ... OK (0.026s)
[08] C64 running before the menu is opened ... OK (0.522s)
[09] open the menu ... OK (0.279s)
[10] C64 frozen while the menu is open ... OK (0.526s)
[11] set Auto Address Mirroring to Disabled while the menu is open ... OK (0.012s)
[12] close the menu ... OK (0.273s)
[13] C64 resumed after the menu closed ... OK (0.523s)
--- OK (7 checks, 2.171s)

--- menu cycle with Auto Address Mirroring Enabled
[14] select 'Freeze' interface with mirroring enabled ... OK (0.025s)
[15] C64 running before the menu is opened ... OK (0.527s)
[16] open the menu ... OK (0.303s)
[17] C64 frozen while the menu is open ... OK (0.535s)
[18] close the menu ... OK (0.273s)
[19] C64 resumed after the menu closed ... OK (0.526s)
--- OK (6 checks, 2.199s)

--- reopen the freezer menu with a context menu left open
[20] select 'Freeze' interface with mirroring enabled ... OK (0.036s)
[21] C64 running before the menu is opened ... OK (0.541s)
[22] open the menu ... OK (0.354s)
[23] C64 frozen while the menu is open ... OK (0.533s)
[24] open the context menu on the first browser entry ... OK (7.476s)
[25] close the menu ... OK (0.290s)
[26] C64 resumed after the menu closed ... OK (0.526s)
[27] reopen the menu with the context menu still on the object stack ... OK (0.300s)
[28] dismiss the restored context menu ... OK (0.269s)
[29] close the menu ... OK (0.281s)
[30] C64 resumed after the menu closed ... OK (0.523s)
--- OK (11 checks, 11.2s)

--- the menu button works inside the Assembly 64 query form
[31] select 'Freeze' interface with mirroring enabled ... OK (0.035s)
[32] C64 running before the menu is opened ... OK (0.522s)
[33] open the menu ... OK (0.291s)
[34] C64 frozen while the menu is open ... OK (0.524s)
[35] open the task menu ... OK (0.299s)
[36] open the Assembly 64 query form ... OK (0.288s)
[37] enter the form's first edit field ... OK (0.286s)
[38] the menu button closes the menu from inside the edit field ... OK (0.286s)
[39] the menu opens again afterwards ... OK (0.281s)
[40] leave the query form ... OK (0.348s)
[41] close the menu ... OK (0.277s)
[42] C64 resumed after the menu closed ... OK (0.525s)
--- OK (12 checks, 4.053s)
freeze_menu_test: OK (42 checks, 24.0s)
freeze-menu: OK (24.0s)

TEARDOWN (overlay): release input ... OK (0.015s)
TEARDOWN (overlay): close active menu UI ... OK (0.025s)
TEARDOWN (overlay): reset machine ... OK (0.055s)

============================================================
Summary
============================================================
     OK   e2e overlay    722s (20 ok)
     slowest: prg-context-menu 155s, browser-filesystem-refresh 117s, machine-code-monitor 105s
     722s in suites, 28.5s in health checks, the UI-state gate and teardown
     750s total

OK  all 20 suite runs passed.
```

</details>
