### PR TITLE
Clear full cartridge memory

### DIFF
--- a/software/io/c64/c64_crt.cc
+++ b/software/io/c64/c64_crt.cc
@@ -333,7 +333,7 @@ SubsysResultCode_e C64_CRT::read_chip_packet(File *f, t_crt_chip_chunk *chunk)
 
 void C64_CRT::clear_cart_mem(void)
 {
-    memset(cart_memory, 0xff, 1024 * 1024); // clear all cart memory
+    memset(cart_memory, 0xff, max_cart); // clear the whole cartridge region
 }
 
 void C64_CRT::auto_mirror(void)


### PR DESCRIPTION
## Summary

Clear the entire cartridge ROM region before loading a CRT.

## Root cause

`C64_CRT::load_crt()` initializes `max_cart` from the linker-defined cartridge ROM range, but `clear_cart_mem()` filled a fixed 1 MiB. The U64 ultimate linker layouts provide a 4 MiB cartridge ROM region, leaving bytes above the first MiB from an earlier CRT load.

## Impact

A later CRT that does not populate those addresses starts with stale cartridge data rather than `0xFF`. Clearing `max_cart` follows the allocation supplied by the caller, so 1 MiB layouts retain their existing bound.

## Validation

- `git diff --check`
- `BUILD_TOOL_ALLOW_PARTIAL=1 ./build-tool -s u64` (compiled and linked the U64 ultimate application)