### PR TITLE
Fix configuration store effectuation lifecycle

### DIFF
--- a/software/components/config.h
+++ b/software/components/config.h
@@ -334,6 +334,15 @@ public:
 
     virtual void on_edit() { }
     virtual void effectuate_settings() { }
+
+    void effectuate_registered_settings()
+    {
+        if (cfg && cfg->need_effectuate()) {
+            cfg->effectuate();
+        } else {
+            effectuate_settings();
+        }
+    }
 };
 
 extern const char *en_dis[];

--- a/software/drive/c1541.cc
+++ b/software/drive/c1541.cc
@@ -229,7 +229,7 @@ void C1541 :: init(void)
     disk_state = e_no_disk;
 
     mfm_controller->init();
-    effectuate_settings();
+    effectuate_registered_settings();
 
 	xTaskCreate( C1541 :: run, (const char *)(this->drive_name.c_str()), configMINIMAL_STACK_SIZE, this, PRIO_FLOPPY, &taskHandle );
 }
@@ -1210,7 +1210,7 @@ void C1541 :: set_rom_config(int idx, const char *fname)
     uint8_t config_ids[] = { CFG_C1541_ROMFILE0, CFG_C1541_ROMFILE1, CFG_C1541_ROMFILE2 };
     cfg->set_string(config_ids[idx], fname);
     cfg->write();
-    effectuate_settings();
+    effectuate_registered_settings();
 }
 
 void C1541 :: list_roms(ConfigItem *it, IndexedList<char *>& strings)

--- a/software/drive/c1541.h
+++ b/software/drive/c1541.h
@@ -164,6 +164,8 @@ class C1541 : public SubSystem, ConfigurableObject, ObjectWithMenu
     SubsysResultCode_e change_drive_type(t_drive_type drv,  UserInterface *ui);
     SubsysResultCode_e load_dos_from_file(const char *path, const char *filename);
 public:
+    using ConfigurableObject::effectuate_registered_settings;
+
     C1541(volatile uint8_t *regs, char letter);
     ~C1541();
 

--- a/software/drive/c1581.cc
+++ b/software/drive/c1581.cc
@@ -136,7 +136,7 @@ void C1581 :: init(void)
     disk_state = e_no_disk;
 
 	xTaskCreate( C1581 :: run, (const char *)(this->drive_name.c_str()), configMINIMAL_STACK_SIZE, this, PRIO_FLOPPY, &taskHandle );
-    effectuate_settings();
+    effectuate_registered_settings();
     ioWrite8(ITU_IRQ_HIGH_EN, ioRead8(ITU_IRQ_HIGH_EN) | 2);
 }
 

--- a/software/io/audio/audio_select.cc
+++ b/software/io/audio/audio_select.cc
@@ -225,7 +225,7 @@ AudioConfig :: AudioConfig()
         }
     }
 
-    effectuate_settings();
+    effectuate_registered_settings();
 }
     
 

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -200,7 +200,7 @@ int C64 :: setCartPrefUI(ConfigItem *item)
 
 void C64 :: init(void)
 {
-    effectuate_settings();
+    effectuate_registered_settings();
 
     if (getFpgaCapabilities() & CAPAB_ULTIMATE64) {
         init_system_roms();

--- a/software/io/iec/iec_drive.cc
+++ b/software/io/iec/iec_drive.cc
@@ -150,7 +150,7 @@ IecDrive :: IecDrive() : SubSystem(SUBSYSID_IEC)
         ->add("Name", "NO NAME")
         ->add("Path", "");
 
-    effectuate_settings();
+    effectuate_registered_settings();
 
     vfs = new IecFileSystem(this);
 
@@ -291,7 +291,7 @@ SubsysResultCode_e IecDrive :: executeCommand(SubsysCommand *cmd)
 
 void IecDrive :: reset(void)
 {
-    effectuate_settings();
+    effectuate_registered_settings();
     for(int i=0; i < 16; i++) {
         channels[i]->reset();
     }

--- a/software/io/iec/iec_ulticopy.cc
+++ b/software/io/iec/iec_ulticopy.cc
@@ -232,10 +232,10 @@ ulticopy_again:
 ulticopy_close:
     ui_window->close();
 	if (c1541_A) {
-		c1541_A->effectuate_settings();
+		c1541_A->effectuate_registered_settings();
 	}
 	if (c1541_B) {
-		c1541_B->effectuate_settings();
+		c1541_B->effectuate_registered_settings();
 	}
     intf->configure();
     xSemaphoreGive(ulticopyMutex);

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -42,6 +42,7 @@ DataStreamer :: DataStreamer()
 
     cfg = ConfigManager :: getConfigManager()->register_store(0x44617461, "Data Streams", stream_cfg, NULL);
     cfg->set_sort_order(SORT_ORDER_CFG_STREAMS);
+    cfg->effectuate();
 
     for (int i=0; i < 4; i++) {
         timers[i] = xTimerCreate("StreamTimer", 100, pdFALSE, (void *)i, DataStreamer :: S_timer);

--- a/software/io/network/debug_streamer_u2p.cc
+++ b/software/io/network/debug_streamer_u2p.cc
@@ -40,6 +40,7 @@ DataStreamer :: DataStreamer()
 
 		cfg = ConfigManager :: getConfigManager()->register_store(0x44617461, "Data Streams", stream_cfg, NULL);
         cfg->set_sort_order(SORT_ORDER_CFG_STREAMS);
+        cfg->effectuate();
 
 		for (int i=0; i < 4; i++) {
 			timers[i] = xTimerCreate("StreamTimer", 100, pdFALSE, (void *)i, DataStreamer :: S_timer);

--- a/software/io/network/network_interface.cc
+++ b/software/io/network/network_interface.cc
@@ -193,7 +193,7 @@ int NetworkInterface :: dhcp_change(ConfigItem *it)
 bool NetworkInterface :: start()
 {
 	memset(&my_net_if, 0, sizeof(my_net_if)); // clear the whole thing
-    effectuate_settings(); // this will set the IP address, netmask and gateway
+    effectuate_registered_settings(); // this will set the IP address, netmask and gateway
     my_net_if.state = this;
     netif_add(&my_net_if, &my_ip, &my_netmask, &my_gateway, this, lwip_init_callback, tcpip_input);
 

--- a/software/io/network/network_interface.h
+++ b/software/io/network/network_interface.h
@@ -104,6 +104,7 @@ protected:
     static void lwip_free_callback(struct pbuf *p);
     static int dhcp_change(ConfigItem *it);
 public:
+    using ConfigurableObject::effectuate_registered_settings;
 
     NetworkInterface(void *driver,
                 driver_output_function_t out,

--- a/software/io/printer/iec_printer.cc
+++ b/software/io/printer/iec_printer.cc
@@ -367,7 +367,7 @@ IecPrinter::IecPrinter() : SubSystem(SUBSYSID_PRINTER)
     is_color = false;
 
     /* Read configuration from nvram if it exists */
-    effectuate_settings();
+    effectuate_registered_settings();
 
     /* Register printer with the interface */
     IecInterface *interface = IecInterface :: get_iec_interface();

--- a/software/io/rtc/rtc.cc
+++ b/software/io/rtc/rtc.cc
@@ -105,6 +105,7 @@ void Rtc::init()
         ConfigManager::getConfigManager()->add_custom_store(cfg);
         cfg->set_sort_order(SORT_ORDER_CFG_CLOCK);
         get_time_from_chip();
+        cfg->set_effectuated();
 
         // Check and correct clock out setting
         if ((rtc_regs[RTC_ADDR_CLOCKOUT] & 0x70) != 0x70)

--- a/software/io/rtc/rtc.h
+++ b/software/io/rtc/rtc.h
@@ -20,9 +20,9 @@ public:
 	RtcConfigStore(const char *name, t_cfg_definition *defs) : ConfigStore(NULL, name, defs, NULL) { }
 	~RtcConfigStore() {  }
 
-	void read(void) { }
-	void write(void) { }
-    void effectuate(void) { }
+	void read(bool ignore) override { }
+	void write(void) override { }
+    void effectuate(void) override { set_effectuated(); }
 	void at_open_config(void);
 	void at_close_config(void);
 

--- a/software/io/rtc/rtc_i2c.cc
+++ b/software/io/rtc/rtc_i2c.cc
@@ -88,6 +88,7 @@ void Rtc::init()
         i2c = new I2C_Driver();
     }
     get_time_from_chip();
+    cfg->set_effectuated();
 }
 
 Rtc::~Rtc()

--- a/software/io/tape/tape_controller.cc
+++ b/software/io/tape/tape_controller.cc
@@ -34,6 +34,7 @@ TapeController :: TapeController() : SubSystem(SUBSYSID_TAPE_PLAYER)
     fm = FileManager :: getFileManager();
     register_store(0x54415045, "Tape Settings", tape_config);
     cfg->set_sort_order(SORT_ORDER_CFG_TAPE);
+    effectuate_registered_settings();
     
     file = NULL;
 	paused = 0;

--- a/software/io/wifi/wifi.cc
+++ b/software/io/wifi/wifi.cc
@@ -47,7 +47,7 @@ void WiFi :: Init(void *obj, void *param)
 #if U64 == 2
     wifi.Enable(); // Unconditionally enable the WiFi module
 #endif
-    wifi.netstack->effectuate_settings(); // may start the WiFi application
+    wifi.netstack->effectuate_registered_settings(); // may start the WiFi application
 }
 
 void WiFi :: RefreshRoot()

--- a/software/monitor/monitor_bookmarks.cc
+++ b/software/monitor/monitor_bookmarks.cc
@@ -581,6 +581,7 @@ MonitorBookmarks :: MonitorBookmarks()
         }
         if (cfg) {
             cfg->hide();
+            cfg->effectuate();
         }
     }
     persistence_available = (cfg != NULL);

--- a/software/network/network_config.cc
+++ b/software/network/network_config.cc
@@ -49,6 +49,8 @@ void NetworkConfig :: init()
     strcpy(default_hostname, hostname ? hostname : "Small Buffer");
     cfg = ConfigManager :: getConfigManager()->register_store(0x4E455400, "Network Settings", network_config, this);
     cfg->set_sort_order(SORT_ORDER_CFG_SERVICES);
+    // Network status starts SNTP once an interface is usable.
+    cfg->set_effectuated();
 }
 
 void NetworkConfig :: list_unique_id_choices(ConfigItem *it, IndexedList<char *>& strings)
@@ -79,4 +81,3 @@ void NetworkConfig :: effectuate_settings(void)
 #include "init_function.h"
 NetworkConfig networkConfig;
 InitFunction init_netcfg("Network Config", [](void *_obj, void *_param) { networkConfig.init(); }, NULL, NULL, 20);
-

--- a/software/test/configio/configio_test.cc
+++ b/software/test/configio/configio_test.cc
@@ -152,13 +152,11 @@ int main(int argc, char **argv)
     check(sid->get_value(0x01) == 1, "precondition: the SID store reads 8580");
 
     MemFile in;
-    IndexedList<ConfigStore *> loaded(8, NULL);
     StreamTextLog log(4096);
     in.load("[SID Socket 1: PDsid]\nEmulation Mode=6581\n\n");
-    bool ok = ConfigIO::S_read_from_file(&in, &log, loaded);
+    bool ok = ConfigIO::S_read_from_file(&in, &log);
     check(ok, "a well-formed .cfg loads without error");
     check(sid->get_value(0x01) == 0, "the value from the file is applied to the store");
-    check(loaded.get_elements() == 1, "only the store named in the file is reported as loaded");
 
     printf("-- enum labels with spaces survive a round trip\n");
     /* An ARMSID writes "8580 Lowest Filt Freq= ~45" into a .cfg, padding and
@@ -176,11 +174,10 @@ int main(int argc, char **argv)
     sid->set_value(0x02, 0);
     sid->set_value(0x03, 2);
     MemFile padback;
-    IndexedList<ConfigStore *> loadedpad(8, NULL);
     StreamTextLog logpad(4096);
     padback.load("[SID Socket 1: PDsid]\n8580 Lowest Filt Freq= ~45\n"
                  "8580 Highest Filt Freq=12 kHz\n\n");
-    check(ConfigIO::S_read_from_file(&padback, &logpad, loadedpad),
+    check(ConfigIO::S_read_from_file(&padback, &logpad),
           "reading those values back is not an error");
     check(sid->get_value(0x02) == 1, "the padded label is matched exactly");
     check(sid->get_value(0x03) == 0, "the label with an inner space is matched");
@@ -193,14 +190,13 @@ int main(int argc, char **argv)
     sid->set_value(0x03, 2);
     sid->set_value(0x01, 0);
     MemFile hand;
-    IndexedList<ConfigStore *> loaded_hand(8, NULL);
     StreamTextLog log_hand(4096);
     hand.load("[SID Socket 1: PDsid]\n"
               "8580 Lowest Filt Freq=30\n"          /* label is "  30" */
               "8580 Highest Filt Freq=  12 kHz  \n" /* inner space kept */
               "  Emulation Mode  =  8580  \n"       /* spaces around both */
               "\n");
-    check(ConfigIO::S_read_from_file(&hand, &log_hand, loaded_hand),
+    check(ConfigIO::S_read_from_file(&hand, &log_hand),
           "a hand-spaced file loads without error");
     check(sid->get_value(0x02) == 0, "an unpadded value matches a padded label");
     check(sid->get_value(0x03) == 0, "outer spaces are ignored, the inner one is not");
@@ -209,46 +205,40 @@ int main(int argc, char **argv)
     printf("-- tolerance is not laxity\n");
     sid->set_value(0x02, 1);
     MemFile bogus;
-    IndexedList<ConfigStore *> loaded_bogus(8, NULL);
     StreamTextLog log_bogus(4096);
     bogus.load("[SID Socket 1: PDsid]\n8580 Lowest Filt Freq=31\n\n");
-    check(!ConfigIO::S_read_from_file(&bogus, &log_bogus, loaded_bogus),
+    check(!ConfigIO::S_read_from_file(&bogus, &log_bogus),
           "a value that is not a choice is still an error");
     check(sid->get_value(0x02) == 1, "and the store keeps its previous value");
 
     printf("-- an unknown item is a warning, not a failure\n");
     MemFile unknown_item;
-    IndexedList<ConfigStore *> loaded2(8, NULL);
     StreamTextLog log2(4096);
     unknown_item.load("[SID Socket 1: PDsid]\nFilter Strength=7\nEmulation Mode=8580\n\n");
-    ok = ConfigIO::S_read_from_file(&unknown_item, &log2, loaded2);
+    ok = ConfigIO::S_read_from_file(&unknown_item, &log2);
     check(ok, "an unknown item does not fail the load");
     check(sid->get_value(0x01) == 1,
           "items after the unknown one are still applied");
 
     printf("-- an unknown store is a warning, not a failure\n");
     MemFile unknown_store;
-    IndexedList<ConfigStore *> loaded3(8, NULL);
     StreamTextLog log3(4096);
     unknown_store.load("[SID Socket 2: PDsid]\nEmulation Mode=6581\n\n");
-    ok = ConfigIO::S_read_from_file(&unknown_store, &log3, loaded3);
+    ok = ConfigIO::S_read_from_file(&unknown_store, &log3);
     check(ok, "a store this machine does not have does not fail the load");
-    check(loaded3.get_elements() == 0, "an unknown store contributes nothing to load");
     check(sid->get_value(0x01) == 1, "an unknown store does not touch another store");
 
     printf("-- a malformed file is still an error\n");
     MemFile broken;
-    IndexedList<ConfigStore *> loaded4(8, NULL);
     StreamTextLog log4(4096);
     broken.load("[SID Socket 1: PDsid]\nEmulation Mode\n\n");
-    ok = ConfigIO::S_read_from_file(&broken, &log4, loaded4);
+    ok = ConfigIO::S_read_from_file(&broken, &log4);
     check(!ok, "a line with no '=' is reported as an error");
 
     MemFile orphan;
-    IndexedList<ConfigStore *> loaded5(8, NULL);
     StreamTextLog log5(4096);
     orphan.load("Emulation Mode=6581\n\n");
-    ok = ConfigIO::S_read_from_file(&orphan, &log5, loaded5);
+    ok = ConfigIO::S_read_from_file(&orphan, &log5);
     check(!ok, "an item outside any store is reported as an error");
 
     printf("\n%d checks, %d failed\n", checks, failures);

--- a/software/test/configio/configio_test_stubs.cc
+++ b/software/test/configio/configio_test_stubs.cc
@@ -1,7 +1,7 @@
 /*
  * configio_test_stubs.cc
  *
- * The three symbols configio.cc needs that only exist on the device. All of
+ * The four symbols configio.cc needs that only exist on the device. All of
  * them belong to menu handlers the tests do not drive: the debug-log actions
  * and "clear config flash".
  *
@@ -15,6 +15,7 @@
 
 #include "stream_textlog.h"
 #include "subsys.h"
+#include "userinterface.h"
 
 extern "C" void outbyte(int c)
 {
@@ -31,4 +32,8 @@ SubsysResultCode_t SubsysCommand::execute(void)
     SubsysResultCode_t result;
     result.status = SSRET_OK;
     return result;
+}
+
+void UserInterface::run_editor(const char *, int)
+{
 }

--- a/software/test/stubs/userinterface.h
+++ b/software/test/stubs/userinterface.h
@@ -83,6 +83,7 @@ public:
     void show_progress(const char *msg, int steps) {} // not blocking
     void update_progress(const char *msg, int steps) {} // not blocking
     void hide_progress(void) {} // not blocking (of course)
+    void run_editor(const char *, int);
 };
 
 #endif

--- a/software/u64/led_strip.cc
+++ b/software/u64/led_strip.cc
@@ -316,7 +316,7 @@ void LedStrip :: run(void)
     RGB fixed;
 
     setup_config_menu();
-    effectuate_settings();
+    effectuate_registered_settings();
     update_menu();
 
     while(1) {

--- a/software/u64/sid_device_armsid.cc
+++ b/software/u64/sid_device_armsid.cc
@@ -99,6 +99,7 @@ SidDeviceArmSid :: ArmSidConfig :: ArmSidConfig(SidDeviceArmSid *parent, volatil
     set_change_hook(CFG_ARMSID_6581FILT_BASE, S_cfg_armsid_filt);
     set_change_hook(CFG_ARMSID_8580FILT_MAX,  S_cfg_armsid_filt);
     set_change_hook(CFG_ARMSID_8580FILT_BASE, S_cfg_armsid_filt);
+    set_effectuated();
 }
 
 void SidDeviceArmSid :: ArmSidConfig :: readParams(volatile uint8_t *base)
@@ -185,6 +186,7 @@ void SidDeviceArmSid :: ArmSidConfig :: effectuate()
     volatile uint8_t *base = parent->pre();
     S_effectuate(base, this);
     parent->post();
+    set_effectuated();
 }
 
 void SidDeviceArmSid :: ArmSidConfig :: write()

--- a/software/u64/sid_device_armsid.h
+++ b/software/u64/sid_device_armsid.h
@@ -32,8 +32,9 @@ class SidDeviceArmSid: public SidDevice {
         void at_open_config(void);
         void write(void);
 
+        void read(bool ignore) override { }
+
         // Not Implemented
-        //void read(void) { printf("ArmSidRead\n"); }
         //void at_close_config(void) { printf("ArmSidClose\n"); }
 
         static volatile uint8_t *pre(ConfigItem *it);

--- a/software/u64/sid_device_fpgasid.cc
+++ b/software/u64/sid_device_fpgasid.cc
@@ -91,7 +91,7 @@ SidDeviceFpgaSid::SidDeviceFpgaSid(int socket, volatile uint8_t *base) : SidDevi
     }
     fpga_rev = base[3];
     config = new SidDeviceFpgaSid :: FpgaSidConfig(this);
-    config->effectuate_settings();
+    config->effectuate_registered_settings();
 }
 
 void SidDeviceFpgaSid :: SetSidType(int type)

--- a/software/u64/sid_device_fpgasid.h
+++ b/software/u64/sid_device_fpgasid.h
@@ -21,6 +21,8 @@ class SidDeviceFpgaSid: public SidDevice {
         static void S_effectuate(volatile uint8_t *base, ConfigStore *store);
         static bool dukestahAdapterPresent;
     public:
+        using ConfigurableObject::effectuate_registered_settings;
+
         static void setDukestahAdapterPresent() {dukestahAdapterPresent = true;}
 
         FpgaSidConfig(SidDeviceFpgaSid *parent);
@@ -54,7 +56,7 @@ class SidDeviceFpgaSid: public SidDevice {
     FpgaSidConfig *config;
 public:
     SidDeviceFpgaSid(int socket, volatile uint8_t *base);
-    void effectuate_settings() { config->effectuate_settings(); }
+    void effectuate_settings() { config->effectuate_registered_settings(); }
     void setDukestahAdapterPresent() { config->setDukestahAdapterPresent(); }
     virtual ~SidDeviceFpgaSid();
 

--- a/software/u64/sid_device_pdsid.cc
+++ b/software/u64/sid_device_pdsid.cc
@@ -33,6 +33,7 @@ SidDevicePdSid::SidDevicePdSid(int socket, volatile uint8_t *base) : SidDevice(s
     // otherwise record 6581 for everyone. ArmSid reads its parameters at this
     // same point for the same reason.
     config->at_open_config();
+    config->set_effectuated();
 }
 
 void SidDevicePdSid :: SetSidType(int type)
@@ -78,6 +79,7 @@ void SidDevicePdSid::PdSidConfig :: effectuate(void)
         // menu enum is 0 = 6581, 1 = 8580; SetSidType takes 1 = 6581, 2 = 8580
         parent->SetSidType(i->getValue() + 1);
     }
+    set_effectuated();
 }
 
 int SidDevicePdSid::PdSidConfig:: S_cfg_pdsid_type(ConfigItem *it)

--- a/software/u64/sid_device_sidkick.cc
+++ b/software/u64/sid_device_sidkick.cc
@@ -55,6 +55,7 @@ SidDeviceSidKick::SidDeviceSidKick(int socket, volatile uint8_t *base, int subty
     // otherwise record 6581 for everyone. ArmSid reads its parameters at this
     // same point for the same reason.
     config->at_open_config();
+    config->set_effectuated();
 }
 
 void SidDeviceSidKick :: SetSidType(int type)
@@ -101,6 +102,7 @@ void SidDeviceSidKick::SidKickConfig :: effectuate(void)
 {
     ConfigItem *i = find_item(CFG_KICKSID_TYPE);
     if (!i) {
+        set_effectuated();
         return;
     }
 
@@ -118,6 +120,7 @@ void SidDeviceSidKick::SidKickConfig :: effectuate(void)
     // Restore C64 mode
     C64_MODE = parent->pre_mode;
     parent->post();
+    set_effectuated();
 }
 
 int SidDeviceSidKick::SidKickConfig:: S_cfg_pdsid_type(ConfigItem *it)

--- a/software/u64/sid_device_swinsid.cc
+++ b/software/u64/sid_device_swinsid.cc
@@ -29,7 +29,7 @@ static struct t_cfg_definition swin_sid_config[] = {
 SidDeviceSwinSid::SidDeviceSwinSid(int socket, volatile uint8_t *base) : SidDevice(socket)
 {
     config = new SidDeviceSwinSid :: SwinSidConfig(this);
-    config->effectuate_settings();
+    config->effectuate_registered_settings();
 }
 
 void SidDeviceSwinSid :: SetSidType(int type)

--- a/software/u64/sid_device_swinsid.h
+++ b/software/u64/sid_device_swinsid.h
@@ -17,6 +17,8 @@ class SidDeviceSwinSid: public SidDevice {
         SidDeviceSwinSid *parent;
         static void S_effectuate(volatile uint8_t *base, ConfigStore *store);
     public:
+        using ConfigurableObject::effectuate_registered_settings;
+
         SwinSidConfig(SidDeviceSwinSid *parent);
         void effectuate_settings();
 

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -955,7 +955,7 @@ U64Config :: U64Config() : SubSystem(SUBSYSID_U64)
         }
 
         // the following sets the HDMI mode
-        u64_configurator->effectuate_settings(); // requires I2C
+        u64_configurator->effectuate_registered_settings(); // requires I2C
 
         hpd_monitor_sem = xSemaphoreCreateBinary();
         xTaskCreate(U64Config::hpd_monitor_task, "HPD Monitor", configMINIMAL_STACK_SIZE, u64_configurator, PRIO_HW_SERVICE, &u64_configurator->hpd_monitor_task_handle);
@@ -963,12 +963,12 @@ U64Config :: U64Config() : SubSystem(SUBSYSID_U64)
         xSemaphoreGive(hpd_monitor_sem);
 
 //        u64_configurator->hdmiMonitor = u64_configurator->IsMonitorHDMI(); // requires I2C
-        u64_configurator->sockets.effectuate_settings();
-        u64_configurator->mixercfg.effectuate_settings();
-        u64_configurator->ultisids.effectuate_settings();
-        u64_configurator->sidaddressing.effectuate_settings();
+        u64_configurator->sockets.effectuate_registered_settings();
+        u64_configurator->mixercfg.effectuate_registered_settings();
+        u64_configurator->ultisids.effectuate_registered_settings();
+        u64_configurator->sidaddressing.effectuate_registered_settings();
 #if U64 == 2
-        u64_configurator->speakercfg.effectuate_settings();
+        u64_configurator->speakercfg.effectuate_registered_settings();
 #endif
 
         if (cfg->is_flash_stale()) {
@@ -1019,11 +1019,11 @@ void U64Config :: run_reset_task()
         printf("U64 reset handler. ");
         if (! skipReset) {
             printf("Resetting Settings\n");
-            effectuate_settings();
-            sockets.effectuate_settings();
-            mixercfg.effectuate_settings();
-            ultisids.effectuate_settings();
-            sidaddressing.effectuate_settings();
+            effectuate_registered_settings();
+            sockets.effectuate_registered_settings();
+            mixercfg.effectuate_registered_settings();
+            ultisids.effectuate_registered_settings();
+            sidaddressing.effectuate_registered_settings();
         } else {
             printf("SKIP\n");
         }
@@ -1747,7 +1747,7 @@ SubsysResultCode_e U64Config :: executeCommand(SubsysCommand *cmd)
         machine->resume();
         sprintf(sidString, "Socket1: %s  Socket2: %s", sid_types[sid1], sid_types[sid2]);
         cmd->user_interface->popup(sidString, BUTTON_OK);
-        effectuate_settings();
+        effectuate_registered_settings();
         break;
 
 #ifdef NO_ESP

--- a/software/userinterface/configio.h
+++ b/software/userinterface/configio.h
@@ -28,7 +28,6 @@ typedef enum {
 class ConfigIO : public ObjectWithMenu
 {
     static void S_write_store_to_file(ConfigStore *s, File *f);
-    static void S_write_to_file(File *f);
 
     static t_cfg_line_result S_read_store_element(ConfigStore *st, const char *line, int linenr, StreamTextLog *log);
     static SubsysResultCode_e S_reset_log(SubsysCommand *cmd);
@@ -59,6 +58,8 @@ public:
     static SubsysResultCode_e S_load_associated_config(SubsysCommand *cmd);
     static SubsysResultCode_e S_load_associated_config_usr(SubsysCommand *cmd);
 
+    // Public so the host test can drive a round trip without a filesystem.
+    static void S_write_to_file(File *f);
     static bool S_read_from_file(File *f, StreamTextLog *log);
 };
 

--- a/software/userinterface/userinterface.cc
+++ b/software/userinterface/userinterface.cc
@@ -155,7 +155,7 @@ UserInterface :: UserInterface(const char *title, bool use_logo) : title(title)
     logo = use_logo;
     register_store(CFG_USERIF_STORE_ID, "User Interface Settings", user_if_config);
     cfg->set_sort_order(SORT_ORDER_CFG_USERIF);
-    effectuate_settings();
+    effectuate_registered_settings();
 }
 
 UserInterface :: ~UserInterface()


### PR DESCRIPTION
## Summary

- Clear each configuration store's pending-effect flag when its initial settings are applied.
- Preserve unconditional runtime reapplication for reconnect, reset, shared-UI, and UltiCopy paths.
- Mark hardware-backed and lazy/no-observer stores clean once their initial state is known.
- Keep `ConfigIO`'s all-store behavior and make the regression test observe actual effectuation.

## Root cause

Every `ConfigStore` starts with `staleEffect` set, and flash reads set it again. Most boot paths called `effectuate_settings()` directly instead of `ConfigStore::effectuate()`, so settings reached the hardware but the store was never marked clean.

The first later CFG load therefore effectuated every still-stale store. That produced unrelated side effects and made `cfg-single-group` fail only on its first run after boot; the load itself cleared the flags, so subsequent runs passed.

This fixes the lifecycle rather than filtering the CFG loader. A small `effectuate_registered_settings()` helper uses the existing store wrapper for the first application, then directly reapplies clean settings when runtime behavior requires it. Custom stores close the same lifecycle explicitly after reading live hardware or completing their own effectuation.

## Validation

- Reproduced on exact `test-merge` `5bdbb5eb`: the first post-flash one-group CFG load effectuated Audio Mixer plus 17 unrelated stores; the immediate second run passed.
- Exact `e4dd6d3e` firmware, first post-flash `cfg-single-group`: 2/2 checks passed with only Audio Mixer effectuated.
- Exact `e4dd6d3e` full hardware E2E over WiFi: all 22 overlay suites passed in 847 seconds; no recovery was needed.
- ConfigIO host test: 23/23 checks passed.
- Final application builds and space gates passed for U2, U2+, U2+L, U64, U64E2 50T, and U64E2 100T.
- `git diff --check`: clean.

Fixes #787
Unblocks #788
