### PR TITLE
Add Doom C64U bisection harness and manual E2E suite

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -264,6 +264,12 @@ SUITES: Sequence[Suite] = (
     # cases. Skips rather than fails when the service is unreachable.
     Suite("e2e", "assembly64", "tests/e2e/io/c64/assembly64_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
+    # Manual: downloads a release from github.com and changes machine settings
+    # while it runs. Third-party software, but the most demanding public
+    # exercise of the U64 bus there is, streaming a 16 MB REU every frame under
+    # turbo. Bitstreams that pass every other suite here have broken it.
+    Suite("e2e", "doom-release", "tests/e2e/io/c64/doom_release_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@", manual=True),
     # Measures the keystroke injection every other suite depends on: a lost key
     # fails whichever check was typing at the time and names no rate, so this
     # names one. One batch of the largest size the input API accepts, which is

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,7 @@ unit tests live next to their owning code, such as `software/api/tests/`,
 | [`perf/`](perf/) | Timing and throughput benchmarks that measure a number rather than assert a pass/fail outcome. Not the gate. |
 | [`soak/`](soak/) | Time- and load-based checks for leaks, exhaustion, races and transport degradation. Not the gate. |
 | [`lib/`](lib/) | Support code shared by all three categories, plus the two gate checks that need no device. |
+| [`bisect/`](bisect/) | Hardware bisection harnesses: drive a device across many firmware revisions to find the commit a defect arrived in. Not the gate, and not run by `run-tests`. |
 
 `./run-tests <target>` runs the E2E gate. Add `--perf`, `--soak` or `--all`
 to run more, and `-m` to repeat the E2E suites in more than one UI profile:

--- a/tests/bisect/doom/README.md
+++ b/tests/bisect/doom/README.md
@@ -186,17 +186,38 @@ records each with sound, and writes a run directory laid out the way
 `run-tests --record` writes one:
 
 ```
-runs/<stamp>/
-  index.md          the whole run, for a person
-  index.json        the whole run, for a program
-  01-<commit>-<blob>/
-    video.mp4       the game, with sound
-    metadata.json   verdict, per-launch measurements, device identity
-    deploy.txt      what the deploy printed
-    launch-N.txt    what each launch measured
-    frame0.png      the first captured frame
-    mask0.png       which pixels changed, if any did
+runs/20260825-1024/                           when the run itself was made
+  index.md                                    the whole run, for a person
+  index.json                                  the whole run, for a program
+  20260502T142608Z-c4be69a2-bff2d1eb/         one candidate
+    video.mp4                                 the game, with sound
+    metadata.json                             verdict and measurements
+    deploy.txt                                what the deploy printed
+    launch-1.txt launch-2.txt launch-3.txt    what each launch measured
+    frame0.png                                the first captured frame
+    mask0.png                                 which pixels changed, if any did
 ```
+
+#### How a candidate folder is named
+
+`20260502T142608Z-c4be69a2-bff2d1eb` has three parts:
+
+| part | meaning |
+|---|---|
+| `20260502T142608Z` | when that commit was made, in UTC, to the second |
+| `c4be69a2` | the **commit** that was checked out and deployed |
+| `bff2d1eb` | the **FPGA bitstream** that commit carries, which is the thing actually under test |
+
+The two hexadecimal parts are different kinds of identifier and are easy to
+confuse. The first is a commit in this repository. The second is the content
+hash of `external/u64.sof` at that commit, from
+`git rev-parse --short <commit>:external/u64.sof`. Several commits in a row
+normally carry the same bitstream, so the second part is what tells you whether
+two folders really tested different hardware.
+
+The timestamp comes first so that an ordinary directory listing puts the
+candidates in the order the changes were made. That order is not obvious from
+the hashes, and the candidates are not all on one branch.
 
 A sweep rather than a binary search, because the defect's rate varies from one
 launch to the next: a candidate can pass by luck, and a binary search would then

--- a/tests/bisect/doom/README.md
+++ b/tests/bisect/doom/README.md
@@ -1,0 +1,267 @@
+# Bisecting the Doom C64U regression
+
+Doom C64U streams level geometry, textures and sprites out of a 16 MB REU every
+frame while the CPU runs at turbo speed, which makes it the most demanding
+public exercise of the U64 bus there is. Two firmware releases broke it, and
+this directory holds the harness that found where.
+
+## What was found
+
+Two separate regressions, on adjacent bitstream bumps. Both commits change
+**only** `external/u64.sof` and `external/u64_mk2_artix.bit`, so neither is a
+firmware source change.
+
+| | first bad commit | last good | effect |
+|---|---|---|---|
+| Picture corruption | `c4be69a2` (2026-05-02) "Adds cartridge compatibility mode to U64/U64E2 FPGA builds (untested)" | `1e387255`, which carries the `f2a14e51` bitstream | the game runs at full speed but pixels in the 3D view are randomly wrong |
+| Total failure | `77f3b381` (2026-05-11) "Updated bridge timing and REU in U64/U64E2" | `198353a8` | `mapOK` is 0, `frameCnt` never advances, the screen is garbled |
+
+`198353a8` is the last commit that still *runs* the game; it already carries the
+corruption, because its bitstream is `c4be69a2`'s.
+
+Measured on an Ultimate 64 Elite I. Reference figures, PAL, at the level's
+starting position with no input:
+
+| bitstream | date | frame rate | frames that differed | different pixel sets |
+|---|---|---|---|---|
+| `87bd7700` (v3.14) | 2025-11-11 | 12.6 fps | none at all | 0 |
+| every bitstream up to `d0d1934a` | to 2026-04-11 | 12.6 fps | 0 to 31% | 1 to 3 |
+| **`bff2d1eb`** (`c4be69a2`) | 2026-05-02 | 12.6 fps | **100%** | **503** |
+| `77cf7e40` (`77f3b381`) | 2026-05-11 | 0 fps, `mapOK=0` | engine never starts | |
+
+On `c4be69a2` nearly every differing frame is wrong in its own way, up to 2130
+pixels at a time, in bursts of four captured frames: the engine renders at about
+12.6 fps into a 50 Hz output, so one rendered frame occupies about four captured
+ones and every second rendered frame is corrupt. That is the roughly 8 Hz
+flicker of a few pixels that a person sees.
+
+`Bus Operation Mode = Compatibility` restores a correct picture on affected
+firmware but drops the machine to about 1 MHz: 0.30 fps against 12.6. It is a
+diagnostic, not a workaround.
+
+### What this does and does not say about the FPGA sources
+
+The bitstreams live in this repository as prebuilt binaries at
+`external/u64.sof`, and they are built from `GideonZ/ultimate64`. **Do not map a
+bitstream to a source commit by date.** Per the author, the two repositories are
+not kept in sync, the submodule link is not maintained, and a checked-in
+bitstream can be *older* than the source commits around it. An earlier version
+of this document named specific `ultimate64` commits on that basis; that
+attribution was wrong and has been removed.
+
+What the sweep does establish is which **bitstream binary** misbehaves, and that
+is what to hand to whoever can map it to sources:
+
+| bitstream blob | introduced by | behaviour |
+|---|---|---|
+| `d0d1934a` | `f2a14e51` | last one that renders correctly |
+| `bff2d1eb` | `c4be69a2` | renders, corrupted |
+| `77cf7e40` | `77f3b381` | engine does not start |
+
+Get a blob's identity with `git rev-parse --short <commit>:external/u64.sof`.
+`core_version` and `fpga_version` in `/v1/info` are hand-bumped labels that
+several distinct builds share, so they do not identify a bitstream.
+
+Also per the author: the timing constraints for these designs are present and
+every checked-in bitstream meets timing. An earlier version of this document
+speculated that a change had pushed the design into timing marginality. There is
+no evidence for that and it should not be repeated.
+
+## How the picture is judged
+
+The player never moves during a measurement, so **every frame of video should
+look exactly the same**. The harness captures about a thousand frames and
+compares each one against the first.
+
+Some frames will still differ, even on a machine that is working perfectly, so
+"any difference at all" cannot be the test. What separates a working machine
+from a broken one is **whether the same pixels keep changing, or different ones
+each time**:
+
+- **A working machine changes the same pixels over and over.** If the game
+  animates something, it is the same handful of pixels every time, so the
+  picture only ever alternates between a small number of fixed images.
+- **A broken machine changes different pixels every time.** When data coming
+  back from the REU is wrong, whichever pixels happen to be affected are wrong
+  *this* frame, and a different set is wrong the next.
+
+So for every frame that differs, the harness records **which pixels** differed
+(that list of pixel positions is what the code calls a "change mask") and then
+counts **how many different such lists it saw**:
+
+| what the numbers mean | working machine | broken machine |
+|---|---|---|
+| how many frames differed at all | anything from none to most of them | most of them |
+| **how many *different* sets of pixels were involved** | a handful, because the same ones keep changing | hundreds, a new one nearly every frame |
+
+Measured by sweeping every bitstream between v3.14 and v3.15 on an Ultimate 64
+Elite, three launches each, about 1000 frames per launch:
+
+| bitstream | frames that differed | different sets of pixels involved |
+|---|---|---|
+| v3.14 | none at all, in all three launches | 0 |
+| every bitstream up to `f2a14e51` | 0 to 31% | 1 to 3 |
+| **`c4be69a2`** | **100%** | **503** |
+
+A build is called broken when it shows **at least 10 different sets of pixels**
+and those account for **at least 30% of the frames that differed**. Both halves
+are needed: a couple of different sets turn up on healthy machines, and "every
+differing frame was unique" means nothing when only three frames differed.
+
+`index.json` calls these `distinct_masks` (how many different sets of pixels)
+and `deviating` (how many frames differed at all); their ratio is `ratio`.
+
+Four measurement traps, all handled by the scripts here, each of which produced
+a wrong answer before it was:
+
+- **Frames must be assembled by header offset, not by concatenating packet
+  payloads in arrival order.** A reordered packet then shifts the rest of the
+  picture, and differently every time, which looks exactly like the defect being
+  hunted. `streams.FrameAssembler` places each packet by its offset and returns
+  only complete frames; do not write another assembler.
+- **The video multicast group is shared between devices.** Another Ultimate
+  streaming into the same group has its packets assembled into these frames.
+  `streams.receive` reports whether the sender was this device.
+- **A joystick in port 2 moves the player without anyone touching it.** The
+  soak reads the player's position and reports whether it moved before the first
+  differing frame, so such a run is voided rather than counted as a defect.
+- **The defect can hide for a whole launch.** Rates vary between launches of one
+  and the same bitstream, so several launches are required before a build is
+  called clean.
+
+`doom_soak.py` also proves the capture can show a change at all, by poking the
+VIC border and requiring the picture to move. Without that, a frozen capture
+would pass trivially. Writing the player's position does not work as a check:
+the engine undoes an out-of-bounds position and renders from cached sine and
+cosine values.
+
+## Running it
+
+### Prerequisites
+
+- A USB Blaster on the JTAG header, and Quartus 18.1 (`quartus_pgm`,
+  `nios2-download`) under `$INTEL_FPGA_ROOT`, default `~/altera_lite/18.1`.
+- The Docker build image, `1541u-build:latest` or `my_docker_image`.
+- A git worktree of this repository for the harness to check commits out into,
+  which must not be the one you are working in:
+
+```sh
+git worktree add --detach ~/.cache/doom-bisect/wt v3.14
+```
+
+- `pip install numpy pillow`, and the device reachable by name (`u64`).
+
+Environment variables, all optional: `DOOM_HOST` (device name, default `u64`),
+`DOOM_REU` (path to `game.reu` on the device), `DOOM_BISECT_WORKTREE`,
+`DOOM_BISECT_LOG`, `DOOM_BISECT_LOGDIR`, `BUILD_IMAGE`, `BUILD_TOOLS_ROOT`,
+`INTEL_FPGA_ROOT`, and `JTAG_CABLE` (default `USB-Blaster [1-6]`; run
+`jtagconfig` to see what this machine calls its cable).
+
+### Install the game
+
+```sh
+tests/bisect/doom/install_assets.py --host u64 --dir /USB2/doom
+```
+
+The USB volume is named differently on different machines; check an FTP
+listing if `/USB2` does not exist.
+
+### Judge one commit
+
+```sh
+tests/bisect/doom/verdict.sh 77f3b381
+```
+
+Deploys that commit's bitstream and application over JTAG, then launches the
+game three times and prints `FINAL: GOOD`, `BAD`, `BROKEN` or `SETUP_FAILED`.
+
+### Sweep a range and keep the evidence
+
+```sh
+tests/bisect/doom/bisect_run.py --range v3.14..v3.15 --launches 3
+```
+
+This is the one to reach for. It measures **every** bitstream in the range,
+records each with sound, and writes a run directory laid out the way
+`run-tests --record` writes one:
+
+```
+runs/<stamp>/
+  index.md          the whole run, for a person
+  index.json        the whole run, for a program
+  01-<commit>-<blob>/
+    video.mp4       the game, with sound
+    metadata.json   verdict, per-launch measurements, device identity
+    deploy.txt      what the deploy printed
+    launch-N.txt    what each launch measured
+    frame0.png      the first captured frame
+    mask0.png       which pixels changed, if any did
+```
+
+A sweep rather than a binary search, because the defect's rate varies from one
+launch to the next: a candidate can pass by luck, and a binary search would then
+step over the answer without saying so. `bisect_bitstreams.sh` still offers the
+binary search when the range is large and time matters, and reports any
+candidate it could not judge.
+
+Search bitstreams rather than commits either way. Only thirteen distinct ones
+exist between v3.14 and v3.15, and different branches carry different bitstream
+lineages, so an ordinary `git bisect` over commits spends most of its rounds on
+builds whose hardware is identical.
+
+### Record what is on screen now
+
+```sh
+tests/bisect/doom/record_run.py --host u64 --seconds 25 -o /tmp/now.mp4
+```
+
+Video and audio, muxed into one mp4. `--no-record-audio` for video only.
+
+### Measure without redeploying
+
+```sh
+tests/bisect/doom/doom_run.py  --host u64 --tag now
+tests/bisect/doom/doom_soak.py --host u64 --label now --seconds 25
+```
+
+`doom_run.py --write-golden` records the current first frame as the reference
+that later runs are compared against.
+
+## Deploying is volatile, and HDMI goes dark
+
+`deploy_commit.sh` programs the FPGA with `quartus_pgm` and downloads the Nios
+application with `nios2-download`. **Nothing is written to flash**, so a power
+cycle always restores the flashed firmware and is the recovery for anything
+that goes wrong.
+
+**HDMI stays dark for the whole session.** The firmware initialises the HDMI
+transmitter only at application start and it does not come back up on an older
+core, so anyone at the bench sees no picture until they reboot the machine.
+This is expected and is not bitstream corruption; the network VIC stream keeps
+working and is what the harness measures. Warn whoever is sitting in front of
+the device.
+
+The FPGA is programmed before the application is built and downloaded, on
+purpose: `nios2-download` writes into DDR that the bitstream brings up, so
+running it against the previous commit's bitstream fails to verify and leaves
+the processor paused.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `bisect_run.py` | Sweep every bitstream in a range and record the evidence |
+| `record_run.py` | Record the device's video and audio to one mp4 |
+| `doomlib.py` | Device access and video capture shared by the scripts below |
+| `install_assets.py` | Fetch the published release and put `game.reu` on the device |
+| `doom_run.py` | Start the game and report whether the engine came up |
+| `doom_soak.py` | Measure picture stability and count distinct change-masks |
+| `deploy_commit.sh` | Put one commit's FPGA bitstream and application on the device |
+| `verdict.sh` | Deploy, launch repeatedly, and decide GOOD or BAD |
+| `list_bitstreams.sh` | List the distinct bitstreams in a commit range |
+| `bisect_bitstreams.sh` | Binary search those bitstreams |
+
+A fast regression check that needs none of this, and no JTAG, is the
+`doom-release` suite: `./run-tests u64 -s doom-release`. It downloads the
+release, runs it and checks the engine's own verdict. See
+[`tests/e2e/io/c64/doom_release_test.py`](../../e2e/io/c64/doom_release_test.py).

--- a/tests/bisect/doom/bisect_bitstreams.sh
+++ b/tests/bisect/doom/bisect_bitstreams.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# bisect_bitstreams.sh <good-commit> <bad-commit> [candidates...]
+#
+# Binary search over the distinct FPGA bitstreams between two commits, testing
+# each through verdict.sh. With no candidates given they are taken from
+# list_bitstreams.sh over <good>..<bad>.
+#
+# Each candidate is the commit that introduced a bitstream, so the FPGA and the
+# Nios application under test always come from the same commit.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GOOD="${1:?usage: bisect_bitstreams.sh <good> <bad> [candidates...]}"
+BAD="${2:?usage: bisect_bitstreams.sh <good> <bad> [candidates...]}"
+shift 2
+LOG="${DOOM_BISECT_LOG:-$HOME/.cache/doom-bisect/bitstream-search.log}"
+mkdir -p "$(dirname "$LOG")"
+: > "$LOG"
+
+if [ "$#" -gt 0 ]; then
+    CANDIDATES=("$@")
+else
+    mapfile -t CANDIDATES < <(bash "$HERE/list_bitstreams.sh" "$GOOD..$BAD" | awk '{print $1}')
+fi
+[ "${#CANDIDATES[@]}" -gt 0 ] || { echo "no bitstream changes in $GOOD..$BAD"; exit 1; }
+
+echo "candidates (oldest first): ${CANDIDATES[*]}" | tee -a "$LOG"
+lo=0; hi=$(( ${#CANDIDATES[@]} - 1 )); first_bad=""; skipped=()
+while [ "$lo" -le "$hi" ]; do
+    mid=$(( (lo + hi) / 2 ))
+    candidate="${CANDIDATES[$mid]}"
+    echo "== testing $candidate (window $lo..$hi)" | tee -a "$LOG"
+    verdict=""
+    for attempt in 1 2; do
+        out=$(bash "$HERE/verdict.sh" "$candidate" "bs-$candidate" 2>&1)
+        echo "$out" | grep -E "^DEPLOYED|^RESULT|^SOAK|^FINAL" >> "$LOG"
+        verdict=$(grep "^FINAL:" <<<"$out" | tail -1 | awk '{print $2}')
+        case "$verdict" in GOOD|BAD|BROKEN) break ;; *) verdict="" ;; esac
+    done
+    echo "== $candidate -> ${verdict:-NO_VERDICT}" | tee -a "$LOG"
+    case "$verdict" in
+        GOOD)       lo=$(( mid + 1 )) ;;
+        BAD|BROKEN) first_bad="$candidate"; hi=$(( mid - 1 )) ;;
+        *)          echo "== skipping $candidate, it could not be judged" | tee -a "$LOG"
+                    skipped+=("$candidate"); lo=$(( mid + 1 )) ;;
+    esac
+done
+# A candidate that could not be judged moved the window like a GOOD one, so say
+# so: the answer is only sound if the list below is empty.
+if [ -z "$first_bad" ]; then
+    echo "NO BAD BITSTREAM FOUND in $GOOD..$BAD" | tee -a "$LOG"
+else
+    echo "FIRST BAD BITSTREAM: $first_bad" | tee -a "$LOG"
+fi
+if [ "${#skipped[@]}" -gt 0 ]; then
+    echo "UNTESTED CANDIDATES: ${skipped[*]}" | tee -a "$LOG"
+fi

--- a/tests/bisect/doom/bisect_run.py
+++ b/tests/bisect/doom/bisect_run.py
@@ -11,7 +11,7 @@ and one Markdown index over the whole run.
     runs/<stamp>/
       index.md                 the whole run, for a person
       index.json               the whole run, for a program
-      <commit>-<blob>/
+      <utc commit time>-<commit>-<bitstream blob>/
         video.mp4              25s of the game, with sound
         metadata.json          verdict, measurements, device identity
         deploy.txt             what deploy_commit.sh printed
@@ -43,7 +43,20 @@ VERDICTS = {"GOOD": "pass", "BAD": "corrupt", "BROKEN": "does not run",
 
 def git(*args, cwd=None):
     return subprocess.run(["git", *args], cwd=cwd or REPO, check=False,
-                          capture_output=True, text=True).stdout.strip()
+                          capture_output=True, text=True,
+                          env={**os.environ, "TZ": "UTC"}).stdout.strip()
+
+
+def commit_stamp(commit):
+    """The commit's own time in UTC, as YYYYMMDDTHHMMSSZ.
+
+    Folders are named with this so that listing the run directory puts the
+    candidates in the order the changes were actually made. A bitstream's
+    position in a range is not obvious from its hash, and the candidates are not
+    all on one branch.
+    """
+    return git("log", "-1", "--format=%cd",
+               "--date=format-local:%Y%m%dT%H%M%SZ", commit) or "00000000T000000Z"
 
 
 def candidates_for(commit_range):
@@ -236,7 +249,8 @@ def main():
     entries = []
     for index, commit in enumerate(candidates, 1):
         blob = git("rev-parse", "--short", f"{commit}:external/u64.sof") or "nosof"
-        folder = f"{index:02d}-{commit}-{blob}"
+        # <commit time in UTC>-<the commit tested>-<the bitstream it carries>
+        folder = f"{commit_stamp(commit)}-{commit}-{blob}"
         directory = run_dir / folder
         directory.mkdir(exist_ok=True)
         print(f"[{index}/{len(candidates)}] {commit} ({blob})", flush=True)

--- a/tests/bisect/doom/bisect_run.py
+++ b/tests/bisect/doom/bisect_run.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Sweep the FPGA bitstreams of a commit range and record the evidence.
+
+Produces a run directory laid out the way `run-tests --record` lays one out: a
+directory per subject, a recording and machine-readable metadata inside each,
+and one Markdown index over the whole run.
+
+    ./bisect_run.py --range v3.14..v3.15 -o runs/
+    ./bisect_run.py --candidates v3.14 c4be69a2 --launches 2
+
+    runs/<stamp>/
+      index.md                 the whole run, for a person
+      index.json               the whole run, for a program
+      <commit>-<blob>/
+        video.mp4              25s of the game, with sound
+        metadata.json          verdict, measurements, device identity
+        deploy.txt             what deploy_commit.sh printed
+        launch-N.txt           what each launch measured
+        frame0.png             the first captured frame
+        mask0.png              which pixels changed, if any did
+
+A sweep rather than a binary search: the defect's rate varies from one launch to
+the next, so a candidate can pass by luck, and a bisection that assumes a
+monotonic boundary would then step over the answer without saying so. Every
+candidate is measured, and the index shows all of them.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parents[1] / "lib"))
+
+REPO = SCRIPT_DIR.parents[2]
+VERDICTS = {"GOOD": "pass", "BAD": "corrupt", "BROKEN": "does not run",
+            "SETUP_FAILED": "not measured"}
+
+
+def git(*args, cwd=None):
+    return subprocess.run(["git", *args], cwd=cwd or REPO, check=False,
+                          capture_output=True, text=True).stdout.strip()
+
+
+def candidates_for(commit_range):
+    """Every commit in the range that introduces a distinct bitstream."""
+    out = subprocess.run(["bash", str(SCRIPT_DIR / "list_bitstreams.sh"), commit_range],
+                         cwd=REPO, check=True, capture_output=True, text=True).stdout
+    return [line.split()[0] for line in out.splitlines() if line.strip()]
+
+
+def measure(commit, directory, launches, soak_seconds, record_seconds, host, reu):
+    """Deploy one candidate, measure it, and record it. Returns its metadata."""
+    entry = {"commit": commit,
+             "subject": git("log", "-1", "--format=%s", commit),
+             "date": git("log", "-1", "--format=%ad", "--date=short", commit),
+             "launches": [], "verdict": "SETUP_FAILED", "reason": ""}
+
+    deployed = subprocess.run(
+        ["bash", str(SCRIPT_DIR / "deploy_commit.sh"), commit],
+        cwd=REPO, capture_output=True, text=True,
+        env={**os.environ, "DOOM_HOST": host})
+    (directory / "deploy.txt").write_text(deployed.stdout + deployed.stderr)
+    line = next((l for l in deployed.stdout.splitlines() if l.startswith("DEPLOYED")), "")
+    if not line:
+        entry["reason"] = "the bitstream could not be deployed; see deploy.txt"
+        return entry
+    for field in line.split():
+        if field.startswith(("sof=", "blob=")):
+            entry[field.split("=")[0]] = field.split("=", 1)[1]
+    entry["device"] = line.split(" ", 4)[-1]
+
+    worst_masks = 0
+    for launch in range(1, launches + 1):
+        run = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "doom_run.py"), "--host", host,
+             "--reu", reu, "--tag", f"{commit}-l{launch}"],
+            cwd=REPO, capture_output=True, text=True)
+        soak = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "doom_soak.py"), "--host", host,
+             "--seconds", str(soak_seconds), "--label", f"{commit}-l{launch}"],
+            cwd=REPO, capture_output=True, text=True)
+        text = run.stdout + run.stderr + "\n" + soak.stdout + soak.stderr
+        (directory / f"launch-{launch}.txt").write_text(text)
+
+        record = {"launch": launch}
+        for source in (run.stdout, soak.stdout):
+            for token in source.split():
+                key, _, value = token.partition("=")
+                if key in ("mapOK", "fps", "frames", "deviating", "distinct_masks",
+                           "worst", "bursts", "cam_moved", "live_border"):
+                    record[key] = value.rstrip("px%")
+        entry["launches"].append(record)
+
+        if "VERDICT: BROKEN" in run.stdout or record.get("mapOK") not in (None, "1"):
+            entry["verdict"] = "BROKEN"
+            entry["reason"] = "the engine rejected the REU image or never rendered"
+            break
+        if "SETUP_FAILED" in run.stdout or "SETUP_FAILED" in soak.stdout:
+            entry["reason"] = "a launch did not happen; see launch-%d.txt" % launch
+            break
+        masks = int(record.get("distinct_masks", "0") or 0)
+        differing = int(record.get("deviating", "0") or 0)
+        ratio = masks / differing if differing else 0.0
+        record["ratio"] = f"{ratio:.3f}"
+        worst_masks = max(worst_masks, masks)
+        if masks >= MIN_CORRUPT_MASKS and ratio >= MIN_CORRUPT_RATIO:
+            entry["verdict"] = "BAD"
+            entry["reason"] = (f"{masks} distinct change-masks over {differing} "
+                               f"differing frames (ratio {ratio:.2f}): the picture "
+                               f"changes a different set of pixels nearly every frame")
+            break
+    else:
+        entry["verdict"] = "GOOD"
+        entry["reason"] = (f"at most {worst_masks} distinct change-mask over "
+                           f"{launches} launches")
+    entry["worst_distinct_masks"] = worst_masks
+
+    if entry["verdict"] != "SETUP_FAILED":
+        recorded = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "record_run.py"), "--host", host,
+             "--seconds", str(record_seconds), "-o", str(directory / "video.mp4")],
+            cwd=REPO, capture_output=True, text=True)
+        entry["recording"] = ("video.mp4" if (directory / "video.mp4").exists()
+                              else f"failed: {recorded.stderr.strip()[:200]}")
+
+    for name in ("frame0", "mask0"):
+        for launch in range(1, launches + 1):
+            source = Path(os.path.expanduser("~/.cache/doom-bisect/shots")) / \
+                f"{commit}-l{launch}-{name}.png"
+            if source.exists():
+                shutil.copy(source, directory / f"{name}.png")
+                break
+    return entry
+
+
+def write_index(run_dir, entries, meta):
+    (run_dir / "index.json").write_text(json.dumps(
+        {"run": meta, "candidates": entries}, indent=2) + "\n")
+
+    first_bad = next((e for e in entries if e["verdict"] in ("BAD", "BROKEN")), None)
+    lines = [
+        "# Doom C64U bitstream sweep", "",
+        f"- range: `{meta['range']}`",
+        f"- device: {meta['host']}",
+        f"- launches per candidate: {meta['launches']}, "
+        f"soak {meta['soak_seconds']}s, recording {meta['record_seconds']}s",
+        f"- a candidate is BAD when at least {meta['min_corrupt_masks']} distinct "
+        f"change-masks appear and they account for at least "
+        f"{meta['min_corrupt_ratio']:.0%} of the differing frames", "",
+    ]
+    if first_bad:
+        lines += [f"**First bad bitstream: `{first_bad['commit']}` "
+                  f"({first_bad['date']}) {first_bad['subject']}**", ""]
+    else:
+        lines += ["**No bad bitstream in this range.**", ""]
+
+    lines += ["| candidate | date | bitstream | verdict | most different "
+              "pixel sets seen | recording |", "|---|---|---|---|---|---|"]
+    for e in entries:
+        folder = e["folder"]
+        lines.append(
+            f"| [`{e['commit']}`]({folder}/) | {e['date']} | `{e.get('blob', '?')}` | "
+            f"**{e['verdict']}** ({VERDICTS.get(e['verdict'], '')}) | "
+            f"{e.get('worst_distinct_masks', '?')} | "
+            f"[video]({folder}/video.mp4) |")
+
+    lines += ["", "## What the numbers mean", "",
+              "The player never moves, so every frame of video should look the same.",
+              "Each frame is compared against the first one, and for every frame that",
+              "differs the harness records *which* pixels differed.",
+              "",
+              "`different pixel sets` counts how many **different** such sets were seen.",
+              "A working machine changes the same pixels over and over, so this stays in",
+              "single figures however many frames differ. A machine corrupting data from",
+              "the REU changes a different set nearly every frame, so this runs into the",
+              "hundreds. `ratio` is that count divided by the number of frames that",
+              "differed at all.", "",
+              "## Per candidate", ""]
+    for e in entries:
+        lines += [f"### `{e['commit']}` {e['subject']}", "",
+                  f"- {e['date']}, bitstream `{e.get('blob', '?')}`",
+                  f"- verdict: **{e['verdict']}** - {e['reason']}",
+                  f"- device: `{e.get('device', 'not deployed')}`", ""]
+        if e["launches"]:
+            lines += ["| launch | fps | frames | frames that differed | "
+                      "different pixel sets | ratio | worst pixels |",
+                      "|---|---|---|---|---|---|---|"]
+            for l in e["launches"]:
+                lines.append(
+                    f"| {l['launch']} | {l.get('fps', '?')} | {l.get('frames', '?')} | "
+                    f"{l.get('deviating', '?')} | {l.get('distinct_masks', '?')} | "
+                    f"{l.get('ratio', '-')} | {l.get('worst', '?')} |")
+            lines.append("")
+    (run_dir / "index.md").write_text("\n".join(lines) + "\n")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    ap.add_argument("--range", default="v3.14..v3.15",
+                    help="commit range to take bitstream candidates from")
+    ap.add_argument("--candidates", nargs="*",
+                    help="test these commits instead of the range")
+    ap.add_argument("-o", "--out", default=os.path.expanduser("~/.cache/doom-bisect/runs"),
+                    help="where the run directory is created")
+    ap.add_argument("--launches", type=int, default=3,
+                    help="independent launches per candidate; the defect can hide "
+                         "for a whole launch")
+    ap.add_argument("--soak-seconds", type=float, default=25.0)
+    ap.add_argument("--record-seconds", type=float, default=25.0)
+    ap.add_argument("--no-record", dest="record", action="store_false")
+    ap.add_argument("--min-corrupt-masks", type=int, default=MIN_CORRUPT_MASKS)
+    ap.add_argument("--min-corrupt-ratio", type=float, default=MIN_CORRUPT_RATIO)
+    ap.add_argument("--reu", default=os.environ.get("DOOM_REU", "/USB2/doom/game.reu"))
+    ap.add_argument("--stamp", default=None, help="run directory name")
+    args = ap.parse_args()
+    globals()["MIN_CORRUPT_MASKS"] = args.min_corrupt_masks
+    globals()["MIN_CORRUPT_RATIO"] = args.min_corrupt_ratio
+
+    candidates = args.candidates or candidates_for(args.range)
+    stamp = args.stamp or time.strftime("%Y%m%d-%H%M%S")
+    run_dir = Path(args.out) / stamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    meta = {"range": args.range, "host": args.host, "launches": args.launches,
+            "soak_seconds": args.soak_seconds,
+            "record_seconds": args.record_seconds if args.record else 0,
+            "min_corrupt_masks": args.min_corrupt_masks,
+            "min_corrupt_ratio": args.min_corrupt_ratio, "candidates": candidates}
+
+    print(f"run directory: {run_dir}")
+    entries = []
+    for index, commit in enumerate(candidates, 1):
+        blob = git("rev-parse", "--short", f"{commit}:external/u64.sof") or "nosof"
+        folder = f"{index:02d}-{commit}-{blob}"
+        directory = run_dir / folder
+        directory.mkdir(exist_ok=True)
+        print(f"[{index}/{len(candidates)}] {commit} ({blob})", flush=True)
+        entry = measure(commit, directory,
+                        args.launches, args.soak_seconds,
+                        args.record_seconds if args.record else 0,
+                        args.host, args.reu)
+        entry["folder"] = folder
+        entry["blob"] = entry.get("blob", blob)
+        (directory / "metadata.json").write_text(json.dumps(entry, indent=2) + "\n")
+        entries.append(entry)
+        print(f"    -> {entry['verdict']}: {entry['reason']}", flush=True)
+        write_index(run_dir, entries, meta)
+
+    write_index(run_dir, entries, meta)
+    print(f"\nindex: {run_dir / 'index.md'}")
+    return 0
+
+
+# Corruption is judged from two numbers together, calibrated by sweeping every
+# bitstream between v3.14 and v3.15 on an Ultimate 64 Elite:
+#
+#   candidate                     distinct masks   masks/differing frames
+#   v3.14                                      0   no differing frames at all
+#   every bitstream up to f2a14e51          1 - 3   0.003 - 0.25
+#   c4be69a2                                 503   0.500
+#
+# The game's own output repeats one pattern however often it recurs, so a low
+# ratio is normal however many frames differ. Corrupt REU data alters a
+# different set of pixels nearly every frame, which drives the ratio up. Both a
+# floor on the count and the ratio are required: a handful of masks appears on
+# healthy bitstreams, and a high ratio over three differing frames means nothing.
+MIN_CORRUPT_MASKS = 10
+MIN_CORRUPT_RATIO = 0.30
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bisect/doom/deploy_commit.sh
+++ b/tests/bisect/doom/deploy_commit.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# deploy_commit.sh <commit> [worktree]
+#
+# Put a U64 on one commit's FPGA bitstream and Nios application over JTAG.
+# Nothing is written to flash: a power cycle always restores the flashed
+# firmware, which is the recovery for anything that goes wrong here.
+#
+# The FPGA is programmed first on purpose. nios2-download writes into DDR that
+# the bitstream brings up, so downloading against the previous commit's
+# bitstream fails to verify and leaves the processor paused; and the build that
+# follows gives the memory controller time to settle.
+#
+# HDMI stays dark for the whole session. The firmware initialises the HDMI
+# transmitter only at application start and it does not come back on an older
+# core. The network VIC stream still works and is what this harness measures.
+set -uo pipefail
+
+COMMIT="${1:?usage: deploy_commit.sh <commit> [worktree]}"
+WT="${2:-${DOOM_BISECT_WORKTREE:-$HOME/.cache/doom-bisect/wt}}"
+HOST="${DOOM_HOST:-u64}"
+JOBS="${JOBS:-8}"
+IMAGE="${BUILD_IMAGE:-1541u-build:latest}"
+# Mount only the toolchain, not the whole home directory.
+TOOLS_ROOT="${BUILD_TOOLS_ROOT:-${INTEL_FPGA_ROOT:-$HOME/altera_lite/18.1}}"
+INTEL_FPGA_ROOT="${INTEL_FPGA_ROOT:-$HOME/altera_lite/18.1}"
+CABLE="${JTAG_CABLE:-USB-Blaster [1-6]}"
+ELF="$WT/target/u64/nios2/ultimate/result/ultimate.elf"
+LOGDIR="${DOOM_BISECT_LOGDIR:-$HOME/.cache/doom-bisect}"
+mkdir -p "$LOGDIR"
+
+export QUARTUS_ROOTDIR="$INTEL_FPGA_ROOT/quartus"
+export PATH="$QUARTUS_ROOTDIR/bin:$INTEL_FPGA_ROOT/nios2eds/bin:$PATH"
+
+die() { echo "DEPLOY_FAIL $*" >&2; exit 2; }
+[ -d "$WT/.git" ] || [ -f "$WT/.git" ] || die "no worktree at $WT (see README)"
+# This script hard-resets and cleans $WT. Refuse to do that to the checkout the
+# script itself lives in, which is where a mistyped path or a stale
+# DOOM_BISECT_WORKTREE would otherwise point.
+_here_root=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || echo "")
+_wt_root=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || echo "")
+[ -n "$_wt_root" ] || die "$WT is not a git worktree"
+[ "$_wt_root" != "$_here_root" ] \
+    || die "$WT is the checkout this script lives in; use a dedicated worktree"
+command -v quartus_pgm >/dev/null || die "quartus_pgm not on PATH"
+docker image inspect "$IMAGE" >/dev/null 2>&1 || IMAGE=my_docker_image
+docker image inspect "$IMAGE" >/dev/null 2>&1 || die "no build image ($IMAGE)"
+
+if [ "${NO_CHECKOUT:-0}" != "1" ]; then
+    git -C "$WT" checkout --detach --force "$COMMIT" >/dev/null 2>&1 \
+        || die "cannot check out $COMMIT"
+else
+    # NO_CHECKOUT skips moving HEAD, not the reset and clean below. Without this
+    # guard a caller with it set would deploy whatever the worktree happened to
+    # be on, while every message still named $COMMIT.
+    [ "$(git -C "$WT" rev-parse "$COMMIT" 2>/dev/null)" \
+        = "$(git -C "$WT" rev-parse HEAD 2>/dev/null)" ] \
+        || die "NO_CHECKOUT=1 but $WT is not on $COMMIT"
+fi
+# The build rewrites tracked files (tools/64tass/64tass), which would abort the
+# next checkout, and stale objects from another commit must not be reused.
+git -C "$WT" reset --hard >/dev/null 2>&1 || die "git reset --hard"
+git -C "$WT" clean -xdf >/dev/null 2>&1 || die "git clean"
+git -C "$WT" submodule update --init --recursive >/dev/null 2>&1 \
+    || die "git submodule update"
+
+cd "$WT" || die "cannot enter $WT"
+# A fresh checkout gives every file the same timestamp, and the Nios BSP
+# makefiles refuse to build when settings.bsp is not older than the makefile.
+for d in software/nios_solo_bsp software/nios_appl_bsp; do
+    touch "$d/Makefile" "$d/public.mk" "$d/mem_init.mk" 2>/dev/null
+done
+# system_info.cc includes gitinfo.h, which the build expects to have been
+# generated for it. Commit time rather than wall-clock time, so the header is
+# stable and an unchanged commit does not recompile.
+git_tag=$(git -C "$WT" describe --tags 2>/dev/null || echo unknown)
+git_branch=$(git -C "$WT" describe --all 2>/dev/null || echo unknown)
+git_date=$(git -C "$WT" log -n 1 --format=%ai 2>/dev/null || echo unknown)
+git_hash=$(git -C "$WT" rev-parse --short HEAD 2>/dev/null || echo unknown)
+while IFS= read -r dir; do
+    mkdir -p "$dir/output" "$dir/result"
+    cat >"$dir/output/gitinfo.h" <<GITINFO
+/* Generated file, do not edit. */
+#define APP_VERSION_TAG    "${git_tag}"
+#define APP_VERSION_BRANCH "${git_branch}"
+#define APP_VERSION_DATE   "${git_date}"
+#define APP_VERSION_HASH   "${git_hash}"
+#define APP_BUILD_DATE     "${git_date}"
+#define APP_BUILD_MACHINE  "$(hostname)"
+GITINFO
+done < <(find target -type f \( -iname 'makefile' -o -iname 'Makefile' \) -printf '%h\n' | sort -u)
+
+echo "== programming FPGA from external/u64.sof"
+# Captured rather than piped into grep -q: grep exits on the first match and
+# closes the pipe, quartus_pgm takes SIGPIPE, and under `pipefail` that turns a
+# successful programming run into a failure, intermittently.
+pgm_output=$(quartus_pgm -c "$CABLE" -m JTAG -o "p;external/u64.sof" 2>&1)
+grep -qE "Configuration succeeded" <<<"$pgm_output" \
+    || die "quartus_pgm (cable '"'"'$CABLE'"'"'; run jtagconfig to list cables)"
+
+echo "== building the Nios application"
+rm -f "$ELF"
+# Under rootless Docker this user is already root inside the container and the
+# mount belongs to it; passing --user then maps to an id that cannot write.
+docker_user=(--user "$(id -u):$(id -g)")
+docker_security=$(docker info --format '{{json .SecurityOptions}}' 2>/dev/null || true)
+if grep -qi rootless <<<"$docker_security"; then
+    docker_user=()
+fi
+docker run --rm --entrypoint /bin/bash \
+    -v "$WT:/__w" "${docker_user[@]}" -e HOME=/tmp/1541u-home \
+    -v "$TOOLS_ROOT:/mnt/build-tools:ro" "$IMAGE" -lc '
+set -euo pipefail
+mkdir -p "$HOME"
+for base in /mnt/build-tools /mnt/build-tools/altera_lite/18.1 \
+            /mnt/build-tools/intelFPGA_lite/18.1; do
+    if [ -d "$base/quartus" ]; then
+        export QUARTUS_ROOTDIR="$base/quartus"
+        export QSYS_ROOTDIR="$QUARTUS_ROOTDIR/sopc_builder/bin"
+        export PATH="$QUARTUS_ROOTDIR/bin:$base/nios2eds/bin:$base/nios2eds/sdk2/bin:$base/nios2eds/bin/gnu/H-x86_64-pc-linux-gnu/bin:$QSYS_ROOTDIR:$PATH"
+        break
+    fi
+done
+[ -n "${QUARTUS_ROOTDIR:-}" ] || { echo "no Quartus under /mnt/build-tools" >&2; exit 1; }
+cd /__w
+make -j '"$JOBS"' -C tools
+make -j '"$JOBS"' -C software/nios_solo_bsp
+make -j '"$JOBS"' -C software/nios_appl_bsp
+make -j '"$JOBS"' -C target/libs/nios2/lwip
+make -j '"$JOBS"' -C target/u64/nios2/ultimate result/ultimate.elf
+' > "$LOGDIR/build.log" 2>&1
+[ -s "$ELF" ] || { tail -25 "$LOGDIR/build.log" >&2; die "build"; }
+
+echo "== downloading the application"
+downloaded=0
+for attempt in 1 2 3; do
+    if nios2-download -g "$ELF" >"$LOGDIR/jtag.log" 2>&1; then
+        downloaded=1; break
+    fi
+    echo "   attempt $attempt failed, retrying"
+    sleep 8
+done
+[ "$downloaded" = "1" ] || { tail -5 "$LOGDIR/jtag.log" >&2; die "nios2-download"; }
+
+info=""
+for _ in $(seq 1 30); do
+    info=$(curl -s -m 4 "http://$HOST/v1/info" || true)
+    [ -n "$info" ] && break
+    sleep 2
+done
+[ -n "$info" ] || die "device did not answer REST"
+curl -s -m 8 -X PUT "http://$HOST/v1/machine:reset" >/dev/null
+sleep 6
+
+# The bitstream blob, because core_version and fpga_version are hand-bumped
+# labels that several distinct builds share.
+echo "DEPLOYED $(git -C "$WT" rev-parse --short HEAD)" \
+     "sof=$(git -C "$WT" log --format=%h -1 -- external/u64.sof)" \
+     "blob=$(git -C "$WT" rev-parse --short HEAD:external/u64.sof)" \
+     "$(echo "$info" | tr -d '\n ')"

--- a/tests/bisect/doom/doom_run.py
+++ b/tests/bisect/doom/doom_run.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Start Doom C64U on a U64 and report whether the engine came up.
+
+Loads the REU image, silences the MOD player that loading it starts, runs
+launcher.prg, leaves the title screen without a keyboard, then reports the
+engine's own integrity result, its frame rate, and how the first frame compares
+against a stored reference frame.
+
+    ./doom_run.py --host u64 --tag mytest
+    ./doom_run.py --write-golden        # record the reference frame
+"""
+import argparse
+import os
+import sys
+import time
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import doomlib as D                                            # noqa: E402
+
+DEFAULT_ASSETS = os.path.expanduser("~/.cache/doom-bisect/assets")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="u64")
+    ap.add_argument("--reu", default="/USB2/doom/game.reu",
+                    help="path to game.reu on the device")
+    ap.add_argument("--prg", default=os.path.join(DEFAULT_ASSETS, "launcher.prg"))
+    ap.add_argument("--tag", default="run")
+    ap.add_argument("--frames", type=int, default=20)
+    ap.add_argument("--settle", type=float, default=15.0,
+                    help="seconds between chaining in and measuring")
+    ap.add_argument("--boot-timeout", type=float, default=45.0,
+                    help="seconds to wait for the title screen")
+    ap.add_argument("--golden", default=os.path.expanduser(
+        "~/.cache/doom-bisect/golden.npy"))
+    ap.add_argument("--write-golden", action="store_true")
+    ap.add_argument("--outdir", default=os.path.expanduser(
+        "~/.cache/doom-bisect/shots"))
+    a = ap.parse_args()
+    os.makedirs(a.outdir, exist_ok=True)
+    shot = lambda n: os.path.join(a.outdir, f"{a.tag}-{n}.png")   # noqa: E731
+
+    try:
+        attempts = D.load_reu(a.host, a.reu)
+    except RuntimeError as e:
+        print(f"VERDICT: SETUP_FAILED ({e})")
+        return 3
+    print(f"[1] REU image loaded after {attempts} attempt(s)")
+
+    D.silence_sampler(a.host)
+    print("[2] sampler channels $DF20-$DFFF silenced")
+
+    D.run_prg(a.host, a.prg)
+    print("[3] launcher.prg started")
+    time.sleep(10.0)
+
+    landed, before, after = D.skip_title(a.host, a.boot_timeout)
+    if not landed:
+        print(f"[4] launcher.prg never reached its title screen within "
+              f"{a.boot_timeout:.0f}s")
+        print("VERDICT: SETUP_FAILED")
+        return 3
+    print(f"[4] title skipped: ${D.SPACE_BNE:04X} {before.hex()} -> {after.hex()}")
+
+    print(f"[5] settling {a.settle:.0f}s")
+    time.sleep(a.settle)
+
+    mapok = D.readmem(a.host, D.MAPOK, 1)
+    maperr = D.readmem(a.host, D.MAPERR, 1)
+    if mapok is None or maperr is None:
+        print("VERDICT: SETUP_FAILED (the device stopped answering readmem)")
+        return 3
+    mapok, maperr = mapok[0], maperr[0]
+
+    c0 = D.framecnt(a.host)
+    t0 = time.time()
+    with D.VideoStream(a.host) as vs:
+        first = vs.frame()
+        height = first.shape[0]
+        frames = [first]
+        mismatched = 0
+        while len(frames) < a.frames and mismatched < 40:
+            nxt = vs.frame(height)
+            # A geometry change mid-capture would make the comparison below
+            # raise rather than report anything useful.
+            if nxt.shape != first.shape:
+                mismatched += 1
+                continue
+            frames.append(nxt)
+        dropped = vs.assembler.counts()
+    c1 = D.framecnt(a.host)
+    if c0 is None or c1 is None:
+        print("VERDICT: SETUP_FAILED (the device stopped answering readmem)")
+        return 3
+    # frameCnt is 16 bits and wraps about every 20 minutes at this frame rate.
+    fps = ((c1 - c0) % 0x10000) / (time.time() - t0)
+
+    base = frames[0]
+    interframe = [int(np.count_nonzero(f != base)) for f in frames[1:]]
+    D.save_png(base, shot("frame0"))
+
+    golden_diff = None
+    if a.write_golden:
+        np.save(a.golden, base)
+        print(f"    wrote reference frame {a.golden} {base.shape}")
+    elif os.path.exists(a.golden):
+        g = np.load(a.golden)
+        golden_diff = int(np.count_nonzero(g != base)) if g.shape == base.shape else -1
+
+    print(f"RESULT mapOK={mapok} mapErr={maperr} fps={fps:.2f} height={height} "
+          f"dropped={dropped} interframe={interframe} golden_diff={golden_diff}")
+    if mapok != 1 or fps < 5.0:
+        print("VERDICT: BROKEN")
+    else:
+        print("VERDICT: STARTED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bisect/doom/doom_soak.py
+++ b/tests/bisect/doom/doom_soak.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Measure whether Doom's picture is stable while the player stands still.
+
+Every streamed VIC frame is compared against the first one. With no input the
+picture should be identical, so anything else is either the game animating or
+the machine corrupting it, and those two are told apart by counting **distinct
+change-masks**:
+
+- an animation toggles the *same* pixels every time. E1M1 has a flickering
+  light sector, and on a healthy machine it produces exactly one distinct mask,
+  even when it changes over two thousand pixels.
+- corruption changes a *different* set nearly every frame. A bitstream with the
+  defect this harness was built for produces three hundred or more.
+
+Counting deviating frames alone cannot separate them, and a plain BASIC screen
+scores 50% deviating frames on any machine because the cursor blinks.
+
+Assumes Doom is already running and settled; see doom_run.py.
+"""
+import argparse
+import hashlib
+import os
+import sys
+import time
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import doomlib as D                                            # noqa: E402
+
+# Anything above this many differing pixels is reported separately: it is the
+# difference between a few pixels on one raster line and a corrupted region.
+LARGE_PIXELS = 200
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="u64")
+    ap.add_argument("--seconds", type=float, default=25.0)
+    ap.add_argument("--label", default="soak")
+    ap.add_argument("--outdir", default=os.path.expanduser(
+        "~/.cache/doom-bisect/shots"))
+    a = ap.parse_args()
+    os.makedirs(a.outdir, exist_ok=True)
+    shot = lambda n: os.path.join(a.outdir, f"{a.label}-{n}.png")   # noqa: E731
+
+    with D.VideoStream(a.host) as vs:
+        ref = vs.frame()
+        height = ref.shape[0]
+        D.save_png(ref, shot("ref"))
+        camera_before = D.camera(a.host)
+        camera_at_first_deviation = None
+
+        frames = deviating = worst = total = large = 0
+        masks = {}
+        runs = []
+        run_length = 0
+        saved = 0
+        end = time.time() + a.seconds
+        while time.time() < end:
+            f = vs.frame(height)
+            if f.shape[0] != height:
+                continue
+            frames += 1
+            diff = int(np.count_nonzero(f != ref))
+            if not diff:
+                if run_length:
+                    runs.append(run_length)
+                    run_length = 0
+                continue
+            deviating += 1
+            total += diff
+            worst = max(worst, diff)
+            run_length += 1
+            if diff > LARGE_PIXELS:
+                large += 1
+            key = hashlib.md5(np.packbits(f != ref).tobytes()).hexdigest()[:8]
+            masks[key] = masks.get(key, 0) + 1
+            if camera_at_first_deviation is None:
+                camera_at_first_deviation = D.camera(a.host)
+            if saved < 3:
+                D.save_png(f, shot(f"dev{saved}"))
+                D.save_png(np.where(f != ref, 2, 0).astype(np.uint8), shot(f"mask{saved}"))
+                saved += 1
+        if run_length:
+            runs.append(run_length)
+
+        # The capture has to be able to show a change at all, or "stable" is
+        # meaningless. Poking the VIC border is the one way that works on every
+        # firmware in range: writing camX/camA does not move the view, because
+        # the engine undoes an out-of-bounds position and renders from cached
+        # sine and cosine values.
+        before_border = D.readmem(a.host, 0xD020, 1)
+        reference = vs.frame(height)
+        D.writemem(a.host, 0xD020, "05")
+        time.sleep(1.0)
+        live = int(np.count_nonzero(vs.frame(height) != reference)) > 0
+        if before_border:
+            D.writemem(a.host, 0xD020, f"{before_border[0]:02X}")
+
+        # Real input, where the firmware serves it. Absent before 3.15.
+        input_reference = vs.frame(height)
+        if D.inject_input(a.host):
+            time.sleep(1.5)
+            responds = ("changed"
+                        if int(np.count_nonzero(vs.frame(height) != input_reference))
+                        else "NO_CHANGE")
+        else:
+            responds = "n/a"
+
+        camera_after = D.camera(a.host)
+
+    moved = "unknown"
+    if camera_before and camera_after:
+        moved = "yes" if camera_before != camera_after else "no"
+    moved_first = "n/a"
+    if camera_before and camera_at_first_deviation:
+        moved_first = "yes" if camera_before != camera_at_first_deviation else "no"
+
+    print(f"SOAK {a.label}: frames={frames} deviating={deviating} "
+          f"({100.0 * deviating / frames if frames else 0:.2f}%) "
+          f"large={large} worst={worst}px "
+          f"mean_px={total // deviating if deviating else 0} "
+          f"distinct_masks={len(masks)} bursts={len(runs)} burst_lengths={runs[:15]} "
+          f"height={height} cam_moved={moved} moved_at_first_deviation={moved_first} "
+          f"live_border={'changed' if live else 'NO_CHANGE'} input={responds}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bisect/doom/doomlib.py
+++ b/tests/bisect/doom/doomlib.py
@@ -1,0 +1,242 @@
+"""Shared helpers for the Doom C64U hardware bisection harness.
+
+Only REST routes that exist from firmware 3.14 onward are used, so the same
+code drives every build in the bisection range. In particular `machine:input`
+is not required: it was added during the 3.15 cycle.
+"""
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import numpy as np
+
+# The suites' shared HTTP policy, so this harness retries the way they do
+# rather than growing its own client. See tests/lib/check_transport_usage.py.
+_TESTS = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_TESTS, "lib"))
+sys.path.insert(0, os.path.join(_TESTS, "e2e", "lib"))
+from rest import retrying_urlopen, url_for                          # noqa: E402
+import streams                                                      # noqa: E402
+
+# VICE-matched C64 palette, indexed by the nibble the video stream carries.
+PALETTE = np.array([
+    (0x00, 0x00, 0x00), (0xEF, 0xEF, 0xEF), (0x8D, 0x2F, 0x34), (0x6A, 0xD4, 0xCD),
+    (0x98, 0x35, 0xA4), (0x4C, 0xB4, 0x42), (0x2C, 0x29, 0xB1), (0xEF, 0xEF, 0x5D),
+    (0x98, 0x4E, 0x20), (0x5B, 0x38, 0x00), (0xD1, 0x67, 0x6D), (0x4A, 0x4A, 0x4A),
+    (0x7B, 0x7B, 0x7B), (0x9F, 0xEF, 0x93), (0x6D, 0x6A, 0xEF), (0xB2, 0xB2, 0xB2),
+], np.uint8)
+
+# Engine state, from the Doom C64U sources (src/defs.asm).
+FRAMECNT = 0x0F40      # 2 bytes, incremented once per rendered frame
+MAPOK    = 0x0F47      # 1 = the REU image was found and verified at boot
+MAPERR   = 0x0F48      # why not, when MAPOK is 0
+CAMERA   = 0x0050      # camX (2B), camY (2B), camZ (2B), camA (1B), camSec (1B)
+
+# launcher.prg polls $DC00/$DC01 for SPACE before chaining into the game. This
+# is the `bne` back-edge of that loop; overwriting it with two NOPs falls
+# through into chainToGame and needs nothing but machine:writemem.
+SPACE_BNE = 0x0945
+SPACE_BNE_OPCODE = b"\xd0\xf4"
+
+
+def req(host, path, method="GET", data=None, ctype=None, timeout=90):
+    """One REST call. Returns (status, body); status 0 means the call failed."""
+    r = urllib.request.Request(url_for(host, path), data=data, method=method)
+    if ctype:
+        r.add_header("Content-Type", ctype)
+    try:
+        with retrying_urlopen(r, timeout, idempotent=(method == "GET")) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+    except Exception as e:                      # noqa: BLE001 - transport errors
+        return 0, str(e).encode()
+
+
+def readmem(host, addr, length):
+    """The bytes at `addr`, or None when the device did not answer with them.
+
+    A caller that treats an error body as memory reports a transient REST
+    failure as a defect in the bitstream under test, which is the one verdict a
+    bisection must never produce.
+    """
+    status, body = req(host, f"/v1/machine:readmem?address={addr:04X}&length={length}")
+    if status != 200 or len(body) != length:
+        return None
+    return body
+
+
+def writemem(host, addr, hexdata):
+    return req(host, f"/v1/machine:writemem?address={addr:04X}&data={hexdata}",
+               "PUT", timeout=15)[0] == 200
+
+
+def framecnt(host):
+    """The engine's frame counter, or None if it could not be read."""
+    b = readmem(host, FRAMECNT, 2)
+    return (b[0] | (b[1] << 8)) if b else None
+
+
+def camera(host):
+    """Player camera. A picture that changed while this did not is corruption;
+    a picture that changed after it moved is the player having moved, which a
+    twitchy joystick on port 2 can cause with nobody touching it."""
+    return readmem(host, CAMERA, 8)
+
+
+def inject_input(host):
+    """Real key and joystick input. Returns False on firmware without the API."""
+    body = json.dumps({"events": [
+        {"kind": "keyboard", "inputs": ["w"], "transition": "tap"},
+        {"kind": "joystick", "port": 2, "inputs": ["left"], "transition": "tap"},
+    ]}).encode()
+    return req(host, "/v1/machine:input", "POST", body,
+               "application/json", timeout=15)[0] == 200
+
+
+class VideoStream:
+    """The VIC video stream, held open so frames can be taken back to back.
+
+    Frame assembly, the socket options and the wire format are
+    tests/e2e/lib/streams.py's, and using anything else here is a mistake that
+    has already been made once: assembling a frame by concatenating payloads in
+    arrival order turns a reordered packet into a scrambled picture, and
+    scrambled differently every time. That reads as random corruption and is
+    indistinguishable from the defect this harness looks for.
+
+    streams.FrameAssembler places each packet by its header offset and only
+    returns complete frames, and packets from any other device on the shared
+    multicast group are discarded: on a bench with more than one Ultimate they
+    otherwise land in the middle of a frame.
+    """
+
+    def __init__(self, host, timeout=10.0):
+        self.host = host
+        self.addresses = streams.source_addresses(host)
+        status, body = req(host, f"/v1/streams/video:start?ip={streams.VIDEO_GROUP}",
+                           "PUT", timeout=15)
+        if status != 200:
+            raise RuntimeError(f"the device refused to start its video stream: "
+                               f"HTTP {status} {body[:120]!r}")
+        time.sleep(0.5)
+        try:
+            self.sock = streams.stream_socket(streams.VIDEO_GROUP, streams.VIDEO_PORT,
+                                              timeout=timeout)
+        except Exception:
+            req(host, "/v1/streams/video:stop", "PUT", timeout=15)
+            raise
+        self.assembler = streams.FrameAssembler()
+        self.timeout = timeout
+
+    def close(self):
+        try:
+            self.sock.close()
+        finally:
+            req(self.host, "/v1/streams/video:stop", "PUT", timeout=15)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def frame(self, expect_lines=None):
+        """The next complete frame, as an array of one colour index per pixel.
+
+        `expect_lines`, when given, skips frames of another height rather than
+        returning one the caller cannot compare against its reference.
+        """
+        for _sock, data, mine in streams.receive([self.sock], self.addresses,
+                                                 self.timeout):
+            if not mine:
+                continue
+            # push() returns a frame only once every packet of it has arrived,
+            # so a frame that lost one is discarded inside the assembler and is
+            # never compared. counts() is the loss accounting.
+            frame = self.assembler.push(data)
+            if frame is None:
+                continue
+            if expect_lines is not None and frame.height != expect_lines:
+                continue
+            pixels = np.frombuffer(streams.unpack(frame.packed), np.uint8)
+            return pixels.reshape(frame.height, frame.width)
+        raise RuntimeError(f"no complete VIC frame within {self.timeout}s")
+
+
+def save_png(indices, path):
+    from PIL import Image
+    Image.fromarray(PALETTE[indices]).save(path)
+
+
+def load_reu(host, remote_path, attempts=20, delay=3.0):
+    """Load a .reu file straight into REU memory.
+
+    runners:modplay is the only REST route that does this; it is the same
+    operation the file browser's "Load into REU" performs. It then starts the
+    MOD player, whose sampler channels keep reading REU in the FPGA, so the
+    caller must silence them before running the game.
+
+    The retries cover USB re-enumeration after a JTAG FPGA reconfigure, during
+    which the path does not exist yet.
+    """
+    path = "/v1/runners:modplay?file=" + urllib.parse.quote(remote_path)
+    status, body, attempt = 0, b"", 0
+    for attempt in range(1, attempts + 1):
+        status, body = req(host, path, "PUT", timeout=240)
+        if status == 200:
+            return attempt
+        time.sleep(delay)
+    raise RuntimeError(f"REU image never loaded: HTTP {status} {body[:120]!r}")
+
+
+SAMPLER_BASE = 0xDF20
+SAMPLER_END = 0xE000            # exclusive: $DF20-$DFFF is 224 bytes
+
+
+def silence_sampler(host):
+    """Gate off every Ultimate Audio channel at $DF20-$DFFF, so the MOD player
+    started by load_reu() stops competing with the engine for REU bandwidth.
+
+    The last chunk is clamped: Doom runs with RAM under the KERNAL, so writing a
+    full 128 bytes from $DFA0 would zero $E000-$E01F of engine memory and the
+    damage would be blamed on the bitstream under test.
+    """
+    for base in range(SAMPLER_BASE, SAMPLER_END, 128):
+        writemem(host, base, "00" * min(128, SAMPLER_END - base))
+
+
+def run_prg(host, prg_path):
+    with open(prg_path, "rb") as fh:
+        prg = fh.read()
+    status, body = req(host, "/v1/runners:run_prg", "POST", prg,
+                       "application/octet-stream", timeout=60)
+    if status != 200:
+        raise RuntimeError(f"run_prg failed: HTTP {status} {body[:120]!r}")
+
+
+def wait_for_title(host, deadline=45.0):
+    """Block until launcher.prg is loaded and sitting in its SPACE loop."""
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        if readmem(host, SPACE_BNE, 2) == SPACE_BNE_OPCODE:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def skip_title(host, deadline=45.0):
+    """Leave the launcher's SPACE wait without a keyboard.
+
+    The loop is confirmed present before it is overwritten. Writing blind would
+    put two NOPs over whatever the launcher had reached instead, and the run
+    would then be reported broken by the harness that broke it.
+    """
+    if not wait_for_title(host, deadline):
+        return False, None, None
+    before = readmem(host, SPACE_BNE, 2)
+    writemem(host, SPACE_BNE, "EAEA")
+    return True, before, readmem(host, SPACE_BNE, 2)

--- a/tests/bisect/doom/install_assets.py
+++ b/tests/bisect/doom/install_assets.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Download the published Doom C64U release and put game.reu on the device.
+
+The bisection harness reloads the REU image on every launch, and doing that
+from a file already on the device is far quicker than uploading 8 MB each time,
+so the image is placed once over FTP. launcher.prg stays local: doom_run.py
+uploads it with the request that starts it.
+
+    ./install_assets.py --host u64 --dir /USB2/doom
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+import ftp as ftp_lib                                              # noqa: E402
+from rest import retrying_urlopen                                  # noqa: E402
+
+RELEASE_API = "https://api.github.com/repos/slesinger/doom/releases/latest"
+ASSETS = ("game.reu", "launcher.prg")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="u64")
+    ap.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""),
+                    help="device FTP password; the shared default is used when "
+                         "this is empty")
+    ap.add_argument("--dir", default="/USB2/doom",
+                    help="device directory for game.reu; the USB volume is "
+                         "named differently on different machines, so check a "
+                         "listing first")
+    ap.add_argument("--cache", default=os.path.expanduser("~/.cache/doom-bisect/assets"))
+    ap.add_argument("--timeout", type=float, default=60.0)
+    a = ap.parse_args()
+
+    with retrying_urlopen(urllib.request.Request(RELEASE_API), a.timeout,
+                          idempotent=True) as resp:
+        release = json.load(resp)
+    tag = release.get("tag_name", "unknown")
+    urls = {x["name"]: x["browser_download_url"] for x in release.get("assets", [])}
+    missing = [n for n in ASSETS if n not in urls]
+    if missing:
+        print(f"release {tag} has no {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    cache = Path(a.cache)
+    cache.mkdir(parents=True, exist_ok=True)
+    local = {}
+    for name in ASSETS:
+        path = cache / name
+        if not path.exists() or path.stat().st_size == 0:
+            with retrying_urlopen(urllib.request.Request(urls[name]), a.timeout,
+                                  idempotent=True) as resp:
+                path.write_bytes(resp.read())
+        local[name] = path
+        print(f"{tag}: {name} {path.stat().st_size} bytes -> {path}")
+
+    # tests/lib/ftp.py already resolves the target's FTP port, knows the shared
+    # credentials, and closes the session on any path: an 8 MB upload that fails
+    # would otherwise hold one of the device's four FTP slots for 300 seconds.
+    with ftp_lib.session(a.host, a.password or None, timeout=a.timeout) as client:
+        ftp_lib.make_dir(client, a.dir)
+        ftp_lib.store(client, f"{a.dir}/game.reu", local["game.reu"].read_bytes())
+    print(f"uploaded game.reu to {a.dir} on {a.host}")
+    print(f"launcher.prg stays local: pass --prg {local['launcher.prg']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bisect/doom/list_bitstreams.sh
+++ b/tests/bisect/doom/list_bitstreams.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# list_bitstreams.sh [good..bad]
+#
+# The FPGA bitstream, not the firmware commit, is the variable that tracks this
+# family of defect, and only a dozen or so distinct ones exist across a release.
+# Different branches also carry different bitstream lineages, so bisecting
+# firmware commits spends most of its rounds on builds whose hardware is
+# identical. This lists each distinct external/u64.sof in a range, oldest
+# first, with the commit that introduced it.
+set -uo pipefail
+RANGE="${1:-v3.14..v3.15}"
+# Deduplicated on the blob: a commit that touched the path without changing the
+# bitstream, or a revert and reapply, would otherwise be listed as a separate
+# build and cost a bisection round on hardware that is already known.
+seen=""
+git log --format="%H|%ad|%s" --date=short "$RANGE" -- external/u64.sof | tac |
+while IFS='|' read -r sha date subject; do
+    blob=$(git rev-parse --short "$sha:external/u64.sof")
+    case " $seen " in *" $blob "*) continue ;; esac
+    seen="$seen $blob"
+    printf '%s  %s  blob=%s  %s\n' \
+        "$(git rev-parse --short "$sha")" "$date" "$blob" "${subject:0:58}"
+done

--- a/tests/bisect/doom/record_run.py
+++ b/tests/bisect/doom/record_run.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Record the device's video and audio to one mp4, so a bisection result can be
+watched rather than taken on trust.
+
+Far simpler than the E2E recorder in tests/e2e/lib/recorder.py: there is no
+harness pane, no run log and no suite timeline, because a bisection has only one
+subject. The stream decoding is that module's, through tests/e2e/lib/streams.py.
+
+    ./record_run.py --host u64 --seconds 25 -o runs/c4be69a2.mp4
+
+Video is written straight to an encoder as it arrives; audio is small enough to
+hold in memory and is muxed in at the end. Feeding one ffmpeg process both from
+one thread deadlocks at this frame size, which is why the E2E recorder uses a
+process per stream and why this one buffers instead.
+"""
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+import wave
+from pathlib import Path
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent          # tests/bisect/doom
+sys.path.insert(0, str(SCRIPT_DIR.parents[1] / "lib"))          # tests/lib
+sys.path.insert(0, str(SCRIPT_DIR.parents[1] / "e2e" / "lib"))  # tests/e2e/lib
+
+import streams                                                     # noqa: E402
+import targets                                                     # noqa: E402
+from api import UltimateApi                                        # noqa: E402
+
+sys.path.insert(0, str(SCRIPT_DIR))
+import doomlib as D                                                # noqa: E402
+
+PAL_FPS = 50
+
+
+def encode(host, seconds, out_path, want_audio, quality, api):
+    handle = targets.resolve(host)
+    addresses = streams.source_addresses(host)
+    video_sock = streams.stream_socket(handle.video_group, handle.video_port, timeout=2.0)
+    audio_sock = None
+    if want_audio:
+        audio_sock = streams.stream_socket(handle.audio_group, handle.audio_port,
+                                           timeout=2.0)
+    assembler = streams.FrameAssembler()
+    timeline = streams.AudioTimeline()
+    pcm = bytearray()
+    encoder = None
+    frames = 0
+    tmp_video = f"{out_path}.video.mp4"
+    tmp_audio = f"{out_path}.audio.wav"
+
+    socks = [s for s in (video_sock, audio_sock) if s is not None]
+    try:
+        for sock, data, mine in streams.receive(socks, addresses, seconds):
+            if not mine:
+                continue
+            if audio_sock is not None and sock is audio_sock:
+                pcm += timeline.push(data).pcm
+                continue
+            frame = assembler.push(data)
+            if frame is None:
+                continue
+            rgb = D.PALETTE[np.frombuffer(streams.unpack(frame.packed), np.uint8)
+                            .reshape(frame.height, frame.width)]
+            if encoder is None:
+                encoder = subprocess.Popen(
+                    ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+                     "-f", "rawvideo", "-pix_fmt", "rgb24",
+                     "-s", f"{frame.width}x{frame.height}", "-r", str(PAL_FPS),
+                     "-i", "pipe:0", "-c:v", "libx264", "-preset", quality,
+                     "-pix_fmt", "yuv420p", tmp_video],
+                    stdin=subprocess.PIPE)
+            encoder.stdin.write(rgb.tobytes())
+            frames += 1
+    finally:
+        for sock in socks:
+            sock.close()
+        if encoder is not None:
+            encoder.stdin.close()
+            encoder.wait(timeout=120)
+
+    if frames == 0:
+        raise RuntimeError("no video frames arrived; is the stream running?")
+
+    if want_audio and pcm:
+        rate = streams.rate_for(api.configs.get("U64 Specific Settings",
+                                                "System Mode") != "NTSC")
+        with wave.open(tmp_audio, "wb") as handle_wav:
+            handle_wav.setnchannels(2)
+            handle_wav.setsampwidth(2)
+            handle_wav.setframerate(int(round(rate)))
+            handle_wav.writeframes(bytes(pcm))
+        subprocess.run(
+            ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+             "-i", tmp_video, "-i", tmp_audio,
+             "-c:v", "copy", "-c:a", "aac", "-b:a", "128k",
+             "-shortest", out_path], check=True)
+        os.remove(tmp_video)
+        os.remove(tmp_audio)
+    else:
+        os.replace(tmp_video, out_path)
+    return frames, len(pcm) // 4
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Record the device's video and audio to an mp4.")
+    ap.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    ap.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    ap.add_argument("-t", "--timeout", type=float, default=30.0)
+    ap.add_argument("--seconds", type=float, default=25.0,
+                    help="how long to record")
+    ap.add_argument("-o", "--out", required=True, help="output mp4")
+    ap.add_argument("--no-record-audio", dest="record_audio", action="store_false",
+                    help="video only")
+    ap.add_argument("--record-quality", default="veryfast",
+                    help="x264 preset; 'veryfast' keeps up with the stream")
+    args = ap.parse_args()
+
+    if not shutil.which("ffmpeg"):
+        print("ffmpeg is not on PATH; cannot record", file=sys.stderr)
+        return 2
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    started = time.monotonic()
+    with streams.Arming(api, args.host) as arming:
+        arming.start("video")
+        if args.record_audio:
+            arming.start("audio")
+        frames, samples = encode(args.host, args.seconds, args.out,
+                                 args.record_audio, args.record_quality, api)
+    print(f"RECORDED {args.out} frames={frames} audio_samples={samples} "
+          f"seconds={time.monotonic() - started:.1f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bisect/doom/verdict.sh
+++ b/tests/bisect/doom/verdict.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# verdict.sh <commit> [tag] [launches] [seconds]
+#
+# Deploy one commit, then launch Doom several times and judge the picture.
+#   BROKEN  the engine rejected the REU image or never rendered
+#   BAD     the picture is randomly corrupted
+#   GOOD    every launch was clean
+#   SETUP_FAILED  the launch itself did not happen; never counted as a defect
+#
+# Several launches, because the corruption rate varies from one launch to the
+# next on one and the same bitstream: 0%, 4.7% and 7.8% were measured on three
+# launches of the same build. One clean launch proves nothing.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMIT="${1:?usage: verdict.sh <commit> [tag] [launches] [seconds]}"
+TAG="${2:-$COMMIT}"
+LAUNCHES="${3:-3}"
+SECONDS_PER="${4:-25}"
+HOST="${DOOM_HOST:-u64}"      # or pass --host through DOOM_HOST
+REU="${DOOM_REU:-/USB2/doom/game.reu}"
+
+deployed=$(NO_CHECKOUT="${NO_CHECKOUT:-0}" bash "$HERE/deploy_commit.sh" "$COMMIT" 2>&1)
+echo "$deployed" | tail -2
+grep -q "^DEPLOYED" <<<"$deployed" || { echo "FINAL: SETUP_FAILED"; exit 3; }
+
+judged=0
+for i in $(seq 1 "$LAUNCHES"); do
+    run=$(python3 "$HERE/doom_run.py" --host "$HOST" --reu "$REU" \
+              --tag "$TAG-r$i" 2>&1)
+    echo "$run" | grep -E "^RESULT|^VERDICT"
+    grep -q "SETUP_FAILED" <<<"$run" && { echo "FINAL: SETUP_FAILED"; exit 3; }
+    grep -q "VERDICT: BROKEN" <<<"$run" && { echo "FINAL: BROKEN (launch $i)"; exit 0; }
+
+    soak=$(python3 "$HERE/doom_soak.py" --host "$HOST" --seconds "$SECONDS_PER" \
+               --label "$TAG-r$i" 2>&1)
+    echo "$soak" | grep "^SOAK"
+    masks=$(grep -oP 'distinct_masks=\K\d+' <<<"$soak" | tail -1)
+    differing=$(grep -oP 'deviating=\K\d+' <<<"$soak" | tail -1)
+    moved=$(grep -oP 'moved_at_first_deviation=\K\S+' <<<"$soak" | tail -1)
+    live=$(grep -oP 'live_border=\K\S+' <<<"$soak" | tail -1)
+    [ -z "${masks:-}" ] && { echo "FINAL: SETUP_FAILED (no soak)"; exit 3; }
+    if [ "${live:-}" != "changed" ]; then
+        echo "FINAL: SETUP_FAILED (the capture cannot show a change)"; exit 3
+    fi
+    if [ "${moved:-no}" = "yes" ]; then
+        echo "   launch $i void: the player moved, so the picture changed legitimately"
+        continue
+    fi
+    judged=$(( judged + 1 ))
+    # Calibrated by sweeping every bitstream between v3.14 and v3.15: healthy
+    # ones produce 1 to 3 masks over 0.3% to 25% of their differing frames,
+    # while the corrupt one produced 503 over 50%. Both a floor on the count and
+    # the ratio are needed, because a few masks appear on healthy bitstreams and
+    # a high ratio over three differing frames means nothing.
+    if [ "${masks:-0}" -ge 10 ] && [ "${differing:-0}" -gt 0 ] \
+       && [ "$(( masks * 10 / differing ))" -ge 3 ]; then
+        echo "FINAL: BAD (distinct_masks=$masks over $differing differing frames, launch $i)"
+        exit 0
+    fi
+done
+# A voided launch judged nothing, so concluding GOOD from a run where every
+# launch was voided would report a candidate as clean that was never tested.
+if [ "$judged" -eq 0 ]; then
+    echo "FINAL: SETUP_FAILED (every launch was void)"; exit 3
+fi
+echo "FINAL: GOOD ($judged clean launches)"

--- a/tests/e2e/io/c64/doom_release_test.py
+++ b/tests/e2e/io/c64/doom_release_test.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""E2E: the published Doom C64U release runs on this machine.
+
+Doom C64U is third-party software, but it is the most demanding public exercise
+of the U64 bus that exists: it streams level geometry, textures and sprites out
+of a 16 MB REU every frame while the CPU runs at turbo speed. Bitstreams that
+pass every other suite here have broken it, so it is worth one check.
+
+Manual, because it downloads a release from github.com and changes machine
+settings while it runs. Both are put back.
+
+What "works" means here is the engine's own verdict, evidence that it is
+rendering, and a short look at the picture:
+
+- `mapOK` is set by the engine's boot-time check of the REU image: it verifies
+  the header and sums each resident block. A REU that answers every transfer
+  with the wrong bytes fails here, and that is exactly the failure this suite
+  exists to catch.
+- `frameCnt` advancing proves the render loop is running rather than wedged
+  behind a bad fetch, and its rate distinguishes a machine whose turbo took
+  effect from one crawling at 1 MHz.
+- the picture, briefly. With the player standing still it should not change,
+  but a machine that flips its double buffer during a capture yields one
+  differing frame, so counting differing frames alone would fail a healthy
+  machine. What separates the two is how many *different* sets of pixels
+  change, relative to how many frames differ at all. The game repeats one
+  pattern; corrupt REU data alters a different set nearly every frame.
+
+The published `doom.cfg` is written for a C64 Ultimate and names settings by
+labels this machine does not necessarily share, so the settings are applied
+through the config API instead. "Turbo Control" is the case in point: the
+value that selects the turbo registers is called "C64U Turbo Registers" on
+some firmware and "U64 Turbo Registers" on others, so it is matched rather
+than hard coded.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parents[2] / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR.parents[1] / "lib"))
+
+from api import UltimateApi                                        # noqa: E402
+from rest import retrying_urlopen                                  # noqa: E402
+import streams                                                     # noqa: E402
+import targets                                                     # noqa: E402
+from report import (Failure, check, check_ok, check_skip, check_start,   # noqa: E402
+                    detail, format_exception, suite_fail, suite_ok)
+
+SUITE = "doom_release_test"
+
+RELEASE_API = "https://api.github.com/repos/slesinger/doom/releases/latest"
+REU_ASSET = "game.reu"
+PRG_ASSET = "launcher.prg"
+
+# Engine state, from the Doom C64U sources (src/defs.asm).
+FRAMECNT = 0x0F40      # 2 bytes, one increment per rendered frame
+MAPOK = 0x0F47         # 1 = the REU image was found and verified at boot
+MAPERR = 0x0F48        # why not, when mapOK is 0
+
+# launcher.prg waits for SPACE by polling the keyboard matrix at $DC00/$DC01.
+# Two NOPs over the loop's `bne` back-edge fall through into chainToGame, which
+# is how this runs without a keyboard. The pattern is checked before it is
+# overwritten, so a future release that moves the loop fails the check rather
+# than corrupting whatever now lives at that address.
+SPACE_BNE = 0x0945
+SPACE_BNE_OPCODE = b"\xd0\xf4"
+
+# Ultimate Audio channel registers. Loading a .reu through runners:modplay also
+# starts the MOD player, whose sampler channels keep reading REU memory in the
+# FPGA; silence them or that traffic competes with the engine's own streaming.
+SAMPLER_BASE = 0xDF20
+SAMPLER_END = 0xE000
+
+# Applied by hand, in place of the published doom.cfg.
+SETTINGS = (
+    ("U64 Specific Settings", "System Mode", "PAL"),
+    ("U64 Specific Settings", "Badline Timing", "Enabled"),
+    ("C64 and Cartridge Settings", "RAM Expansion Unit", "Enabled"),
+    ("C64 and Cartridge Settings", "REU Size", "16 MB"),
+    ("C64 and Cartridge Settings", "Map Ultimate Audio $DF20-DFFF", "Enabled"),
+    ("C64 and Cartridge Settings", "Command Interface", "Enabled"),
+)
+TURBO_STORE = "U64 Specific Settings"
+TURBO_ITEM = "Turbo Control"
+TURBO_MATCH = "Turbo Registers"     # the label carries a model prefix
+
+MIN_FPS = 5.0                       # a machine at 1 MHz renders about 0.3
+
+# Corruption is judged from two numbers together, calibrated by sweeping every
+# bitstream between v3.14 and v3.15 on an Ultimate 64 Elite:
+#
+#   candidate                     distinct masks   masks/differing frames
+#   v3.14                                      0   no differing frames at all
+#   every bitstream up to f2a14e51          1 - 3   0.003 - 0.25
+#   c4be69a2                                 503   0.500
+#
+# The game's own output repeats one pattern however often it recurs, so a low
+# ratio is normal however many frames differ. Corrupt REU data alters a
+# different set of pixels nearly every frame, which drives the ratio up. Both a
+# floor on the count and the ratio are required: a handful of masks appears on
+# healthy bitstreams, and a high ratio over three differing frames means nothing.
+MIN_CORRUPT_MASKS = 10
+MIN_CORRUPT_RATIO = 0.30
+
+# Maps every non-zero byte to 1, so two frames differing in the same pixels hash
+# alike whatever the colours involved.
+_NONZERO = bytes(0 if value == 0 else 1 for value in range(256))
+CORRUPTION_FRAMES = 120             # about 2.5s of PAL output
+
+
+def cache_dir() -> Path:
+    root = os.environ.get("DOOM_ASSET_DIR")
+    if root:
+        return Path(root)
+    return Path(os.environ.get("XDG_CACHE_HOME",
+                               Path.home() / ".cache")) / "doom-c64u"
+
+
+def fetch_release(timeout: float) -> tuple:
+    """Return (tag, {asset name: local path}), downloading only what is missing."""
+    request = urllib.request.Request(RELEASE_API)
+    with retrying_urlopen(request, timeout, idempotent=True) as resp:
+        release = json.load(resp)
+    tag = release.get("tag_name", "unknown")
+    wanted = {a["name"]: a["browser_download_url"]
+              for a in release.get("assets", []) if a["name"] in (REU_ASSET, PRG_ASSET)}
+    missing = {REU_ASSET, PRG_ASSET} - set(wanted)
+    if missing:
+        raise Failure(f"release {tag} has no {', '.join(sorted(missing))}")
+
+    out = cache_dir() / tag
+    out.mkdir(parents=True, exist_ok=True)
+    paths = {}
+    for name, url in wanted.items():
+        path = out / name
+        if not path.exists() or path.stat().st_size == 0:
+            request = urllib.request.Request(url)
+            with retrying_urlopen(request, timeout, idempotent=True) as resp, \
+                    open(path, "wb") as fh:
+                fh.write(resp.read())
+        paths[name] = path
+    return tag, paths
+
+
+def serves(api: UltimateApi, store: str, item: str) -> bool:
+    """Whether this machine has that setting, without raising if it has not."""
+    try:
+        return item in api.configs.category(store)
+    except Failure:
+        return False
+
+
+def turbo_register_value(api: UltimateApi) -> str:
+    values = api.configs.item(TURBO_STORE, TURBO_ITEM).get("values", [])
+    for value in values:
+        if isinstance(value, str) and TURBO_MATCH in value:
+            return value
+    raise Failure(f"{TURBO_STORE}/{TURBO_ITEM} offers no turbo-register "
+                  f"setting: {values!r}")
+
+
+def apply_settings(api: UltimateApi, previous: dict) -> None:
+    """Apply what Doom needs, recording each previous value in `previous`.
+
+    The caller owns the dict, so a failure part way through still leaves it
+    holding everything already changed. Returning it instead would abandon the
+    machine in PAL with a 16 MB REU and turbo selected.
+    """
+    wanted = list(SETTINGS) + [(TURBO_STORE, TURBO_ITEM, turbo_register_value(api))]
+    for store, item, value in wanted:
+        current = api.configs.current(store, item)
+        previous[(store, item)] = current
+        if current != value:
+            api.configs.set(store, item, value)
+
+
+def restore_settings(api: UltimateApi, previous: dict) -> None:
+    for (store, item), value in previous.items():
+        if not value:
+            # current() answers "" when the device reported no value; writing
+            # that back is refused, and silently swallowing it would hide a
+            # setting this suite changed and did not put back.
+            detail(f"cannot restore {store}/{item}: it had no readable value")
+            continue
+        try:
+            api.configs.set(store, item, value)
+        except Exception as exc:        # noqa: BLE001 - teardown must continue
+            detail(f"could not restore {store}/{item} to {value!r}: {exc}")
+
+
+def silence_sampler(api: UltimateApi) -> None:
+    """Gate off every channel in $DF20-$DFFF.
+
+    The last chunk is clamped. Doom runs with RAM under the KERNAL, so a full
+    128-byte write from $DFA0 would zero $E000-$E01F of engine memory, and the
+    firmware accepts it: route_machine.cc only rejects writes past $FFFF.
+    """
+    for addr in range(SAMPLER_BASE, SAMPLER_END, 128):
+        api.machine.writemem(addr, b"\x00" * min(128, SAMPLER_END - addr),
+                             idempotent=True)
+
+
+def wait_for_launcher(api: UltimateApi, deadline: float) -> None:
+    """Wait until launcher.prg is in RAM and sitting in its SPACE loop."""
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        if api.machine.readmem(SPACE_BNE, 2) == SPACE_BNE_OPCODE:
+            return
+        time.sleep(0.5)
+    raise Failure(
+        f"launcher.prg never reached its title screen: ${SPACE_BNE:04X} is not "
+        f"{SPACE_BNE_OPCODE.hex()} within {deadline:.0f}s")
+
+
+def distinct_change_masks(host, frames_wanted: int, timeout: float) -> tuple:
+    """Capture frames of a still picture and count how many distinct sets of
+    pixels differ from the first one.
+
+    Frames are assembled by header offset and packets from any other device on
+    the shared multicast group are discarded, so neither reordering nor another
+    Ultimate streaming into the same group reads as a change.
+    """
+    import hashlib
+
+    addresses = streams.source_addresses(host)
+    handle = targets.resolve(host)
+    sock = streams.stream_socket(handle.video_group, handle.video_port, timeout=2.0)
+    assembler = streams.FrameAssembler()
+    reference = None
+    masks = {}
+    frames = deviating = worst = 0
+    try:
+        for _sock, data, mine in streams.receive([sock], addresses, timeout):
+            if not mine:
+                continue
+            frame = assembler.push(data)
+            if frame is None or not frame.complete:
+                continue
+            pixels = streams.unpack(frame.packed)
+            if reference is None or len(pixels) != len(reference):
+                reference = pixels
+                continue
+            frames += 1
+            # Done with whole-buffer operations. An interpreted pass over
+            # 104,448 pixels costs more than the 20 ms a PAL frame allows, and a
+            # reader that falls behind loses packets; FrameAssembler then
+            # completes almost no frame and the suite fails for its own slowness.
+            size = len(pixels)
+            xored = (int.from_bytes(pixels, "big")
+                     ^ int.from_bytes(reference, "big")).to_bytes(size, "big")
+            unchanged = xored.count(0)
+            if unchanged != size:
+                deviating += 1
+                worst = max(worst, size - unchanged)
+                key = hashlib.md5(xored.translate(_NONZERO)).hexdigest()[:8]
+                masks[key] = masks.get(key, 0) + 1
+            if frames >= frames_wanted:
+                break
+    finally:
+        sock.close()
+    return frames, deviating, len(masks), worst
+
+
+def read_framecnt(api: UltimateApi) -> int:
+    raw = api.machine.readmem(FRAMECNT, 2)
+    return raw[0] | (raw[1] << 8)
+
+
+def wait_for_engine(api: UltimateApi, deadline: float) -> None:
+    end = time.monotonic() + deadline
+    previous = None
+    while time.monotonic() < end:
+        now = read_framecnt(api)
+        if previous is not None and now != previous:
+            return
+        previous = now
+        time.sleep(0.5)
+    mapok = api.machine.readmem(MAPOK, 1)[0]
+    maperr = api.machine.readmem(MAPERR, 1)[0]
+    raise Failure(
+        f"the engine never rendered a frame within {deadline:.0f}s "
+        f"(mapOK={mapok}, mapErr={maperr}). A garbled picture with mapOK=0 is "
+        f"the REU image arriving corrupt.")
+
+
+def measure_fps(api: UltimateApi, seconds: float) -> float:
+    start_count = read_framecnt(api)
+    start = time.monotonic()
+    time.sleep(seconds)
+    return (read_framecnt(api) - start_count) / (time.monotonic() - start)
+
+
+def run(args) -> bool:
+    """Returns True when the suite has already reported itself and should stop."""
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+
+    info = api.info()
+    # Asked before the check opens: a machine without these stores answers with
+    # an error, and ConfigsApi.category raises on it. Inside the check that
+    # would report FAIL on exactly the machines meant to be skipped, and leave
+    # the check open.
+    equipped = (serves(api, "C64 and Cartridge Settings", "REU Size")
+                and serves(api, TURBO_STORE, TURBO_ITEM))
+    check_start("the machine has the REU and turbo this release needs")
+    if not equipped:
+        check_skip(f"{info.product} does not serve both a REU Size and a "
+                   f"{TURBO_ITEM} setting")
+        suite_ok(SUITE)
+        return True
+    check_ok(f"{info.product}, firmware {info.firmware_version}, "
+             f"FPGA {info.fpga_version}")
+
+    with check("download the published release"):
+        tag, assets = fetch_release(args.timeout)
+        detail(f"release {tag}: " + ", ".join(
+            f"{name} ({path.stat().st_size} bytes)" for name, path in sorted(assets.items())))
+
+    previous = {}
+    try:
+        with check("apply the settings the release documents"):
+            apply_settings(api, previous)
+
+        with check("load the level image into the REU"):
+            # POST to runners:modplay puts the body straight into REU memory,
+            # which is what the file browser's "Load into REU" does, without
+            # needing the file on the device first.
+            payload = assets[REU_ASSET].read_bytes()
+            code, _, body = api.runners.upload("modplay", payload,
+                                               timeout=args.upload_timeout)
+            if code != 200:
+                raise Failure(f"runners:modplay returned HTTP {code}: {body[:160]!r}")
+            silence_sampler(api)
+
+        with check("start the game and reach the engine"):
+            code, _, body = api.runners.upload("run_prg", assets[PRG_ASSET].read_bytes())
+            if code != 200:
+                raise Failure(f"runners:run_prg returned HTTP {code}: {body[:160]!r}")
+            wait_for_launcher(api, args.boot_timeout)
+            api.machine.writemem(SPACE_BNE, b"\xea\xea", idempotent=True)
+            wait_for_engine(api, args.boot_timeout)
+
+        with check("the engine verified its REU image"):
+            mapok = api.machine.readmem(MAPOK, 1)[0]
+            maperr = api.machine.readmem(MAPERR, 1)[0]
+            if mapok != 1:
+                raise Failure(
+                    f"mapOK={mapok}, mapErr={maperr}: the engine rejected the REU "
+                    f"image it just read back, so the REU returned wrong bytes")
+
+        with check(f"the engine renders faster than {MIN_FPS:.0f} fps"):
+            fps = measure_fps(api, args.measure_seconds)
+            detail(f"{fps:.2f} fps")
+            if fps < MIN_FPS:
+                raise Failure(
+                    f"{fps:.2f} fps: the engine renders but the turbo is not in "
+                    f"effect (a 1 MHz machine measures about 0.3)")
+
+        with check("the picture is not corrupted while the player stands still"):
+            # Arming knows whether the stream was already running, so a
+            # recording run does not lose its video when this suite ends.
+            with streams.Arming(api, args.host) as arming:
+                arming.start("video")
+                frames, deviating, masks, worst = distinct_change_masks(
+                    args.host, CORRUPTION_FRAMES, args.capture_seconds)
+            detail(f"{frames} frames, {deviating} differing, {masks} distinct "
+                   f"change-mask(s), ratio "
+                   f"{masks / deviating if deviating else 0:.2f}, worst {worst} px")
+            if frames < CORRUPTION_FRAMES // 2:
+                raise Failure(f"only {frames} frames arrived; the video stream "
+                              f"did not deliver enough to judge the picture")
+            ratio = masks / deviating if deviating else 0.0
+            if masks >= MIN_CORRUPT_MASKS and ratio >= MIN_CORRUPT_RATIO:
+                raise Failure(
+                    f"{masks} distinct change-masks over {deviating} differing "
+                    f"frames (ratio {ratio:.2f}): the picture changes a different "
+                    f"set of pixels nearly every frame, which is REU data "
+                    f"arriving corrupt, not the game's own output")
+        return False
+    finally:
+        restore_settings(api, previous)
+        try:
+            api.machine.reset()
+        except Exception:               # noqa: BLE001 - best effort teardown
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the published Doom C64U release and check it works.")
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    parser.add_argument("-t", "--timeout", type=float, default=30.0)
+    parser.add_argument("--upload-timeout", type=float, default=240.0,
+                        help="the REU image is megabytes and the device answers "
+                             "only once all of it is written")
+    parser.add_argument("--boot-timeout", type=float, default=45.0,
+                        help="seconds to wait for the title screen and the engine")
+    parser.add_argument("--measure-seconds", type=float, default=3.0,
+                        help="seconds over which the frame rate is measured")
+    parser.add_argument("--capture-seconds", type=float, default=15.0,
+                        help="deadline for collecting the frames the picture "
+                             "check compares; not a per-request timeout")
+    args = parser.parse_args()
+    try:
+        if run(args):
+            return 0
+        suite_ok(SUITE)
+        return 0
+    except Failure as exc:
+        suite_fail(SUITE, str(exc))
+        return 1
+    except Exception as exc:            # noqa: BLE001
+        suite_fail(SUITE, format_exception(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -765,11 +765,18 @@ class RunnersApi:
         self._run("modplay", {"file": file})
 
     def upload(self, action: str, payload: bytes,
-               params: Optional[Dict[str, object]] = None) -> Response:
-        """POST a file body to a runner, e.g. `upload("run_prg", prg_bytes)`."""
+               params: Optional[Dict[str, object]] = None,
+               timeout: Optional[float] = None) -> Response:
+        """POST a file body to a runner, e.g. `upload("run_prg", prg_bytes)`.
+
+        `timeout` is worth setting for a large body. A megabytes-sized REU image
+        is streamed into memory as it arrives, but the device answers only once
+        all of it is written, so the client's ordinary per-request timeout can
+        expire on a request that is progressing normally.
+        """
         return self._rest.request(
             "POST", f"/v1/runners:{action}", params=params, body=payload,
-            headers={"Content-Type": "application/octet-stream"})
+            headers={"Content-Type": "application/octet-stream"}, timeout=timeout)
 
 
 class StreamsApi:


### PR DESCRIPTION
Adds a hardware harness for bisecting Doom C64U failures on the Ultimate 64, and a manual E2E suite that runs the published release and checks it works. Nothing in the firmware changes.

## Why

Doom C64U streams level geometry, textures and sprites out of a 16 MB REU every frame while the CPU runs at turbo speed. That makes it the most demanding public exercise of the U64 bus, and it broke between 3.14 and 3.15 (slesinger/doom#5) while every existing suite stayed green.

## What is in the change

- `tests/e2e/io/c64/doom_release_test.py`, registered in `run-tests` as the manual suite `doom-release`. It downloads the current release from GitHub, applies the settings the release needs through the config API, uploads the level image straight into REU memory, starts the game, and checks the engine's own integrity flag, the frame rate, and the picture. About 25 seconds. It is manual because it reaches github.com and changes machine settings, and it puts the settings back.
- `tests/bisect/doom/`, the bisection harness. `bisect_run.py` sweeps every FPGA bitstream in a commit range, deploying each over JTAG, measuring it across several launches, and recording each one to an mp4 with sound. It writes a run directory laid out the way `run-tests --record` writes one, with a Markdown index for people and a JSON index for programs.
- One shared-library change: `RunnersApi.upload` now accepts a `timeout`. The REU image is megabytes and the device only answers once all of it is written, so the ordinary per-request timeout can expire on a request that is progressing normally.

## Two things worth knowing before reading the harness

**The FPGA bitstream is the variable, not the firmware commit.** Only thirteen distinct `external/u64.sof` binaries exist between v3.14 and v3.15, and different branches carry different bitstream lineages, so an ordinary `git bisect` over commits spends most of its rounds on builds whose hardware is identical. The harness enumerates and searches the bitstreams instead.

**Deploying is volatile.** `deploy_commit.sh` programs the FPGA with `quartus_pgm` and downloads the Nios application with `nios2-download`. Nothing is written to flash, so a power cycle always restores the flashed firmware. HDMI stays dark for the session, because the firmware initialises the HDMI transmitter only at application start and it does not come back on an older core; the network video stream still works and is what the harness measures.

## How the picture is judged

The player never moves, so every frame of video should look identical. Some frames still differ on a machine that is working correctly, so "any difference" cannot be the test. What separates the two cases is whether the same pixels keep changing or different ones each time. For each differing frame the harness records which pixels differed, then counts how many *different* such sets it saw. A working machine changes the same pixels repeatedly and stays in single figures; a machine returning corrupt REU data changes a different set nearly every frame.

Calibrated by sweeping every bitstream between v3.14 and v3.15 on an Ultimate 64 Elite, three launches each, about 1000 frames per launch:

| bitstream | frames that differed | different sets of pixels |
|---|---|---|
| v3.14 | none at all, in all three launches | 0 |
| every bitstream up to `f2a14e51` | 0 to 31% | 1 to 3 |
| `c4be69a2` | 100% | 503 |

A build is called broken at 10 or more different sets accounting for at least 30% of the differing frames. Both halves are needed: a couple of different sets appear on healthy machines, and a high proportion means nothing when only three frames differed.

## What the harness found

Two failures, on adjacent bitstream bumps, both changing only the prebuilt binaries `external/u64.sof` and `external/u64_mk2_artix.bit`:

| | first bad commit | last good | effect |
|---|---|---|---|
| Picture corruption | `c4be69a2` | `1e387255`, which carries the `f2a14e51` bitstream | the game runs at full speed, pixels in the 3D view are wrong |
| Game does not start | `77f3b381` | `198353a8` | `mapOK` is 0, the frame counter never advances, the screen is garbled |

`Bus Operation Mode = Compatibility` restores a correct picture on affected firmware but drops the machine to roughly 1 MHz: 0.30 fps against 12.6. It is a diagnostic, not a workaround.

## How it was verified

The E2E suite was run against four deployed commits, red and green in both directions:

| deployed commit | suite result |
|---|---|
| v3.14 | pass |
| `1e387255` | pass |
| `c4be69a2` | fail, on the picture check |
| `77f3b381` | fail, on the engine's integrity flag |

The bisection scripts were run end to end and independently reproduce `c4be69a2`. The three device-free gate suites (`transport-usage`, `runner-policy`, `esp-depends`) pass.

## Measurement traps the scripts handle

Each of these produced a wrong answer before it was fixed, and each is commented where it is handled:

- Frames must be assembled by header offset. Concatenating packet payloads in arrival order turns a reordered packet into a scrambled picture, scrambled differently each time, which is indistinguishable from the defect being hunted.
- The video multicast group is shared between devices on a bench, so packets from another Ultimate get assembled into these frames unless the sender is checked.
- A joystick in port 2 moves the player untouched. The harness reads the player position and voids such a run instead of counting it as a defect.
- The defect can hide for a whole launch, so several launches are required before a build is called clean.
