### PR TITLE
Configurable power on behavior after loss of input power (UE2/C64U)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ observability_test:
 # these need a host g++.
 host_tests:
 	@$(MAKE) -C target/pc/linux/configiotest test
+	@$(MAKE) -C target/pc/linux/powerstate test
 
 esp32: esp32_raw_u64 esp32_raw_c3 esp32_u64ctrl
 

--- a/run-tests
+++ b/run-tests
@@ -265,8 +265,9 @@ SUITES: Sequence[Suite] = (
     # Manual: asserting what the machine does when its input power returns
     # means actually removing mains, which the suite asks the operator to do
     # unless it is given commands for a socket it can script. Two of its four
-    # scenarios end with the machine deliberately off, and only the power
-    # button can revive it, so no adapter support makes this unattended.
+    # scenarios end with the machine deliberately off, which only the machine's
+    # power button can undo -- so running it unattended takes an actuator for
+    # that button too (--power-button-cmd), not a scriptable socket alone.
     Suite("e2e", "power-cycle", "tests/e2e/u64ctrl/power_cycle_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@", manual=True),
 

--- a/run-tests
+++ b/run-tests
@@ -262,6 +262,13 @@ SUITES: Sequence[Suite] = (
     # fix stalls the whole Nios on this scenario and needs a JTAG recovery.
     Suite("e2e", "freeze-menu", "tests/e2e/io/c64/freeze_menu_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"),
+    # Manual: asserting what the machine does when its input power returns
+    # means actually removing mains, which the suite asks the operator to do
+    # unless it is given commands for a socket it can script. Two of its four
+    # scenarios end with the machine deliberately off, and only the power
+    # button can revive it, so no adapter support makes this unattended.
+    Suite("e2e", "power-cycle", "tests/e2e/u64ctrl/power_cycle_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@", manual=True),
 
     # --------------------------------------------------------------- perf --
     Suite("perf", "temp-auto-cleanup-perf", "tests/perf/temp_auto_cleanup_perf_test.py",

--- a/software/components/config.h
+++ b/software/components/config.h
@@ -40,6 +40,7 @@
 #define SORT_ORDER_CFG_MEM      210 //
 #define SORT_ORDER_CFG_TURBO    220 //
 #define SORT_ORDER_CFG_TWEAKS   230 //
+#define SORT_ORDER_CFG_POWER    240 //
 
 #define SORT_ORDER_HDR_USERIF   300
 #define SORT_ORDER_CFG_USERIF   310 //

--- a/software/io/wifi/wifi.cc
+++ b/software/io/wifi/wifi.cc
@@ -14,6 +14,9 @@
 #include "rpc_calls.h"
 #include "filemanager.h"
 #include "network_esp32.h"
+#if U64 == 2
+#include "u64_config.h"
+#endif
 #include "init_function.h"
 
 #define DEBUG_INPUT  0
@@ -255,6 +258,9 @@ void WiFi :: RunModeThread()
                 if (voltages.vbus < 8500) {
                     UserInterface :: postMessage("Low input voltage.");
                 }
+                // The module keeps the power on behavior in its own NVS; make
+                // sure it matches the setting of this machine.
+                U64Config :: pushPowerOnMode();
 #endif
                 RefreshRoot();
             }

--- a/software/io/wifi/wifi_cmd.cc
+++ b/software/io/wifi/wifi_cmd.cc
@@ -136,6 +136,31 @@ int wifi_get_serial(char *serial)
     }
     RETURN_ESP;
 }
+
+int wifi_set_power_mode(uint8_t mode)
+{
+    BUFARGS(set_power_mode, CMD_SET_POWER_MODE);
+    args->mode = mode;
+    TRANSMIT(espcmd);
+    RETURN_ESP;
+}
+
+int wifi_get_power_mode(uint8_t *mode, uint8_t *last_state)
+{
+    BUFARGS(identify, CMD_GET_POWER_MODE);
+    TRANSMIT(get_power_mode);
+    if (result->esp_err == 0) {
+        if (mode) {
+            *mode = result->mode;
+        }
+        if (last_state) {
+            *last_state = result->last_state;
+        }
+    } else {
+        printf("Get Power Mode returned %d as error code.\n", result->esp_err);
+    }
+    RETURN_ESP;
+}
 #endif
 
 int wifi_is_connected(uint8_t &status)

--- a/software/io/wifi/wifi_cmd.h
+++ b/software/io/wifi/wifi_cmd.h
@@ -51,6 +51,11 @@ int wifi_forget_aps();
 int wifi_set_serial(const char *serial);
 int wifi_get_serial(char *serial);
 
+// Power on behavior after loss of input power; the mode values are the
+// POWERON_MODE_* defines of the control module (software/u64ctrl).
+int wifi_set_power_mode(uint8_t mode);
+int wifi_get_power_mode(uint8_t *mode, uint8_t *last_state);
+
 extern uint16_t sequence_nr;
 extern TaskHandle_t tasksWaitingForReply[NUM_TX_BUFFERS];
 extern "C" { void print_uart_status(); }

--- a/software/test/power_state/power_state_test.c
+++ b/software/test/power_state/power_state_test.c
@@ -1,0 +1,116 @@
+/*
+ * Host side tests for the power on behavior of the control module.
+ *
+ *   make -C target/pc/linux/powerstate && ./target/pc/linux/powerstate/result/powerstate
+ *
+ * The real software/u64ctrl/main/power_state.c is compiled here against the
+ * NVS stub in software/test/stubs/esp, so what is exercised is the code that
+ * ships, not a copy of it.
+ */
+#include <stdio.h>
+#include <string.h>
+#include "power_state.h"
+#include "nvs.h"
+
+static int failures;
+static int checks;
+
+static void check(int condition, const char *what)
+{
+    checks++;
+    if (!condition) {
+        failures++;
+        printf("  FAIL  %s\n", what);
+    } else {
+        printf("  ok    %s\n", what);
+    }
+}
+
+static void check_eq(int got, int expected, const char *what)
+{
+    checks++;
+    if (got != expected) {
+        failures++;
+        printf("  FAIL  %s (expected %d, got %d)\n", what, expected, got);
+    } else {
+        printf("  ok    %s\n", what);
+    }
+}
+
+// A machine that has been running: the mode is set and the buttons have
+// recorded a state, as they do on every press.
+static void given(uint8_t mode, uint8_t last_state)
+{
+    nvs_stub_erase_all();
+    power_set_mode(mode);
+    power_store_last_state(last_state);
+    nvs_stub_reset_commits();
+}
+
+int main(void)
+{
+    printf("A factory fresh module\n");
+    nvs_stub_erase_all();
+    check_eq(power_get_mode(), POWERON_MODE_OFF, "defaults to OFF");
+    check_eq(power_get_last_state(), 0, "reports the machine as off");
+    check_eq(power_initial_state(0), 0, "stays off on a cold start");
+
+    printf("Mode OFF\n");
+    given(POWERON_MODE_OFF, 1);
+    check_eq(power_initial_state(0), 0, "stays off although the machine was on");
+    check_eq(power_get_last_state(), 0, "records that it came up off");
+
+    printf("Mode ON\n");
+    given(POWERON_MODE_ON, 0);
+    check_eq(power_initial_state(0), 1, "comes up although the machine was off");
+    check_eq(power_get_last_state(), 1, "records that it came up on");
+    given(POWERON_MODE_ON, 1);
+    check_eq(power_initial_state(0), 1, "comes up when the machine was on");
+
+    printf("Mode LAST_STATE\n");
+    given(POWERON_MODE_LAST_STATE, 1);
+    check_eq(power_initial_state(0), 1, "comes up when the machine was on");
+    check_eq(power_get_last_state(), 1, "leaves the recorded state on");
+    given(POWERON_MODE_LAST_STATE, 0);
+    check_eq(power_initial_state(0), 0, "stays off when the machine was off");
+    check_eq(power_get_last_state(), 0, "leaves the recorded state off");
+
+    printf("Switching to LAST_STATE after the machine came up by itself\n");
+    given(POWERON_MODE_ON, 0);
+    (void)power_initial_state(0);                 // comes up, machine is now on
+    power_set_mode(POWERON_MODE_LAST_STATE);      // user changes the mode
+    check_eq(power_initial_state(0), 1, "acts on the state this boot established");
+
+    printf("An already loaded application FPGA\n");
+    given(POWERON_MODE_OFF, 0);
+    check_eq(power_initial_state(1), 1, "leaves the machine on, whatever the mode says");
+    check_eq(power_get_last_state(), 1, "records that the machine is on");
+
+    printf("A stored mode that is out of range\n");
+    nvs_stub_erase_all();
+    power_store_last_state(1);                    // creates the namespace
+    {
+        nvs_handle_t h;
+        check_eq(nvs_open("power", NVS_READWRITE, &h), ESP_OK, "namespace can be opened");
+        nvs_set_u8(h, "mode", 42);
+        nvs_commit(h);
+        nvs_close(h);
+    }
+    check_eq(power_get_mode(), POWERON_MODE_OFF, "is read as OFF");
+    check_eq(power_initial_state(0), 0, "keeps the machine off");
+
+    printf("Storing a mode that does not exist\n");
+    given(POWERON_MODE_ON, 0);
+    check_eq(power_set_mode(3), ESP_ERR_INVALID_ARG, "is refused");
+    check_eq(power_get_mode(), POWERON_MODE_ON, "leaves the stored mode alone");
+
+    printf("Writing a value that has not changed\n");
+    given(POWERON_MODE_LAST_STATE, 1);
+    power_store_last_state(1);
+    check_eq(nvs_stub_commits(), 0, "does not touch the flash");
+    power_store_last_state(0);
+    check(nvs_stub_commits() > 0, "a real change does touch the flash");
+
+    printf("\n%d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/software/test/stubs/esp/esp_err.h
+++ b/software/test/stubs/esp/esp_err.h
@@ -1,0 +1,16 @@
+/* Minimal esp_err.h for building ESP32 sources on the host, see
+   software/test/power_state. Only what the code under test uses. */
+#ifndef TEST_STUB_ESP_ERR_H
+#define TEST_STUB_ESP_ERR_H
+
+typedef int esp_err_t;
+
+#define ESP_OK                   0
+#define ESP_FAIL                -1
+#define ESP_ERR_INVALID_ARG      0x102
+#define ESP_ERR_NOT_FOUND        0x105
+#define ESP_ERR_NVS_NOT_FOUND    0x1102
+
+const char *esp_err_to_name(esp_err_t code);
+
+#endif

--- a/software/test/stubs/esp/esp_log.h
+++ b/software/test/stubs/esp/esp_log.h
@@ -1,0 +1,12 @@
+/* Minimal esp_log.h for host builds: the log lines are part of what the
+   firmware prints, so keep them, but send them to stdout. */
+#ifndef TEST_STUB_ESP_LOG_H
+#define TEST_STUB_ESP_LOG_H
+
+#include <stdio.h>
+
+#define ESP_LOGI(tag, fmt, ...) printf("I (%s) " fmt "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) printf("W (%s) " fmt "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGE(tag, fmt, ...) printf("E (%s) " fmt "\n", tag, ##__VA_ARGS__)
+
+#endif

--- a/software/test/stubs/esp/nvs.h
+++ b/software/test/stubs/esp/nvs.h
@@ -1,0 +1,28 @@
+/* Minimal nvs.h for host builds. The implementation in nvs_stub.c keeps the
+   key/value pairs in memory and counts commits, so a test can tell an actual
+   flash write from a write that was skipped because nothing changed. */
+#ifndef TEST_STUB_NVS_H
+#define TEST_STUB_NVS_H
+
+#include <stdint.h>
+#include "esp_err.h"
+
+typedef unsigned int nvs_handle_t;
+
+typedef enum {
+    NVS_READONLY = 0,
+    NVS_READWRITE = 1,
+} nvs_open_mode_t;
+
+esp_err_t nvs_open(const char *namespace_name, nvs_open_mode_t open_mode, nvs_handle_t *out_handle);
+esp_err_t nvs_get_u8(nvs_handle_t handle, const char *key, uint8_t *out_value);
+esp_err_t nvs_set_u8(nvs_handle_t handle, const char *key, uint8_t value);
+esp_err_t nvs_commit(nvs_handle_t handle);
+void      nvs_close(nvs_handle_t handle);
+
+/* Test-only controls, not part of the ESP-IDF API. */
+void nvs_stub_erase_all(void);   // a factory fresh module
+int  nvs_stub_commits(void);     // how often the flash was actually written
+void nvs_stub_reset_commits(void);
+
+#endif

--- a/software/test/stubs/esp/nvs_flash.h
+++ b/software/test/stubs/esp/nvs_flash.h
@@ -1,0 +1,5 @@
+#ifndef TEST_STUB_NVS_FLASH_H
+#define TEST_STUB_NVS_FLASH_H
+#include "esp_err.h"
+esp_err_t nvs_flash_init(void);
+#endif

--- a/software/test/stubs/esp/nvs_stub.c
+++ b/software/test/stubs/esp/nvs_stub.c
@@ -1,0 +1,131 @@
+/*
+ * An in-memory stand-in for the NVS of the control module, so that the power
+ * on behavior can be exercised on the host. Values survive nvs_close(), like
+ * flash does, and only nvs_commit() counts as a write.
+ */
+#include <string.h>
+#include <stdio.h>
+#include "nvs.h"
+#include "nvs_flash.h"
+
+#define MAX_ENTRIES 16
+#define MAX_KEY     16
+
+static struct {
+    char    ns[MAX_KEY];
+    char    key[MAX_KEY];
+    uint8_t value;
+    int     used;
+} entries[MAX_ENTRIES];
+
+#define MAX_HANDLES 8
+
+static char handle_ns[MAX_HANDLES][MAX_KEY];
+static int  handle_writable[MAX_HANDLES];
+static int  handle_used[MAX_HANDLES];
+static int  commits;
+
+const char *esp_err_to_name(esp_err_t code)
+{
+    switch (code) {
+        case ESP_OK:                return "ESP_OK";
+        case ESP_FAIL:              return "ESP_FAIL";
+        case ESP_ERR_INVALID_ARG:   return "ESP_ERR_INVALID_ARG";
+        case ESP_ERR_NVS_NOT_FOUND: return "ESP_ERR_NVS_NOT_FOUND";
+    }
+    return "?";
+}
+
+esp_err_t nvs_flash_init(void) { return ESP_OK; }
+
+void nvs_stub_erase_all(void)
+{
+    memset(entries, 0, sizeof(entries));
+    memset(handle_used, 0, sizeof(handle_used));
+    commits = 0;
+}
+
+int  nvs_stub_commits(void)       { return commits; }
+void nvs_stub_reset_commits(void) { commits = 0; }
+
+esp_err_t nvs_open(const char *namespace_name, nvs_open_mode_t open_mode, nvs_handle_t *out_handle)
+{
+    int handle = 0;
+    for (int i = 1; i < MAX_HANDLES; i++) {
+        if (!handle_used[i]) {
+            handle = i;
+            break;
+        }
+    }
+    if (!handle) {
+        return ESP_FAIL; // every handle still open: the code under test leaks
+    }
+    // Opening a namespace that does not exist yet read-only fails on the real
+    // NVS, and power_state.c depends on that to fall back to its default.
+    if (open_mode == NVS_READONLY) {
+        int found = 0;
+        for (int i = 0; i < MAX_ENTRIES; i++) {
+            if (entries[i].used && strcmp(entries[i].ns, namespace_name) == 0) {
+                found = 1;
+            }
+        }
+        if (!found) {
+            return ESP_ERR_NVS_NOT_FOUND;
+        }
+    }
+    strncpy(handle_ns[handle], namespace_name, MAX_KEY - 1);
+    handle_writable[handle] = (open_mode == NVS_READWRITE);
+    handle_used[handle] = 1;
+    *out_handle = (nvs_handle_t)handle;
+    return ESP_OK;
+}
+
+esp_err_t nvs_get_u8(nvs_handle_t handle, const char *key, uint8_t *out_value)
+{
+    for (int i = 0; i < MAX_ENTRIES; i++) {
+        if (entries[i].used && strcmp(entries[i].ns, handle_ns[handle]) == 0
+                            && strcmp(entries[i].key, key) == 0) {
+            *out_value = entries[i].value;
+            return ESP_OK;
+        }
+    }
+    return ESP_ERR_NVS_NOT_FOUND;
+}
+
+esp_err_t nvs_set_u8(nvs_handle_t handle, const char *key, uint8_t value)
+{
+    if (!handle_writable[handle]) {
+        return ESP_FAIL;
+    }
+    for (int i = 0; i < MAX_ENTRIES; i++) {
+        if (entries[i].used && strcmp(entries[i].ns, handle_ns[handle]) == 0
+                            && strcmp(entries[i].key, key) == 0) {
+            entries[i].value = value;
+            return ESP_OK;
+        }
+    }
+    for (int i = 0; i < MAX_ENTRIES; i++) {
+        if (!entries[i].used) {
+            entries[i].used = 1;
+            strncpy(entries[i].ns, handle_ns[handle], MAX_KEY - 1);
+            strncpy(entries[i].key, key, MAX_KEY - 1);
+            entries[i].value = value;
+            return ESP_OK;
+        }
+    }
+    return ESP_FAIL;
+}
+
+esp_err_t nvs_commit(nvs_handle_t handle)
+{
+    (void)handle;
+    commits++;
+    return ESP_OK;
+}
+
+void nvs_close(nvs_handle_t handle)
+{
+    if (handle < MAX_HANDLES) {
+        handle_used[handle] = 0;
+    }
+}

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -163,7 +163,9 @@ static SemaphoreHandle_t resetSemaphore;
 #define CFG_SPEED_PREF        0x52
 #define CFG_BADLINES_EN       0x53
 #define CFG_SUPERCPU_DET      0x54
-// 0x55..0x5E are taken by the USB HID settings, see usb_hid_config.h
+// 0x55..0x5E are used by the USB HID store (io/usb/usb_hid_config.h) and
+// 0x56..0x63 by the audio selection store (io/audio/audio_select.cc); both are
+// different stores, but kept clear here to keep the ids readable side by side
 #define CFG_POWERON_MODE      0x5F
 
 #define CFG_SCAN_MODE_TEST    0xA8
@@ -1384,12 +1386,19 @@ void U64Config :: pushPowerOnMode(void)
     }
     uint8_t mode = 0xFF;
     uint8_t last_state = 0xFF;
-    if (wifi_get_power_mode(&mode, &last_state) == 0) {
-        printf("Power on behavior of the control module: %d (machine was %s at the last transition)\n",
-               mode, last_state ? "on" : "off");
-        if (mode == (uint8_t)it->getValue()) {
-            return; // already in sync
-        }
+    if (wifi_get_power_mode(&mode, &last_state) != 0) {
+        // A control module that predates these commands answers "not
+        // implemented", and cannot store the setting either. Offering a choice
+        // that quietly does nothing is worse than offering none.
+        printf("Control module does not support the power on behavior; disabling the setting.\n");
+        u64_configurator->cfg->disable(CFG_POWERON_MODE);
+        return;
+    }
+    printf("Power on behavior of the control module: %d (machine was %s at the last transition)\n",
+           mode, last_state ? "on" : "off");
+    u64_configurator->cfg->enable(CFG_POWERON_MODE);
+    if (mode == (uint8_t)it->getValue()) {
+        return; // already in sync
     }
     setPowerOnMode(it);
 }

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -29,6 +29,9 @@ extern "C" {
 //#include "sys/alt_irq.h"
 #include "c64.h"
 #include "esp32.h"
+#if U64 == 2
+#include "wifi_cmd.h"
+#endif
 #include "sid_editor.h"
 #include "sid_device_fpgasid.h"
 #include "sid_device_swinsid.h"
@@ -160,6 +163,8 @@ static SemaphoreHandle_t resetSemaphore;
 #define CFG_SPEED_PREF        0x52
 #define CFG_BADLINES_EN       0x53
 #define CFG_SUPERCPU_DET      0x54
+// 0x55..0x5E are taken by the USB HID settings, see usb_hid_config.h
+#define CFG_POWERON_MODE      0x5F
 
 #define CFG_SCAN_MODE_TEST    0xA8
 #define CFG_VIC_TEST          0xA9
@@ -302,6 +307,8 @@ static const uint8_t stereo_bits[] = { 0x00, 0x02, 0x04, 0x08, 0x10, 0x20 };
 static const uint8_t split_bits[] = { 0x00, 0x02, 0x04, 0x08, 0x10, 0x06, 0x12, 0x18 };
 static const char *speeds_u64[]   = { " 1", " 2", " 3", " 4", " 5", " 6", " 8", "10", "12", "14", "16", "20", "24", "32", "40", "48" };
 static const char *speeds_u64ii[] = { " 1", " 2", " 3", " 4", " 6", " 8", "10", "12", "14", "16", "20", "24", "32", "40", "48", "64" };
+// The order of these must match the POWERON_MODE_* defines of the control module
+static const char *poweron_modes[] = { "Off", "On", "Last State" };
 static const char *speed_regs[] = { "Off", "Manual", "U64 Turbo Registers", "TurboEnable Bit", "a", "b" };
 static const uint8_t speedregs_regvalues[] = { 0x00, 0x00, 0x01, 0x05, 0x00, 0x00 }; // removed 3 and 7
 
@@ -372,6 +379,9 @@ struct t_cfg_definition u64_cfg[] = {
 #endif
     { CFG_BADLINES_EN,          CFG_TYPE_ENUM, "Badline Timing",               "%s", en_dis,       0,  1, 1 },
     { CFG_SUPERCPU_DET,         CFG_TYPE_ENUM, "SuperCPU Detect (D0BC)",       "%s", en_dis,       0,  1, 0 },
+#if U64 == 2
+    { CFG_POWERON_MODE,         CFG_TYPE_ENUM, "Power On After Power Loss",    "%s", poweron_modes, 0, 2, 0 },
+#endif
     { CFG_TYPE_END,             CFG_TYPE_END,  "",                             "",   NULL,         0,  0, 0 } };
 
 struct t_cfg_definition u64_sid_detection_cfg[] = {
@@ -900,6 +910,9 @@ U64Config :: U64Config() : SubSystem(SUBSYSID_U64)
         cfg->set_change_hook(CFG_SPEED_PREF, U64Config::setCpuSpeed);
         cfg->set_change_hook(CFG_BADLINES_EN, U64Config::setCpuSpeed);
         cfg->set_change_hook(CFG_SUPERCPU_DET, U64Config::setCpuSpeed);
+#if U64 == 2
+        cfg->set_change_hook(CFG_POWERON_MODE, U64Config::setPowerOnMode);
+#endif
 
         if (!isEliteBoard()) {
             cfg->disable(CFG_JOYSWAP);
@@ -1341,6 +1354,46 @@ int U64Config :: setLedSelector(ConfigItem *it)
     }
     return 0;
 }
+
+#if U64 == 2
+// What the machine does when the input power returns is decided by the control
+// module (ESP32), as that is the only part of the machine that is powered at
+// that moment. The setting is therefore stored in the NVS of that module; here
+// it is only presented to the user and pushed down on every change.
+int U64Config :: setPowerOnMode(ConfigItem *it)
+{
+    if(it) {
+        int retval = wifi_set_power_mode((uint8_t)it->getValue());
+        if (retval) {
+            printf("Setting the power on behavior failed with error %d.\n", retval);
+        }
+    }
+    return 0;
+}
+
+// Called when the control module reports in; it may have been updated or
+// replaced since the setting was last changed, so bring the two in sync.
+void U64Config :: pushPowerOnMode(void)
+{
+    if (!u64_configurator || !u64_configurator->cfg) {
+        return;
+    }
+    ConfigItem *it = u64_configurator->cfg->find_item(CFG_POWERON_MODE);
+    if (!it) {
+        return;
+    }
+    uint8_t mode = 0xFF;
+    uint8_t last_state = 0xFF;
+    if (wifi_get_power_mode(&mode, &last_state) == 0) {
+        printf("Power on behavior of the control module: %d (machine was %s at the last transition)\n",
+               mode, last_state ? "on" : "off");
+        if (mode == (uint8_t)it->getValue()) {
+            return; // already in sync
+        }
+    }
+    setPowerOnMode(it);
+}
+#endif
 
 int U64Config :: setCpuSpeed(ConfigItem *it)
 {
@@ -2646,6 +2699,14 @@ void U64Config :: setup_config_menu(void)
     grp->append(cfg->find_item(CFG_PARCABLE_ENABLE)->set_item_altname("Parallel Cable to Drive A"));
     grp->append(cfg->find_item(CFG_IEC_BUS_MODE));
     //grp->append(cfg->find_item(CFG_HDMI_TX_SWING));
+
+#if U64 == 2
+    grp = ConfigGroupCollection :: getGroup("Power Settings", SORT_ORDER_CFG_POWER);
+    grp->append(cfg->find_item(CFG_POWERON_MODE));
+    grp->append(ConfigItem :: separator());
+    grp->append(ConfigItem :: heading("'Last State' powers the machine up if"));
+    grp->append(ConfigItem :: heading("it was on when the power was lost."));
+#endif
 
     grp = ConfigGroupCollection :: getGroup("SID Player Behavior", SORT_ORDER_CFG_SIDPLAY);
     grp->append(cfg->find_item(CFG_PLAYER_AUTOCONFIG));

--- a/software/u64/u64_config.h
+++ b/software/u64/u64_config.h
@@ -144,6 +144,10 @@ public:
     static int setFilter(ConfigItem *it);
     static int setSidEmuParams(ConfigItem *it);
     static int setLedSelector(ConfigItem *it);
+#if U64 == 2
+    static int setPowerOnMode(ConfigItem *it);
+    static void pushPowerOnMode(void);
+#endif
     static int setCpuSpeed(ConfigItem *it);
 
     static void SetResampleFilter(t_video_mode mode);

--- a/software/u64ctrl/main/CMakeLists.txt
+++ b/software/u64ctrl/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(EXTERNAL "../../io/uart")
-idf_component_register(SRCS "button_handler.c" "control_main.c" "my_uart.c" "dump_hex.c" "rpc_dispatch.c" "wifi_modem.c" "button_handler.c" "jtag.c" "sntp.c" ${EXTERNAL}/cmd_buffer.c
+idf_component_register(SRCS "button_handler.c" "control_main.c" "my_uart.c" "dump_hex.c" "rpc_dispatch.c" "wifi_modem.c" "button_handler.c" "jtag.c" "sntp.c" "power_state.c" ${EXTERNAL}/cmd_buffer.c
                        INCLUDE_DIRS "." ${EXTERNAL})

--- a/software/u64ctrl/main/button_handler.c
+++ b/software/u64ctrl/main/button_handler.c
@@ -93,23 +93,23 @@ static void handle_button_event(int event)
 
 static void button_handler(void *arg)
 {
-    int initial_power_state = *((int *)arg);
+    int initial_state = *((int *)arg);
     int up, down;
     int up_count = 0;
     int down_count = 0;
-    int machine_on = initial_power_state;
+    int machine_on = initial_state;
     uint8_t event;
 
     gpio_set_direction(IO_BUTTON_UP, GPIO_MODE_INPUT);
     gpio_set_direction(IO_BUTTON_DOWN, GPIO_MODE_INPUT);
     gpio_set_pull_mode(IO_BUTTON_UP, GPIO_PULLUP_ONLY);
     gpio_set_pull_mode(IO_BUTTON_DOWN, GPIO_PULLUP_ONLY);
-    gpio_set_level(IO_ENABLE_V50, initial_power_state);
-    gpio_set_level(IO_ENABLE_MOD, initial_power_state);
+    gpio_set_level(IO_ENABLE_V50, initial_state);
+    gpio_set_level(IO_ENABLE_MOD, initial_state);
     gpio_set_direction(IO_ENABLE_V50, GPIO_MODE_OUTPUT);
     gpio_set_direction(IO_ENABLE_MOD, GPIO_MODE_OUTPUT);
     vTaskDelay(100 / portTICK_PERIOD_MS); // Allow pull up to do its work.
-    regulator_enable(initial_power_state, 0); // turn off uart also
+    regulator_enable(initial_state, 0); // turn off uart also
 
     while (1) {
         up = gpio_get_level(IO_BUTTON_UP);
@@ -177,8 +177,11 @@ static void button_handler(void *arg)
 
 void start_button_handler(int initial)
 {
+    // The task reads its argument after this function has returned, so it must
+    // not point into our own stack frame.
+    initial_power_state = initial;
     button_queue = xQueueCreate(8, sizeof(uint8_t));
-    xTaskCreate(button_handler, "button_handler", 3072, &initial, tskIDLE_PRIORITY + 2, NULL);
+    xTaskCreate(button_handler, "button_handler", 3072, &initial_power_state, tskIDLE_PRIORITY + 2, NULL);
 }
 
 void extern_button_event(uint8_t button)

--- a/software/u64ctrl/main/button_handler.c
+++ b/software/u64ctrl/main/button_handler.c
@@ -10,6 +10,7 @@
 #include "rpc_dispatch.h"
 #include "jtag.h"
 #include "wifi_modem.h"
+#include "power_state.h"
 
 #define SHORT_PRESS 100
 #define LONG_PRESS 1000
@@ -78,15 +79,18 @@ static void handle_button_event(int event)
         case BUTTON_ON:
             ESP_LOGI(TAG, "** ON **");
             regulator_enable(1, 0);
+            power_store_last_state(1);
             break;
         case BUTTON_ON2:
             ESP_LOGI(TAG, "** ON with delay **");
             regulator_enable(1, 20);
+            power_store_last_state(1);
             break;
         case BUTTON_OFF:
             ESP_LOGI(TAG, "** OFF **");
             regulator_enable(0, 0);
             disable_hook();
+            power_store_last_state(0);
             break;
     }
 }

--- a/software/u64ctrl/main/control_main.c
+++ b/software/u64ctrl/main/control_main.c
@@ -22,6 +22,7 @@
 #include "button_handler.h"
 #include "jtag.h"
 #include "sntp.h"
+#include "power_state.h"
 
 static const char *TAG = "u64ctrl";
 
@@ -182,14 +183,18 @@ int check_fpga(void)
 
 void app_main(void)
 {
-    // Check whether the application FPGA was already loaded.
-    int initial_state = check_fpga();
+    // Check whether the application FPGA was already loaded. If it was, only the
+    // ESP32 restarted, and the machine should simply stay on.
+    int fpga_running = check_fpga();
 
     // Configure IOs
     jtag_disable_io();
     configure_led();
     configure_adc();
-    setup_modem();
+    setup_modem(); // also initializes the NVS, which power_initial_state() reads
+
+    // On a cold start, the configured power on behavior decides.
+    int initial_state = power_initial_state(fpga_running);
     start_button_handler(initial_state);
 
     while (1) {

--- a/software/u64ctrl/main/power_state.c
+++ b/software/u64ctrl/main/power_state.c
@@ -1,0 +1,127 @@
+/*
+ * power_state.c
+ *
+ * See power_state.h.
+ */
+
+#include "power_state.h"
+#include "esp_log.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+
+static const char *TAG = "power_state";
+
+#define NVS_NAMESPACE "power"
+#define NVS_KEY_MODE  "mode"
+#define NVS_KEY_LAST  "last"
+
+static uint8_t read_u8(const char *key, uint8_t dflt)
+{
+    nvs_handle_t handle;
+    uint8_t value;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (err == ESP_OK) {
+        err = nvs_get_u8(handle, key, &value);
+        nvs_close(handle);
+    }
+    if (err != ESP_OK) {
+        ESP_LOGI(TAG, "'%s' not read (%s); using default %d", key, esp_err_to_name(err), dflt);
+        return dflt;
+    }
+    return value;
+}
+
+static esp_err_t write_u8(const char *key, uint8_t value)
+{
+    nvs_handle_t handle;
+    uint8_t current;
+
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Cannot open NVS namespace '%s': %s", NVS_NAMESPACE, esp_err_to_name(err));
+        return err;
+    }
+    // The last state is written on every power transition, so don't wear out
+    // the flash when there is nothing to change.
+    if ((nvs_get_u8(handle, key, &current) == ESP_OK) && (current == value)) {
+        nvs_close(handle);
+        return ESP_OK;
+    }
+    err = nvs_set_u8(handle, key, value);
+    if (err == ESP_OK) {
+        err = nvs_commit(handle);
+    }
+    nvs_close(handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Cannot store '%s' = %d: %s", key, value, esp_err_to_name(err));
+    }
+    return err;
+}
+
+const char *power_mode_name(uint8_t mode)
+{
+    switch(mode) {
+        case POWERON_MODE_OFF:        return "OFF";
+        case POWERON_MODE_ON:         return "ON";
+        case POWERON_MODE_LAST_STATE: return "LAST_STATE";
+    }
+    return "?";
+}
+
+uint8_t power_get_mode(void)
+{
+    uint8_t mode = read_u8(NVS_KEY_MODE, POWERON_MODE_OFF);
+    if (mode > POWERON_MODE_MAX) {
+        ESP_LOGW(TAG, "Stored mode %d is out of range; falling back to OFF", mode);
+        mode = POWERON_MODE_OFF;
+    }
+    return mode;
+}
+
+esp_err_t power_set_mode(uint8_t mode)
+{
+    if (mode > POWERON_MODE_MAX) {
+        ESP_LOGE(TAG, "Refusing to store unknown mode %d", mode);
+        return ESP_ERR_INVALID_ARG;
+    }
+    ESP_LOGI(TAG, "Power on after power loss: %s", power_mode_name(mode));
+    return write_u8(NVS_KEY_MODE, mode);
+}
+
+uint8_t power_get_last_state(void)
+{
+    return read_u8(NVS_KEY_LAST, 0) ? 1 : 0;
+}
+
+void power_store_last_state(uint8_t machine_on)
+{
+    // Kept up to date in all modes, such that switching to LAST_STATE later on
+    // does not act on a stale value.
+    write_u8(NVS_KEY_LAST, machine_on ? 1 : 0);
+}
+
+int power_initial_state(int fpga_running)
+{
+    if (fpga_running) {
+        ESP_LOGI(TAG, "Application FPGA is already loaded; leaving the machine on.");
+        return 1;
+    }
+
+    uint8_t mode = power_get_mode();
+    int machine_on;
+
+    switch(mode) {
+        case POWERON_MODE_ON:
+            machine_on = 1;
+            break;
+        case POWERON_MODE_LAST_STATE:
+            machine_on = (int)power_get_last_state();
+            break;
+        default:
+            machine_on = 0;
+            break;
+    }
+    ESP_LOGI(TAG, "Cold start with mode %s; machine comes up %s.", power_mode_name(mode),
+             machine_on ? "ON" : "OFF");
+    return machine_on;
+}

--- a/software/u64ctrl/main/power_state.c
+++ b/software/u64ctrl/main/power_state.c
@@ -104,6 +104,7 @@ int power_initial_state(int fpga_running)
 {
     if (fpga_running) {
         ESP_LOGI(TAG, "Application FPGA is already loaded; leaving the machine on.");
+        power_store_last_state(1);
         return 1;
     }
 
@@ -123,5 +124,9 @@ int power_initial_state(int fpga_running)
     }
     ESP_LOGI(TAG, "Cold start with mode %s; machine comes up %s.", power_mode_name(mode),
              machine_on ? "ON" : "OFF");
+    // The state the machine comes up in is a power transition like any other:
+    // record it, or a later switch to LAST_STATE acts on the state before this
+    // boot rather than on the state this boot established.
+    power_store_last_state((uint8_t)machine_on);
     return machine_on;
 }

--- a/software/u64ctrl/main/power_state.h
+++ b/software/u64ctrl/main/power_state.h
@@ -1,0 +1,43 @@
+/*
+ * power_state.h
+ *
+ * Determines what the machine does when the input power returns after it has
+ * been lost. The ESP32 is the only part of the machine that is powered before
+ * the user presses the power button, so the desired behavior is stored here,
+ * in the NVS of the ESP32.
+ */
+
+#ifndef SOFTWARE_U64CTRL_MAIN_POWER_STATE_H_
+#define SOFTWARE_U64CTRL_MAIN_POWER_STATE_H_
+
+#include <stdint.h>
+#include "esp_err.h"
+
+/* These values are also used as the enum values of the "Power On After Power
+   Loss" setting in the menu of the machine, so don't renumber them. */
+#define POWERON_MODE_OFF        0  // stay off, until the power button is pressed (default)
+#define POWERON_MODE_ON         1  // always power up
+#define POWERON_MODE_LAST_STATE 2  // power up if the machine was on when the power was lost
+#define POWERON_MODE_MAX        POWERON_MODE_LAST_STATE
+
+/* Human readable name of a mode, for logging. Never returns NULL. */
+const char *power_mode_name(uint8_t mode);
+
+/* The configured behavior; POWERON_MODE_OFF when nothing was stored yet. */
+uint8_t power_get_mode(void);
+
+/* Stores the behavior; ESP_ERR_INVALID_ARG for an unknown mode. */
+esp_err_t power_set_mode(uint8_t mode);
+
+/* Whether the machine was on the last time the power state was stored. */
+uint8_t power_get_last_state(void);
+
+/* Called on every power transition, to keep POWERON_MODE_LAST_STATE informed. */
+void power_store_last_state(uint8_t machine_on);
+
+/* The state the machine should come up in. When the application FPGA is
+   already loaded, this is not a cold start (only the ESP32 restarted), and the
+   machine is left on, regardless of the configured behavior. */
+int power_initial_state(int fpga_running);
+
+#endif /* SOFTWARE_U64CTRL_MAIN_POWER_STATE_H_ */

--- a/software/u64ctrl/main/rpc_calls.h
+++ b/software/u64ctrl/main/rpc_calls.h
@@ -85,6 +85,18 @@ typedef struct {
     char serial[16];
 } rpc_get_serial_resp;
 
+typedef struct {
+    rpc_header_t hdr;
+    uint8_t mode; // POWERON_MODE_* from power_state.h
+} rpc_set_power_mode_req;
+
+typedef struct {
+    rpc_header_t hdr;
+    int esp_err;
+    uint8_t mode;       // POWERON_MODE_* from power_state.h
+    uint8_t last_state; // 1 when the machine was on at the last power transition
+} rpc_get_power_mode_resp;
+
 /* 42 byte AP record */
 typedef struct {
     uint8_t bssid[6];            // MAC address of AP
@@ -180,6 +192,8 @@ typedef struct {
 #define CMD_MACHINE_REBOOT    0x13
 #define CMD_SET_SERIAL        0x14
 #define CMD_GET_SERIAL        0x15
+#define CMD_SET_POWER_MODE    0x16
+#define CMD_GET_POWER_MODE    0x17
 
 #define EVENT_CONNECTED     0x40
 #define EVENT_GOTIP         0x41

--- a/software/u64ctrl/main/rpc_dispatch.c
+++ b/software/u64ctrl/main/rpc_dispatch.c
@@ -11,6 +11,7 @@
 #include "esp_wifi.h"
 #include "esp_log.h"
 #include "nvs_flash.h"
+#include "power_state.h"
 #include "driver/uart.h"
 #include "rpc_calls.h"
 #include "rpc_dispatch.h"
@@ -307,6 +308,33 @@ void cmd_get_serial(command_buf_t *buf)
     my_uart_transmit_packet(UART_CHAN, buf);
 }
 
+void cmd_set_power_mode(command_buf_t *buf)
+{
+    rpc_set_power_mode_req *param = (rpc_set_power_mode_req *)buf->data;
+    rpc_espcmd_resp *resp = (rpc_espcmd_resp *)buf->data;
+
+    if (buf->size < (int)sizeof(rpc_set_power_mode_req)) {
+        resp->esp_err = ESP_ERR_INVALID_ARG;
+        buf->size = sizeof(rpc_espcmd_resp);
+        my_uart_transmit_packet(UART_CHAN, buf);
+        return;
+    }
+    uint8_t mode = param->mode; // read before the response overwrites the request
+    resp->esp_err = power_set_mode(mode);
+    buf->size = sizeof(rpc_espcmd_resp);
+    my_uart_transmit_packet(UART_CHAN, buf);
+}
+
+void cmd_get_power_mode(command_buf_t *buf)
+{
+    rpc_get_power_mode_resp *resp = (rpc_get_power_mode_resp *)buf->data;
+    resp->mode = power_get_mode();
+    resp->last_state = power_get_last_state();
+    resp->esp_err = ESP_OK;
+    buf->size = sizeof(rpc_get_power_mode_resp);
+    my_uart_transmit_packet(UART_CHAN, buf);
+}
+
 void cmd_not_implemented(command_buf_t *buf)
 {
     rpc_espcmd_resp *resp = (rpc_espcmd_resp *)buf->data;
@@ -427,6 +455,12 @@ void dispatch(void *ct)
             break;
         case CMD_GET_SERIAL:
             cmd_get_serial(pbuffer);
+            break;
+        case CMD_SET_POWER_MODE:
+            cmd_set_power_mode(pbuffer);
+            break;
+        case CMD_GET_POWER_MODE:
+            cmd_get_power_mode(pbuffer);
             break;
         default:
             cmd_not_implemented(pbuffer);

--- a/software/u64ctrl/main/rpc_dispatch.h
+++ b/software/u64ctrl/main/rpc_dispatch.h
@@ -26,13 +26,14 @@ void start_dispatch(QueueHandle_t queue);
 void send_button_event(uint8_t button);
 void send_keepalive();
 
-#define IDENT_STRING "ESP32 WiFi Bridge V1.12"
+#define IDENT_STRING "ESP32 WiFi Bridge V1.13"
 #define IDENT_MAJOR   1
+// 1.13: the module stores the power on behavior after a loss of input power.
 // 1.12: the connector retries after a dropped link instead of idling in
 // Disconnected forever. The Ultimate's updater only reflashes the module
 // when this differs from what the module reports, so a module change that
 // does not bump it is silently never installed.
-#define IDENT_MINOR   12
+#define IDENT_MINOR   13
 #define MULTITHREADED 0
 #define DISPATCHER_STACK 3072
 

--- a/target/pc/linux/powerstate/Makefile
+++ b/target/pc/linux/powerstate/Makefile
@@ -1,0 +1,39 @@
+#
+# Host build of the power on behavior of the control module, with the NVS
+# stubbed out. Runs anywhere gcc runs; no hardware and no ESP-IDF needed.
+#
+#   make          build
+#   make test     build and run
+#
+PRJ     = powerstate
+RESULT  = result
+OUTPUT  = output
+
+PATH_SW = ../../../../software
+
+VPATH   = $(PATH_SW)/u64ctrl/main $(PATH_SW)/test/stubs/esp $(PATH_SW)/test/power_state
+
+CC      = gcc
+COPTIONS = -std=c99 -g -O0 -Wall -Wextra -Wno-unused-parameter \
+           $(addprefix -I, $(VPATH))
+
+SRCS_C  = power_state.c nvs_stub.c power_state_test.c
+OBJS    = $(addprefix $(OUTPUT)/, $(SRCS_C:%.c=%.o))
+
+.PHONY: all test clean
+
+all: $(RESULT)/$(PRJ)
+
+$(OUTPUT)/%.o: %.c
+	@mkdir -p $(OUTPUT)
+	$(CC) $(COPTIONS) -c -o $@ $<
+
+$(RESULT)/$(PRJ): $(OBJS)
+	@mkdir -p $(RESULT)
+	$(CC) -o $@ $(OBJS)
+
+test: all
+	@$(RESULT)/$(PRJ)
+
+clean:
+	@rm -rf $(OUTPUT) $(RESULT)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -63,6 +63,7 @@ to drive it.
 | `io/` | `software/io/` | Device-facing I/O subsystems, nested by production package (`c64/`, `command_interface/`, `printer/`) |
 | `monitor/` | `software/monitor/` | Machine-code monitor behaviour |
 | `network/` | `software/network/` | Network service and connection lifecycle |
+| `u64ctrl/` | `software/u64ctrl/` | The ESP32 control module: what it does across a loss of input power |
 | `lib/` | - | Support code shared by E2E suites only: the UI backend (`ui_backend.py`), its menu primitives (`menu.py`), the UI-state gate (`ui_state.py`), the spool of every screen the harness read (`screens.py`), and the device-free check of the Telnet drain state machine (`telnet_drain_test.py`) |
 
 Assets and narrowly scoped helpers stay beside the suite that owns them.

--- a/tests/e2e/u64ctrl/machine_power.py
+++ b/tests/e2e/u64ctrl/machine_power.py
@@ -29,9 +29,17 @@ from report import Failure, detail
 # A cold start has to load the FPGA before the application answers anything.
 DEFAULT_UP_TIMEOUT = 90.0
 # How long a machine that is supposed to stay off has to stay silent for a
-# check to believe it. Sized above the boot time above, so that "still off"
-# cannot just mean "not up yet".
-DEFAULT_SILENCE_SECONDS = 30.0
+# check to believe it.
+#
+# It has to be at least the boot budget above, and for a reason worth stating:
+# the two are the same question asked twice. A machine that wrongly powers up
+# has to load the FPGA, boot the application and get on the network before
+# anything answers, and this suite already says that may take up to
+# DEFAULT_UP_TIMEOUT. A shorter silence window therefore proves nothing -- it
+# ends while a machine that did wrongly come up is still booting, and reads its
+# silence as "stayed off". This was 30s, which is a third of the budget the
+# positive checks give the very same boot.
+DEFAULT_SILENCE_SECONDS = DEFAULT_UP_TIMEOUT
 POLL_SECONDS = 2.0
 
 

--- a/tests/e2e/u64ctrl/machine_power.py
+++ b/tests/e2e/u64ctrl/machine_power.py
@@ -1,0 +1,134 @@
+"""Watching a machine go off and come back, and the hands that make it happen.
+
+Shared by the suites in this folder, all of which assert what the control module
+does with the machine's power. Two things they have in common:
+
+- While the machine is off, the Ultimate application is not running, and with
+  it neither the REST API nor the IP stack it serves. "Off" is therefore read
+  as silence, and silence has to be waited out rather than sampled: a machine
+  that is booting is silent too.
+- Getting a deliberately-off machine back needs something outside the network.
+  That is the operator, unless a power-button actuator is given, and either way
+  it is `PowerButton` that knows which.
+
+The waits here are their own rather than `tests/lib/wait.py`'s: these are
+measured in minutes, the negative ones have to keep polling to prove absence
+rather than stop at the first hit, and a timeout is a check's own failure text
+rather than an exception from the helper.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+from api import UltimateApi
+from report import Failure, detail
+
+# A cold start has to load the FPGA before the application answers anything.
+DEFAULT_UP_TIMEOUT = 90.0
+# How long a machine that is supposed to stay off has to stay silent for a
+# check to believe it. Sized above the boot time above, so that "still off"
+# cannot just mean "not up yet".
+DEFAULT_SILENCE_SECONDS = 30.0
+POLL_SECONDS = 2.0
+
+
+def alive(api: UltimateApi) -> bool:
+    """Whether the application answers. Nothing answers while the machine is off."""
+    try:
+        return bool(api.version())
+    except Exception:  # noqa: BLE001  (any transport failure means "not there")
+        return False
+
+
+def wait_for_state(api: UltimateApi, want_alive: bool, timeout: float) -> bool:
+    """Poll until the device reaches `want_alive`, or the timeout runs out.
+
+    Returns whether it got there. Polling rather than sleeping is what lets the
+    up cases finish as soon as the machine is back instead of always paying the
+    worst case.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if alive(api) == want_alive:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(POLL_SECONDS)
+
+
+def stays_off(api: UltimateApi, seconds: float) -> bool:
+    """Whether the device keeps quiet for the whole window.
+
+    The negative assertion cannot be made by a single probe: a machine that is
+    booting is also silent for a while. This one fails the moment it hears
+    anything, so it costs the full window only when the answer is the one the
+    check wants.
+    """
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if alive(api):
+            return False
+        time.sleep(POLL_SECONDS)
+    return True
+
+
+def switch_machine_off(api: UltimateApi, up_timeout: float) -> None:
+    """Put the machine in the off state a scenario needs it to be in."""
+    api.machine.poweroff()
+    if not wait_for_state(api, False, up_timeout):
+        raise Failure("the machine still answered after machine:poweroff")
+
+
+def run_command(cmd: str, what: str) -> None:
+    """Run one of the caller's shell commands, failing the check if it does."""
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Failure(f"{what} command failed with {result.returncode}: "
+                      f"{(result.stderr or result.stdout).strip()[:200]}")
+
+
+def ask(instruction: str) -> None:
+    """Ask the operator to do something the harness cannot do itself."""
+    print(f"      >>> {instruction}, then press Enter: ", end="", flush=True)
+    sys.stdin.readline()
+
+
+class PowerButton:
+    """The machine's power button: an actuator that can be driven, or a person.
+
+    A machine that is off cannot be switched on over the network -- that is the
+    whole point of the setting these suites cover -- so this is the only way
+    back from the scenarios that end with the machine off. Without an actuator
+    it is a person, and a person needs a terminal to be asked on: a run whose
+    stdin is at EOF would otherwise sail past the prompt and wait out a timeout
+    with nobody having touched the machine.
+    """
+
+    def __init__(self, press_cmd: str = "") -> None:
+        self.press_cmd = press_cmd
+        self.scripted = bool(press_cmd)
+        if not self.scripted and not sys.stdin.isatty():
+            raise Failure(
+                "no terminal to prompt on and no power-button actuator given.\n"
+                "Two of these scenarios end with the machine deliberately off, "
+                "and only its power button can revive it. Pass "
+                "--power-button-cmd to drive an actuator, or run this from a "
+                "terminal.")
+
+    def press(self, api: UltimateApi, up_timeout: float) -> None:
+        """Get a deliberately-off machine running again, for what comes next.
+
+        Leaving the machine off would fail the next check and then the runner's
+        own teardown, which resets the machine after every suite.
+        """
+        if self.scripted:
+            run_command(self.press_cmd, "power button")
+            detail("power button pressed by the actuator")
+        else:
+            ask("press the machine's power button to switch it back on")
+        if not wait_for_state(api, True, up_timeout):
+            raise Failure("the machine did not come back after the power button; "
+                          "the rest of the suite cannot run")

--- a/tests/e2e/u64ctrl/power_cycle_test.py
+++ b/tests/e2e/u64ctrl/power_cycle_test.py
@@ -53,7 +53,7 @@ from api import UltimateApi
 from machine_power import (DEFAULT_SILENCE_SECONDS, DEFAULT_UP_TIMEOUT,
                            PowerButton, alive, ask, run_command, stays_off,
                            switch_machine_off, wait_for_state)
-from report import (Failure, check, check_skip, check_start, detail,
+from report import (Failure, check, check_ok, check_skip, check_start, detail,
                     format_exception, section, suite_fail, suite_ok)
 
 SUITE = "power_cycle_test"
@@ -165,7 +165,12 @@ def main() -> int:
             check_skip(f"nothing answers on {args.host}; switch the machine on first")
             suite_ok(SUITE)
             return 0
-        detail(f"firmware {api.version()}")
+        # api.version() is the REST API's version, not the machine's, and
+        # saying "firmware 0.1" of a device running 1.1.0 is worse than saying
+        # nothing. The firmware and the product come from /v1/info.
+        info = api.info()
+        detail(f"{info.product}, firmware {info.firmware_version} "
+               f"(REST API {api.version()})")
         store = find_store(api)
         if not store:
             check_skip(f"no config store serves {ITEM!r}; "
@@ -174,6 +179,11 @@ def main() -> int:
             return 0
         original = api.configs.current(store, ITEM)
         detail(f"store {store!r}, currently {original!r}")
+        # Closes the check the two skips above would have closed. Leaving it
+        # open makes report.py treat every check that follows as nested inside
+        # it, which prints no verdict, counts nothing, and holds back the
+        # details above -- a whole run reported as one check.
+        check_ok()
         # After the skips and before anything destructive: a run that cannot be
         # completed says so now rather than after the first mains cut, and a run
         # that was going to skip anyway is not asked for hands it never needs.

--- a/tests/e2e/u64ctrl/power_cycle_test.py
+++ b/tests/e2e/u64ctrl/power_cycle_test.py
@@ -5,6 +5,13 @@ Supported target: a C64 Ultimate carrying the "Power On After Power Loss"
 setting. The suite skips, rather than fails, on firmware that does not serve
 the item, so it is safe to name on an older build.
 
+What it cannot detect is the other half of the pair: an application that has
+the setting on top of a control module too old to store it. The menu greys the
+item out in that case, but `cfg->disable()` is a menu affordance only -- the
+REST store still serves it -- so the suite finds the item, runs, and fails
+every scenario. A run that fails all four with the machine ignoring the mode
+should have the module's version checked before the firmware is suspected.
+
 The setting lives in the control module's NVS, because the module is the only
 part of the machine powered before the power button is pressed. Asserting it
 therefore means actually removing mains from the machine: the whole point is

--- a/tests/e2e/u64ctrl/power_cycle_test.py
+++ b/tests/e2e/u64ctrl/power_cycle_test.py
@@ -159,11 +159,6 @@ def main() -> int:
     original = ""
     store = ""
     try:
-        # Both are checked before the first scenario, so a run that cannot be
-        # completed says so now rather than after the first mains cut.
-        mains = Mains(args.power_off_cmd, args.power_on_cmd, args.off_seconds)
-        button = PowerButton(args.power_button_cmd)
-
         section("1. Preconditions")
         check_start("the machine answers")
         if not alive(api):
@@ -179,6 +174,11 @@ def main() -> int:
             return 0
         original = api.configs.current(store, ITEM)
         detail(f"store {store!r}, currently {original!r}")
+        # After the skips and before anything destructive: a run that cannot be
+        # completed says so now rather than after the first mains cut, and a run
+        # that was going to skip anyway is not asked for hands it never needs.
+        mains = Mains(args.power_off_cmd, args.power_on_cmd, args.off_seconds)
+        button = PowerButton(args.power_button_cmd)
 
         # Every check below waits out a real mains interruption, so all of them
         # are past the ten second mark that report.py paints yellow. That time

--- a/tests/e2e/u64ctrl/power_cycle_test.py
+++ b/tests/e2e/u64ctrl/power_cycle_test.py
@@ -16,17 +16,20 @@ cannot be recovered by software. While the machine is off the Ultimate
 application is not running, and with it neither the REST API nor the IP stack
 it serves -- the control module only bridges Ethernet frames, it does not
 listen on anything itself. So a machine that correctly stays off can only be
-revived by the power button, and the suite asks the operator to press it. This
-is why the suite is registered `manual`, and why adapter support cannot make
-it unattended.
+revived by its power button. This is why the suite is registered `manual`.
 
-Switching the mains is asked of the operator by default, which needs no
-hardware beyond whatever socket the tester already owns. Give
---power-off-cmd/--power-on-cmd to drive a socket that can be scripted; the
-outcome is still read from the device either way, never from the operator's
-say-so. Some command lines that work, for a reader who would rather not
-research their own -- untested here beyond the shape, so treat them as
-starting points:
+Two separate pairs of hands are therefore needed, and a scripted socket
+supplies only one of them:
+
+    the mains   --power-off-cmd / --power-on-cmd, or the operator
+    the button  --power-button-cmd, or the operator
+
+Give all three and the suite runs unattended; give the socket commands alone
+and it still stops at the button, so it still needs a terminal to ask on. The
+outcome is read from the device in every case, never from the operator's
+say-so. Some command lines that work for the socket, for a reader who would
+rather not research their own -- untested here beyond the shape, so treat them
+as starting points:
 
     Zigbee2MQTT  mosquitto_pub -t zigbee2mqtt/c64u/set -m '{"state":"OFF"}'
     Tasmota      curl -s -o /dev/null 'http://PLUG/cm?cmnd=Power%20Off'
@@ -39,14 +42,17 @@ Run it by hand, or with --manual, when the power-on behaviour is changed:
 
 import argparse
 import os
-import subprocess
 import sys
 import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from api import UltimateApi
+from machine_power import (DEFAULT_SILENCE_SECONDS, DEFAULT_UP_TIMEOUT,
+                           PowerButton, alive, ask, run_command, stays_off,
+                           switch_machine_off, wait_for_state)
 from report import (Failure, check, check_skip, check_start, detail,
                     format_exception, section, suite_fail, suite_ok)
 
@@ -62,53 +68,6 @@ MODE_LAST = "Last State"
 # was, which reads exactly like the setting being ignored. Ten seconds was
 # enough on the machine this was written against; fifteen is comfortable.
 DEFAULT_OFF_SECONDS = 15.0
-# A cold start has to load the FPGA before the application answers anything.
-DEFAULT_UP_TIMEOUT = 90.0
-# How long a machine that is supposed to stay off has to stay silent for the
-# check to believe it. Sized above the boot time above, so that "still off"
-# cannot just mean "not up yet".
-DEFAULT_SILENCE_SECONDS = 30.0
-POLL_SECONDS = 2.0
-
-
-def alive(api: UltimateApi) -> bool:
-    """Whether the application answers. Nothing answers while the machine is off."""
-    try:
-        return bool(api.version())
-    except Exception:  # noqa: BLE001  (any transport failure means "not there")
-        return False
-
-
-def wait_for(api: UltimateApi, want_alive: bool, timeout: float) -> bool:
-    """Poll until the device reaches `want_alive`, or the timeout runs out.
-
-    Returns whether it got there. Polling rather than sleeping is what lets the
-    up cases finish as soon as the machine is back instead of always paying the
-    worst case.
-    """
-    deadline = time.monotonic() + timeout
-    while True:
-        if alive(api) == want_alive:
-            return True
-        if time.monotonic() >= deadline:
-            return False
-        time.sleep(POLL_SECONDS)
-
-
-def stays_off(api: UltimateApi, seconds: float) -> bool:
-    """Whether the device keeps quiet for the whole window.
-
-    The negative assertion cannot be made by a single probe: a machine that is
-    booting is also silent for a while. This one fails the moment it hears
-    anything, so it costs the full window only when the answer is the one the
-    check wants.
-    """
-    deadline = time.monotonic() + seconds
-    while time.monotonic() < deadline:
-        if alive(api):
-            return False
-        time.sleep(POLL_SECONDS)
-    return True
 
 
 class Mains:
@@ -125,43 +84,20 @@ class Mains:
         if not self.scripted and not sys.stdin.isatty():
             raise Failure(
                 "no terminal to prompt on and no socket commands given.\n"
-                "Pass --power-off-cmd and --power-on-cmd to run this without "
-                "an operator, or run it from a terminal.")
-
-    def _run(self, cmd: str, what: str) -> None:
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-        if result.returncode != 0:
-            raise Failure(f"{what} command failed with {result.returncode}: "
-                          f"{(result.stderr or result.stdout).strip()[:200]}")
-
-    def _ask(self, instruction: str) -> None:
-        print(f"      >>> {instruction}, then press Enter: ", end="", flush=True)
-        sys.stdin.readline()
+                "Pass --power-off-cmd and --power-on-cmd to switch the mains "
+                "without an operator, or run this from a terminal.")
 
     def cycle(self) -> None:
         """Remove mains, hold it off long enough to matter, put it back."""
         if self.scripted:
-            self._run(self.off_cmd, "power off")
+            run_command(self.off_cmd, "power off")
             detail(f"mains off for {self.off_seconds:.0f}s")
             time.sleep(self.off_seconds)
-            self._run(self.on_cmd, "power on")
+            run_command(self.on_cmd, "power on")
         else:
-            self._ask(f"switch the socket OFF and leave it off for "
-                      f"{self.off_seconds:.0f}s")
-            self._ask("switch the socket back ON")
-
-    def revive(self, api: UltimateApi, up_timeout: float) -> None:
-        """Get a deliberately-off machine running again, for what comes next.
-
-        Only the power button can do this, so it is always the operator's job,
-        even when the socket itself is scripted. Leaving the machine off would
-        fail the next check and then the runner's own teardown, which resets
-        the machine after every suite.
-        """
-        self._ask("press the machine's power button to switch it back on")
-        if not wait_for(api, True, up_timeout):
-            raise Failure("the machine did not come back after the power button; "
-                          "the rest of the suite cannot run")
+            ask(f"switch the socket OFF and leave it off for "
+                f"{self.off_seconds:.0f}s")
+            ask("switch the socket back ON")
 
 
 def find_store(api: UltimateApi) -> str:
@@ -190,13 +126,6 @@ def set_mode(api: UltimateApi, store: str, mode: str) -> None:
     detail(f"mode is {mode!r}")
 
 
-def switch_machine_off(api: UltimateApi, up_timeout: float) -> None:
-    """Put the machine in the off state the next scenario needs it to be in."""
-    api.machine.poweroff()
-    if not wait_for(api, False, up_timeout):
-        raise Failure("the machine still answered after machine:poweroff")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -209,6 +138,12 @@ def main() -> int:
                              "Without it the operator is asked to switch the socket.")
     parser.add_argument("--power-on-cmd", default="",
                         help="Shell command that puts mains back.")
+    parser.add_argument("--power-button-cmd", default="",
+                        help="Shell command that presses the machine's power "
+                             "button. Without it the operator is asked, which "
+                             "needs a terminal: two scenarios end with the "
+                             "machine off and nothing on the network can "
+                             "revive it.")
     parser.add_argument("--off-seconds", type=float, default=DEFAULT_OFF_SECONDS,
                         help=f"How long mains stays off (default: {DEFAULT_OFF_SECONDS:.0f}). "
                              "Below about ten the control module keeps running "
@@ -224,7 +159,10 @@ def main() -> int:
     original = ""
     store = ""
     try:
+        # Both are checked before the first scenario, so a run that cannot be
+        # completed says so now rather than after the first mains cut.
         mains = Mains(args.power_off_cmd, args.power_on_cmd, args.off_seconds)
+        button = PowerButton(args.power_button_cmd)
 
         section("1. Preconditions")
         check_start("the machine answers")
@@ -250,14 +188,14 @@ def main() -> int:
             set_mode(api, store, MODE_ON)
             switch_machine_off(api, args.up_timeout)
             mains.cycle()
-            if not wait_for(api, True, args.up_timeout):
+            if not wait_for_state(api, True, args.up_timeout):
                 raise Failure(f"stayed off with the mode at {MODE_ON!r}")
 
         section("3. Mode Last State, machine on before the cut")
         with check("comes up by itself"):
             set_mode(api, store, MODE_LAST)
             mains.cycle()
-            if not wait_for(api, True, args.up_timeout):
+            if not wait_for_state(api, True, args.up_timeout):
                 raise Failure("stayed off although it was on when power was lost")
 
         # The two negative scenarios go last, because each one ends with a
@@ -269,7 +207,7 @@ def main() -> int:
             mains.cycle()
             if not stays_off(api, args.silence_seconds):
                 raise Failure("came up although it was off when power was lost")
-        mains.revive(api, args.up_timeout)
+        button.press(api, args.up_timeout)
 
         section("5. Mode Off, machine on before the cut")
         with check("stays off"):
@@ -277,7 +215,7 @@ def main() -> int:
             mains.cycle()
             if not stays_off(api, args.silence_seconds):
                 raise Failure(f"came up with the mode at {MODE_OFF!r}")
-        mains.revive(api, args.up_timeout)
+        button.press(api, args.up_timeout)
 
         suite_ok(SUITE)
         return 0

--- a/tests/e2e/u64ctrl/power_cycle_test.py
+++ b/tests/e2e/u64ctrl/power_cycle_test.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""E2E: what the machine does when its input power comes back.
+
+Supported target: a C64 Ultimate carrying the "Power On After Power Loss"
+setting. The suite skips, rather than fails, on firmware that does not serve
+the item, so it is safe to name on an older build.
+
+The setting lives in the control module's NVS, because the module is the only
+part of the machine powered before the power button is pressed. Asserting it
+therefore means actually removing mains from the machine: the whole point is
+what happens when the module cold starts, and nothing reachable over the
+network can bring that about.
+
+Two of the four scenarios end with the machine deliberately off, and those
+cannot be recovered by software. While the machine is off the Ultimate
+application is not running, and with it neither the REST API nor the IP stack
+it serves -- the control module only bridges Ethernet frames, it does not
+listen on anything itself. So a machine that correctly stays off can only be
+revived by the power button, and the suite asks the operator to press it. This
+is why the suite is registered `manual`, and why adapter support cannot make
+it unattended.
+
+Switching the mains is asked of the operator by default, which needs no
+hardware beyond whatever socket the tester already owns. Give
+--power-off-cmd/--power-on-cmd to drive a socket that can be scripted; the
+outcome is still read from the device either way, never from the operator's
+say-so. Some command lines that work, for a reader who would rather not
+research their own -- untested here beyond the shape, so treat them as
+starting points:
+
+    Zigbee2MQTT  mosquitto_pub -t zigbee2mqtt/c64u/set -m '{"state":"OFF"}'
+    Tasmota      curl -s -o /dev/null 'http://PLUG/cm?cmnd=Power%20Off'
+    Shelly       curl -s -o /dev/null 'http://PLUG/relay/0?turn=off'
+
+Run it by hand, or with --manual, when the power-on behaviour is changed:
+
+    ./run-tests --suite power-cycle --manual c64u
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+
+from api import UltimateApi
+from report import (Failure, check, check_skip, check_start, detail,
+                    format_exception, section, suite_fail, suite_ok)
+
+SUITE = "power_cycle_test"
+
+ITEM = "Power On After Power Loss"
+MODE_OFF = "Off"
+MODE_ON = "On"
+MODE_LAST = "Last State"
+
+# Long enough for the control module to lose power. A brief dip leaves the
+# ESP32 running, so nothing cold starts and the machine simply stays as it
+# was, which reads exactly like the setting being ignored. Ten seconds was
+# enough on the machine this was written against; fifteen is comfortable.
+DEFAULT_OFF_SECONDS = 15.0
+# A cold start has to load the FPGA before the application answers anything.
+DEFAULT_UP_TIMEOUT = 90.0
+# How long a machine that is supposed to stay off has to stay silent for the
+# check to believe it. Sized above the boot time above, so that "still off"
+# cannot just mean "not up yet".
+DEFAULT_SILENCE_SECONDS = 30.0
+POLL_SECONDS = 2.0
+
+
+def alive(api: UltimateApi) -> bool:
+    """Whether the application answers. Nothing answers while the machine is off."""
+    try:
+        return bool(api.version())
+    except Exception:  # noqa: BLE001  (any transport failure means "not there")
+        return False
+
+
+def wait_for(api: UltimateApi, want_alive: bool, timeout: float) -> bool:
+    """Poll until the device reaches `want_alive`, or the timeout runs out.
+
+    Returns whether it got there. Polling rather than sleeping is what lets the
+    up cases finish as soon as the machine is back instead of always paying the
+    worst case.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if alive(api) == want_alive:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(POLL_SECONDS)
+
+
+def stays_off(api: UltimateApi, seconds: float) -> bool:
+    """Whether the device keeps quiet for the whole window.
+
+    The negative assertion cannot be made by a single probe: a machine that is
+    booting is also silent for a while. This one fails the moment it hears
+    anything, so it costs the full window only when the answer is the one the
+    check wants.
+    """
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if alive(api):
+            return False
+        time.sleep(POLL_SECONDS)
+    return True
+
+
+class Mains:
+    """The socket the machine is plugged into, scripted or switched by hand."""
+
+    def __init__(self, off_cmd: str, on_cmd: str, off_seconds: float) -> None:
+        self.off_cmd = off_cmd
+        self.on_cmd = on_cmd
+        self.off_seconds = off_seconds
+        self.scripted = bool(off_cmd and on_cmd)
+        if bool(off_cmd) != bool(on_cmd):
+            raise Failure("--power-off-cmd and --power-on-cmd go together; "
+                          "give both or neither")
+        if not self.scripted and not sys.stdin.isatty():
+            raise Failure(
+                "no terminal to prompt on and no socket commands given.\n"
+                "Pass --power-off-cmd and --power-on-cmd to run this without "
+                "an operator, or run it from a terminal.")
+
+    def _run(self, cmd: str, what: str) -> None:
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise Failure(f"{what} command failed with {result.returncode}: "
+                          f"{(result.stderr or result.stdout).strip()[:200]}")
+
+    def _ask(self, instruction: str) -> None:
+        print(f"      >>> {instruction}, then press Enter: ", end="", flush=True)
+        sys.stdin.readline()
+
+    def cycle(self) -> None:
+        """Remove mains, hold it off long enough to matter, put it back."""
+        if self.scripted:
+            self._run(self.off_cmd, "power off")
+            detail(f"mains off for {self.off_seconds:.0f}s")
+            time.sleep(self.off_seconds)
+            self._run(self.on_cmd, "power on")
+        else:
+            self._ask(f"switch the socket OFF and leave it off for "
+                      f"{self.off_seconds:.0f}s")
+            self._ask("switch the socket back ON")
+
+    def revive(self, api: UltimateApi, up_timeout: float) -> None:
+        """Get a deliberately-off machine running again, for what comes next.
+
+        Only the power button can do this, so it is always the operator's job,
+        even when the socket itself is scripted. Leaving the machine off would
+        fail the next check and then the runner's own teardown, which resets
+        the machine after every suite.
+        """
+        self._ask("press the machine's power button to switch it back on")
+        if not wait_for(api, True, up_timeout):
+            raise Failure("the machine did not come back after the power button; "
+                          "the rest of the suite cannot run")
+
+
+def find_store(api: UltimateApi) -> str:
+    """The config store serving the setting, or "" when this firmware has none.
+
+    The store is looked up rather than named because it answers to "U64
+    Specific Settings" on an Ultimate 64 and to "C64U Specific Settings" on a
+    Commodore machine, and because its absence is exactly how firmware without
+    the feature presents itself.
+    """
+    names = api.configs.categories().get("categories")
+    if not isinstance(names, list):
+        raise Failure(f"configs: no category list in the answer: {names!r}")
+    for category in names:
+        if isinstance(category, str) and ITEM in api.configs.category(category):
+            return category
+    return ""
+
+
+def set_mode(api: UltimateApi, store: str, mode: str) -> None:
+    """Set the mode and read it back, so a silent refusal is not mistaken for a pass."""
+    api.configs.set(store, ITEM, mode)
+    current = api.configs.current(store, ITEM)
+    if current != mode:
+        raise Failure(f"setting the mode to {mode!r} left it at {current!r}")
+    detail(f"mode is {mode!r}")
+
+
+def switch_machine_off(api: UltimateApi, up_timeout: float) -> None:
+    """Put the machine in the off state the next scenario needs it to be in."""
+    api.machine.poweroff()
+    if not wait_for(api, False, up_timeout):
+        raise Failure("the machine still answered after machine:poweroff")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "c64u"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "5.0")))
+    parser.add_argument("--power-off-cmd", default="",
+                        help="Shell command that removes mains from the machine. "
+                             "Without it the operator is asked to switch the socket.")
+    parser.add_argument("--power-on-cmd", default="",
+                        help="Shell command that puts mains back.")
+    parser.add_argument("--off-seconds", type=float, default=DEFAULT_OFF_SECONDS,
+                        help=f"How long mains stays off (default: {DEFAULT_OFF_SECONDS:.0f}). "
+                             "Below about ten the control module keeps running "
+                             "and nothing cold starts.")
+    parser.add_argument("--up-timeout", type=float, default=DEFAULT_UP_TIMEOUT,
+                        help=f"How long a cold start may take (default: {DEFAULT_UP_TIMEOUT:.0f}).")
+    parser.add_argument("--silence-seconds", type=float, default=DEFAULT_SILENCE_SECONDS,
+                        help="How long a machine that should stay off must stay "
+                             f"silent (default: {DEFAULT_SILENCE_SECONDS:.0f}).")
+    args = parser.parse_args()
+
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    original = ""
+    store = ""
+    try:
+        mains = Mains(args.power_off_cmd, args.power_on_cmd, args.off_seconds)
+
+        section("1. Preconditions")
+        check_start("the machine answers")
+        if not alive(api):
+            check_skip(f"nothing answers on {args.host}; switch the machine on first")
+            suite_ok(SUITE)
+            return 0
+        detail(f"firmware {api.version()}")
+        store = find_store(api)
+        if not store:
+            check_skip(f"no config store serves {ITEM!r}; "
+                       "this firmware predates the setting")
+            suite_ok(SUITE)
+            return 0
+        original = api.configs.current(store, ITEM)
+        detail(f"store {store!r}, currently {original!r}")
+
+        # Every check below waits out a real mains interruption, so all of them
+        # are past the ten second mark that report.py paints yellow. That time
+        # is the behaviour under test and cannot be polled away.
+        section("2. Mode On, machine switched off before the cut")
+        with check("comes up by itself"):
+            set_mode(api, store, MODE_ON)
+            switch_machine_off(api, args.up_timeout)
+            mains.cycle()
+            if not wait_for(api, True, args.up_timeout):
+                raise Failure(f"stayed off with the mode at {MODE_ON!r}")
+
+        section("3. Mode Last State, machine on before the cut")
+        with check("comes up by itself"):
+            set_mode(api, store, MODE_LAST)
+            mains.cycle()
+            if not wait_for(api, True, args.up_timeout):
+                raise Failure("stayed off although it was on when power was lost")
+
+        # The two negative scenarios go last, because each one ends with a
+        # machine only the operator can revive.
+        section("4. Mode Last State, machine switched off before the cut")
+        with check("stays off"):
+            set_mode(api, store, MODE_LAST)
+            switch_machine_off(api, args.up_timeout)
+            mains.cycle()
+            if not stays_off(api, args.silence_seconds):
+                raise Failure("came up although it was off when power was lost")
+        mains.revive(api, args.up_timeout)
+
+        section("5. Mode Off, machine on before the cut")
+        with check("stays off"):
+            set_mode(api, store, MODE_OFF)
+            mains.cycle()
+            if not stays_off(api, args.silence_seconds):
+                raise Failure(f"came up with the mode at {MODE_OFF!r}")
+        mains.revive(api, args.up_timeout)
+
+        suite_ok(SUITE)
+        return 0
+    except Failure as exc:
+        suite_fail(SUITE, str(exc))
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        suite_fail(SUITE, format_exception(exc))
+        return 1
+    finally:
+        # Put the setting back if it was read and the machine is there to take
+        # it. A machine left off cannot be written to, and saying so is better
+        # than a traceback out of the cleanup path.
+        if store and original:
+            try:
+                api.configs.set(store, ITEM, original)
+            except Exception:  # noqa: BLE001
+                detail(f"could not restore {ITEM!r} to {original!r}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the request from https://github.com/GideonZ/ultimate_releases/issues/64 — a choice of what the C64U does when the input power returns after it was lost.

_Disclosure: the code in this PR, and the tests that go with it, were written using Claude Code. I directed the work, reviewed every change, and did the hardware testing on my own machine myself._

## Base

Rebased onto `test-merge` at your request; this PR now targets that branch. Eight
of the nine commits replayed untouched. The one conflict was `IDENT_MINOR`, which
`test-merge` had already taken to 12 — see below. `CFG_POWERON_MODE` and the two
new RPC command ids are free on this base as well.

Adversarial review, as asked for in the review below: Opus 5 at high reasoning
effort, briefed for minimal churn and changes consistent with the existing code
base. It produced one change, which is in the branch. `power_initial_state()`
already records the state a cold start establishes, and `button_handler.c`
recorded it a second time, with the same value, when its task started -- a
guaranteed no-op, since the write is skipped when the value has not changed, but
dead code either way. The duplicate is gone, so `button_handler.c` now carries
only the three button events and the lifetime fix from the first commit. It also
caught a claim of mine in the thread below that was wrong when I made it: I said
the recording had *moved* out of `button_handler.c`, when in fact it had been
added in both places. It has now.

Two further candidates did not survive checking and are deliberately left alone:
the `BUFARGS(identify, ...)` idiom for a command that takes no arguments, which
is what the other thirteen no-argument commands in `wifi_cmd.cc` already do, and
the file-scope `initial_power_state`, which predates this PR on both `master` and
`test-merge`.

## The problem

On a cold start the control module powers the machine up only when the application FPGA turns out to be loaded already, which is the case when just the ESP32 restarted. After a real power loss the FPGA is empty, so the machine stays off until someone presses the power button.

That makes the machine awkward behind a switched socket. I run some machines on ZigBee sockets and expect the servers on them to come up when I switch the socket on; walking over to press the power button defeats the purpose. A C64 with a 1541-Ultimate in it does come up in that situation.

## The change

A setting with three modes, the same three most equipment with a soft power button offers:

| Mode | Behavior after the input power returns |
| --- | --- |
| `Off` | Stay off until the power button is pressed. Default, and what the current firmware does. |
| `On` | Always power up. |
| `Last State` | Power up if the machine was on when the power was lost. |

It appears in the C64U menu as "Power On After Power Loss", in a new "Power Settings" group.

The control module is the only part of the machine that is powered before the power button is pressed, so the setting has to live in its NVS rather than in the configuration flash of the Ultimate. The menu therefore pushes the value down over the existing UART RPC link on every change, and reads it back once when the module reports its application, in case the module was updated in between. The last state is updated on every power transition in all three modes, so that switching to `Last State` later on does not act on a stale value, and it is only written when it actually changes, to spare the flash.

Detection of an already loaded FPGA still wins over the configured mode: if only the ESP32 restarted, the machine keeps running, exactly as before.

## The module version has to move with the module

`update_esp32()` in `update_u64ii.cc` writes the ESP32 only when the version the module reports differs from the `IDENT_MAJOR`/`IDENT_MINOR` the application was built with, and prints "No WiFi module update needed!" otherwise. A change to `software/u64ctrl` that leaves those defines alone therefore never reaches the machine.

I learned this the hard way: my first build of this branch installed the application but not the module, so the setting appeared in the menu, `CMD_SET_POWER_MODE` fell into `cmd_not_implemented`, nothing was ever stored, and the machine still stayed off after a power loss — with no indication that half the update had been skipped. `IDENT_MINOR` therefore goes to 13 in this branch — `test-merge` already ships 1.12, for the connector retry after a dropped link — and the resync now disables the menu item when the module answers "not implemented", so the same mismatch is visible instead of silent.

Both are worth a thought beyond this PR: nothing enforces the bump, and a skipped module update is otherwise indistinguishable from a successful one.

## Compatibility

The two new RPC commands are additive, so the halves can be flashed independently and in either order:

- Old control module, new application: `cmd_not_implemented` answers `ESP_ERR_NOT_SUPPORTED`, and the setting is disabled in the menu rather than silently doing nothing.
- New control module, old application: nothing ever sets a mode, so it stays at `Off`, which is today's behavior.

Rolling back to an earlier firmware is clean as well. `ConfigStore::unpack` skips configuration ids it does not know, so the new `0x5F` entry is ignored, and the `power` NVS namespace simply goes unread. An older application also carries an older `IDENT_MINOR`, so it flashes the module back on the way down.

The U64 (`U64 == 1`) and U2+L builds are untouched; everything new is behind `#if U64 == 2` or lives in `software/u64ctrl`.

## Points for your judgement

- **The default is `Off`**, which preserves current behavior. `Last State` would arguably be friendlier for anyone on a switched socket, but that changes behavior for existing machines, so I left the choice to you.
- **`CFG_POWERON_MODE` is `0x5F`.** In this store the ids stop at `0x54` and resume at `0xA8`, so it is free on either base. `0x55`–`0x5E` belong to the USB HID store (`io/usb/usb_hid_config.h`) and `0x56`–`0x63` to the audio selection store (`io/audio/audio_select.cc`) — both different stores, so there is no actual collision either way, but I kept them clear so the ids stay readable side by side. An earlier revision of this description attributed `0x55`–`0x5E` to the audio store alone; that was the wrong file, and the comment in the source is corrected with it. Say the word if you would rather it went elsewhere.
- **New NVS namespace `power`**, keys `mode` and `last`, rather than extending `board`.
- **New menu group** with one setting in it. Happy to fold it into "Machine Tweaks" instead if you prefer fewer pages.
- **The first commit is a drive-by fix** and is independent of the feature: `start_button_handler()` passed the address of its own parameter to `xTaskCreate()`, and the task dereferences that pointer when it is first scheduled, which may be after the function has returned. Drop that commit if you would rather handle it separately.

## Testing

`make esp32_u64ctrl && make u64ii` completes in the image from `docker/Dockerfile`, both halves, with no new warnings. The only warning in the touched files is the pre-existing unused `_err` in `cmd_send_eth_packet`. The mode decision logic was also compiled for the host with a stubbed NVS and exercised over: factory-fresh NVS, each of the three modes, `Last State` with the machine previously on and previously off, an out-of-range mode stored in NVS, a rejected out-of-range write, the already-loaded-FPGA override, and the write-only-on-change behavior.

Since I opened this PR I have run the branch on my own machine, and both modes do what they say: with `On`, and with `Last State` after the machine was on, cutting the input power and restoring it brings the machine back up; with `Last State` after the machine was off, it stays off. The missing module update described above was found there too, rather than deduced.

The cold start recording in `ac36e9de` is verified on hardware too, by the sequence it exists for: with `On` and the machine switched off, cut the mains and let it come up; then, without touching the power button, switch to `Last State` and cut the mains again. It comes up both times. Without that commit the second cut leaves the machine off, because the state it came up in was never recorded — which is what four of the host checks assert.

One note for anyone else testing this, which cost me an evening: the interruption has to be long enough for the control module to actually lose power. A brief dip leaves the ESP32 running, so nothing cold starts and nothing re-evaluates the setting — the machine simply stays as it was, which looks deceptively like `On` behaving as `Last State`. Ten seconds without mains was enough on my machine.

What I would still like a second pair of eyes on:

- The resync at `eWifi_AppDetected` relative to the construction of `U64Config`. It is skipped when the configurator does not exist yet, which is safe, but means that on such a boot the value is pushed only when the user next changes the setting.
- Whether the NVS write in `handle_button_event()` sits comfortably inside the power-down path in every case. It survived my testing, but I would not call the timing proven from one machine.
