### PR TITLE
Apply network service switches live

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -339,6 +339,10 @@ SUITES: Sequence[Suite] = (
     # under --mode telnet.
     Suite("e2e", "machine-code-monitor", "tests/e2e/monitor/monitor_test.py",
           "--host @HOST@ --password @PASS@ --timeout @TIMEOUT@ --mode @MODE@", profile=profiles.DEEP),
+    # Reproduces #783: service settings used to start listeners live but could
+    # not stop them again until reboot. Ident is the smallest protocol probe.
+    Suite("e2e", "ident-service-switch", "tests/e2e/network/ident_service_switch_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     # The device's own FTP server: a name it reports in a listing has to be a
     # name it accepts back for SIZE and DELE.
     # In smoke because nothing else there touches a filesystem. The rest of

--- a/software/network/config/lwipopts.h
+++ b/software/network/config/lwipopts.h
@@ -766,13 +766,13 @@
  * LWIP_NETIF_LOOPBACK==1: Support sending packets with a destination IP
  * address equal to the netif IP address, looping them back up the stack.
  */
-#define LWIP_NETIF_LOOPBACK             0
+#define LWIP_NETIF_LOOPBACK             1
 
 /**
  * LWIP_LOOPBACK_MAX_PBUFS: Maximum number of pbufs on queue for loopback
  * sending for each netif (0 = disabled)
  */
-#define LWIP_LOOPBACK_MAX_PBUFS         0
+#define LWIP_LOOPBACK_MAX_PBUFS         8
 
 /**
  * LWIP_NETIF_LOOPBACK_MULTITHREADING: Indicates whether threading is enabled in
@@ -1011,9 +1011,10 @@
 #define RECV_BUFSIZE_DEFAULT            INT_MAX
 
 /**
- * SO_REUSE==1: Enable SO_REUSEADDR and SO_REUSEPORT options. DO NOT USE!
+ * SO_REUSE==1: Enable SO_REUSEADDR and SO_REUSEPORT options. Listener tasks
+ * use this to rebind immediately after a service is disabled and re-enabled.
  */
-#define SO_REUSE                        0
+#define SO_REUSE                        1
 
 /*
    ----------------------------------------

--- a/software/network/ftpd.cc
+++ b/software/network/ftpd.cc
@@ -212,9 +212,17 @@ static int EndsWith(const char *str, const char *suffix)
 }
 FTPDaemon *ftpd = NULL; 
 
-FTPDaemon::FTPDaemon()
+FTPDaemon::FTPDaemon() : enabled(false)
 {
+    cfg = networkConfig.cfg;
+    cfg->addObject(this);
+    enabled = cfg->get_value(CFG_NETWORK_FTP_SERVICE) != 0;
     xTaskCreate(ftp_listen_task, "FTP Listener", configMINIMAL_STACK_SIZE, this, PRIO_NETSERVICE, &listenTaskHandle);
+}
+
+void FTPDaemon::effectuate_settings(void)
+{
+    enabled = cfg->get_value(CFG_NETWORK_FTP_SERVICE) != 0;
 }
 
 void FTPDaemon::ftp_listen_task(void *a)
@@ -227,71 +235,89 @@ void FTPDaemon::ftp_listen_task(void *a)
 
 int FTPDaemon::listen_task()
 {
-    while (networkConfig.cfg->get_value(CFG_NETWORK_FTP_SERVICE) == 0) {
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-    }
-    puts("FTP server starting");
-
     int sockfd, portno;
     socklen_t clilen;
     struct sockaddr_in serv_addr, cli_addr;
 
-    sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd < 0) {
-        puts("FTPD: ERROR opening socket");
-        return -1;
-    }
-    memset((char *) &serv_addr, 0, sizeof(serv_addr));
-    portno = 21;
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_addr.s_addr = INADDR_ANY;
-    serv_addr.sin_port = htons(portno);
-    // Retry binding rather than exiting permanently: a transient failure (port
-    // briefly in use, stack not ready) would otherwise kill the FTP listener
-    // until reboot.
-    while (bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
-        puts("FTPD: ERROR on binding; retrying in 2s");
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-    }
-
-    listen(sockfd, 2);
-
     while (1) {
-        clilen = sizeof(cli_addr);
-        int actual_socket = accept(sockfd, (struct sockaddr * ) &cli_addr, &clilen);
-        if (actual_socket < 0) {
-            puts("FTPD: ERROR on accept");
-            vTaskDelay(100 / portTICK_PERIOD_MS);
-            continue;  // Remote probably closed, just wait for another connection
+        while (!enabled) {
+            vTaskDelay(2000 / portTICK_PERIOD_MS);
         }
+        puts("FTP server starting");
 
-        ftp_set_control_socket_timeouts(actual_socket);
-        // A vanished client would hold its session slot forever.
-        net_enable_client_keepalive(actual_socket);
-
-        // Cap concurrent sessions: refuse politely rather than let abandoned
-        // connections accumulate and drain the shared netconn pool.
-        if (num_threads >= FTPD_MAX_SESSIONS) {
-            const char *busy = "421 Too many FTP connections, try again later.\r\n";
-            send(actual_socket, busy, strlen(busy), 0);
-            closesocket(actual_socket);
-            vTaskDelay(100 / portTICK_PERIOD_MS);
+        sockfd = socket(AF_INET, SOCK_STREAM, 0);
+        if (sockfd < 0) {
+            puts("FTPD: ERROR opening socket");
+            vTaskDelay(2000 / portTICK_PERIOD_MS);
+            continue;
+        }
+        int reuse = 1;
+        setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char *)&reuse, sizeof(reuse));
+        ftp_set_socket_timeout(sockfd, 0, 250000);
+        memset((char *) &serv_addr, 0, sizeof(serv_addr));
+        portno = 21;
+        serv_addr.sin_family = AF_INET;
+        serv_addr.sin_addr.s_addr = INADDR_ANY;
+        serv_addr.sin_port = htons(portno);
+        // Retry binding rather than exiting permanently: a transient failure (port
+        // briefly in use, stack not ready) would otherwise kill the FTP listener
+        // until reboot.
+        while (enabled && bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
+            puts("FTPD: ERROR on binding; retrying in 2s");
+            vTaskDelay(2000 / portTICK_PERIOD_MS);
+        }
+        if (!enabled) {
+            closesocket(sockfd);
             continue;
         }
 
-        FTPDaemonThread *thread = new FTPDaemonThread(actual_socket, cli_addr.sin_addr.s_addr, cli_addr.sin_port);
+        listen(sockfd, 2);
 
-        BaseType_t res = xTaskCreate(FTPDaemonThread::run, "FTP Task", configMINIMAL_STACK_SIZE, thread, PRIO_NETSERVICE, NULL);
-        if (res != pdPASS) {
-            puts("FTPD: xTaskCreate failed; dropping connection");
-            closesocket(actual_socket);
-            delete thread;
-            portENTER_CRITICAL();
-            num_threads--;
-            portEXIT_CRITICAL();
-            vTaskDelay(100 / portTICK_PERIOD_MS);
-            continue;
+        while (enabled) {
+            clilen = sizeof(cli_addr);
+            int actual_socket = accept(sockfd, (struct sockaddr * ) &cli_addr, &clilen);
+            if (!enabled) {
+                if (actual_socket >= 0) {
+                    closesocket(actual_socket);
+                }
+                break;
+            }
+            if (actual_socket < 0) {
+                if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                    puts("FTPD: ERROR on accept");
+                    vTaskDelay(100 / portTICK_PERIOD_MS);
+                }
+                continue;
+            }
+
+            ftp_set_control_socket_timeouts(actual_socket);
+            // A vanished client would hold its session slot forever.
+            net_enable_client_keepalive(actual_socket);
+
+            // Cap concurrent sessions: refuse politely rather than let abandoned
+            // connections accumulate and drain the shared netconn pool.
+            if (num_threads >= FTPD_MAX_SESSIONS) {
+                const char *busy = "421 Too many FTP connections, try again later.\r\n";
+                send(actual_socket, busy, strlen(busy), 0);
+                closesocket(actual_socket);
+                vTaskDelay(100 / portTICK_PERIOD_MS);
+                continue;
+            }
+
+            FTPDaemonThread *thread = new FTPDaemonThread(actual_socket, cli_addr.sin_addr.s_addr, cli_addr.sin_port);
+
+            BaseType_t res = xTaskCreate(FTPDaemonThread::run, "FTP Task", configMINIMAL_STACK_SIZE, thread, PRIO_NETSERVICE, NULL);
+            if (res != pdPASS) {
+                puts("FTPD: xTaskCreate failed; dropping connection");
+                closesocket(actual_socket);
+                delete thread;
+                portENTER_CRITICAL();
+                num_threads--;
+                portEXIT_CRITICAL();
+                vTaskDelay(100 / portTICK_PERIOD_MS);
+            }
         }
+        closesocket(sockfd);
     }
 }
 

--- a/software/network/ftpd.h
+++ b/software/network/ftpd.h
@@ -41,21 +41,25 @@
 
 #include "FreeRTOS.h"
 #include "task.h"
+#include <atomic>
+#include "config.h"
 //#include "semphr.h"
 #include "indexed_list.h"
 #include "vfs.h"
 
 #define ERR_OK 0
 
-class FTPDaemon
+class FTPDaemon : public ConfigurableObject
 {
 	static void ftp_listen_task(void *a);
+	std::atomic<bool> enabled;
 public:
 	TaskHandle_t listenTaskHandle;
 
 	FTPDaemon();
 	~FTPDaemon() { }
 
+	void effectuate_settings(void);
 	int listen_task(void);
 };
 

--- a/software/network/httpd.cc
+++ b/software/network/httpd.cc
@@ -15,27 +15,62 @@ extern "C" {
 HTTPDaemon httpd; // the class that causes us to exist
 HTTPServer srv;
 
-HTTPDaemon::HTTPDaemon()
+HTTPDaemon::HTTPDaemon() : enabled(false), listenTaskHandle(NULL)
 {
     new InitFunction("HTTP Daemon", [](void *obj, void *_param) { 
         HTTPDaemon *httpd = (HTTPDaemon *)obj;
+        httpd->cfg = networkConfig.cfg;
+        httpd->cfg->addObject(httpd);
+        httpd->enabled = httpd->cfg->get_value(CFG_NETWORK_HTTP_SERVICE) != 0;
         xTaskCreate(http_listen_task, "HTTP Listener", configMINIMAL_STACK_SIZE, httpd, PRIO_NETSERVICE, &(httpd->listenTaskHandle));
     }, this, NULL, 103);
 }
 
+void HTTPDaemon::effectuate_settings(void)
+{
+    bool was_enabled = enabled;
+    enabled = cfg->get_value(CFG_NETWORK_HTTP_SERVICE) != 0;
+    if (was_enabled && !enabled && listenTaskHandle && listenTaskHandle != xTaskGetCurrentTaskHandle()) {
+        int socket = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (socket >= 0) {
+            struct sockaddr_in address;
+            memset(&address, 0, sizeof(address));
+            address.sin_family = AF_INET;
+            address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+            address.sin_port = htons(MHS_PORT);
+            connect(socket, (struct sockaddr *)&address, sizeof(address));
+            closesocket(socket);
+        }
+    }
+}
+
 void HTTPDaemon::http_listen_task(void *a)
 {
+    HTTPDaemon *daemon = (HTTPDaemon *)a;
     printf("<http_listen_task>\n");
-    while (networkConfig.cfg->get_value(CFG_NETWORK_HTTP_SERVICE) == 0) {
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-    }
+    while (1) {
+        while (!daemon->enabled) {
+            vTaskDelay(2000 / portTICK_PERIOD_MS);
+        }
 
-    /* Running the MicroHTTPServer code */
-	HTTPServerInit(&srv, MHS_PORT);
-	/* Run the HTTP server forever. */
-	/* Run the dispatch callback if there is a new request */
-    printf("Run HTTP Server Loop.\n");
-	HTTPServerRunLoop(&srv, Dispatch);
-	HTTPServerClose(&srv);
-    vTaskSuspend(NULL);
+        /* Running the MicroHTTPServer code */
+        HTTPServerInit(&srv, MHS_PORT);
+        if (srv.sock < 0) {
+            vTaskDelay(2000 / portTICK_PERIOD_MS);
+            continue;
+        }
+        printf("Run HTTP Server Loop.\n");
+        bool accepting = true;
+        while ((daemon->enabled && accepting) || srv.available_connections < MAX_HTTP_CLIENT) {
+            if (!daemon->enabled) {
+                FD_CLR(srv.sock, &srv._read_sock_pool);
+                if (accepting) {
+                    shutdown(srv.sock, SHUT_RDWR);
+                    accepting = false;
+                }
+            }
+            HTTPServerRun(&srv, Dispatch);
+        }
+        HTTPServerClose(&srv);
+    }
 }

--- a/software/network/httpd.h
+++ b/software/network/httpd.h
@@ -8,19 +8,23 @@
 
 #include "FreeRTOS.h"
 #include "task.h"
+#include <atomic>
+#include "config.h"
 #include "indexed_list.h"
 
 #define ERR_OK 0
 
-class HTTPDaemon
+class HTTPDaemon : public ConfigurableObject
 {
 	static void http_listen_task(void *a);
+	std::atomic<bool> enabled;
 public:
 	TaskHandle_t listenTaskHandle;
 
 	HTTPDaemon();
 	~HTTPDaemon() { }
 
+	void effectuate_settings(void);
 	int listen_task(void);
 };
 

--- a/software/network/socket_dma.cc
+++ b/software/network/socket_dma.cc
@@ -69,16 +69,26 @@ static void socket_dma_set_timeouts(int socket_fd)
 extern cart_def sid_cart;
 extern cart_def boot_cart;
 
-SocketDMA::SocketDMA() {
+SocketDMA::SocketDMA() : dmaEnabled(false), identEnabled(false) {
+	cfg = networkConfig.cfg;
+	cfg->addObject(this);
+	dmaEnabled = cfg->get_value(CFG_NETWORK_ULTIMATE_DMA_SERVICE) != 0;
+	identEnabled = cfg->get_value(CFG_NETWORK_ULTIMATE_IDENT_SERVICE) != 0;
 	load_buffer = new uint8_t[SOCKET_BUFFER_SIZE];
 	if (load_buffer) {
-	    xTaskCreate( dmaThread, "DMA Load Task", configMINIMAL_STACK_SIZE, (void *)load_buffer, PRIO_NETSERVICE, NULL );
+	    xTaskCreate( dmaThread, "DMA Load Task", configMINIMAL_STACK_SIZE, this, PRIO_NETSERVICE, NULL );
 	}
-    xTaskCreate(identThread, "UDP Ident Task", configMINIMAL_STACK_SIZE, NULL, PRIO_NETSERVICE, NULL );
+    xTaskCreate(identThread, "UDP Ident Task", configMINIMAL_STACK_SIZE, this, PRIO_NETSERVICE, NULL );
 }
 
 SocketDMA::~SocketDMA() {
     delete[] load_buffer;
+}
+
+void SocketDMA::effectuate_settings(void)
+{
+	dmaEnabled = cfg->get_value(CFG_NETWORK_ULTIMATE_DMA_SERVICE) != 0;
+	identEnabled = cfg->get_value(CFG_NETWORK_ULTIMATE_IDENT_SERVICE) != 0;
 }
 
 bool SocketDMA :: performCommand(int socket, void *load_buffer, int length, uint16_t cmd, uint32_t len, struct in_addr *client_ip, bool &authenticated)
@@ -374,12 +384,15 @@ int SocketDMA::writeSocket(int socket, void *buffer, int length)
     return sent;
 }
 
-void SocketDMA::dmaThread(void *load_buffer)
+void SocketDMA::dmaThread(void *a)
 {
-    while (networkConfig.cfg->get_value(CFG_NETWORK_ULTIMATE_DMA_SERVICE) == 0) {
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-    }
-    puts("Socket DMA server starting");
+    SocketDMA *daemon = (SocketDMA *)a;
+    void *load_buffer = daemon->load_buffer;
+    while (1) {
+        while (!daemon->dmaEnabled) {
+            vTaskDelay(2000 / portTICK_PERIOD_MS);
+        }
+        puts("Socket DMA server starting");
 
 	int sockfd, newsockfd, portno;
 	unsigned long int clilen;
@@ -389,11 +402,15 @@ void SocketDMA::dmaThread(void *load_buffer)
     /* First call to socket() function */
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
 
-    if (sockfd < 0)
+	if (sockfd < 0)
 	{
     	puts("ERROR dmaThread opening socket");
-    	return;
+		vTaskDelay(2000 / portTICK_PERIOD_MS);
+		continue;
 	}
+	int reuse = 1;
+	setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char *)&reuse, sizeof(reuse));
+	socket_dma_set_timeouts(sockfd);
 
     printf("DMA Thread Sockfd = %8x\n", sockfd);
 
@@ -409,7 +426,9 @@ void SocketDMA::dmaThread(void *load_buffer)
     if (bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0)
     {
  	    puts("dmaThread ERROR on binding");
-	    return;
+	    closesocket(sockfd);
+	    vTaskDelay(2000 / portTICK_PERIOD_MS);
+	    continue;
     }
 
     /* Now start listening for the clients, here process will
@@ -421,14 +440,22 @@ void SocketDMA::dmaThread(void *load_buffer)
     uint8_t your_ip[4];
     uint16_t your_port;
 
-    while(1) {
+    while(daemon->dmaEnabled) {
 		/* Accept actual connection from the client */
         clilen = sizeof(cli_addr);
 		newsockfd = accept(sockfd, (struct sockaddr *)&cli_addr, &clilen);
+		if (!daemon->dmaEnabled) {
+			if (newsockfd >= 0) {
+				closesocket(newsockfd);
+			}
+			break;
+		}
 		if (newsockfd < 0)
 		{
-			puts("dmaThread ERROR on accept");
-            vTaskDelay(100 / portTICK_PERIOD_MS);
+			if (errno != EAGAIN && errno != EWOULDBLOCK) {
+				puts("dmaThread ERROR on accept");
+                vTaskDelay(100 / portTICK_PERIOD_MS);
+			}
             continue;
 		}
 
@@ -450,7 +477,7 @@ void SocketDMA::dmaThread(void *load_buffer)
 		const char *password = networkConfig.cfg->get_string(CFG_NETWORK_PASSWORD);
 		if (!*password)
 	            authenticated = true;
-		while(1) {
+		while(daemon->dmaEnabled) {
 	        n = recv(newsockfd, buf, 2, 0);
 	        if (n <= 0) {
 	            break;
@@ -490,17 +517,13 @@ void SocketDMA::dmaThread(void *load_buffer)
         puts("ERROR reading from socket");
         closesocket(newsockfd);
     }
-    // this will never happen
     closesocket(sockfd);
+    }
 }
 
-void SocketDMA::identThread(void *_a)
+void SocketDMA::identThread(void *a)
 {
-    while (networkConfig.cfg->get_value(CFG_NETWORK_ULTIMATE_IDENT_SERVICE) == 0) {
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-    }
-    puts("Socket ident server starting");
-
+	SocketDMA *daemon = (SocketDMA *)a;
 	int sockfd, newsockfd, portno;
 	unsigned long int clilen;
     struct sockaddr_in serv_addr, cli_addr;
@@ -510,17 +533,24 @@ void SocketDMA::identThread(void *_a)
     char menu_header[64];
 
     getProductTitleString(menu_header, sizeof(menu_header), true);
+	while (1) {
+        while (!daemon->identEnabled) {
+            vTaskDelay(2000 / portTICK_PERIOD_MS);
+        }
+        puts("Socket ident server starting");
 
     /* First call to socket() function */
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 
-    if (sockfd < 0)
+	if (sockfd < 0)
 	{
     	puts("ERROR identThread opening socket");
-    	vTaskDelete(NULL);
+		vTaskDelay(2000 / portTICK_PERIOD_MS);
+		continue;
 	}
+	socket_dma_set_timeouts(sockfd);
 
-    while(1) {
+    while(daemon->identEnabled) {
         /* Initialize socket structure */
         memset((char *) &serv_addr, 0, sizeof(serv_addr));
         portno = 64;
@@ -536,14 +566,19 @@ void SocketDMA::identThread(void *_a)
             vTaskDelay(500); // some seconds
             continue; // try again
         }
-        while(1) {
+        while(daemon->identEnabled) {
             // Receive client's message:
             int n = recvfrom(sockfd, client_message, sizeof(client_message), 0,
                 (struct sockaddr*)&cli_addr, &client_struct_length);
+            if (!daemon->identEnabled) {
+                break;
+            }
             if (n < 0) {
-                printf("Couldn't receive: %d\n", n);
-                vTaskDelay(500); // some seconds
-                continue; // try again
+                if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                    printf("Couldn't receive: %d\n", n);
+                    vTaskDelay(500); // some seconds
+                }
+                continue;
             }
             printf("Received Ident Request from IP: %s and port: %i\n",
                 inet_ntoa(cli_addr.sin_addr), ntohs(cli_addr.sin_port));
@@ -613,8 +648,8 @@ void SocketDMA::identThread(void *_a)
             }
         }
     }
-    // this will never happen
     lwip_close(sockfd);
+	}
 }
 
 #include "init_function.h"

--- a/software/network/socket_dma.h
+++ b/software/network/socket_dma.h
@@ -11,10 +11,12 @@
 #include "menu.h"
 #include "filemanager.h"
 #include "subsys.h"
+#include <atomic>
+#include "config.h"
 
 #define SOCKET_BUFFER_SIZE 200000
 
-class SocketDMA {
+class SocketDMA : public ConfigurableObject {
 	static void dmaThread(void *a);
 	static void identThread(void *a);
 	static bool performCommand(int socket, void *load_buffer, int length, uint16_t cmd, uint32_t len, struct in_addr *client_ip, bool &authenticated);
@@ -22,9 +24,12 @@ class SocketDMA {
 	static int  writeSocket(int socket, void *buffer, int length);
 
 	uint8_t *load_buffer;
+	std::atomic<bool> dmaEnabled;
+	std::atomic<bool> identEnabled;
 public:
 	SocketDMA();
 	virtual ~SocketDMA();
+	void effectuate_settings(void);
 
 };
 

--- a/software/network/socket_gui.cc
+++ b/software/network/socket_gui.cc
@@ -62,10 +62,18 @@ static void socket_gui_set_timeouts(int socket_fd)
     net_enable_client_keepalive(socket_fd);
 }
 
-SocketGui :: SocketGui()
+SocketGui :: SocketGui() : enabled(false)
 {
     printf("Starting Telnet Server\n");
+	cfg = networkConfig.cfg;
+	cfg->addObject(this);
+	enabled = cfg->get_value(CFG_NETWORK_TELNET_SERVICE) != 0;
 	xTaskCreate( socket_gui_listen_task, "Socket Gui Listener", configMINIMAL_STACK_SIZE, this, PRIO_NETSERVICE, &listenTaskHandle );
+}
+
+void SocketGui :: effectuate_settings(void)
+{
+	enabled = cfg->get_value(CFG_NETWORK_TELNET_SERVICE) != 0;
 }
 
 static bool socket_ensure_authenticated(SocketStream *str) {
@@ -211,73 +219,98 @@ void socket_gui_task(void *a)
 
 int SocketGui :: listenTask(void)
 {
-    while (networkConfig.cfg->get_value(CFG_NETWORK_TELNET_SERVICE) == 0) {
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-    }
-    puts("Telnet server starting");
-
-	int sockfd, portno;
+	int portno;
 	socklen_t clilen;
     struct sockaddr_in serv_addr, cli_addr;
 
-    sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd < 0) {
-       puts("ERROR opening socket");
-       return -1;
-    }
-    memset((char *) &serv_addr, 0, sizeof(serv_addr));
-    portno = 23;
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_addr.s_addr = INADDR_ANY;
-    serv_addr.sin_port = htons(portno);
-    // Retry binding rather than exiting permanently: a transient failure would
-    // otherwise kill the telnet listener until reboot.
-    while (bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
-        puts("Telnet: ERROR on binding; retrying in 2s");
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-    }
-
-    listen(sockfd, 2);
-
     while(1) {
-    	clilen = sizeof(cli_addr);
-		int actual_socket = accept(sockfd, (struct sockaddr *) &cli_addr, &clilen);
-		if (actual_socket < 0) {
-			 puts("ERROR on accept");
-			 vTaskDelay(100 / portTICK_PERIOD_MS);
-			 continue;
+        while (!enabled) {
+            vTaskDelay(2000 / portTICK_PERIOD_MS);
+        }
+        puts("Telnet server starting");
+
+		int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+		if (sockfd < 0) {
+			puts("ERROR opening socket");
+			vTaskDelay(2000 / portTICK_PERIOD_MS);
+			continue;
 		}
-
-        socket_gui_set_timeouts(actual_socket);
-
-		// Cap concurrent telnet sessions: refuse politely rather than let
-		// abandoned connections accumulate and drain the shared netconn pool.
-		if (telnet_sessions >= TELNET_MAX_SESSIONS) {
-			const char *busy = "Too many connections, try again later.\r\n";
-			send(actual_socket, busy, strlen(busy), 0);
-			shutdown(actual_socket, 2);
-			lwip_close(actual_socket);
-			vTaskDelay(100 / portTICK_PERIOD_MS);
+		int reuse = 1;
+		setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char *)&reuse, sizeof(reuse));
+		struct timeval timeout;
+		timeout.tv_sec = 0;
+		timeout.tv_usec = 250000;
+		setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof(timeout));
+		if (!enabled) {
+			lwip_close(sockfd);
+			continue;
+		}
+		memset((char *) &serv_addr, 0, sizeof(serv_addr));
+		portno = 23;
+		serv_addr.sin_family = AF_INET;
+		serv_addr.sin_addr.s_addr = INADDR_ANY;
+		serv_addr.sin_port = htons(portno);
+		// Retry binding rather than exiting permanently: a transient failure would
+		// otherwise kill the telnet listener until reboot.
+		while (enabled && bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
+			puts("Telnet: ERROR on binding; retrying in 2s");
+			vTaskDelay(2000 / portTICK_PERIOD_MS);
+		}
+		if (!enabled) {
+			lwip_close(sockfd);
 			continue;
 		}
 
-		SocketStream *stream = new SocketStream(actual_socket);
-		// telnet_sessions is decremented from each session task on exit; guard the
-		// read-modify-write so concurrent decrements cannot lose an update and drift
-		// the count (which would eventually make the cap refuse every connection).
-		portENTER_CRITICAL();
-		telnet_sessions++;
-		portEXIT_CRITICAL();
-		BaseType_t res = xTaskCreate( socket_gui_task, "Socket Gui Task", configMINIMAL_STACK_SIZE, stream, PRIO_USERIFACE, NULL );
-		if (res != pdPASS) {
-			puts("Telnet: xTaskCreate failed; dropping connection");
-			portENTER_CRITICAL();
-			telnet_sessions--;
-			portEXIT_CRITICAL();
-			stream->close();
-			delete stream;
-			vTaskDelay(100 / portTICK_PERIOD_MS);
-			continue;
+		listen(sockfd, 2);
+
+		while(enabled) {
+			clilen = sizeof(cli_addr);
+			int actual_socket = accept(sockfd, (struct sockaddr *) &cli_addr, &clilen);
+			if (!enabled) {
+				if (actual_socket >= 0) {
+					lwip_close(actual_socket);
+				}
+				break;
+			}
+			if (actual_socket < 0) {
+				if (errno != EAGAIN && errno != EWOULDBLOCK) {
+					puts("ERROR on accept");
+					vTaskDelay(100 / portTICK_PERIOD_MS);
+				}
+				continue;
+			}
+
+            socket_gui_set_timeouts(actual_socket);
+
+            // Cap concurrent telnet sessions: refuse politely rather than let
+            // abandoned connections accumulate and drain the shared netconn pool.
+            if (telnet_sessions >= TELNET_MAX_SESSIONS) {
+                const char *busy = "Too many connections, try again later.\r\n";
+                send(actual_socket, busy, strlen(busy), 0);
+                shutdown(actual_socket, 2);
+                lwip_close(actual_socket);
+                vTaskDelay(100 / portTICK_PERIOD_MS);
+                continue;
+            }
+
+            SocketStream *stream = new SocketStream(actual_socket);
+            // telnet_sessions is decremented from each session task on exit; guard the
+            // read-modify-write so concurrent decrements cannot lose an update and drift
+            // the count (which would eventually make the cap refuse every connection).
+            portENTER_CRITICAL();
+            telnet_sessions++;
+            portEXIT_CRITICAL();
+            BaseType_t res = xTaskCreate( socket_gui_task, "Socket Gui Task", configMINIMAL_STACK_SIZE, stream, PRIO_USERIFACE, NULL );
+            if (res != pdPASS) {
+                puts("Telnet: xTaskCreate failed; dropping connection");
+                portENTER_CRITICAL();
+                telnet_sessions--;
+                portEXIT_CRITICAL();
+                stream->close();
+                delete stream;
+                vTaskDelay(100 / portTICK_PERIOD_MS);
+			}
 		}
+		lwip_close(sockfd);
     }
 }

--- a/software/network/socket_gui.h
+++ b/software/network/socket_gui.h
@@ -10,13 +10,17 @@
 
 #include "FreeRTOS.h"
 #include "task.h"
+#include <atomic>
+#include "config.h"
 
-class SocketGui
+class SocketGui : public ConfigurableObject
 {
+	std::atomic<bool> enabled;
 public:
 	TaskHandle_t listenTaskHandle;
 
 	SocketGui();
+	void effectuate_settings(void);
 	int listenTask(void);
 };
 

--- a/tests/e2e/network/ident_service_switch_test.py
+++ b/tests/e2e/network/ident_service_switch_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""E2E: disabling and re-enabling the ident listener takes effect live."""
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+
+from api import UltimateApi
+from report import Failure, check, check_count, format_exception, suite_fail, suite_ok
+
+STORE = "Network Settings"
+ITEM = "Ultimate Ident Service"
+PORT = 64
+PROBE_TIMEOUT = 0.25
+STATE_TIMEOUT = 3.0
+QUIET_SECONDS = 1.0
+
+
+def identify(host: str) -> bool:
+    nonce = f"switch-{time.monotonic_ns()}"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(PROBE_TIMEOUT)
+    try:
+        sock.sendto(f"json{nonce}".encode("ascii"), (host, PORT))
+        payload, _ = sock.recvfrom(4096)
+        response = json.loads(payload.decode("utf-8"))
+        return response.get("your_string") == nonce
+    except (OSError, ValueError):
+        return False
+    finally:
+        sock.close()
+
+
+def wait_enabled(host: str) -> None:
+    deadline = time.monotonic() + STATE_TIMEOUT
+    while time.monotonic() < deadline:
+        if identify(host):
+            return
+    raise Failure(f"ident did not answer within {STATE_TIMEOUT:.1f}s")
+
+
+def wait_disabled(host: str) -> None:
+    deadline = time.monotonic() + STATE_TIMEOUT
+    quiet_since = None
+    while time.monotonic() < deadline:
+        if identify(host):
+            quiet_since = None
+        elif quiet_since is None:
+            quiet_since = time.monotonic()
+        elif time.monotonic() - quiet_since >= QUIET_SECONDS:
+            return
+    raise Failure(f"ident kept answering for {STATE_TIMEOUT:.1f}s after it was disabled")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "5.0")))
+    args = parser.parse_args()
+
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    original = api.configs.current(STORE, ITEM)
+    if original not in {"Enabled", "Disabled"}:
+        suite_fail("ident_service_switch_test", "device did not report the original setting")
+        return 1
+
+    failure = ""
+    try:
+        with check("ident answers when enabled"):
+            api.configs.set(STORE, ITEM, "Enabled")
+            wait_enabled(args.host)
+        with check("ident stops answering when disabled"):
+            api.configs.set(STORE, ITEM, "Disabled")
+            wait_disabled(args.host)
+        with check("ident answers again when re-enabled"):
+            api.configs.set(STORE, ITEM, "Enabled")
+            wait_enabled(args.host)
+    except Failure as exc:
+        failure = str(exc)
+    except Exception as exc:  # noqa: BLE001
+        failure = format_exception(exc)
+
+    try:
+        api.configs.set(STORE, ITEM, original)
+    except Exception as exc:  # noqa: BLE001
+        restore_failure = f"could not restore {ITEM}: {format_exception(exc)}"
+        failure = f"{failure}; {restore_failure}" if failure else restore_failure
+
+    if failure:
+        suite_fail("ident_service_switch_test", failure)
+        return 1
+    suite_ok("ident_service_switch_test", f"{check_count()} checks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Make HTTP, FTP, Telnet, DMA, and Ident service settings take effect in both directions without rebooting.
- Keep socket ownership in each listener task: config callbacks publish atomic desired state, and the owning task closes and recreates its listener.
- Add an Ident enable/disable/re-enable hardware regression test to the shared E2E runner.

## Root cause

Each service checked its setting only while waiting to start. Once enabled, its task left that gate and blocked in accept or recvfrom forever, so changing the setting to Disabled could not affect the live listener.

Closing those sockets directly from the config callback is unsafe in this lwIP configuration because cross-thread netconn close support is disabled. Listener receive timeouts provide bounded wakeups for FTP, Telnet, DMA, and Ident. HTTP uses a loopback connection to wake its select loop, stops accepting, drains active clients, and then recreates the listener when re-enabled.

SO_REUSEADDR permits immediate rebind after shutdown. lwIP loopback is enabled for the internal HTTP wakeup.

## Hardware validation

Tested on an Ultimate 64 Elite over Wi-Fi with the generated U64 firmware flashed:

- Stock 3.14d: Ident enabled successfully; disabling still answered after 3 seconds.
- This branch: Ident enabled in 0.040s, disabled in 1.282s, and re-enabled in 0.816s.
- Registered ident-service-switch suite: 3/3 checks passed.
- Full E2E: 22/23 suites passed in 854 seconds; Wi-Fi remained stable throughout.

The only full-gate failure was cfg-single-group. It fails deterministically in isolation because commit 03284765 removed the loaded-store tracking from #765 while leaving its regression test active. That failure is unrelated to this network change and is tracked with a proposed compatible fix in #787.

## Build and host validation

- Cross-built U2, U2+, U2+L, U64, and U64-II application/lwIP targets on beast.
- Final make u64_no_esp build passed with 307.8 KiB application space free.
- make app_space_test: 36 tests passed.
- runner_policy_test.py: 39 checks passed.
- check_transport_usage.py: 50 files passed.
- Python compilation and git diff whitespace checks passed.

## Draft blocker

- [ ] Resolve #787 and rerun the full E2E gate green before marking this PR ready for review.

Fixes #783
