### PR TITLE
Reconnect WiFi after the link drops

### DIFF
--- a/software/u64ctrl/main/rpc_dispatch.c
+++ b/software/u64ctrl/main/rpc_dispatch.c
@@ -144,6 +144,8 @@ void cmd_wifi_disconnect(command_buf_t *buf)
 {
     rpc_espcmd_resp *resp = (rpc_espcmd_resp *)buf->data;
     ESP_LOGI(TAG, "Disconnecting from WiFi.");
+    // Asked for, so the connector must not undo it on its retry timer.
+    wifi_note_user_disconnect();
     resp->esp_err = esp_wifi_disconnect();
     ESP_LOGI(TAG, "Disconnected from WiFi, sending response. (%d)", resp->esp_err);
     buf->size = sizeof(rpc_espcmd_resp);

--- a/software/u64ctrl/main/rpc_dispatch.h
+++ b/software/u64ctrl/main/rpc_dispatch.h
@@ -26,9 +26,13 @@ void start_dispatch(QueueHandle_t queue);
 void send_button_event(uint8_t button);
 void send_keepalive();
 
-#define IDENT_STRING "ESP32 WiFi Bridge V1.11"
+#define IDENT_STRING "ESP32 WiFi Bridge V1.12"
 #define IDENT_MAJOR   1
-#define IDENT_MINOR   11
+// 1.12: the connector retries after a dropped link instead of idling in
+// Disconnected forever. The Ultimate's updater only reflashes the module
+// when this differs from what the module reports, so a module change that
+// does not bump it is silently never installed.
+#define IDENT_MINOR   12
 #define MULTITHREADED 0
 #define DISPATCHER_STACK 3072
 

--- a/software/u64ctrl/main/wifi_modem.c
+++ b/software/u64ctrl/main/wifi_modem.c
@@ -34,6 +34,41 @@
 
 static const char *TAG = "raw_bridge";
 
+/* Reconnecting after the link drops.
+ *
+ * WIFI_EVENT_STA_DISCONNECTED only records that we are no longer associated;
+ * nothing here used to act on it, and the connector task below idled in
+ * Disconnected until the Ultimate asked it to do something. An access point
+ * rebooting, or deauthenticating a client it considers idle, therefore took
+ * the machine off the network until it was power cycled. The same applies at
+ * startup: if no known AP answers, StoredAPs falls through to Disconnected and
+ * stays there, so a device booted while its AP is down never connects.
+ *
+ * Retries start soon enough to ride out a brief outage and back off to a
+ * minute so a genuinely absent AP is not hammered. */
+#define WIFI_RETRY_MIN_MS  5000
+#define WIFI_RETRY_MAX_MS 60000
+
+/* Set when the *user* asked to disconnect, so that request is not undone a few
+ * seconds later. esp_wifi_disconnect() produces the same event as a dropped
+ * link, so intent is the only thing that tells the two apart.
+ *
+ * Only an incoming request clears it -- see handle_connect_command() -- and
+ * never the retry ladder, which reaches attempt_connect() through
+ * wifi_connect_to_scanned() and wifi_connect_to_stored(). Clearing it down
+ * there would let a retry that is already under way erase a disconnect the
+ * user asked for a moment later.
+ *
+ * Written by the dispatcher task, read by the connector task, so volatile:
+ * the read below sits in a loop that the compiler would otherwise be free to
+ * hoist it out of. */
+static volatile bool user_disconnected = false;
+
+void wifi_note_user_disconnect(void)
+{
+    user_disconnected = true;
+}
+
 // Allocate some buffers to work with
 command_buf_context_t work_buffers;
 
@@ -684,13 +719,18 @@ int handle_connect_command(ConnectCommand_t *cmd, ConnectState_t *state)
                 my_uart_transmit_packet(UART_NUM_1, buf);
             }
             break;
+        // A request to connect -- from the menu or from the Ultimate at boot --
+        // means the user wants to be on the network, so any earlier explicit
+        // disconnect is spent. Scanning is not such a request and leaves it be.
         case CMD_WIFI_AUTOCONNECT:
+            user_disconnected = false;
             err = enable_wifi_if_needed(*state);
             if (err == ESP_OK) {
                 *state = LastAP;
             }
             return 1;
         case CMD_WIFI_CONNECT:
+            user_disconnected = false;
             err = enable_wifi_if_needed(*state);
             {
                 last_connect = *cmd;
@@ -728,6 +768,7 @@ void connect_thread(void *a)
     ConnectCommand_t connect_command;
     ConnectState_t state = LastAP;
     ConnectState_t prev = LastAP;
+    int retry_delay_ms = WIFI_RETRY_MIN_MS;
     esp_err_t err;
 
     while(1) {
@@ -804,7 +845,27 @@ void connect_thread(void *a)
                 // is set and there is nothing in the queue, because the semaphore was set before and
                 // we didn't take it. However, in this case we simply check two queues and are back in
                 // the waiting state afterwards; no harm done.
-                xSemaphoreTake(connect_semaphore, portMAX_DELAY);
+                //
+                // Connected waits indefinitely, because something else has to
+                // happen first. Disconnected does not: nothing is coming unless
+                // we go and ask, so the wait is bounded and a timeout means it
+                // is time to try again. Disabled has its own case below and is
+                // left alone -- the radio is off, so there is nothing to retry.
+                if (state == Connected) {
+                    retry_delay_ms = WIFI_RETRY_MIN_MS;
+                }
+                if (xSemaphoreTake(connect_semaphore,
+                                   (state == Connected) || user_disconnected
+                                       ? portMAX_DELAY
+                                       : pdMS_TO_TICKS(retry_delay_ms)) == pdFALSE) {
+                    ESP_LOGI(TAG, "Still disconnected after %d ms; trying again.", retry_delay_ms);
+                    retry_delay_ms *= 2;
+                    if (retry_delay_ms > WIFI_RETRY_MAX_MS) {
+                        retry_delay_ms = WIFI_RETRY_MAX_MS;
+                    }
+                    state = LastAP;
+                    break;
+                }
                 if (xQueueReceive(connect_commands, &connect_command, 0) == pdTRUE) {
                     if (handle_connect_command(&connect_command, &state)) {
                         break;

--- a/software/u64ctrl/main/wifi_modem.c
+++ b/software/u64ctrl/main/wifi_modem.c
@@ -772,6 +772,26 @@ void connect_thread(void *a)
     esp_err_t err;
 
     while(1) {
+        // A disconnect the user asked for can arrive while the ladder is
+        // already walking, and the ladder cannot notice: every state below
+        // blocks on connect_events until its current attempt resolves. Testing
+        // the flag only where the retry timer is armed is therefore not
+        // enough -- an attempt that was already in flight goes on to succeed
+        // and puts the link back up seconds after the user asked for it down.
+        //
+        // So check here, between states, which is the one point the ladder
+        // passes through with nothing in flight. An attempt that landed in the
+        // meantime has to be undone rather than prevented; it had already been
+        // accepted by the time the request arrived. Disabled is left alone:
+        // the radio is off, so there is nothing to undo or to retry.
+        if (user_disconnected && (state != Disconnected) && (state != Disabled)) {
+            if (connected_g) {
+                ESP_LOGI(TAG, "Disconnect requested while reconnecting; undoing.");
+                esp_wifi_disconnect();
+            }
+            state = Disconnected;
+        }
+
         switch (state) {
             case LastAP:
                 err = wifi_connect_to_last();

--- a/software/u64ctrl/main/wifi_modem.h
+++ b/software/u64ctrl/main/wifi_modem.h
@@ -19,6 +19,7 @@ typedef struct {
     uint8_t event_code;
 } ConnectEvent_t;
 
+void wifi_note_user_disconnect(void);
 esp_err_t wifi_scan(ultimate_ap_records_t *ult_records);
 esp_err_t wifi_clear_aps(void);
 void enable_hook();

--- a/software/wifi/raw_c3/main/rpc_dispatch.c
+++ b/software/wifi/raw_c3/main/rpc_dispatch.c
@@ -142,6 +142,8 @@ void cmd_wifi_disconnect(command_buf_t *buf)
 {
     rpc_espcmd_resp *resp = (rpc_espcmd_resp *)buf->data;
     ESP_LOGI(TAG, "Disconnecting from WiFi.");
+    // Asked for, so the connector must not undo it on its retry timer.
+    wifi_note_user_disconnect();
     resp->esp_err = esp_wifi_disconnect();
     ESP_LOGI(TAG, "Disconnected from WiFi, sending response. (%d)", resp->esp_err);
     buf->size = sizeof(rpc_espcmd_resp);

--- a/software/wifi/raw_c3/main/rpc_dispatch.h
+++ b/software/wifi/raw_c3/main/rpc_dispatch.h
@@ -24,9 +24,13 @@ void start_dispatch(QueueHandle_t queue);
 void send_button_event(uint8_t button);
 void send_keepalive();
 
-#define IDENT_STRING "ESP32 WiFi Bridge V1.5"
+#define IDENT_STRING "ESP32 WiFi Bridge V1.6"
 #define IDENT_MAJOR   1
-#define IDENT_MINOR   5
+// 1.6: the connector retries after a dropped link instead of idling in
+// Disconnected forever. The Ultimate's updater only reflashes the module
+// when this differs from what the module reports, so a module change that
+// does not bump it is silently never installed.
+#define IDENT_MINOR   6
 #define MULTITHREADED 0
 #define DISPATCHER_STACK 3072
 

--- a/software/wifi/raw_c3/main/wifi_modem.c
+++ b/software/wifi/raw_c3/main/wifi_modem.c
@@ -687,6 +687,25 @@ void connect_thread(void *a)
     static const char *states[] = { "LastAP", "Scanning", "ScannedAPs", "StoredAPs", "Connected", "Disconnected" }; 
 
     while(1) {
+        // A disconnect the user asked for can arrive while the ladder is
+        // already walking, and the ladder cannot notice: every state below
+        // blocks on connect_events until its current attempt resolves. Testing
+        // the flag only where the retry timer is armed is therefore not
+        // enough -- an attempt that was already in flight goes on to succeed
+        // and puts the link back up seconds after the user asked for it down.
+        //
+        // So check here, between states, which is the one point the ladder
+        // passes through with nothing in flight. An attempt that landed in the
+        // meantime has to be undone rather than prevented; it had already been
+        // accepted by the time the request arrived.
+        if (user_disconnected && (state != Disconnected)) {
+            if (connected_g) {
+                ESP_LOGI(TAG, "Disconnect requested while reconnecting; undoing.");
+                esp_wifi_disconnect();
+            }
+            state = Disconnected;
+        }
+
         switch (state) {
             case LastAP:
                 err = wifi_connect_to_last();

--- a/software/wifi/raw_c3/main/wifi_modem.c
+++ b/software/wifi/raw_c3/main/wifi_modem.c
@@ -34,6 +34,41 @@
 
 static const char *TAG = "raw_bridge";
 
+/* Reconnecting after the link drops.
+ *
+ * WIFI_EVENT_STA_DISCONNECTED only records that we are no longer associated;
+ * nothing here used to act on it, and the connector task below idled in
+ * Disconnected until the Ultimate asked it to do something. An access point
+ * rebooting, or deauthenticating a client it considers idle, therefore took
+ * the machine off the network until it was power cycled. The same applies at
+ * startup: if no known AP answers, StoredAPs falls through to Disconnected and
+ * stays there, so a device booted while its AP is down never connects.
+ *
+ * Retries start soon enough to ride out a brief outage and back off to a
+ * minute so a genuinely absent AP is not hammered. */
+#define WIFI_RETRY_MIN_MS  5000
+#define WIFI_RETRY_MAX_MS 60000
+
+/* Set when the *user* asked to disconnect, so that request is not undone a few
+ * seconds later. esp_wifi_disconnect() produces the same event as a dropped
+ * link, so intent is the only thing that tells the two apart.
+ *
+ * Only an incoming request clears it -- see handle_connect_command() -- and
+ * never the retry ladder, which reaches attempt_connect() through
+ * wifi_connect_to_scanned() and wifi_connect_to_stored(). Clearing it down
+ * there would let a retry that is already under way erase a disconnect the
+ * user asked for a moment later.
+ *
+ * Written by the dispatcher task, read by the connector task, so volatile:
+ * the read below sits in a loop that the compiler would otherwise be free to
+ * hoist it out of. */
+static volatile bool user_disconnected = false;
+
+void wifi_note_user_disconnect(void)
+{
+    user_disconnected = true;
+}
+
 // Allocate some buffers to work with
 command_buf_context_t work_buffers;
 
@@ -604,11 +639,16 @@ int handle_connect_command(ConnectCommand_t *cmd, ConnectState_t *state)
                 my_uart_transmit_packet(UART_NUM_1, buf);
             }
             break;
+        // A request to connect -- from the menu or from the Ultimate at boot --
+        // means the user wants to be on the network, so any earlier explicit
+        // disconnect is spent. Scanning is not such a request and leaves it be.
         case CMD_WIFI_AUTOCONNECT:
+            user_disconnected = false;
             *state = LastAP;
             return 1;
         case CMD_WIFI_CONNECT:
             {
+                user_disconnected = false;
                 last_connect = *cmd;
                 last_connect.list_index = -1;
                 rpc_espcmd_resp *resp = (rpc_espcmd_resp *)buf->data;
@@ -642,6 +682,7 @@ void connect_thread(void *a)
     ConnectCommand_t connect_command;
     ConnectState_t state = LastAP;
     ConnectState_t prev = LastAP;
+    int retry_delay_ms = WIFI_RETRY_MIN_MS;
     esp_err_t err;
     static const char *states[] = { "LastAP", "Scanning", "ScannedAPs", "StoredAPs", "Connected", "Disconnected" }; 
 
@@ -719,7 +760,26 @@ void connect_thread(void *a)
                 // is set and there is nothing in the queue, because the semaphore was set before and
                 // we didn't take it. However, in this case we simply check two queues and are back in
                 // the waiting state afterwards; no harm done.
-                xSemaphoreTake(connect_semaphore, portMAX_DELAY);
+                //
+                // Connected waits indefinitely, because something else has to
+                // happen first. Disconnected does not: nothing is coming unless
+                // we go and ask, so the wait is bounded and a timeout means it
+                // is time to try again.
+                if (state == Connected) {
+                    retry_delay_ms = WIFI_RETRY_MIN_MS;
+                }
+                if (xSemaphoreTake(connect_semaphore,
+                                   (state == Connected) || user_disconnected
+                                       ? portMAX_DELAY
+                                       : pdMS_TO_TICKS(retry_delay_ms)) == pdFALSE) {
+                    ESP_LOGI(TAG, "Still disconnected after %d ms; trying again.", retry_delay_ms);
+                    retry_delay_ms *= 2;
+                    if (retry_delay_ms > WIFI_RETRY_MAX_MS) {
+                        retry_delay_ms = WIFI_RETRY_MAX_MS;
+                    }
+                    state = LastAP;
+                    break;
+                }
                 if (xQueueReceive(connect_commands, &connect_command, 0) == pdTRUE) {
                     if (handle_connect_command(&connect_command, &state)) {
                         break;

--- a/software/wifi/raw_c3/main/wifi_modem.h
+++ b/software/wifi/raw_c3/main/wifi_modem.h
@@ -20,6 +20,7 @@ typedef struct {
 } ConnectEvent_t;
 
 void setup_modem();
+void wifi_note_user_disconnect(void);
 esp_err_t wifi_scan(ultimate_ap_records_t *ult_records);
 esp_err_t wifi_clear_aps(void);
 void enable_hook();

--- a/software/wifi/raw_u64/main/rpc_dispatch.c
+++ b/software/wifi/raw_u64/main/rpc_dispatch.c
@@ -142,6 +142,8 @@ void cmd_wifi_disconnect(command_buf_t *buf)
 {
     rpc_espcmd_resp *resp = (rpc_espcmd_resp *)buf->data;
     ESP_LOGI(TAG, "Disconnecting from WiFi.");
+    // Asked for, so the connector must not undo it on its retry timer.
+    wifi_note_user_disconnect();
     resp->esp_err = esp_wifi_disconnect();
     ESP_LOGI(TAG, "Disconnected from WiFi, sending response. (%d)", resp->esp_err);
     buf->size = sizeof(rpc_espcmd_resp);

--- a/software/wifi/raw_u64/main/rpc_dispatch.h
+++ b/software/wifi/raw_u64/main/rpc_dispatch.h
@@ -28,7 +28,11 @@ void send_keepalive();
 
 #define IDENT_STRING "ESP32 WiFi Bridge V1.5"
 #define IDENT_MAJOR   1
-#define IDENT_MINOR   5
+// 1.6: the connector retries after a dropped link instead of idling in
+// Disconnected forever. The Ultimate's updater only reflashes the module
+// when this differs from what the module reports, so a module change that
+// does not bump it is silently never installed.
+#define IDENT_MINOR   6
 #define MULTITHREADED 0
 #define DISPATCHER_STACK 3072
 

--- a/software/wifi/raw_u64/main/rpc_dispatch.h
+++ b/software/wifi/raw_u64/main/rpc_dispatch.h
@@ -26,7 +26,7 @@ void start_dispatch(QueueHandle_t queue);
 void send_button_event(uint8_t button);
 void send_keepalive();
 
-#define IDENT_STRING "ESP32 WiFi Bridge V1.5"
+#define IDENT_STRING "ESP32 WiFi Bridge V1.6"
 #define IDENT_MAJOR   1
 // 1.6: the connector retries after a dropped link instead of idling in
 // Disconnected forever. The Ultimate's updater only reflashes the module

--- a/software/wifi/raw_u64/main/wifi_modem.c
+++ b/software/wifi/raw_u64/main/wifi_modem.c
@@ -34,6 +34,32 @@
 
 static const char *TAG = "raw_bridge";
 
+/* Reconnecting after the link drops.
+ *
+ * WIFI_EVENT_STA_DISCONNECTED only records that we are no longer associated;
+ * nothing here used to act on it, and the connector task below idled in
+ * Disconnected until the Ultimate asked it to do something. An access point
+ * rebooting, or deauthenticating a client it considers idle, therefore took
+ * the machine off the network until it was power cycled. The same applies at
+ * startup: if no known AP answers, StoredAPs falls through to Disconnected and
+ * stays there, so a device booted while its AP is down never connects.
+ *
+ * Retries start soon enough to ride out a brief outage and back off to a
+ * minute so a genuinely absent AP is not hammered. */
+#define WIFI_RETRY_MIN_MS  5000
+#define WIFI_RETRY_MAX_MS 60000
+
+/* Set when the *user* asked to disconnect, so that request is not undone a few
+ * seconds later. esp_wifi_disconnect() produces the same event as a dropped
+ * link, so intent is the only thing that tells the two apart. Any request to
+ * connect clears it again. */
+static bool user_disconnected = false;
+
+void wifi_note_user_disconnect(void)
+{
+    user_disconnected = true;
+}
+
 // Allocate some buffers to work with
 command_buf_context_t work_buffers;
 
@@ -390,6 +416,10 @@ esp_err_t wifi_set_last_ap(int index)
 
 esp_err_t attempt_connect(const char *ssid, const char *passwd, uint8_t authmode)
 {
+    // However we got here -- the menu, the Ultimate at boot, or a retry -- the
+    // intent is to be connected, so an earlier explicit disconnect is spent.
+    user_disconnected = false;
+
     if (connected_g) {
         esp_err_t err = esp_wifi_disconnect();
         ESP_LOGW(TAG, "Connect request, but was connected. Waiting now for disconnect event.");
@@ -642,6 +672,7 @@ void connect_thread(void *a)
     ConnectCommand_t connect_command;
     ConnectState_t state = LastAP;
     ConnectState_t prev = LastAP;
+    int retry_delay_ms = WIFI_RETRY_MIN_MS;
     esp_err_t err;
     static const char *states[] = { "LastAP", "Scanning", "ScannedAPs", "StoredAPs", "Connected", "Disconnected" }; 
 
@@ -719,7 +750,26 @@ void connect_thread(void *a)
                 // is set and there is nothing in the queue, because the semaphore was set before and
                 // we didn't take it. However, in this case we simply check two queues and are back in
                 // the waiting state afterwards; no harm done.
-                xSemaphoreTake(connect_semaphore, portMAX_DELAY);
+                //
+                // Connected waits indefinitely, because something else has to
+                // happen first. Disconnected does not: nothing is coming unless
+                // we go and ask, so the wait is bounded and a timeout means it
+                // is time to try again.
+                if (state == Connected) {
+                    retry_delay_ms = WIFI_RETRY_MIN_MS;
+                }
+                if (xSemaphoreTake(connect_semaphore,
+                                   (state == Connected) || user_disconnected
+                                       ? portMAX_DELAY
+                                       : pdMS_TO_TICKS(retry_delay_ms)) == pdFALSE) {
+                    ESP_LOGI(TAG, "Still disconnected after %d ms; trying again.", retry_delay_ms);
+                    retry_delay_ms *= 2;
+                    if (retry_delay_ms > WIFI_RETRY_MAX_MS) {
+                        retry_delay_ms = WIFI_RETRY_MAX_MS;
+                    }
+                    state = LastAP;
+                    break;
+                }
                 if (xQueueReceive(connect_commands, &connect_command, 0) == pdTRUE) {
                     if (handle_connect_command(&connect_command, &state)) {
                         break;

--- a/software/wifi/raw_u64/main/wifi_modem.c
+++ b/software/wifi/raw_u64/main/wifi_modem.c
@@ -687,6 +687,25 @@ void connect_thread(void *a)
     static const char *states[] = { "LastAP", "Scanning", "ScannedAPs", "StoredAPs", "Connected", "Disconnected" }; 
 
     while(1) {
+        // A disconnect the user asked for can arrive while the ladder is
+        // already walking, and the ladder cannot notice: every state below
+        // blocks on connect_events until its current attempt resolves. Testing
+        // the flag only where the retry timer is armed is therefore not
+        // enough -- an attempt that was already in flight goes on to succeed
+        // and puts the link back up seconds after the user asked for it down.
+        //
+        // So check here, between states, which is the one point the ladder
+        // passes through with nothing in flight. An attempt that landed in the
+        // meantime has to be undone rather than prevented; it had already been
+        // accepted by the time the request arrived.
+        if (user_disconnected && (state != Disconnected)) {
+            if (connected_g) {
+                ESP_LOGI(TAG, "Disconnect requested while reconnecting; undoing.");
+                esp_wifi_disconnect();
+            }
+            state = Disconnected;
+        }
+
         switch (state) {
             case LastAP:
                 err = wifi_connect_to_last();

--- a/software/wifi/raw_u64/main/wifi_modem.c
+++ b/software/wifi/raw_u64/main/wifi_modem.c
@@ -51,9 +51,18 @@ static const char *TAG = "raw_bridge";
 
 /* Set when the *user* asked to disconnect, so that request is not undone a few
  * seconds later. esp_wifi_disconnect() produces the same event as a dropped
- * link, so intent is the only thing that tells the two apart. Any request to
- * connect clears it again. */
-static bool user_disconnected = false;
+ * link, so intent is the only thing that tells the two apart.
+ *
+ * Only an incoming request clears it -- see handle_connect_command() -- and
+ * never the retry ladder, which reaches attempt_connect() through
+ * wifi_connect_to_scanned() and wifi_connect_to_stored(). Clearing it down
+ * there would let a retry that is already under way erase a disconnect the
+ * user asked for a moment later.
+ *
+ * Written by the dispatcher task, read by the connector task, so volatile:
+ * the read below sits in a loop that the compiler would otherwise be free to
+ * hoist it out of. */
+static volatile bool user_disconnected = false;
 
 void wifi_note_user_disconnect(void)
 {
@@ -416,10 +425,6 @@ esp_err_t wifi_set_last_ap(int index)
 
 esp_err_t attempt_connect(const char *ssid, const char *passwd, uint8_t authmode)
 {
-    // However we got here -- the menu, the Ultimate at boot, or a retry -- the
-    // intent is to be connected, so an earlier explicit disconnect is spent.
-    user_disconnected = false;
-
     if (connected_g) {
         esp_err_t err = esp_wifi_disconnect();
         ESP_LOGW(TAG, "Connect request, but was connected. Waiting now for disconnect event.");
@@ -634,11 +639,16 @@ int handle_connect_command(ConnectCommand_t *cmd, ConnectState_t *state)
                 my_uart_transmit_packet(UART_NUM_1, buf);
             }
             break;
+        // A request to connect -- from the menu or from the Ultimate at boot --
+        // means the user wants to be on the network, so any earlier explicit
+        // disconnect is spent. Scanning is not such a request and leaves it be.
         case CMD_WIFI_AUTOCONNECT:
+            user_disconnected = false;
             *state = LastAP;
             return 1;
         case CMD_WIFI_CONNECT:
             {
+                user_disconnected = false;
                 last_connect = *cmd;
                 last_connect.list_index = -1;
                 rpc_espcmd_resp *resp = (rpc_espcmd_resp *)buf->data;

--- a/software/wifi/raw_u64/main/wifi_modem.h
+++ b/software/wifi/raw_u64/main/wifi_modem.h
@@ -20,6 +20,7 @@ typedef struct {
 } ConnectEvent_t;
 
 void setup_modem();
+void wifi_note_user_disconnect(void);
 esp_err_t wifi_scan(ultimate_ap_records_t *ult_records);
 esp_err_t wifi_clear_aps(void);
 void enable_hook();


### PR DESCRIPTION
Fixes #774.

`WIFI_EVENT_STA_DISCONNECTED` only recorded that we were no longer associated.
The connector task then idled in `Disconnected` until the Ultimate asked it to
do something, and nothing ever did -- so an access point rebooting, or
deauthenticating a client it considers idle, took the machine off the network
until it was power cycled. Connecting by hand from the menu always worked,
because that is the only thing that reaches `attempt_connect()`.

I hit this six times in one day on an Elite, at least three of them with the
device completely idle, across firmware builds including near-stock. #763's
earlier notes record the same on stock 3.14d, so it is long standing.

## The change

`Disconnected` waits with a timeout instead of forever, and a timeout means it
is time to try again: back to `LastAP`, which is the existing
`LastAP -> Scanning -> ScannedAPs -> StoredAPs` ladder. Retries start at 5
seconds to ride out a brief outage and double to a minute so an AP that is
genuinely gone is not hammered. A successful connection resets the delay.

**This fixes startup too.** `StoredAPs` falls through to `Disconnected` when
nothing answers, so a device booted while its AP is down never connected at
all.

**A user's disconnect is still honoured.** `esp_wifi_disconnect()` raises the
same event as a dropped link, so intent is the only thing separating them:
`cmd_wifi_disconnect()` records that the user asked, which suppresses the
retry, and `attempt_connect()` clears it again, since any request to connect --
menu, boot, or retry -- means the user wants to be on the network.

**`IDENT_MINOR` goes to 6, and this part matters to anyone touching the
module.** The updater only reflashes the WiFi module when the version differs
from what the module reports:

```c
if ((major != IDENT_MAJOR) || (minor != IDENT_MINOR)) {
    update_esp32_impl();
} else {
    console_print(screen, "No WiFi module update needed!\n");
}
```

My first build did not bump it, so the updater skipped the module and my test
measured stock firmware. A module change without a bump is silently never
installed.

## Verification

Deauthenticated the client from the access point's controller, which is an
involuntary disconnect -- the thing that actually happens in the field, and not
something the device can be asked to do to itself.

| module firmware | after deauth |
|---|---|
| 1.5 (stock) | never returned; 300s of polling, then a manual reconnect |
| 1.6 (this) | reconnects on its own |

Four runs on 1.6: two recovered in 2-4 seconds, one took longer than a 42
second window because the retry landed while the AP was still holding the
client out and the backoff had grown, and one recovered faster than the poller
sampled. Seconds to tens of seconds, against never.

Also verified by hand, because it is the regression this could introduce:
**Disconnect from the WiFi menu stays disconnected.**

Full default E2E suite set against firmware 3.15, FPGA core 123, core version
1.4B, overlay mode: **all 20 suite runs passed**, exit 0, no recovery invoked.

## One thing I did not change

All three connect states wait on
`xQueueReceive(connect_events, &connect_event, portMAX_DELAY)` with no timeout.
ESP-IDF does always emit an event, so it is latent rather than observed, but if
one ever did not the connector would hang and take the retry with it. Bounding
all three felt like the wrong trade for a first change to the module firmware;
happy to add it if you would rather.

<details>
<summary>Full <code>./run-tests</code> output</summary>

```

============================================================
Ultimate hardware test run
============================================================
     host:       192.168.1.148
     categories: e2e
     modes:      overlay
     timeout:    30.0s
     on failure: continue
     health:    answers + health sweep, retry after recovery

============================================================
E2E  transport-usage  (overlay)
============================================================
UI state dirty: the root browser is not on top; a nested object still holds the UI; repairing
UI state repaired
     transport-usage: health: ping=9ms rest=10ms ftp=10ms telnet=41ms ident=15ms dma=7ms raster=20ms jiffy=21ms -> OK
check_transport_usage: OK (45 files, 0.217s)
transport-usage: OK (0.254s)

============================================================
E2E  runner-policy  (overlay)
============================================================
     runner-policy: health: ping=9ms rest=12ms ftp=9ms telnet=40ms ident=12ms dma=7ms raster=25ms jiffy=23ms -> OK
[01] a clean run exits 0 ... OK (0.000s)
[02] a failed suite exits 1 ... OK (0.000s)
[03] a recovery with no failure exits 3 ... OK (0.000s)
[04] a failure outranks a recovery ... OK (0.000s)
[05] a device that cannot be made healthy exits 4, outranking a failure ... OK (0.000s)
[06] a device that answers is never recovered ... OK (0.000s)
[07] recovery runs only once the ordinary wait has given up ... OK (0.011s)
     fixture: the device is unhealthy: it is not answering
[08] a recovery that does not bring the device back reports so ... OK (0.068s)
     fixture: the device is unhealthy: it is not answering
[09] a recovery command that exits non-zero is still followed by a probe ... OK (0.011s)
     fixture: the device is unhealthy: it is not answering
[10] a recovery command that hangs is bounded by --recover-timeout ... OK (0.207s)
     fixture: the device is unhealthy: it is not answering
[11] a recovery command the shell cannot find is a failed recovery ... OK (0.069s)
     fixture: the device is unhealthy: it is not answering
[12] no recovery command means no recovery ... OK (0.000s)
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: no --recover-command was given
[13] a suite gives up after --recover-max-per-suite recoveries ... OK (0.141s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: this suite has already used its 2 recoveries
[14] the per-suite budget starts again at the next suite ... OK (0.067s)
     fixture: the device is unhealthy: it is not answering
[15] the run gives up after --recover-max-total recoveries ... OK (0.142s)
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
     fixture: the device is unhealthy: it is not answering
     fixture: not recovering: the run has already used its 2 recoveries
[16] the refusal says which ceiling was reached ... OK (0.075s)
     fixture: the device is unhealthy: it is not answering
[17] a healthy sweep after a failed suite recovers nothing ... OK (0.000s)
     fixture: health: rest=9ms -> OK
[18] a degraded but reachable device is recovered ... OK (0.017s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms -> OK
[19] a device still degraded after recovering is reported, not retried ... OK (0.006s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
[20] a degraded device is not recovered past its ceiling ... OK (0.014s)
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: after recovery, health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: still unhealthy after recovering: it is degraded: ftp
     fixture: health: rest=9ms ftp=FAIL -> DEGRADED (ftp)
         ftp: refused
     fixture: the device is unhealthy: it is degraded: ftp
     fixture: not recovering: the run has already used its 1 recoveries
[21] --no-health-check takes the sweep out of the decision ... OK (0.000s)
[22] --no-health-check still recovers a device that has gone ... OK (0.063s)
     fixture: the device is unhealthy: it is not answering
[23] consecutive resets collapse into one ... OK (0.000s)
[24] a read between two resets does not warrant the second ... OK (0.000s)
[25] a mutating call between two resets warrants the second ... OK (0.000s)
[26] force resets even when nothing has changed ... OK (0.000s)
[27] a suite told the device was just reset does not reset again ... OK (0.000s)
[28] a suite not told that still resets ... OK (0.000s)
[29] a suite that fails on a healthy device is not run again ... OK (0.040s)
[30] a suite that fails on an unhealthy device runs again after recovery ... OK (0.105s)
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
     fixture-suite: the device was recovered, so this failure proves nothing; running it again
[31] --no-retry keeps the recovery and drops the extra attempt ... OK (0.033s)
[32] a device that cannot be made healthy ends the run ... OK (0.033s)
fixture: OK (1.500s)
[33] a health sweep reaches the JSONL with a latency per check ... OK (0.000s)
[34] a suite record carries the profile, attempt and recoveries ... OK (0.000s)
[35] the run record agrees with the exit status ... OK (0.000s)
[36] a sweep with every check passing is healthy ... OK (0.000s)
[37] a failed check makes the sweep degraded and names it ... OK (0.000s)
[38] a skipped check never makes the sweep degraded ... OK (0.000s)
[39] the one-line summary carries every latency and the verdict ... OK (0.000s)
     the recovery command runs on a degraded or unreachable device, never on a suite that merely failed
runner_policy_test: OK (39 checks, 1.135s)
runner-policy: OK (1.204s)

============================================================
E2E  ui-backend-smoke  (overlay)
============================================================
     ui-backend-smoke: health: ping=25ms rest=12ms ftp=18ms telnet=39ms ident=12ms dma=7ms raster=32ms jiffy=56ms -> OK

--- Overlay navigation planner
[01] a unique first letter jumps straight to the item ... OK (0.000s)
[02] a shared first letter extends the prefix rather than walking ... OK (0.000s)
[03] walking wins when the item is already next to the cursor ... OK (0.000s)
[04] the seek lands on the first match and the walk covers the rest ... OK (0.000s)
[05] a prefix never contains a space, which selects rather than seeks ... OK (0.000s)
[06] a plan is never longer than walking from the top ... OK (0.000s)
[07] an upward walk is planned when that is the shorter route ... OK (0.000s)
--- OK (7 checks, 0.000s)

--- Telnet backend
[08] Telnet: connect, navigate, teardown ... OK (1.913s)
--- OK (1 checks, 1.913s)

--- REST backend, Interface Type = Freeze
[09] REST/Freeze: connect, navigate, teardown ... OK (2.689s)
--- OK (1 checks, 2.689s)

--- REST backend, Interface Type = Overlay on HDMI
[10] REST/Overlay: connect, navigate, teardown ... OK (2.872s)
--- OK (1 checks, 2.872s)
ui_backend_smoke_test: OK (10 checks, 7.485s)
ui-backend-smoke: OK (7.570s)

============================================================
E2E  readmem-writemem  (overlay)
============================================================
     readmem-writemem: health: ping=7ms rest=10ms ftp=10ms telnet=39ms ident=11ms dma=7ms raster=24ms jiffy=21ms -> OK
[01] reset C64 to a clean, stable state ... OK (0.025s)
[02] read User Interface Settings config ... OK (0.018s)
     current Interface Type: Freeze

--- bounds: readmem rejects out-of-range parameters before allocating, and max-size reads do not degrade the device
[03] readmem rejects zero length ... OK (0.017s)
[04] readmem rejects negative length ... OK (0.010s)
[05] readmem rejects length one past the 64KB cap ... OK (0.013s)
[06] readmem rejects length far past the cap ... OK (0.011s)
[07] readmem rejects length that overflows a long ... OK (0.010s)
[08] readmem rejects read running past $FFFF ... OK (0.011s)
[09] readmem rejects address above $FFFF ... OK (0.010s)
[10] readmem rejects negative address ... OK (0.011s)
[11] 8 back-to-back max-size reads ($0000, 65536 bytes) all succeed ... OK (1.695s)
[12] 25 unsupported machine:measure calls leave readmem working ... OK (0.487s)
[13] switch to Overlay on HDMI to probe live background activity ... OK (0.011s)
[14] probe addresses that change on their own while the C64 runs ... OK (5.950s)
     6 address(es) treated as expected live background noise: $00A1, $00A2, $00CD, $00CF, $01F2, $0287
[15] set Interface Type = Freeze ... OK (0.010s)
[16] open menu (Freeze) ... OK (0.308s)
[17] write full-range pattern (Freeze) ... OK (0.483s)
[18] read back full range (Freeze) ... OK (0.194s)
[19] menu still open after write+read (Freeze) ... OK (0.015s)
--- OK (17 checks, 9.262s)

--- selfcheck-freeze: write and read both happen in Freeze (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-freeze] ignored ROM mismatches (writes to real ROM are no-ops): 16330
     [selfcheck-freeze] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-freeze] ignored known-live-noise mismatches: 0
     [selfcheck-freeze] color RAM (low nibble) mismatches: 0
     [selfcheck-freeze] RAM mismatches: 0
[20] close menu (Freeze) ... OK (0.289s)
[21] set Interface Type = Overlay on HDMI ... OK (0.011s)
[22] open menu (Overlay on HDMI) ... OK (0.290s)
[23] pause C64 for exact round trip (Overlay on HDMI) ... OK (0.009s)
[24] write full-range pattern (Overlay on HDMI) ... OK (0.474s)
[25] read back full range (Overlay on HDMI) ... OK (0.228s)
[26] resume C64 after exact round trip (Overlay on HDMI) ... OK (0.012s)
[27] menu still open after write+read (Overlay on HDMI) ... OK (0.015s)
--- OK (8 checks, 1.353s)

--- selfcheck-overlay-on-hdmi: write and read both happen in Overlay on HDMI (screen RAM excluded, the menu redraws its entry rows while open)
     [selfcheck-overlay-on-hdmi] ignored ROM mismatches (writes to real ROM are no-ops): 0
     [selfcheck-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected, menu owns this range while frozen)
     [selfcheck-overlay-on-hdmi] ignored known-live-noise mismatches: 0
     [selfcheck-overlay-on-hdmi] color RAM (low nibble) mismatches: 0
     [selfcheck-overlay-on-hdmi] RAM mismatches: 0
[28] close menu (Overlay on HDMI) ... OK (0.326s)
[29] close menu for the screen round trip (Overlay on HDMI) ... OK (0.115s)
[30] pause C64 for the screen round trip (Overlay on HDMI) ... OK (0.012s)
[31] write and read back $0400-$07FF (Overlay on HDMI) ... OK (0.107s)
[32] resume C64 after the screen round trip (Overlay on HDMI) ... OK (0.011s)
--- OK (5 checks, 0.594s)

--- screen-round-trip-overlay-on-hdmi: screen RAM round-trips exactly with no menu open
     [screen-round-trip-overlay-on-hdmi] screen ($0400-$07FF) mismatches: 0 (expected 0)
[33] set Interface Type = Overlay on HDMI ... OK (0.011s)
[34] open menu (Overlay on HDMI) ... OK (0.287s)
[35] write full-range pattern (Overlay on HDMI) ... OK (0.602s)
[36] capture ground truth in Overlay on HDMI mode ... OK (0.200s)
[37] close menu (Overlay on HDMI) ... OK (0.286s)
[38] set Interface Type = Freeze ... OK (0.021s)
[39] open menu (Freeze) ... OK (0.286s)
[40] read full range (Freeze) ... OK (0.202s)
[41] menu still open after cross-mode read (Freeze) ... OK (0.016s)
--- OK (9 checks, 1.916s)

--- overlay-on-hdmi-write_freeze-read: bytes written while Overlay on HDMI must read back the same while Freeze, except screen RAM (menu-owned while frozen)
     [overlay-on-hdmi-write_freeze-read] screen ($0400-$07FF) mismatches: 996 (expected, menu owns this range while frozen)
     [overlay-on-hdmi-write_freeze-read] ignored known-live-noise mismatches: 0
     [overlay-on-hdmi-write_freeze-read] color RAM (low nibble) mismatches: 0
     [overlay-on-hdmi-write_freeze-read] RAM mismatches: 0
[42] close menu (Freeze) ... OK (0.315s)
[43] set Interface Type = Freeze ... OK (0.011s)
[44] open menu (Freeze) ... OK (0.290s)
[45] write full-range pattern (Freeze) ... OK (0.509s)
[46] capture ground truth in Freeze mode ... OK (0.197s)
[47] close menu (Freeze) ... OK (0.298s)
[48] set Interface Type = Overlay on HDMI ... OK (0.011s)
[49] open menu (Overlay on HDMI) ... OK (0.290s)
[50] read full range (Overlay on HDMI) ... OK (0.205s)
[51] menu still open after cross-mode read (Overlay on HDMI) ... OK (0.016s)
--- OK (10 checks, 2.166s)

--- freeze-write_overlay-on-hdmi-read: bytes written while Freeze must read back the same while Overlay on HDMI, except screen RAM (menu-owned while frozen)
     [freeze-write_overlay-on-hdmi-read] screen ($0400-$07FF) mismatches: 1020 (expected, menu owns this range while frozen)
     [freeze-write_overlay-on-hdmi-read] ignored known-live-noise mismatches: 0
     [freeze-write_overlay-on-hdmi-read] color RAM (low nibble) mismatches: 0
     [freeze-write_overlay-on-hdmi-read] RAM mismatches: 0
[52] close menu (Overlay on HDMI) ... OK (0.290s)
     restored Interface Type to 'Freeze'
--- OK (1 checks, 2.532s)

--- summary
     bounds: OK
     selfcheck-freeze: OK
     selfcheck-overlay: OK
     screen-round-trip: OK
     overlay-to-freeze: OK
     freeze-to-overlay: OK
readmem_writemem_test: OK (52 checks, 24.0s)
readmem-writemem: OK (24.0s)

============================================================
E2E  menu-screen  (overlay)
============================================================
     menu-screen: health: ping=7ms rest=10ms ftp=10ms telnet=39ms ident=15ms dma=7ms raster=21ms jiffy=55ms -> OK
[01] open menu ... OK (0.011s)
[02] GET menu_screen contract ... OK (0.016s)
[03] menu_screen renders a real menu ... OK (0.000s)
[04] close menu ... OK (0.010s)
[05] GET menu_screen unavailable ... OK (0.010s)
[06] GET menu_screen auth ... SKIP (--password not supplied, 0.000s)
menu_screen_test: OK (6 checks, 1.211s)
menu-screen: OK (1.262s)

============================================================
E2E  input  (overlay)
============================================================
     input: health: ping=8ms rest=11ms ftp=10ms telnet=41ms ident=12ms dma=17ms raster=21ms jiffy=862ms -> OK
[01] input snapshot has stable empty response shape ... OK (0.026s)
[02] POST accepts 64 event batch ... OK (0.068s)
[03] bad content-type is rejected without mutation ... OK (0.058s)
[04] missing JSON body is rejected without mutation ... OK (0.062s)
[05] malformed JSON is rejected without mutation ... OK (0.055s)
[06] unknown root field is rejected without mutation ... OK (0.065s)
[07] late invalid event keeps whole batch atomic ... OK (0.066s)
[08] joystick port 2 fire keeps Anykey buttons 2 and 3 released ... OK (0.228s)
[09] joystick port 2 fire2 lights only Anykey button 2 ... OK (0.177s)
[10] joystick port 2 fire3 lights only Anykey button 3 ... OK (0.178s)
[11] joystick port 1 up press is visible on CIA reads ... OK (0.103s)
[12] joystick port 1 all inputs and idempotent release are visible on CIA reads ... OK (0.112s)
[13] joystick port 2 diagonal and fire are visible on CIA reads ... OK (0.112s)
[14] joystick partial release is visible on CIA reads ... OK (0.112s)
[15] joystick fire2/fire3 round-trip through REST state ... OK (0.202s)
[16] joystick release_all then press in same batch is visible on CIA reads ... OK (0.092s)
[17] joystick unusual combination is visible on CIA reads ... OK (0.087s)
[18] joystick tap does not release persistent input ... OK (0.325s)
[19] joystick tap auto releases ... OK (0.308s)
[20] invalid joystick batch does not mutate state ... OK (0.132s)
[21] joystick release_all clears both ports ... OK (0.089s)
[22] machine reset clears keyboard and joystick REST state ... OK (3.107s)
[23] keyboard single-tap batch is consumed by BASIC in order ... OK (0.880s)
[24] keyboard 10 Hz mixed alphabet echo has no missed presses ... OK (5.448s)
[25] keyboard 20 Hz alternating ab echo has no missed presses ... OK (6.277s)
[26] keyboard 5 Hz alternating ab echo has no missed presses ... OK (3.898s)
[27] keyboard single letter reaches the live C64 matrix ... OK (0.133s)
[28] keyboard shifted pair reaches the live C64 matrix ... OK (0.214s)
[29] keyboard batch applies multiple presses atomically ... OK (0.205s)
[30] keyboard ordered batch and idempotent release ... OK (0.071s)
[31] keyboard release_all can be followed by press in same batch ... OK (0.073s)
[32] keyboard accepts eight simultaneous inputs ... OK (0.075s)
[33] keyboard tap does not release persistent key ... OK (0.172s)
[34] keyboard release_all clears state ... OK (0.061s)
[35] keyboard restore tap auto releases ... OK (0.245s)
[36] keyboard special-key taps snapshot correctly and auto release ... OK (2.485s)
[37] keyboard tap is visible in the live hardware snapshot and auto releases ... OK (0.271s)
[38] keyboard cursor-left tap is visible in the live hardware snapshot and auto releases ... OK (0.292s)
[39] keyboard tap batch drains through the live matrix path ... OK (1.269s)
[40] keyboard long repeated tap train drains fully without sticky state ... OK (6.120s)
[41] invalid keyboard batch does not mutate state ... OK (0.040s)
[42] menu editor accepts an unshifted control character ... OK (0.991s)
[43] menu editor keeps separate-batch shift active across POSTs ... OK (2.781s)
[44] menu editor repeats a held printable key ... OK (3.607s)
[45] menu editor stops printable repeat after release ... OK (5.710s)
[46] menu editor accepts a single cursor-left control ... OK (4.529s)
[47] menu editor repeats a held cursor-left control ... OK (4.637s)
[48] menu editor stops cursor repeat after release ... OK (6.146s)
input_test: OK (48 checks, 78.0s)
input: OK (78.2s)

============================================================
E2E  prg-context-menu  (overlay)
============================================================
     prg-context-menu: health: ping=9ms rest=9ms ftp=10ms telnet=39ms ident=16ms dma=17ms raster=23ms jiffy=23ms -> OK
[01] reset the machine to a clean starting state ... OK (2.909s)
[02] seed /Temp with prgmenu90152.prg, prgmenu90152.d64 and a long-named PRG ... OK (0.401s)

--- every context-menu action on a plain PRG
[03] read the context menu of a plain PRG ... OK (2.134s)
     offers: Run, Load, DMA, View, Hex View, Copy to..., Move to..., Rename, Delete
[04] a plain PRG: every offered action is covered ... OK (0.000s)
[05] Run on a plain PRG ... OK (7.082s)
[06] Load on a plain PRG ... OK (6.272s)
[07] DMA on a plain PRG ... OK (7.866s)
[08] View on a plain PRG ... OK (3.282s)
[09] Hex View on a plain PRG ... OK (3.686s)
[10] Copy to... on a plain PRG ... OK (5.824s)
[11] Rename on a plain PRG ... OK (5.763s)
[12] Move to... on a plain PRG ... OK (6.260s)
[13] Delete on a plain PRG ... OK (3.444s)
--- OK (11 checks, 51.6s)

--- every context-menu action on a PRG inside a D64
[14] read the context menu of a PRG inside a D64 ... OK (3.218s)
     offers: Run, Load, DMA, Mount & Run, Real Run, View, Hex View, Copy to..., Move to..., Rename, Delete
[15] a PRG inside a D64: every offered action is covered ... OK (0.000s)
[16] Run on a PRG inside a D64 ... OK (8.195s)
[17] Load on a PRG inside a D64 ... OK (6.788s)
[18] DMA on a PRG inside a D64 ... OK (8.650s)
[19] Mount & Run on a PRG inside a D64 ... OK (9.297s)
[20] Real Run on a PRG inside a D64 ... OK (12.4s SLOW)
[21] View on a PRG inside a D64 ... OK (4.817s)
[22] Hex View on a PRG inside a D64 ... OK (4.829s)
[23] Copy to... on a PRG inside a D64 ... OK (7.566s)
[24] Rename on a PRG inside a D64 ... OK (7.186s)
[25] Move to... on a PRG inside a D64 ... OK (8.678s)
[26] Delete on a PRG inside a D64 ... OK (5.091s)
[27] Run a PRG whose name is far longer than the boot-cart display ... OK (7.886s)
--- OK (14 checks, 94.6s)
prg_context_menu_test: OK (23 actions, 150s)
prg-context-menu: OK (151s)

============================================================
E2E  browser-long-filename  (overlay)
============================================================
     browser-long-filename: health: ping=7ms rest=10ms ftp=10ms telnet=40ms ident=20ms dma=8ms raster=22ms jiffy=21ms -> OK
[01] reset the machine to a clean starting state ... OK (0.563s)
[02] seed long-name fixture for rename ... OK (0.907s)
[03] browser rename on long filename ... OK (7.076s)
[04] reseed long-name fixture for mount ... OK (0.872s)
[05] browser mount on long filename ... OK (4.633s)
browser_long_filename_test: OK (5 checks, 14.4s)
browser-long-filename: OK (15.6s)

============================================================
E2E  browser-filesystem-refresh  (overlay)
============================================================
     browser-filesystem-refresh: health: ping=7ms rest=10ms ftp=10ms telnet=39ms ident=20ms dma=8ms raster=22ms jiffy=22ms -> OK
[01] reset the machine to a clean starting state ... OK (0.600s)
[02] prepare fixture directories ... OK (0.095s)
[03] open Menu, Telnet and FTP on the fixture directory ... OK (3.915s)
[04] rename from the Menu ... OK (3.702s)
[05] rename from Telnet ... OK (3.140s)
[06] rename from FTP ... OK (1.364s)
[07] rename under observer-queue pressure from the Menu ... OK (5.328s)
[08] rename under observer-queue pressure from Telnet ... OK (4.704s)
[09] rename a directory from the Menu ... OK (3.305s)
[10] rename a directory from Telnet ... OK (2.859s)
[11] delete from the Menu ... OK (2.356s)
[12] delete from Telnet ... OK (3.068s)
[13] delete from FTP ... OK (1.247s)
[14] delete a non-empty directory from the Menu ... OK (2.068s)
[15] delete a non-empty directory from Telnet ... OK (2.600s)
[16] remove a directory from FTP ... OK (1.232s)
[17] select all and bulk delete from the Menu ... OK (2.194s)
[18] create from the Menu ... OK (3.374s)
[19] create from Telnet ... OK (3.249s)
[20] create from FTP ... OK (1.705s)
     STOR phase 1 (open, 0 bytes committed): Menu=<empty>; Telnet=<empty>; FTP=<empty>
[21] create from FTP (mkd) ... OK (0.915s)
[22] create from REST (d64) ... OK (1.120s)
[23] create from REST (d71) ... OK (1.109s)
[24] create from REST (d81) ... OK (1.244s)
[25] create from REST (dnp) ... OK (1.151s)
[26] write from the Menu ... OK (2.779s)
[27] write from Telnet ... OK (2.900s)
[28] write from FTP ... OK (1.800s)
     STOR phase 1 (open, truncated): Menu=wftp1.tst[ 100 ]; Telnet=wftp1.tst[ 100 ]; FTP=wftp1.tst[ 100 ]=100
[29] copy over an existing file from the Menu ... OK (10.9s SLOW)
[30] copy over an existing file from Telnet ... OK (11.0s SLOW)
[31] move an entry out of the watched directory from the Menu ... OK (5.376s)
[32] move an entry out of the watched directory from Telnet ... OK (5.112s)
[33] paste into the watched directory from the Menu ... OK (7.191s)
[34] paste into the watched directory from Telnet ... OK (7.202s)
[35] failed rename shows nothing ... OK (1.138s)
[36] failed delete removes nothing ... OK (0.935s)
[37] failed write creates nothing ... OK (0.821s)
[38] short write commits consistently ... OK (1.061s)
     short write committed 100 bytes

operation x origin x observer matrix
------------------------------------------------------------------------------
  rename       Menu    Menu    OK    0.20s
  rename       Menu    Telnet  OK    0.20s
  rename       Menu    FTP     OK    0.20s
  rename       Menu    REST    OK    0.20s
  rename       Telnet  Menu    OK    0.19s
  rename       Telnet  Telnet  OK    0.19s
  rename       Telnet  FTP     OK    0.19s
  rename       Telnet  REST    OK    0.19s
  rename       FTP     Menu    OK    0.53s
  rename       FTP     Telnet  OK    0.53s
  rename       FTP     FTP     OK    0.53s
  rename       FTP     REST    OK    0.53s
  rename-under-load Menu    Menu    OK    0.20s
  rename-under-load Menu    Telnet  OK    0.20s
  rename-under-load Menu    FTP     OK    0.20s
  rename-under-load Menu    REST    OK    0.20s
  rename-under-load Telnet  Menu    OK    0.19s
  rename-under-load Telnet  Telnet  OK    0.19s
  rename-under-load Telnet  FTP     OK    0.19s
  rename-under-load Telnet  REST    OK    0.19s
  rename-dir   Menu    Menu    OK    0.19s
  rename-dir   Menu    Telnet  OK    0.19s
  rename-dir   Menu    FTP     OK    0.19s
  rename-dir   Menu    REST    OK    0.19s
  rename-dir   Telnet  Menu    OK    0.20s
  rename-dir   Telnet  Telnet  OK    0.20s
  rename-dir   Telnet  FTP     OK    0.20s
  rename-dir   Telnet  REST    OK    0.20s
  delete       Menu    Menu    OK    0.19s
  delete       Menu    Telnet  OK    0.19s
  delete       Menu    FTP     OK    0.19s
  delete       Menu    REST    OK    0.19s
  delete       Telnet  Menu    OK    0.19s
  delete       Telnet  Telnet  OK    0.19s
  delete       Telnet  FTP     OK    0.19s
  delete       Telnet  REST    OK    0.19s
  delete       FTP     Menu    OK    0.60s
  delete       FTP     Telnet  OK    0.60s
  delete       FTP     FTP     OK    0.60s
  delete       FTP     REST    OK    0.60s
  delete-dir   Menu    Menu    OK    0.24s
  delete-dir   Menu    Telnet  OK    0.24s
  delete-dir   Menu    FTP     OK    0.24s
  delete-dir   Menu    REST    OK    0.24s
  delete-dir   Telnet  Menu    OK    0.20s
  delete-dir   Telnet  Telnet  OK    0.20s
  delete-dir   Telnet  FTP     OK    0.20s
  delete-dir   Telnet  REST    OK    0.20s
  delete-dir   FTP/rmd Menu    OK    0.60s
  delete-dir   FTP/rmd Telnet  OK    0.60s
  delete-dir   FTP/rmd FTP     OK    0.60s
  delete-dir   FTP/rmd REST    OK    0.60s
  delete-bulk  Menu    Menu    OK    0.19s
  delete-bulk  Menu    Telnet  OK    0.19s
  delete-bulk  Menu    FTP     OK    0.19s
  delete-bulk  Menu    REST    OK    0.19s
  create       Menu    Menu    OK    0.20s
  create       Menu    Telnet  OK    0.20s
  create       Menu    FTP     OK    0.20s
  create       Menu    REST    OK    0.20s
  create       Telnet  Menu    OK    0.20s
  create       Telnet  Telnet  OK    0.20s
  create       Telnet  FTP     OK    0.20s
  create       Telnet  REST    OK    0.20s
  create       FTP     Menu    OK    0.60s
  create       FTP     Telnet  OK    0.60s
  create       FTP     FTP     OK    0.60s
  create       FTP     REST    OK    0.60s
  create       FTP/mkd Menu    OK    0.50s
  create       FTP/mkd Telnet  OK    0.50s
  create       FTP/mkd FTP     OK    0.50s
  create       FTP/mkd REST    OK    0.50s
  create       REST/d64 Menu    OK    0.66s
  create       REST/d64 Telnet  OK    0.66s
  create       REST/d64 FTP     OK    0.66s
  create       REST/d64 REST    OK    0.66s
  create       REST/d71 Menu    OK    0.60s
  create       REST/d71 Telnet  OK    0.60s
  create       REST/d71 FTP     OK    0.60s
  create       REST/d71 REST    OK    0.60s
  create       REST/d81 Menu    OK    0.52s
  create       REST/d81 Telnet  OK    0.52s
  create       REST/d81 FTP     OK    0.52s
  create       REST/d81 REST    OK    0.52s
  create       REST/dnp Menu    OK    0.64s
  create       REST/dnp Telnet  OK    0.64s
  create       REST/dnp FTP     OK    0.64s
  create       REST/dnp REST    OK    0.64s
  write        Menu    Menu    OK    0.20s
  write        Menu    Telnet  OK    0.20s
  write        Menu    FTP     OK    0.20s
  write        Menu    REST    OK    0.20s
  write        Telnet  Menu    OK    0.19s
  write        Telnet  Telnet  OK    0.19s
  write        Telnet  FTP     OK    0.19s
  write        Telnet  REST    OK    0.19s
  write        FTP     Menu    OK    0.59s
  write        FTP     Telnet  OK    0.59s
  write        FTP     FTP     OK    0.59s
  write        FTP     REST    OK    0.59s
  copy-write   Menu    Menu    N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Menu    Telnet  OK    0.18s
  copy-write   Menu    FTP     OK    0.18s
  copy-write   Menu    REST    OK    0.18s
  copy-arrival Menu    Menu    OK    no stale cache on re-entry
  copy-write   Telnet  Telnet  N/A   origin stands on the source entry elsewhere; see arrival check + paste-write
  copy-write   Telnet  Menu    OK    0.05s
  copy-write   Telnet  FTP     OK    0.05s
  copy-write   Telnet  REST    OK    0.05s
  copy-arrival Telnet  Telnet  OK    no stale cache on re-entry
  move-out     Menu    Menu    OK    0.20s
  move-out     Menu    Telnet  OK    0.20s
  move-out     Menu    FTP     OK    0.20s
  move-out     Menu    REST    OK    0.20s
  move-out     Telnet  Menu    OK    0.22s
  move-out     Telnet  Telnet  OK    0.22s
  move-out     Telnet  FTP     OK    0.22s
  move-out     Telnet  REST    OK    0.22s
  paste-write  Menu    Menu    OK    0.21s
  paste-write  Menu    Telnet  OK    0.21s
  paste-write  Menu    FTP     OK    0.21s
  paste-write  Menu    REST    OK    0.21s
  paste-write  Telnet  Menu    OK    0.20s
  paste-write  Telnet  Telnet  OK    0.20s
  paste-write  Telnet  FTP     OK    0.20s
  paste-write  Telnet  REST    OK    0.20s
  rename-fail  FTP     Menu    OK    0.20s
  rename-fail  FTP     Telnet  OK    0.20s
  rename-fail  FTP     FTP     OK    0.20s
  rename-fail  FTP     REST    OK    0.20s
  delete-fail  FTP     Menu    OK    0.20s
  delete-fail  FTP     Telnet  OK    0.20s
  delete-fail  FTP     FTP     OK    0.20s
  delete-fail  FTP     REST    OK    0.20s
  write-fail   FTP     Menu    OK    0.19s
  write-fail   FTP     Telnet  OK    0.19s
  write-fail   FTP     FTP     OK    0.19s
  write-fail   FTP     REST    OK    0.19s
  short-write  FTP     Menu    OK    0.27s
  short-write  FTP     Telnet  OK    0.27s
  short-write  FTP     FTP     OK    0.27s
  short-write  FTP     REST    OK    0.27s
------------------------------------------------------------------------------
  N/A=2, OK=140
browser_filesystem_refresh_test: OK (38 checks, 117s)
browser-filesystem-refresh: OK (119s)

============================================================
E2E  ftp-client  (overlay)
============================================================
     ftp-client: health: ping=7ms rest=15ms ftp=10ms telnet=42ms ident=12ms dma=7ms raster=31ms jiffy=748ms -> OK
     inferred --ftp-advertised-host 192.168.1.78
     controlled FTP server on 0.0.0.0:2121 (advertised 192.168.1.78)
[I 2026-08-12 23:07:22] concurrency model: async
[I 2026-08-12 23:07:22] masquerade (NAT) address: 192.168.1.78
[I 2026-08-12 23:07:22] passive ports: 30000->30019
[I 2026-08-12 23:07:22] >>> starting FTP server on 0.0.0.0:2121, pid=44161 <<<
     server root: /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-bw6g7sng (marker E2E-1786590442)
[01] GET /v1/version reachable ... OK (0.1, 0.025s)
[02] menu closed -> menu_screen 404 ... OK (0.036s)
[03] menu_button opens menu ... OK (0.316s)
[04] menu_screen returns 2000-byte matrix ... OK (2000 bytes, 0.017s)
[05] input release_all works ... OK (0.018s)
[06] menu closes from anywhere ... OK (0.314s)
[07] remove any stale hosts left by a prior run ... OK (0 removed, 1.247s)

--- stage: smoke
[08] create FTP host 'E2EFTP0443twyf' through the New Host form ... OK (5.879s)
[09] new alias appears under /ftp ... OK (1.036s)
[10] enter host: server sees login + TYPE I + LIST ... [I 2026-08-12 23:07:32] 192.168.1.62:52432-[] FTP session opened (connect)
[I 2026-08-12 23:07:32] 192.168.1.62:52432-[u64e2e] USER 'u64e2e' logged in.
OK (PASS,TYPE,LIST, 1.183s)
[11] root listing shows fixture entries ... OK (README,DIRA,SMALL, 0.016s)
[12] open README.TXT -> RETR (52 bytes) ... [I 2026-08-12 23:07:34] 192.168.1.62:52432-[u64e2e] RETR /private/var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-bw6g7sng/README.TXT completed=1 bytes=52 seconds=0.0
OK (52 bytes, 2.187s)
[13] remove host and confirm it disappears ... [I 2026-08-12 23:07:36] 192.168.1.62:52432-[u64e2e] FTP session closed (disconnect).
OK (3.169s)
--- OK (6 checks, 13.5s)

--- cleanup
     preserved: nothing

--- summary
     Phase    Operation              Result             Commands       Fixture/Notes
     ------------------------------------------------------------------------------
     smoke    create host            OK                                E2EFTP0443twyf
     smoke    list host              OK                                E2EFTP0443twyf
     smoke    enter/LIST             OK                 USER/PASS/TYPE E2EFTP0443twyf
     smoke    root entries           OK                 LIST           README/DIRA/SMALL
     smoke    RETR README            OK                 RETR           README.TXT 52 bytes
     smoke    remove host            OK                                E2EFTP0443twyf
     ------------------------------------------------------------------------------
     Total REST requests   : 155
     Total menu snapshots  : 65
     Total keyboard events : 102
     Total FTP commands    : 24
     Created host alias    : (removed)
     Remote root path      : /var/folders/52/5656d2050tz7nvc4b1m1tfqw0000gn/T/u64ftp-bw6g7sng
     Cleanup status        : clean
Exception in thread Thread-1 (serve_forever):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/servers.py", line 254, in serve_forever
    self.ioloop.loop(timeout, blocking)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 376, in loop
    poll(timeout)
    ~~~~^^^^^^^^^
  File "/Users/barry/Library/Python/3.13/lib/python/site-packages/pyftpdlib/ioloop.py", line 741, in poll
    kevents = self._kqueue.control(
        None, _len(self.socket_map), timeout
    )
OSError: [Errno 9] Bad file descriptor
ftp-client: OK (16.7s)

============================================================
E2E  prg-load-path-trim  (overlay)
============================================================
     prg-load-path-trim: health: ping=8ms rest=12ms ftp=9ms telnet=39ms ident=22ms dma=8ms raster=21ms jiffy=21ms -> OK

--- Ultimate 64 PRG load path trim
     host: 192.168.1.148
     PUT file path: /Temp/rest-prg-path-trim-target-example.prg
     POST upload name: rest-prg-path-trim-upload-example.prg

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configure Temp Settings
[01] set Temp Auto Cleanup to Enabled ... OK (0.012s)
[02] set Temp Subfolders to Enabled ... OK (0.011s)
--- OK (2 checks, 0.023s)

--- 3. Prepare PRG Fixture
[03] upload PUT fixture rest-prg-path-trim-target-example.prg ... OK (0.114s)
--- OK (1 checks, 0.115s)

--- 4. Validate PUT Endpoints
[04] exercise PUT runners:load_prg ... OK (0.385s)
     PUT load_prg boot-cart name: ...T-EXAMPLE
[05] exercise PUT runners:run_prg ... OK (1.768s)
     PUT run_prg boot-cart name: ...T-EXAMPLE
--- OK (2 checks, 2.295s)

--- 5. Validate POST Endpoints
[06] exercise POST runners:load_prg ... OK (0.420s)
     POST load_prg boot-cart name: ...D-EXAMPLE
[07] exercise POST runners:run_prg ... OK (1.784s)
     POST run_prg boot-cart name: ...D-EXAMPLE
--- OK (2 checks, 2.855s)
prg_load_path_trim_test: OK (7 checks, 5.913s)

--- restore User Interface Settings
[08] set Temp Auto Cleanup to Enabled ... OK (0.013s)
[09] set Temp Subfolders to Enabled ... OK (0.012s)
prg-load-path-trim: OK (6.639s)

============================================================
E2E  temp-auto-cleanup  (overlay)
============================================================
     temp-auto-cleanup: health: ping=7ms rest=10ms ftp=10ms telnet=39ms ident=13ms dma=15ms raster=22ms jiffy=21ms -> OK

--- Ultimate 64 Temp auto cleanup
     host: 192.168.1.148

--- 1. Capture Current Configuration
     Temp Auto Cleanup: Enabled
     Temp Subfolders: Enabled

--- 2. Configuration Setup
[01] set Temp Auto Cleanup to Enabled ... OK (0.012s)
[02] set Temp Subfolders to Enabled ... OK (0.012s)
--- OK (2 checks, 0.023s)

--- 3. Purging /Temp
     purge complete

--- 4. Mounting D64 Images
[03] create /Temp/mount-drive-8.d64 ... OK (0.056s)
[04] download mount-drive-8.d64 for the upload mount ... OK (0.354s)
[05] remove staging source mount-drive-8.d64 ... OK (0.034s)
[06] mount drive A ... OK (0.971s)
OK (0.971s)
[07] create /Temp/mount-drive-9.d64 ... OK (0.052s)
[08] download mount-drive-9.d64 for the upload mount ... OK (0.364s)
[09] remove staging source mount-drive-9.d64 ... OK (0.035s)
[10] mount drive B ... OK (0.989s)
OK (0.989s)
--- OK (10 checks, 2.856s)

--- 5. Seeding Baseline (10 files)
[11] upload base_1.bin ... OK (0.923s)
[12] upload base_2.bin ... OK (0.967s)
[13] upload base_3.bin ... OK (0.890s)
[14] upload base_4.bin ... OK (0.903s)
[15] upload base_5.bin ... OK (0.908s)
[16] upload base_6.bin ... OK (0.902s)
[17] upload base_7.bin ... OK (0.920s)
[18] upload base_8.bin ... OK (1.026s)
[19] upload base_9.bin ... OK (0.939s)
[20] upload base_10.bin ... OK (1.013s)
--- OK (10 checks, 9.433s)

--- 6. Managed Temp File Limit (Target: 10)
[21] upload managed_1.bin over REST ... OK (4.257s)
     managed count=1 (limit=10)
[22] upload managed_2.bin over REST ... OK (4.444s)
     managed count=2 (limit=10)
[23] upload managed_3.bin over REST ... OK (4.167s)
     managed count=3 (limit=10)
[24] upload managed_4.bin over REST ... OK (4.263s)
     managed count=4 (limit=10)
[25] upload managed_5.bin over REST ... OK (4.183s)
     managed count=5 (limit=10)
[26] upload managed_6.bin over REST ... OK (4.247s)
     managed count=6 (limit=10)
[27] upload managed_7.bin over REST ... OK (4.237s)
     managed count=7 (limit=10)
[28] upload managed_8.bin over REST ... OK (4.221s)
     managed count=8 (limit=10)
[29] upload managed_9.bin over REST ... OK (4.202s)
     managed count=9 (limit=10)
[30] upload managed_10.bin over REST ... OK (4.233s)
     managed count=10 (limit=10)
[31] upload managed_11.bin over REST ... OK (4.269s)
     managed count=10 (limit=10)
[32] upload managed_12.bin over REST ... OK (4.304s)
     managed count=10 (limit=10)
OK (4.597s)
OK (4.658s)
--- OK (14 checks, 54.4s)

--- 7. Unmounted Uploads Rejoin Cleanup
[33] remove drive A ... OK (0.122s)
[34] upload post_a_1.bin over REST ... OK (4.226s)
OK (4.295s)
     removed after 1 uploads
[35] remove drive B ... OK (0.120s)
[36] upload post_b_1.bin over REST ... OK (4.229s)
     removed after 1 uploads
--- OK (5 checks, 9.054s)

--- 8. Final Integrity Check
     user files intact
temp_auto_cleanup_test: OK (36 checks, 77.9s)

--- restore User Interface Settings
[37] set Temp Auto Cleanup to Enabled ... OK (0.020s)
[38] set Temp Subfolders to Enabled ... OK (0.013s)
temp-auto-cleanup: OK (78.4s)

============================================================
E2E  cfg-single-group  (overlay)
============================================================
     cfg-single-group: health: ping=7ms rest=10ms ftp=10ms telnet=39ms ident=12ms dma=16ms raster=24ms jiffy=24ms -> OK
[01] load a one-group CFG file through the browser ... OK (7.223s)
[02] only the CFG group is considered after loading ... OK (0.074s)
cfg_single_group_test: OK (2 checks, 7.722s)
cfg-single-group: OK (8.245s)

============================================================
E2E  cfg-unknown-items  (overlay)
============================================================
     cfg-unknown-items: health: ping=7ms rest=10ms ftp=16ms telnet=39ms ident=12ms dma=9ms raster=32ms jiffy=25ms -> OK

--- an item this firmware does not have
[01] a CFG with an unknown item loads without being called an error ... OK (6.653s)
[02] the settings it could apply were applied ... OK (0.017s)
     Vol Master: ' 0 dB' -> 'OFF'
[03] the log names the unknown item and its value ... OK (0.066s)
--- OK (3 checks, 6.753s)

--- a store this machine does not have
[04] a CFG naming an absent store loads without being called an error ... OK (6.913s)
[05] the store that does exist was still applied ... OK (0.018s)
[06] the log names the absent store ... OK (0.065s)
--- OK (3 checks, 7.008s)
cfg_unknown_items_test: OK (6 checks, 14.2s)
cfg-unknown-items: OK (14.8s)

============================================================
E2E  printer  (overlay)
============================================================
     printer: health: ping=7ms rest=10ms ftp=10ms telnet=39ms ident=12ms dma=7ms raster=22ms jiffy=24ms -> OK
[01] REST reachable at 192.168.1.148 ... OK (0.011s)
[02] reset before run ... OK (0.110s)
[03] load printer_e2e.prg ... OK (914 bytes, 0.000s)
[04] capture original Printer Settings ... OK (0.162s)
[05] print epson/bitmap: apply settings + run PRG ... OK (phase=printer closed heartbeat=4, 2.777s)
[06] print epson/bitmap: Flush/Eject via on-screen menu ... OK (3.749s)

--- restoring original Printer Settings
     IEC printer: Disabled
     Bus ID: 4
     Output file: /Usb0/printer
     Output type: PNG B&W
     Ink density: Medium
     Page top margin (default is 5): 5
     Page height (default is 60): 60
     Emulation: Commodore MPS
     Commodore charset: USA/UK
     Epson charset: Basic
     IBM table 2: International 1

--- summary
     epson      bitmap PASS_NO_VERIFY       /USB1/printer/e2e-eb9fea
printer: OK (7.483s)

============================================================
E2E  uci-targets  (overlay)
============================================================
     uci-targets: health: ping=7ms rest=10ms ftp=12ms telnet=39ms ident=14ms dma=7ms raster=23ms jiffy=23ms -> OK
[01] reset the C64 so the command interface starts idle ... OK (3.065s)
[02] read 'C64 and Cartridge Settings' ... OK (0.017s)
     current: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}
[03] enable the Command Interface registers at $DF1B-$DF1F ... OK (0.081s)
[04] transport: an empty command returns an empty reply ... OK (0.119s)
     <empty> -> 0.03s, data b'', status b''
[05] transport: unregistered target answers IDENTIFY ... OK (0.531s)
     0f 01 -> 0.05s, data b'NO TARGET', status b'00,OK'
[06] transport: unregistered target rejects anything else ... OK (0.685s)
     0f 7f -> 0.06s, data b'', status b'21,UNKNOWN COMMAND'
[07] transport: a no-reply command returns straight to Idle ... OK (0.128s)
[08] transport: pushing while a reply is pending sets and clears ERROR ... OK (0.899s)
[09] transport: the next command is not prefixed by leftover bytes ... OK (0.816s)
     04 28 00 -> 0.06s, data b'Ultimate 64 Elite', status b'00,OK'
[10] transport: ABORT releases a pending reply back to Idle ... OK (0.140s)
[11] control-target: IDENTIFY answers with the target name ... OK (0.861s)
     04 01 -> 0.06s, data b'CONTROL TARGET V1.1', status b'00,OK'
[12] control-target: an unimplemented command is reported as unknown ... OK (0.679s)
     04 7f -> 0.06s, data b'', status b'21,UNKNOWN COMMAND'
[13] control-target: LOAD_REU without a filename is rejected, not run ... OK (0.662s)
     04 08 -> 0.06s, data b'', status b'81,INVALID PARAMS'
[14] control-target: SAVE_REU without a filename is rejected, not run ... OK (0.659s)
     04 09 -> 0.06s, data b'', status b'81,INVALID PARAMS'
[15] control-target: GET_HWINFO rejects a device number it does not have ... OK (0.662s)
     04 28 02 -> 0.07s, data b'', status b'81,INVALID PARAMS'
[16] issue-740-matrix: confirm /Temp/uci_e2e_absent.reu does not exist ... OK (0.014s)
[17] issue-740-matrix: put a 16384-byte image at /Temp/uci_e2e_present.reu ... OK (0.123s)
[18] issue-740-matrix: REU Enabled, image absent, name at offset 2 ... OK (3.140s)
     04 08 52 45 55 2e 49 4d 47 -> 0.14s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[19] issue-740-matrix: REU Enabled, image absent, name at offset 4 ... OK (3.232s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.19s, data b"\xff\xff\xff\xffREU LOAD: FAILED TO OPEN /TEMP/UCI_E2E_ABSENT.REU: FILE DOESN'T EXIST", status b'85,REU FILE CANNOT BE OPENED'
[20] issue-740-matrix: REU Disabled, image absent, name at offset 2 ... OK (0.967s)
     04 08 52 45 55 2e 49 4d 47 -> 0.16s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[21] issue-740-matrix: REU Disabled, image absent, name at offset 4 ... OK (1.049s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.24s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[22] issue-740-matrix: REU Enabled, image present, name at offset 2 ... OK (2.532s)
     04 08 52 45 55 2e 49 4d 47 -> 0.20s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[23] issue-740-matrix: REU Enabled, image present, name at offset 4 ... OK (2.609s)
     04 08 00 00 52 45 55 2e 49 4d 47 -> 0.20s, data b'\x00@\x00\x00REU LOAD: LOADED 16384 BYTES TO $000000 FROM /TEMP/UCI_E2E_PRESENT.REU', status b'00,OK'
[24] save-reu-offset-past-end: put the preload offset at the end of a 128 KB REU ... OK (0.067s)
[25] save-reu-offset-past-end: SAVE_REU reports the offset and saves nothing ... OK (2.944s)
     04 09 52 45 55 2e 49 4d 47 -> 0.16s, data b'\xfd\xff\xff\xffREU SAVE: OFFSET 131072 >= REU SIZE 131072, SKIPPING', status b'86,REU OFFSET > SIZE. NOT SAVED'
[26] load-reu-disabled: disable the REU ... OK (0.019s)
[27] load-reu-disabled: leave text in the reply buffer from a previous command ... OK (0.811s)
     04 28 00 -> 0.08s, data b'Ultimate 64 Elite', status b'00,OK'
[28] load-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (0.898s)
     04 08 52 45 55 2e 49 4d 47 -> 0.16s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[29] save-reu-disabled: disable the REU ... OK (0.030s)
[30] save-reu-disabled: leave text in the reply buffer from a previous command ... OK (0.847s)
     04 28 00 -> 0.07s, data b'Ultimate 64 Elite', status b'00,OK'
[31] save-reu-disabled: command reports the REU is disabled and replies with 4 bytes ... OK (0.876s)
     04 09 52 45 55 2e 49 4d 47 -> 0.14s, data b'\xfe\xff\xff\xff', status b'84,REU NOT ENABLED'
[32] softiec-single-part-reply: SoftIEC target answers IDENTIFY ... OK (0.992s)
     05 01 -> 0.06s, data b'SOFTWARE IEC TARGET V1.0', status b'00,OK'
[33] softiec-single-part-reply: LOAD_SU on a missing file completes in one part ... OK (0.428s)
     05 10 00 00 00 00 00 00 4e 4f 53 55 43 48 46 49 4c 45 -> 0.29s, data b'', status b'\x01'
[34] softiec-single-part-reply: GET_FATNAME reply completes in one part ... OK (0.435s)
     05 22 02 23 -> 0.09s, data b'/buffer', status b'\x00'
[35] softiec-single-part-reply: an unimplemented SoftIEC command is reported as unknown ... OK (0.232s)
     05 7f -> 0.07s, data b'', status b'\x04'
[36] interface-usable-after: the control target still answers IDENTIFY ... OK (0.824s)
     04 01 -> 0.05s, data b'CONTROL TARGET V1.1', status b'00,OK'
     restored C64 and Cartridge Settings: {'Command Interface': 'Disabled', 'RAM Expansion Unit': 'Disabled', 'REU Preload Image': '/Usb0/preload.reu', 'REU Size': '2 MB', 'REU Preload Offset': '0 KB'}

--- summary
     transport: OK
     control-target: OK
     issue-740-matrix: OK
     save-reu-offset-past-end: OK
     load-reu-disabled: OK
     save-reu-disabled: OK
     softiec-single-part-reply: OK
     interface-usable-after: OK
     cleanup: OK
uci_targets_test: OK (36 checks, 33.3s)
uci-targets: OK (33.4s)

============================================================
E2E  machine-code-monitor  (overlay)
============================================================
     machine-code-monitor: health: ping=7ms rest=10ms ftp=10ms telnet=39ms ident=19ms dma=7ms raster=21ms jiffy=23ms -> OK
[01] initial CPU7/KERNAL monitor status ... OK (0.014s)
[02] KERNAL $E000 hex view and REST match ... OK (0.535s)
[03] paging away and back keeps memory view stable ... OK (0.564s)
[04] KERNAL disassembly formatting ... OK (1.633s)
[05] KERNAL $E010 REST match ... OK (0.837s)
[06] CPU6 RAM under BASIC write/read ... OK (4.021s)
[07] CPU5 RAM under KERNAL status ... OK (2.618s)
[08] ASCII view width and scrolling ... OK (6.617s)
[09] ASCII and Screen mapping semantics ... OK (10.8s SLOW)
[10] HEX edit writes both nibbles ... OK (2.629s)
[11] CPU bank cycling reaches CHAR and RAM mappings ... OK (3.308s)
[12] COMPARE reports differing address ... OK (3.711s)
[13] G executes finite loop and returns to monitor ... OK (2.266s)
[14] G repeated execution updates RAM sentinel ... OK (6.708s)
[15] G handoff preserves stable VIC state ... SKIP (the on-device UI owns the VIC while it is up; only comparable over telnet, 0.000s)
OK (0.000s)
[16] bookmarks recall, set, list, and label edit ... OK (6.927s)
[17] memory bookmark jump restores width 16 ... OK (5.050s)
[18] binary width cycling and bookmark jump restores width 4 ... OK (6.040s)
[19] follow and return navigation ... OK (5.349s)
[20] asm edit mnemonic validation and Return advance ... OK (7.383s)
[21] number popup arithmetic ... OK (2.761s)
[22] save/load round-trip to top-level /Temp file ... OK (8.502s)
[23] save/load round-trip to file in new /Temp D64 ... OK (16.3s SLOW)

--- Telnet transport checks
[24] telnet blocks poll mode ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
[25] telnet opcode dropdown scroll does not flood the connection ... SKIP (requires --mode telnet, running under overlay, 0.000s)
OK (0.000s)
--- SKIP (4 checks, 0.130s)
monitor_test: OK (25 checks, 107s)
machine-code-monitor: OK (107s)

============================================================
E2E  ftp-server  (overlay)
============================================================
     ftp-server: health: ping=7ms rest=10ms ftp=10ms telnet=48ms ident=27ms dma=8ms raster=23ms jiffy=56ms -> OK

--- a name the listing reports can address the file it names
[01] a 40-character name is listed unchanged ... OK (0.063s)
[02] that file is removed by the name the listing reported ... OK (0.072s)
[03] a 100-character name is listed unchanged ... OK (0.075s)
     100 characters survived the listing
[04] SIZE answers for the long name the listing reported ... OK (0.046s)
[05] that file is removed by the name the listing reported ... OK (0.091s)
--- OK (5 checks, 0.459s)
ftp_server_test: OK (5 checks, 0.463s)
ftp-server: OK (0.511s)

============================================================
E2E  assembly64  (overlay)
============================================================
     assembly64: health: ping=7ms rest=15ms ftp=9ms telnet=45ms ident=12ms dma=7ms raster=30ms jiffy=23ms -> OK

--- the form opens from the task menu and closes again
[01] open the Assembly 64 query form ... OK (0.922s)
[02] the form leaves cleanly with RUN/STOP ... OK (0.381s)
--- OK (2 checks, 1.394s)

--- a real query is sent to the Assembly 64 service
[03] open the form and enter the first field ... OK (0.965s)
[04] the typed term lands in the Name field ... OK (0.675s)
[05] the service answers and the results match what was asked for ... OK (1.031s)
--- OK (3 checks, 3.225s)

--- the menu button must work from inside the edit field
[06] open the form and enter the edit field ... OK (0.940s)
[07] the menu button closes the menu from inside the field ... OK (0.087s)
[08] the menu opens again, so the UI task left string_edit ... OK (0.036s)
--- OK (3 checks, 1.528s)

--- an aborted edit must not wedge the form
[09] open the form, type into a field, then abort ... OK (1.445s)
[10] the form is still usable after the abort ... OK (0.031s)
--- OK (2 checks, 1.933s)

--- over-long and empty input
[11] type more than the field accepts ... OK (2.307s)
[12] an empty query is refused rather than sent ... OK (2.472s)
[13] the warning is dismissed and the form is still usable ... OK (0.235s)
--- OK (3 checks, 5.618s)

--- a user mashing keys while the form is busy
[14] submit a query and hammer keys while it runs ... OK (4.591s)
[15] the device is still answering after the mashing ... OK (0.010s)
--- OK (2 checks, 5.071s)

--- opening and abandoning the form repeatedly
[16] open and abandon the form three times ... OK (2.945s)
[17] the menu button closes and reopens the form three times ... OK (3.476s)
--- OK (2 checks, 6.629s)
assembly64_test: OK (17 checks, 25.8s)
assembly64: OK (25.9s)

============================================================
E2E  freeze-menu  (overlay)
============================================================
     freeze-menu: health: ping=7ms rest=10ms ftp=10ms telnet=39ms ident=22ms dma=18ms raster=21ms jiffy=22ms -> OK
     captured 'Interface Type'=Freeze, 'Auto Address Mirroring'=Enabled

--- menu cycle with Auto Address Mirroring Disabled
[01] select 'Freeze' interface with mirroring disabled ... OK (0.023s)
[02] C64 running before the menu is opened ... OK (1.588s)
[03] open the menu ... OK (0.281s)
[04] C64 frozen while the menu is open ... OK (0.535s)
[05] close the menu ... OK (0.274s)
[06] C64 resumed after the menu closed ... OK (0.522s)
--- OK (6 checks, 3.232s)

--- Auto Address Mirroring switched off while the menu is open
[07] select 'Freeze' interface with mirroring enabled ... OK (0.028s)
[08] C64 running before the menu is opened ... OK (0.526s)
[09] open the menu ... OK (0.282s)
[10] C64 frozen while the menu is open ... OK (0.522s)
[11] set Auto Address Mirroring to Disabled while the menu is open ... OK (0.015s)
[12] close the menu ... OK (0.276s)
[13] C64 resumed after the menu closed ... OK (0.522s)
--- OK (7 checks, 2.184s)

--- menu cycle with Auto Address Mirroring Enabled
[14] select 'Freeze' interface with mirroring enabled ... OK (0.028s)
[15] C64 running before the menu is opened ... OK (0.525s)
[16] open the menu ... OK (0.282s)
[17] C64 frozen while the menu is open ... OK (0.526s)
[18] close the menu ... OK (0.272s)
[19] C64 resumed after the menu closed ... OK (0.523s)
--- OK (6 checks, 2.169s)

--- reopen the freezer menu with a context menu left open
[20] select 'Freeze' interface with mirroring enabled ... OK (0.023s)
[21] C64 running before the menu is opened ... OK (0.524s)
[22] open the menu ... OK (0.280s)
[23] C64 frozen while the menu is open ... OK (0.522s)
[24] open the context menu on the first browser entry ... OK (7.387s)
[25] close the menu ... OK (0.277s)
[26] C64 resumed after the menu closed ... OK (0.524s)
[27] reopen the menu with the context menu still on the object stack ... OK (0.280s)
[28] dismiss the restored context menu ... OK (0.266s)
[29] close the menu ... OK (0.274s)
[30] C64 resumed after the menu closed ... OK (0.525s)
--- OK (11 checks, 10.9s)

--- the menu button works inside the Assembly 64 query form
[31] select 'Freeze' interface with mirroring enabled ... OK (0.031s)
[32] C64 running before the menu is opened ... OK (0.526s)
[33] open the menu ... OK (0.282s)
[34] C64 frozen while the menu is open ... OK (0.528s)
[35] open the task menu ... OK (0.299s)
[36] open the Assembly 64 query form ... OK (0.284s)
[37] enter the form's first edit field ... OK (0.288s)
[38] the menu button closes the menu from inside the edit field ... OK (0.283s)
[39] the menu opens again afterwards ... OK (0.280s)
[40] leave the query form ... OK (0.366s)
[41] close the menu ... OK (0.275s)
[42] C64 resumed after the menu closed ... OK (0.537s)
--- OK (12 checks, 4.066s)
freeze_menu_test: OK (42 checks, 23.7s)
freeze-menu: OK (23.7s)

TEARDOWN (overlay): release input ... OK (0.015s)
TEARDOWN (overlay): close active menu UI ... OK (0.026s)
TEARDOWN (overlay): reset machine ... OK (0.051s)

============================================================
Summary
============================================================
     OK   e2e overlay    721s (20 ok)
     slowest: prg-context-menu 151s, browser-filesystem-refresh 119s, machine-code-monitor 107s
     721s in suites, 28.1s in health checks, the UI-state gate and teardown
     749s total

OK  all 20 suite runs passed.
```

</details>
