### PR TITLE
Watch raw_u64 in the ESP32 build cache key

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -97,6 +97,11 @@ SUITES: Sequence[Suite] = (
     # way, and each was found only when a transient timeout failed a whole run.
     # First, so that lands as a clear message rather than as a flaky suite.
     Suite("e2e", "transport-usage", "tests/lib/check_transport_usage.py", ""),
+    # Needs no device either: CI skips the ESP32 build on a cache hit, so a
+    # project missing from the cache key gets its previous binary handed back
+    # forever. raw_u64 was, for a misspelling, and the firmware change that
+    # exposed it had already been merged before anyone noticed.
+    Suite("e2e", "esp-depends", "tests/lib/esp_depends_test.py", ""),
     # Also needs no device: it checks the two decisions this runner makes when
     # a run goes wrong - when the recovery command may fire, and what status the
     # run exits with. Both only show themselves on a run that has already gone

--- a/software/esp_depends.py
+++ b/software/esp_depends.py
@@ -11,10 +11,15 @@ def get_hash(path="", hash_type='md5'):
     return func.hexdigest()
 
 # Find dependencies
-dirs = [ 'wifi/raw_c3/main', 'wifi/raw_c3', 'wifi/raw_c64/main', 'wifi/raw_c64', 'u64ctrl', 'u64ctrl/main' ]
+dirs = [ 'wifi/raw_c3/main', 'wifi/raw_c3', 'wifi/raw_u64/main', 'wifi/raw_u64', 'u64ctrl', 'u64ctrl/main' ]
 ptrns = [ '*.c', '*.h', '*.mk', '*.txt', 'sdkconfig']
 fns = [ ]
 for d in dirs:
+    # A directory that is not there contributes no files and no hash, so the
+    # cache key stops depending on it without anything going wrong out loud.
+    # That is how raw_u64 went unwatched: the name was simply misspelled.
+    if not os.path.isdir(d):
+        sys.exit(f"esp_depends: no such directory: {d}")
     for ptrn in ptrns:
         fns += glob(f"{d}/{ptrn}")
 

--- a/tests/lib/esp_depends_test.py
+++ b/tests/lib/esp_depends_test.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Gate check: every cached ESP32 project is watched by the build cache key.
+
+"""Verify software/esp_depends.py covers every ESP32 project CI caches, no device.
+
+The ESP32 build step in .github/workflows/build.yml is skipped on a cache hit,
+and the key is a hash of the file list `software/esp_depends.py` prints. So the
+two files have to agree: a project whose binaries are *stored* in that cache
+but whose sources are *not* in the hash gets its stale binary handed back
+forever, and the build step that would have refreshed it never runs.
+
+They did not agree. The list said `wifi/raw_c64`, which does not exist, so no
+raw_u64 file was ever hashed while raw_u64's bridge.bin was being cached. A
+misspelling was enough because `glob()` on a missing directory returns an empty
+list and says nothing about it.
+
+Neither check here needs a device, so this runs at the start of the gate beside
+check_transport_usage.py and costs nothing.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from report import Failure, check, detail, suite_fail, suite_ok  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SOFTWARE_DIR = os.path.join(ROOT, "software")
+DEPENDS_SCRIPT = os.path.join(SOFTWARE_DIR, "esp_depends.py")
+WORKFLOW = os.path.join(ROOT, ".github", "workflows", "build.yml")
+
+# Paths in the workflow are repo-relative and always name the build directory,
+# e.g. "software/wifi/raw_u64/build/bridge.bin". The project is what precedes
+# "/build/", minus the leading "software/" that esp_depends.py runs inside of.
+CACHED_ARTIFACT = re.compile(r"^\s*software/(\S+?)/build/\S+\s*$", re.MULTILINE)
+
+
+def cached_projects():
+    """The ESP32 projects whose build output CI stores in the ESP32 cache."""
+    with open(WORKFLOW, encoding="utf-8") as handle:
+        workflow = handle.read()
+
+    # Only the ESP32 cache step; the FPGA caches list .bit files elsewhere.
+    start = workflow.find("name: Cache ESP32 Targets")
+    if start < 0:
+        raise Failure("build.yml has no 'Cache ESP32 Targets' step any more; "
+                      "this check needs updating to wherever the ESP32 cache moved")
+    end = workflow.find("restore-keys:", start)
+    projects = sorted(set(CACHED_ARTIFACT.findall(workflow[start:end])))
+    if not projects:
+        raise Failure("no software/<project>/build/... paths in the ESP32 cache step")
+    return projects
+
+
+def hashed_projects():
+    """The projects esp_depends.py actually contributes files for."""
+    result = subprocess.run([sys.executable, DEPENDS_SCRIPT], cwd=SOFTWARE_DIR,
+                            capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Failure(f"esp_depends.py failed: {result.stderr.strip() or result.returncode}")
+
+    # Each line is "<path>: <md5>", with the path relative to software/.
+    seen = {}
+    for line in result.stdout.splitlines():
+        path = line.split(":", 1)[0]
+        # Longest project prefix wins: raw_u64/main files belong to raw_u64.
+        parts = path.split("/")
+        for depth in range(1, len(parts)):
+            seen["/".join(parts[:depth])] = seen.get("/".join(parts[:depth]), 0) + 1
+    return seen
+
+
+def run_coverage_check():
+    with check("every cached ESP32 project contributes to the cache key"):
+        cached = cached_projects()
+        hashed = hashed_projects()
+        missing = [p for p in cached if not hashed.get(p)]
+        if missing:
+            raise Failure(
+                "cached in CI but absent from the esp_depends.py hash, so a change "
+                f"to it can never invalidate its cached binary: {', '.join(missing)}")
+        detail("watched: " + ", ".join(f"{p} ({hashed[p]} files)" for p in cached))
+
+
+def run_missing_directory_check():
+    """A directory that is not there has to be an error, not a quiet no-op."""
+    with check("a misspelt directory fails instead of silently hashing nothing"):
+        with open(DEPENDS_SCRIPT, encoding="utf-8") as handle:
+            original = handle.read()
+        if "wifi/raw_u64/main" not in original:
+            raise Failure("esp_depends.py no longer lists wifi/raw_u64/main; "
+                          "this check needs updating")
+        # The copy runs from software/ because the globs are relative to it, but
+        # it is a copy: a run interrupted here must not leave the real script
+        # holding a deliberately broken directory name.
+        broken_path = os.path.join(SOFTWARE_DIR, ".esp_depends_missing_dir_check.py")
+        try:
+            with open(broken_path, "w", encoding="utf-8") as handle:
+                handle.write(original.replace("wifi/raw_u64/main",
+                                              "wifi/raw_does_not_exist/main"))
+            result = subprocess.run([sys.executable, broken_path], cwd=SOFTWARE_DIR,
+                                    capture_output=True, text=True)
+        finally:
+            if os.path.exists(broken_path):
+                os.remove(broken_path)
+        if result.returncode == 0:
+            raise Failure("a missing directory was accepted; the cache key would "
+                          "silently stop depending on that project")
+
+
+def main():
+    for path in (DEPENDS_SCRIPT, WORKFLOW):
+        if not os.path.isfile(path):
+            suite_fail("esp_depends_test", f"missing {path}")
+            return 1
+    try:
+        run_coverage_check()
+        run_missing_directory_check()
+    except Failure as exc:
+        suite_fail("esp_depends_test", str(exc))
+        return 1
+
+    detail("a change to any ESP32 project invalidates the cached binaries CI "
+           "would otherwise hand back unbuilt")
+    suite_ok("esp_depends_test")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`software/esp_depends.py` lists `wifi/raw_c64`, which does not exist. `glob()` on a
missing directory returns an empty list and says nothing, so no `raw_u64` file has
ever entered the hash that keys the ESP32 cache — while `.github/workflows/build.yml`
stores `software/wifi/raw_u64/build/bridge.bin` in that same cache.

The result is that any change confined to `raw_u64` gets a cache hit, the ESP32 build
step is skipped, and CI hands back the previous binary. It looks like a successful
build. It happened on #778, where the WiFi module change under review was never
rebuilt.

Running the current script: **37 files hashed, none of them `raw_u64`'s.**
With the name corrected: **54, seventeen of them `raw_u64`'s.**

## The change

- Correct `raw_c64` to `raw_u64`.
- Exit with an error when a listed directory is absent, instead of silently
  contributing nothing. The silence is what made this expensive: a weaker cache key
  is indistinguishable from a working one.
- Add `esp-depends` to the E2E gate. It reads the cache paths out of `build.yml`,
  runs `esp_depends.py`, and fails if a project whose binaries CI caches contributes
  no files to the hash. It needs no device, so it runs at the front of the gate next
  to `transport-usage`, and costs about 70ms.

## Verification

The new suite fails against the unfixed script, naming the project that is missing:

```
[01] every cached ESP32 project contributes to the cache key ... FAIL
esp_depends_test: FAIL (cached in CI but absent from the esp_depends.py hash, so a
change to it can never invalidate its cached binary: wifi/raw_u64)
```

and passes against the fixed one:

```
[01] every cached ESP32 project contributes to the cache key ... OK
     watched: u64ctrl (20 files), wifi/raw_c3 (17 files), wifi/raw_u64 (17 files)
[02] a misspelt directory fails instead of silently hashing nothing ... OK
esp_depends_test: OK (2 checks, 0.074s)
```

Adding a fourth ESP32 project without touching the dependency list fails the same way.

## On the E2E requirement

This changes no firmware, so the full hardware gate says nothing about it; the two
checks above are the relevant evidence and both are device-free. For completeness,
the full default suite set passes on the device I have here — Ultimate 64 Elite,
firmware 3.15, FPGA 123, core 1.4B — 20 of 20 in 834s, attached to #778 where the
firmware change actually lives.
