### PR TITLE
Concurrent run of observability tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,40 +21,19 @@ jobs:
         run: echo "GIT_VERSION=$(git describe --tags --always)" >>$GITHUB_ENV
 
       # The harness that watches an E2E gate run, checked on every push. It
-      # needs no device and no network beyond loopback, so it has no ordering
-      # dependency on the FPGA/ESP32 dependency step below: run both
-      # containers at once and fail if either does. Each container's output
-      # is captured to its own file and printed as one contiguous block once
-      # both finish, so the log stays in step order instead of interleaving
-      # two containers' output line by line.
-      - name: Check Observability Harness & Determine FPGA/ESP32 dependencies
+      # needs no device and no network beyond loopback, and it runs before the
+      # firmware builds because it costs seconds and a broken report generator
+      # is better reported now than after an hour of building.
+      - name: Check Observability Harness
         run: |
           docker run --rm \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make observability_test" \
-          >observability.log 2>&1 &
-          observability_pid=$!
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make observability_test"
 
+      - name: Determine FPGA & ESP32 dependencies
+        run: |
           docker run --rm \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make fpga_depends && make esp_depends" \
-          >deps.log 2>&1 &
-          deps_pid=$!
-
-          status=0
-          wait "$observability_pid" || status=$?
-          wait "$deps_pid" || status=$?
-
-          echo "::group::Check Observability Harness"
-          cat observability.log
-          echo "::endgroup::"
-          rm -f observability.log
-
-          echo "::group::Determine FPGA & ESP32 dependencies"
-          cat deps.log
-          echo "::endgroup::"
-          rm -f deps.log
-
-          exit $status
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make fpga_depends && make esp_depends"
 
       - name: Cache U2 FPGA
         id: cache-u2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,19 +21,25 @@ jobs:
         run: echo "GIT_VERSION=$(git describe --tags --always)" >>$GITHUB_ENV
 
       # The harness that watches an E2E gate run, checked on every push. It
-      # needs no device and no network beyond loopback, and it runs before the
-      # firmware builds because it costs seconds and a broken report generator
-      # is better reported now than after an hour of building.
-      - name: Check Observability Harness
+      # needs no device and no network beyond loopback, so it has no ordering
+      # dependency on the firmware build below: run both containers at once
+      # and fail if either does. A broken report generator is still reported
+      # before an hour of building elapses, at no cost to the total run time.
+      - name: Check Observability Harness & Determine FPGA/ESP32 dependencies
         run: |
           docker run --rm \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make observability_test"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make observability_test" &
+          observability_pid=$!
 
-      - name: Determine FPGA & ESP32 dependencies
-        run: |
           docker run --rm \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make fpga_depends && make esp_depends"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make fpga_depends && make esp_depends" &
+          deps_pid=$!
+
+          status=0
+          wait "$observability_pid" || status=$?
+          wait "$deps_pid" || status=$?
+          exit $status
 
       - name: Cache U2 FPGA
         id: cache-u2
@@ -92,61 +98,61 @@ jobs:
         run: |
           docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make esp32"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) esp32"
 
       - if: steps.cache-u2.outputs.cache-hit != 'true'
         name: Build U2 including FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2_rv && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2_rv && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
 
       - if: steps.cache-u2.outputs.cache-hit == 'true'
         name: Build U2 using cached FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2_rv_swonly && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2_rv_swonly && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
 
       - if: steps.cache-u2p.outputs.cache-hit != 'true'
         name: Build U2+ including FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2plus && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2plus && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
 
       - if: steps.cache-u2p.outputs.cache-hit == 'true'
         name: Build U2+ using cached FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2plus_swonly && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2plus_swonly && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
 
       - if: steps.cache-u2pl.outputs.cache-hit != 'true'
         name: Build U2+L including FPGA
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2pl_no_esp && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2pl_no_esp && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
 
       - if: steps.cache-u2pl.outputs.cache-hit == 'true'
         name: Build U2+L using cached FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2pl_swonly && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2pl_swonly && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
 
       - name: Build U64 Software
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u64_no_esp && mv update.u64 update_${{ env.GIT_VERSION }}.u64"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u64_no_esp && mv update.u64 update_${{ env.GIT_VERSION }}.u64"
 
       - name: Build U64-II Software
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u64ii_no_esp && mv update.ue2 update_${{ env.GIT_VERSION }}.ue2 && mv update.cfw update_${{ env.GIT_VERSION }}.cfw"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u64ii_no_esp && mv update.ue2 update_${{ env.GIT_VERSION }}.ue2 && mv update.cfw update_${{ env.GIT_VERSION }}.cfw"
 
       - name: Check Firmware Application Space
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,23 +22,38 @@ jobs:
 
       # The harness that watches an E2E gate run, checked on every push. It
       # needs no device and no network beyond loopback, so it has no ordering
-      # dependency on the firmware build below: run both containers at once
-      # and fail if either does. A broken report generator is still reported
-      # before an hour of building elapses, at no cost to the total run time.
+      # dependency on the FPGA/ESP32 dependency step below: run both
+      # containers at once and fail if either does. Each container's output
+      # is captured to its own file and printed as one contiguous block once
+      # both finish, so the log stays in step order instead of interleaving
+      # two containers' output line by line.
       - name: Check Observability Harness & Determine FPGA/ESP32 dependencies
         run: |
           docker run --rm \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make observability_test" &
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make observability_test" \
+          >observability.log 2>&1 &
           observability_pid=$!
 
           docker run --rm \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make fpga_depends && make esp_depends" &
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make fpga_depends && make esp_depends" \
+          >deps.log 2>&1 &
           deps_pid=$!
 
           status=0
           wait "$observability_pid" || status=$?
           wait "$deps_pid" || status=$?
+
+          echo "::group::Check Observability Harness"
+          cat observability.log
+          echo "::endgroup::"
+          rm -f observability.log
+
+          echo "::group::Determine FPGA & ESP32 dependencies"
+          cat deps.log
+          echo "::endgroup::"
+          rm -f deps.log
+
           exit $status
 
       - name: Cache U2 FPGA
@@ -98,61 +113,61 @@ jobs:
         run: |
           docker run --rm --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) esp32"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make esp32"
 
       - if: steps.cache-u2.outputs.cache-hit != 'true'
         name: Build U2 including FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2_rv && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2_rv && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
 
       - if: steps.cache-u2.outputs.cache-hit == 'true'
         name: Build U2 using cached FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2_rv_swonly && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2_rv_swonly && mv update.u2r update_${{ env.GIT_VERSION }}.u2r"
 
       - if: steps.cache-u2p.outputs.cache-hit != 'true'
         name: Build U2+ including FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2plus && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2plus && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
 
       - if: steps.cache-u2p.outputs.cache-hit == 'true'
         name: Build U2+ using cached FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2plus_swonly && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2plus_swonly && mv update.u2p update_${{ env.GIT_VERSION }}.u2p"
 
       - if: steps.cache-u2pl.outputs.cache-hit != 'true'
         name: Build U2+L including FPGA
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2pl_no_esp && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2pl_no_esp && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
 
       - if: steps.cache-u2pl.outputs.cache-hit == 'true'
         name: Build U2+L using cached FPGAs
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u2pl_swonly && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u2pl_swonly && mv update.u2l update_${{ env.GIT_VERSION }}.u2l"
 
       - name: Build U64 Software
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u64_no_esp && mv update.u64 update_${{ env.GIT_VERSION }}.u64"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u64_no_esp && mv update.u64 update_${{ env.GIT_VERSION }}.u64"
 
       - name: Build U64-II Software
         run: |
           docker run --rm -e GITHUB_ACTIONS --net=custom_network --mac-address=4c:cc:6a:06:b3:79 \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -j\$(nproc) u64ii_no_esp && mv update.ue2 update_${{ env.GIT_VERSION }}.ue2 && mv update.cfw update_${{ env.GIT_VERSION }}.cfw"
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make u64ii_no_esp && mv update.ue2 update_${{ env.GIT_VERSION }}.ue2 && mv update.cfw update_${{ env.GIT_VERSION }}.cfw"
 
       - name: Check Firmware Application Space
         if: always()

--- a/tests/lib/observability_test.py
+++ b/tests/lib/observability_test.py
@@ -5644,6 +5644,34 @@ def the_spool_is_off_when_a_run_says_so() -> str:
     return "no spool"
 
 
+@case(3, "OBS-3.1")
+def the_documented_command_line_writes_the_document() -> str:
+    """The generator is run the way its documentation says to run it.
+
+    Every other case here imports the module, and an import defines every
+    function in the file whatever order they are written in. Running it as a
+    program does not: a name defined below the `__main__` guard does not exist
+    by the time the guard calls into it, and only a subprocess sees that.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+
+    require_fixture()
+    with tempfile.TemporaryDirectory() as workspace:
+        tree = os.path.join(workspace, "run")
+        shutil.copytree(FIXTURE, tree)
+        finished = subprocess.run(
+            [sys.executable, REPORT_TOOL, tree],
+            capture_output=True, text=True, timeout=120)
+    if finished.returncode != 0:
+        raise Failure(f"exit {finished.returncode}: "
+                      f"{finished.stderr.strip().splitlines()[-1:]}")
+    expect("the path it printed", finished.stdout.strip(),
+           os.path.join(tree, "index.md"))
+    return "written by the command in the documentation"
+
+
 # ---------------------------------------------------------------------------
 # Tier 4: the golden document, and the fixture behind it
 # ---------------------------------------------------------------------------
@@ -6492,34 +6520,6 @@ def a_report_is_generated_from_a_run_the_runner_just_wrote() -> str:
     if "127.0.0.1/overlay/broken/1/1" not in document:
         raise Failure("the failing check is not named by its identity key")
     return status
-
-
-@case(1, "OBS-3.1")
-def the_documented_command_line_writes_the_document() -> str:
-    """The generator is run the way its documentation says to run it.
-
-    Every other case here imports the module, and an import defines every
-    function in the file whatever order they are written in. Running it as a
-    program does not: a name defined below the `__main__` guard does not exist
-    by the time the guard calls into it, and only a subprocess sees that.
-    """
-    import shutil
-    import subprocess
-    import tempfile
-
-    require_fixture()
-    with tempfile.TemporaryDirectory() as workspace:
-        tree = os.path.join(workspace, "run")
-        shutil.copytree(FIXTURE, tree)
-        finished = subprocess.run(
-            [sys.executable, REPORT_TOOL, tree],
-            capture_output=True, text=True, timeout=120)
-    if finished.returncode != 0:
-        raise Failure(f"exit {finished.returncode}: "
-                      f"{finished.stderr.strip().splitlines()[-1:]}")
-    expect("the path it printed", finished.stdout.strip(),
-           os.path.join(tree, "index.md"))
-    return "written by the command in the documentation"
 
 
 # Requirements this suite deliberately does not name a test for, and why. A

--- a/tests/lib/observability_test.py
+++ b/tests/lib/observability_test.py
@@ -37,11 +37,13 @@ tests/lib/README.md says is not negotiable.
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import os
 import re
 import sys
 import tempfile
+import threading
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -76,6 +78,10 @@ FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
 EXPECTED = os.path.join(FIXTURES, "e2e-run.expected.md")
 FIXTURE: Optional[str] = None
 _FIXTURE_PROBLEM: Optional[str] = None
+# Guards building FIXTURE: several golden cases call require_fixture()
+# concurrently, and only the first should pay for the real scripted run that
+# builds it - the rest just wait and then read what it built.
+_FIXTURE_LOCK = threading.Lock()
 
 # The port overrides a case must not inherit from whoever ran it. Two cases
 # assert the built-in defaults, and a developer who has exported one of these
@@ -96,23 +102,37 @@ class Case:
     label: str
     requirements: Tuple[str, ...]
     run: Callable[[], object]
+    exclusive: bool = False
 
 
 CASES: List[Case] = []
 
 
-def case(tier: int, *requirements: str, label: str = ""):
+def case(tier: int, *requirements: str, label: str = "", exclusive: bool = False):
     """Register one case, naming the requirements it holds.
 
     The requirement numbers are on the case rather than only in a docstring so
     the registry check of OBS-16.7 can read them, and so a reviewer can read a
     list of requirement numbers with a test each instead of reading the
     specification against the code.
+
+    `exclusive=True` marks a case that must not run at the same time as any
+    other case's own reporting, or that touches state outside its own tempdir
+    in a way another case running at the same time could observe. That covers
+    a case that mutates process-global state directly (an os.environ entry,
+    a module-level path like interactions.LOG_PATH), one that calls report.py
+    itself - directly (report.detail(), for a coverage note) or by calling a
+    run-tests function in-process that does (report.warn(), for instance) -
+    instead of only returning its one-line summary, and one that edits a real
+    file this checkout tracks rather than one under tempfile.TemporaryDirectory.
+    Cases run concurrently by default; an exclusive one runs on the main
+    thread instead, in its normal place in registration order, so it is never
+    running at the same time as anything else that touches that same state.
     """
 
     def register(function: Callable[[], object]) -> Callable[[], object]:
         CASES.append(Case(tier, label or function.__name__.replace("_", " "),
-                          tuple(requirements), function))
+                          tuple(requirements), function, exclusive))
         return function
 
     return register
@@ -169,7 +189,7 @@ def without_port_overrides():
 # ---------------------------------------------------------------------------
 
 
-@case(1, "OBS-15.13", "OBS-8.14", "OBS-7.18")
+@case(1, "OBS-15.13", "OBS-8.14", "OBS-7.18", exclusive=True)
 def target_carries_every_port() -> str:
     """A parsed target answers where each of the device's surfaces is."""
     with without_port_overrides():
@@ -195,7 +215,7 @@ def target_carries_every_port() -> str:
     return "4 ports, and which machine is which"
 
 
-@case(1, "OBS-15.13", "OBS-15.14")
+@case(1, "OBS-15.13", "OBS-15.14", exclusive=True)
 def rest_port_environment_override() -> str:
     """U64_REST_PORT moves the REST port the way U64_TELNET_PORT moves Telnet."""
     with without_port_overrides():
@@ -207,7 +227,7 @@ def rest_port_environment_override() -> str:
     return "8080"
 
 
-@case(1, "OBS-15.14")
+@case(1, "OBS-15.14", exclusive=True)
 def rest_url_names_the_port_only_when_it_moved() -> str:
     """A URL against a real device reads exactly as it does with no port field."""
     import rest as rest_lib
@@ -313,7 +333,7 @@ def a_device_that_stops_answering_raises_rather_than_hangs() -> str:
     return "offline then back"
 
 
-@case(2, "OBS-1.1", "OBS-1.2", "OBS-16.6")
+@case(2, "OBS-1.1", "OBS-1.2", "OBS-16.6", exclusive=True)
 def an_unwritable_output_directory_does_not_end_the_run() -> str:
     """Where a run records itself is not part of what the run is testing.
 
@@ -527,7 +547,7 @@ def the_report_says_who_sent_the_lines_nobody_claimed() -> str:
     return "two senders, each with its count and its reason"
 
 
-@case(3, "OBS-16.6", "OBS-1.1")
+@case(3, "OBS-16.6", "OBS-1.1", exclusive=True)
 def a_scripted_run_does_not_inherit_the_gate_state() -> str:
     """This suite runs inside the gate, and a run of its own is not a child of it.
 
@@ -1363,7 +1383,7 @@ def runner_variables() -> "set":
 KEPT_VARIABLES: "set" = set()
 
 
-@case(1, "OBS-2.20")
+@case(1, "OBS-2.20", exclusive=True)
 def a_harness_edited_mid_run_is_reported() -> str:
     """A run whose own files change under it says so on its record.
 
@@ -1595,7 +1615,7 @@ def logged_interactions(path):
         return [json.loads(line) for line in handle if line.strip()]
 
 
-@case(1, "OBS-2.17")
+@case(1, "OBS-2.17", exclusive=True)
 def identical_interactions_collapse_and_bodies_are_kept_once() -> str:
     """An exhaustive log is only affordable if repetition costs nothing.
 
@@ -1638,7 +1658,7 @@ def identical_interactions_collapse_and_bodies_are_kept_once() -> str:
     return "34 interactions, 3 records, 1 body"
 
 
-@case(1, "OBS-2.17")
+@case(1, "OBS-2.17", exclusive=True)
 def a_short_answer_is_in_the_record_itself() -> str:
     """A reader should not have to open a file to see a 30-character error."""
     import interactions
@@ -1665,7 +1685,7 @@ def a_short_answer_is_in_the_record_itself() -> str:
     return "inline under the threshold, as text and as hex"
 
 
-@case(2, "OBS-2.17", "OBS-15.13")
+@case(2, "OBS-2.17", "OBS-15.13", exclusive=True)
 def every_transport_writes_to_the_interaction_log() -> str:
     """REST, Telnet and FTP all reach the log without a suite asking them to.
 
@@ -2045,7 +2065,7 @@ def a_frame_the_decoder_cannot_read_is_counted_rather_than_dropped() -> str:
     return "two refusals counted, one screen written"
 
 
-@case(1, "OBS-2.17")
+@case(1, "OBS-2.17", exclusive=True)
 def the_transcript_and_the_records_share_one_sequence() -> str:
     """One line a person reads, one record a program reads, one number joining.
 
@@ -2126,7 +2146,7 @@ def the_interaction_log_never_ends_a_run() -> str:
     return "an unwritable path and an undescribable object, both survived"
 
 
-@case(1, "OBS-7.7")
+@case(1, "OBS-7.7", exclusive=True)
 def a_device_pointed_at_another_port_is_named() -> str:
     """A run that will collect nothing says so before it collects nothing.
 
@@ -3043,7 +3063,7 @@ def the_screen_spool_is_not_a_suite() -> str:
     return "one suite, not two"
 
 
-@case(1, "OBS-7.5", "OBS-7.6")
+@case(1, "OBS-7.5", "OBS-7.6", exclusive=True)
 def a_second_interface_can_be_declared() -> str:
     """A device logs from whichever interface the route picked.
 
@@ -3584,7 +3604,7 @@ def the_band_shows_what_the_run_is_doing_and_counts_the_rest() -> str:
     return counters.strip()
 
 
-@case(1, "OBS-2.17", "OBS-8.40")
+@case(1, "OBS-2.17", "OBS-8.40", exclusive=True)
 def sent_and_received_are_byte_counts_on_every_transport() -> str:
     """One meaning per field name, across REST and Telnet.
 
@@ -5850,18 +5870,43 @@ def require_fixture() -> None:
         raise Failure(_FIXTURE_PROBLEM)
     if FIXTURE is not None:
         return
-    try:
-        made = build_fixture()
-        for _attempt in range(2):
-            if _fixture_is_well_formed(made):
-                break
+    with _FIXTURE_LOCK:
+        # Checked again with the lock held: another case may have built it, or
+        # learned it cannot be built, while this one was waiting for the lock.
+        if _FIXTURE_PROBLEM is not None:
+            raise Failure(_FIXTURE_PROBLEM)
+        if FIXTURE is not None:
+            return
+        try:
             made = build_fixture()
-        FIXTURE = made.directory
+            for _attempt in range(2):
+                if _fixture_is_well_formed(made):
+                    break
+                made = build_fixture()
+            FIXTURE = made.directory
+        except Failure:
+            raise
+        except Exception as error:  # noqa: BLE001
+            _FIXTURE_PROBLEM = f"the fixture could not be built: {error}"
+            raise Failure(_FIXTURE_PROBLEM) from error
+
+
+def prewarm_fixture() -> None:
+    """Build FIXTURE, if needed, before tier 4's cases run concurrently.
+
+    build_fixture() drives a real scripted run, so its own content - a retry
+    count among the things it can carry - depends on whatever else the
+    machine is doing while it runs. `require_fixture()`'s lock keeps two
+    golden cases from building it at once, but a case that already holds the
+    lock still has roughly twenty others doing their own real work beside it.
+    Called here instead, before that tier's pool exists, the build has the
+    same quiet machine a sequential run would have given the first case that
+    needed it.
+    """
+    try:
+        require_fixture()
     except Failure:
-        raise
-    except Exception as error:  # noqa: BLE001
-        _FIXTURE_PROBLEM = f"the fixture could not be built: {error}"
-        raise Failure(_FIXTURE_PROBLEM) from error
+        pass  # Each case that needs FIXTURE raises this again on its own line.
 
 
 def record_fixture() -> int:
@@ -6553,7 +6598,7 @@ def specified_requirements() -> "dict":
     return found
 
 
-@case(1, "OBS-16.7")
+@case(1, "OBS-16.7", exclusive=True)
 def every_requirement_with_logic_has_a_test() -> str:
     """Report which requirements no case names, and why, rather than failing.
 
@@ -7095,7 +7140,7 @@ def the_report_shows_the_device_log_around_a_failure() -> str:
     return "one slice, one restart"
 
 
-@case(4, "OBS-4.1", "OBS-1.7")
+@case(4, "OBS-4.1", "OBS-1.7", exclusive=True)
 def the_job_summary_is_a_copy_of_part_of_the_report() -> str:
     """The summary is the report's own bytes, plus at most the two lines.
 
@@ -7147,7 +7192,7 @@ def the_job_summary_is_a_copy_of_part_of_the_report() -> str:
     return f"{len(wanted.splitlines())} lines copied"
 
 
-@case(1, "OBS-4.1", "OBS-4.3")
+@case(1, "OBS-4.1", "OBS-4.3", exclusive=True)
 def the_job_summary_stays_inside_its_limits() -> str:
     """No marker copies the whole file; an oversized one truncates and says so."""
     import tempfile
@@ -7186,7 +7231,7 @@ def the_job_summary_stays_inside_its_limits() -> str:
     return f"{len(cut.encode()) // 1024} KiB after truncation"
 
 
-@case(1, "OBS-4.1")
+@case(1, "OBS-4.1", exclusive=True)
 def the_job_summary_step_does_nothing_outside_ci() -> str:
     """With no GITHUB_STEP_SUMMARY the step exits zero and writes nothing."""
     import tempfile
@@ -7284,6 +7329,71 @@ def run_case(entry: Case) -> str:
     return report.OK
 
 
+@dataclass
+class _Outcome:
+    """A non-exclusive case's result, computed on a worker thread."""
+    verdict: str
+    message: str
+    elapsed: float
+
+
+def _execute_case(entry: Case) -> _Outcome:
+    """Run a non-exclusive case's body on a worker thread and time it.
+
+    Never raises: a case must not end the suite. Calls nothing in report.py -
+    only an exclusive case does that (report.detail(), for a coverage note),
+    which is exactly why a case that does is marked exclusive and runs through
+    `run_case` instead, never through here.
+    """
+    started = time.monotonic()
+    try:
+        extra = entry.run() or ""
+    except Skipped as exc:
+        return _Outcome(report.SKIP, str(exc), time.monotonic() - started)
+    except Failure as exc:
+        return _Outcome(report.FAIL, str(exc), time.monotonic() - started)
+    except Exception as exc:  # noqa: BLE001 - a case must not end the suite
+        return _Outcome(report.FAIL,
+                        f"{type(exc).__name__}: {report.format_exception(exc)}",
+                        time.monotonic() - started)
+    return _Outcome(report.OK, str(extra), time.monotonic() - started)
+
+
+def _report_outcome(entry: Case, outcome: _Outcome) -> str:
+    """Print one non-exclusive case's already-computed outcome as its check line."""
+    report.check_start(entry.label)
+    if outcome.verdict == report.SKIP:
+        report.check_skip(outcome.message, elapsed=outcome.elapsed)
+    elif outcome.verdict == report.FAIL:
+        report.check_fail(outcome.message, elapsed=outcome.elapsed)
+    else:
+        report.check_ok(outcome.message, elapsed=outcome.elapsed)
+    return outcome.verdict
+
+
+def run_cases(cases: List[Case]) -> List[str]:
+    """Run a tier's cases, its non-exclusive ones concurrently, in registration order.
+
+    A non-exclusive case runs on a worker thread from a pool, all submitted up
+    front so they run concurrently; its result is reported here on the main
+    thread once its future resolves. An exclusive case runs the plain
+    sequential way instead, through `run_case`, right here in its normal place
+    in the order: check_start before its body runs and its verdict after,
+    exactly as when every case ran one at a time. That is what a case mutating
+    shared state (os.environ, a module-level path) needs to never overlap
+    another case touching the same state, and what the one case that calls
+    report.detail() itself needs for that call to queue under its own check
+    rather than print out of place - report.detail() only holds a line back
+    for the check it belongs to if that check's line is already open.
+    """
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        futures = [None if entry.exclusive else pool.submit(_execute_case, entry)
+                  for entry in cases]
+        return [run_case(entry) if future is None
+                else _report_outcome(entry, future.result())
+                for entry, future in zip(cases, futures)]
+
+
 def main(argv: List[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--tier", action="append", type=int, default=[],
@@ -7306,7 +7416,9 @@ def main(argv: List[str]) -> int:
         if not cases:
             continue
         report.section(f"tier {tier}: {title}")
-        verdicts += [run_case(entry) for entry in cases]
+        if tier == 4:
+            prewarm_fixture()
+        verdicts += run_cases(cases)
 
     failed = verdicts.count(report.FAIL)
     skipped = verdicts.count(report.SKIP)

--- a/tests/lib/report.py
+++ b/tests/lib/report.py
@@ -362,7 +362,7 @@ def step_start(label: str) -> None:
     print(f"{label} ... ", end="", flush=True)
 
 
-def _close(verdict: str, extra: str = "") -> None:
+def _close(verdict: str, extra: str = "", *, elapsed: Optional[float] = None) -> None:
     global _depth, _line_open
     _depth = max(0, _depth - 1)
     if _depth:
@@ -373,7 +373,13 @@ def _close(verdict: str, extra: str = "") -> None:
         # a skipped check was written as SKIP and then as OK.
         return
     _line_open = False
-    elapsed = time.monotonic() - _check_started
+    # A caller that measured its own check's duration (a case run on a worker
+    # thread, reported afterwards on the main thread once the future resolves)
+    # passes it explicitly, because time.monotonic() - _check_started would
+    # otherwise measure from this call's check_start rather than from when the
+    # work actually started.
+    if elapsed is None:
+        elapsed = time.monotonic() - _check_started
     parts = [extra] if extra else []
     duration = format_duration(elapsed)
     if elapsed >= SLOW_CHECK_SECONDS:
@@ -396,20 +402,20 @@ def _close(verdict: str, extra: str = "") -> None:
             scenario=_scenario["title"] if _scenario else None)
 
 
-def check_ok(extra: str = "") -> None:
-    _close(OK, extra)
+def check_ok(extra: str = "", *, elapsed: Optional[float] = None) -> None:
+    _close(OK, extra, elapsed=elapsed)
 
 
-def check_fail(reason: str = "") -> None:
-    _close(FAIL, reason)
+def check_fail(reason: str = "", *, elapsed: Optional[float] = None) -> None:
+    _close(FAIL, reason, elapsed=elapsed)
 
 
-def check_warn(reason: str = "") -> None:
-    _close(WARN, reason)
+def check_warn(reason: str = "", *, elapsed: Optional[float] = None) -> None:
+    _close(WARN, reason, elapsed=elapsed)
 
 
-def check_skip(reason: str = "") -> None:
-    _close(SKIP, reason)
+def check_skip(reason: str = "", *, elapsed: Optional[float] = None) -> None:
+    _close(SKIP, reason, elapsed=elapsed)
 
 
 @contextmanager


### PR DESCRIPTION
## What changed

`.github/workflows/build.yml` is unchanged - byte-identical to test-merge. The speedup is entirely in `tests/lib/observability_test.py` (plus a small additive change to `tests/lib/report.py`), the suite the workflow's "Check Observability Harness" step runs via `make observability_test`.

Each tier's cases now run on a worker pool (`concurrent.futures.ThreadPoolExecutor`) instead of one at a time. `report.py`'s own state (the check counter, the currently-open line) is written from the main thread only: a case's outcome and duration are computed on its worker thread, then reported on the main thread once that future resolves, in registration order - so the printed check numbers, their order and their content match a plain sequential run exactly, only the wall-clock time changes.

A case is marked `exclusive=True` - run synchronously, in its normal place in that order, never on the pool - when running it at the same time as another case's own reporting is not safe:
- it mutates process-global state another case also reads or writes (an `os.environ` entry, a module-level path like `interactions.LOG_PATH`)
- it calls `report.py` itself - directly (`report.detail()`, for a coverage note) or indirectly by calling a `run-tests` function in-process that does (`report.warn()`, for instance) - instead of only returning its one-line summary. This matters because `report.detail()` only holds a line back for its own check if that check's line is already open, which needs `check_start` called before the case body runs, not after - the first version of this change got that ordering backwards and printed detail lines under the wrong check.
- it edits a real file this checkout tracks (`report.py`, briefly, to prove a dirty harness is detected) rather than only a `tempfile.TemporaryDirectory()`

`report.py` gains an optional `elapsed=` override on `check_ok`/`check_fail`/`check_warn`/`check_skip`, used only when a case's real duration was measured on its own worker thread rather than by `check_start`'s own timer. Every existing caller across every other suite keeps computing elapsed the same way it always did - this is purely additive.

`FIXTURE`, the fixture tree several golden (tier 4) cases share, was an unguarded lazy singleton (`if FIXTURE is not None: return`, else build it). Concurrent tier 4 cases could double-build it, so `require_fixture()` now takes a lock around the build (standard double-checked lazy-init). Separately, building `FIXTURE` is itself a real scripted run whose content - a retry count among the things it can carry - depends on the machine being otherwise idle, so tier 4 now prewarms it once, before that tier's pool exists, in the same quiet window a sequential run would have given the first case that needed it.

## Verification

Measured with matched clean-tree conditions (a temporary worktree with each version committed, so `run-tests`' own dirty-harness detection - which this suite tests - can't skew the comparison): **5 baseline runs, 94-134s (avg 117s); 7 modified runs, 53-65s (avg 58s), a ~50% reduction.** Same 172 cases, same 2 skips every run - no coverage change.

Two failures surfaced during verification and were run down to ground:
1. A case that calls `report.detail()` printed its detail lines under the *previous* check instead of its own - fixed by keeping `check_start`-before-body for exclusive cases (see above), rather than the deferred-report model used for pool cases.
2. The unguarded `FIXTURE` singleton double-built under concurrent tier 4 access - fixed with the lock and the prewarm described above.

Two further failures turned out to be pre-existing flakes unrelated to this change, confirmed by reproducing each on the unmodified baseline in isolation (no thread pool involved): a real-time video encoding case (`the recorder writes what it says it wrote`) that occasionally drops a frame under this runner's scheduling jitter, and a case asserting an exact `0.000s` duration (`a suite console reaches the log and the terminal`) that occasionally measures `0.00Ns` instead. Both fail at the same rate on this branch as on test-merge; concurrent execution does not measurably change that rate in the runs collected here.