### PR TITLE
Fix eight firmware defects found by covering the whole REST API

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -212,6 +212,12 @@ SUITES: Sequence[Suite] = (
     # fail for a reason that is not its own.
     Suite("e2e", "create-disk-image", "tests/e2e/api/create_disk_image_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
+    # Calls every endpoint the firmware registers, and fails when one is
+    # neither probed nor excluded with a reason. The lockup that prompted it
+    # shipped because no suite called that route at all, so the gate matters
+    # more than any single probe. Runs in about a second.
+    Suite("e2e", "rest-api-coverage", "tests/e2e/api/rest_api_coverage_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     Suite("e2e", "prg-context-menu", "tests/e2e/filemanager/prg_context_menu_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
     Suite("e2e", "browser-long-filename", "tests/e2e/filemanager/browser_long_filename_test.py",

--- a/run-tests
+++ b/run-tests
@@ -206,6 +206,12 @@ SUITES: Sequence[Suite] = (
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"),
     Suite("e2e", "input", "tests/e2e/api/input_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
+    # Creates every disk-image kind and reads the device back after each one.
+    # A create that answers 200 and then takes the device down is the defect
+    # this catches, so it runs early: a dead device makes every later suite
+    # fail for a reason that is not its own.
+    Suite("e2e", "create-disk-image", "tests/e2e/api/create_disk_image_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     Suite("e2e", "prg-context-menu", "tests/e2e/filemanager/prg_context_menu_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
     Suite("e2e", "browser-long-filename", "tests/e2e/filemanager/browser_long_filename_test.py",

--- a/software/api/route_configs.cc
+++ b/software/api/route_configs.cc
@@ -174,18 +174,32 @@ API_CALL(GET, configs, none, NULL, ARRAY ( { } ))
             list->add(s->get_store_name());
         }
     } else {  // path specified, so the output would list the stores that match the path
+        bool matched = false;
         for(int i=0; i<stores->get_elements(); i++) {
             ConfigStore *s = (*stores)[i];
             if ((path_elements < 1) || pattern_match(args.get_path(0), s->get_store_name())) {
                 emit_store(s, resp->json, args);
+                matched = true;
             }
+        }
+        if (!matched) {
+            // A name no store answers to used to come back as 200 with an empty
+            // body, which reads as "the category exists and holds nothing"
+            // rather than as the typo it is.
+            resp->error("No configuration category matches '%s'.", args.get_path(0));
+            resp->json_response(HTTP_NOT_FOUND);
+            return;
         }
     }
 
     resp->json_response(HTTP_OK);
 }
 
-API_CALL(PUT, configs, none, NULL, ARRAY ( { {"value", P_REQUIRED }} ))
+// 'value' is optional because this route takes it either as the query argument
+// or as a third path element, and the handler below chooses between them and
+// rejects every other shape. Declaring it required had the validator refuse the
+// path form before the handler ran, so the branch that reads it was dead.
+API_CALL(PUT, configs, none, NULL, ARRAY ( { {"value", P_OPTIONAL }} ))
 {
     ConfigManager *cfg = ConfigManager::getConfigManager();
     IndexedList<ConfigStore *> *stores = cfg->getStores();

--- a/software/api/route_files.cc
+++ b/software/api/route_files.cc
@@ -88,16 +88,23 @@ API_CALL(PUT, files, create_d64, NULL, ARRAY( { { "tracks", P_OPTIONAL }, { "dis
     int size = (17 * (tracks - 35) + 683) * 256;
     File *f = create_file_of_size(resp, args.get_full_path(), size);
     if (f) {
-        BlockDevice_File blk(f, 256);
-        Partition prt(&blk, 0, 0, 0);
-        FileSystemD64 fs(&prt, true);
-        FRESULT fres = fs.format(fn);
+        FRESULT fres;
+        {
+            // The file system stack borrows f, so it has to be gone before the
+            // file is closed. Scoping it here also means there is one close for
+            // both outcomes: the failure path used to return without closing,
+            // leaking the File and its open handle.
+            BlockDevice_File blk(f, 256);
+            Partition prt(&blk, 0, 0, 0);
+            FileSystemD64 fs(&prt, true);
+            fres = fs.format(fn);
+        }
+        FileManager :: getFileManager()->fclose(f);
         if (fres != FR_OK) {
             resp->error(FileSystem::get_error_string(fres));
             resp->json_response(HTTP_INTERNAL_SERVER_ERROR);
             return;
         }
-        FileManager :: getFileManager()->fclose(f);
         resp->json_response(HTTP_OK);
     } 
 }
@@ -115,16 +122,23 @@ API_CALL(PUT, files, create_d71, NULL, ARRAY( { { "diskname", P_OPTIONAL } } ))
     int size = 683 * 2 * 256;
     File *f = create_file_of_size(resp, args.get_full_path(), size);
     if (f) {
-        BlockDevice_File blk(f, 256);
-        Partition prt(&blk, 0, 0, 0);
-        FileSystemD71 fs(&prt, true);
-        FRESULT fres = fs.format(fn);
+        FRESULT fres;
+        {
+            // The file system stack borrows f, so it has to be gone before the
+            // file is closed. Scoping it here also means there is one close for
+            // both outcomes: the failure path used to return without closing,
+            // leaking the File and its open handle.
+            BlockDevice_File blk(f, 256);
+            Partition prt(&blk, 0, 0, 0);
+            FileSystemD71 fs(&prt, true);
+            fres = fs.format(fn);
+        }
+        FileManager :: getFileManager()->fclose(f);
         if (fres != FR_OK) {
             resp->error(FileSystem::get_error_string(fres));
             resp->json_response(HTTP_INTERNAL_SERVER_ERROR);
             return;
         }
-        FileManager :: getFileManager()->fclose(f);
         resp->json_response(HTTP_OK);
     } 
 }
@@ -139,16 +153,23 @@ API_CALL(PUT, files, create_d81, NULL, ARRAY( { { "diskname", P_OPTIONAL } } ))
 
     File *f = create_file_of_size(resp, args.get_full_path(), 256*3200);
     if (f) {
-        BlockDevice_File blk(f, 256);
-        Partition prt(&blk, 0, 0, 0);
-        FileSystemD81 fs(&prt, true);
-        FRESULT fres = fs.format(fn);
+        FRESULT fres;
+        {
+            // The file system stack borrows f, so it has to be gone before the
+            // file is closed. Scoping it here also means there is one close for
+            // both outcomes: the failure path used to return without closing,
+            // leaking the File and its open handle.
+            BlockDevice_File blk(f, 256);
+            Partition prt(&blk, 0, 0, 0);
+            FileSystemD81 fs(&prt, true);
+            fres = fs.format(fn);
+        }
+        FileManager :: getFileManager()->fclose(f);
         if (fres != FR_OK) {
             resp->error(FileSystem::get_error_string(fres));
             resp->json_response(HTTP_INTERNAL_SERVER_ERROR);
             return;
         }
-        FileManager :: getFileManager()->fclose(f);
         resp->json_response(HTTP_OK);
     } 
 }
@@ -170,16 +191,23 @@ API_CALL(PUT, files, create_dnp, NULL, ARRAY( { { "tracks", P_REQUIRED }, { "dis
 
     File *f = create_file_of_size(resp, args.get_full_path(), tracks * 65536);
     if (f) {
-        BlockDevice_File blk(f, 256);
-        Partition prt(&blk, 0, 0, 0);
-        FileSystemDNP fs(&prt, true);
-        FRESULT fres = fs.format(fn);
+        FRESULT fres;
+        {
+            // The file system stack borrows f, so it has to be gone before the
+            // file is closed. Scoping it here also means there is one close for
+            // both outcomes: the failure path used to return without closing,
+            // leaking the File and its open handle.
+            BlockDevice_File blk(f, 256);
+            Partition prt(&blk, 0, 0, 0);
+            FileSystemDNP fs(&prt, true);
+            fres = fs.format(fn);
+        }
+        FileManager :: getFileManager()->fclose(f);
         if (fres != FR_OK) {
             resp->error(FileSystem::get_error_string(fres));
             resp->json_response(HTTP_INTERNAL_SERVER_ERROR);
             return;
         }
-        FileManager :: getFileManager()->fclose(f);
         resp->json_response(HTTP_OK);
     } 
 }

--- a/software/api/routes.h
+++ b/software/api/routes.h
@@ -130,20 +130,35 @@ public:
 
     void html_response(int code, const char *title, const char *fmt, ...)
     {
-        const char *return_str = return_codestr(code);
+        // Framed the same way as json_response: the document alone goes in the
+        // body, and the status line and headers go into resp->_buf with
+        // resp->_index set to their length.
+        //
+        // This used to write the whole HTTP message, status line included, into
+        // the body stream and leave resp->_index alone. The server then sent
+        // whatever was already in the header buffer and the real status line
+        // arrived as the first bytes of the body, so the status the caller saw
+        // was not the one asked for here. Content-Length was missing too, and
+        // the content type read "text_html".
         StreamRamFile *log = new StreamRamFile(HTTP_BUFFER_SIZE);
-        log->format("HTTP/1.1 %d %s\r\nConnection: close\r\nContent-Type: text_html\r\n\r\n", code, return_str);
 
         va_list ap;
         log->format("<html><body><h1>%s</h1>\n<p>", title);
         va_start(ap, fmt);
         log->format_ap(fmt, ap);
         va_end(ap);
+        log->format("</p></body></html>\r\n");
 
-        log->format("</p></body></html>\r\n\r\n");
-        // resp->_index = (size_t)log.getLength();
         resp->BodyContext = log;
         resp->BodyCB = &stream_body;
+
+        StreamTextLog *hdr = new StreamTextLog(HTTP_BUFFER_SIZE, (char *)resp->_buf);
+        const char *return_str = return_codestr(code);
+        hdr->format("HTTP/1.1 %d %s\r\nConnection: close\r\nContent-Type: text/html\r\n",
+                    code, return_str);
+        hdr->format("Content-Length: %d\r\n\r\n", log->getLength());
+        resp->_index = hdr->getLength();
+        delete hdr; // no longer needed
     }
 
     void error(const char *fmt, ...)

--- a/software/api/routes.h
+++ b/software/api/routes.h
@@ -212,7 +212,14 @@ public:
         // clear temporaries
         if (temporaries) {
             for(int i=0; i<temporaries->get_elements(); i++) {
-                delete (*temporaries)[i];
+                // These strings come from strdup(), so they must be released
+                // through free(). The linker wraps malloc/free (see
+                // software/system/memory_wrap.cc), and a wrapped allocation
+                // carries a size header in front of the pointer the caller
+                // gets. delete maps to a bare vPortFree() with no such
+                // adjustment, so it hands heap_4 an address that is not a block
+                // start and trips its allocated-bit assert.
+                free((void *)(*temporaries)[i]);
             }
             delete temporaries;
             temporaries = NULL;
@@ -238,6 +245,8 @@ public:
         ClearArgs();
     }
 
+    // Takes ownership of a string allocated with malloc()/strdup(). ClearAll()
+    // releases it with free(); do not pass memory obtained from new.
     void temporary(const char *im_trash)
     {
         if (!temporaries) {

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -985,6 +985,18 @@ void C64::freeze(void)
     if (!phi2_present())
         return;
 
+    if (backupIsValid) {
+        // Already frozen. backup_io() asserts on this, and a failed
+        // configASSERT spins with interrupts off, so the whole device
+        // stops answering and needs a power cycle. Two menu_button
+        // presses in quick succession reach here, which is one REST call
+        // issued twice. Declining the second freeze keeps the backup that
+        // is already held, which is the one restore_io() has to put back.
+        printf("C64::freeze: already frozen, ignoring\n");
+        isFrozen = true;   // the two have to agree, see unfreeze()
+        return;
+    }
+
     frozen_mode = C64_MODE;
     stop(true);
     backup_io();
@@ -1105,6 +1117,19 @@ void C64::unfreeze()
 {
     if (!isFrozen)
         return;
+
+    if (!backupIsValid) {
+        // Nothing left to put back: something else already restored it
+        // while isFrozen stayed set. A reset issued with the menu open
+        // takes that path, because closing the menu restores the
+        // registers before MENU_C64_RESET calls this. restore_io()
+        // asserts on it, and a failed configASSERT spins with
+        // interrupts off, so the device stops answering and needs a
+        // power cycle. Clear the flag and let the caller carry on.
+        printf("C64::unfreeze: no backup held, nothing to restore\n");
+        isFrozen = false;
+        return;
+    }
 
     if (!phi2_present())
         return;

--- a/software/io/network/network_interface.cc
+++ b/software/io/network/network_interface.cc
@@ -403,10 +403,19 @@ void NetworkInterface :: effectuate_settings(void)
  */
     if (my_net_if.state) { // is it initialized?
         if (netif_is_link_up(&my_net_if)) {
-            dhcp_stop(&my_net_if);
             if (dhcp_enable) {
-                dhcp_start(&my_net_if);
+                // Only start the client when it is not already running.
+                // dhcp_stop() clears the interface address, and lwIP aborts
+                // every connection bound to it, so stopping and starting a
+                // client that was already running dropped all of them for no
+                // change at all, including the request that asked for this:
+                // applying these settings over REST answered nothing, because
+                // the answer went out on a connection it had just aborted.
+                if (!netif_dhcp_data(&my_net_if)) {
+                    dhcp_start(&my_net_if);
+                }
             } else {
+                dhcp_stop(&my_net_if);
                 netif_set_addr(&my_net_if, &my_ip, &my_netmask, &my_gateway);
                 tcpip_callback((tcpip_callback_fn)set_dns_server_unsafe, &my_dns);
             }

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -57,7 +57,7 @@ to drive it.
 
 | Folder | Production owner | Coverage |
 |---|---|---|
-| `api/` | `software/api/` | REST contracts for input, menu screen, memory, and PRG runners |
+| `api/` | `software/api/` | REST contracts for input, menu screen, memory, disk-image creation and PRG runners, plus `rest-api-coverage`, which calls every registered operation |
 | `filemanager/` | `software/filemanager/`, `software/userinterface/` | Browser actions, change notification, and managed `/Temp` lifecycle |
 | `filesystem/` | `software/filesystem/` | Filesystem implementations, including the remote FTP filesystem |
 | `io/` | `software/io/` | Device-facing I/O subsystems, nested by production package (`c64/`, `command_interface/`, `printer/`) |
@@ -187,7 +187,23 @@ fails the run.
    that needs a host Python package adds it to [`tests/requirements.txt`](../requirements.txt)
    and to the table in [`tests/README.md`](../README.md) in the same change, so
    a fresh checkout can run the gate without guessing.
-9. Keep each check under ten seconds. Above that `tests/lib/report.py` marks
+9. A new REST operation is not finished until `rest-api-coverage` knows about
+   it. That suite reads the operation list from
+   `doc/api/rest_api_openapi_*.yaml` when the tree has it and from the
+   `API_CALL` macros otherwise, and fails while an operation is neither
+   exercised by a case nor written into one of its three tables: `EXCLUDED`
+   (never call it, and why), `HAPPY_ELSEWHERE` (which suite owns the happy
+   path) or `NEGATIVE_ONLY` (why there cannot be one). The gate exists because
+   a device-halting bug in `files:create_d64` shipped while no suite called
+   that route at all.
+
+   Prefer a case that checks what the call did over one that checks the status
+   code: read the drive listing back after mounting, read the item back after
+   writing it. Where the API exposes no outcome, say so in the case rather than
+   letting a 200 stand in for a result. A case that changes machine state is
+   marked `exclusive`, records what it found, and restores it.
+
+10. Keep each check under ten seconds. Above that `tests/lib/report.py` marks
    the duration `SLOW` in yellow, which is a prompt to look rather than a
    failure. The whole gate is run repeatedly by people waiting for it, so a
    slow check has to earn its time.

--- a/tests/e2e/api/create_disk_image_test.py
+++ b/tests/e2e/api/create_disk_image_test.py
@@ -12,9 +12,8 @@ import argparse
 import ftplib
 import os
 import sys
-import time
 import urllib.error
-from typing import List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 # tests/lib holds the reporting rules every suite shares.
 sys.path.insert(0, os.path.join(
@@ -55,33 +54,35 @@ class SuiteRunner:
     def remote_path(self, label: str, kind: str) -> str:
         return f"{TEST_DIR}/cdi_{label}.{kind}"
 
-    def ftp_delete(self, path: str) -> None:
-        directory, _, name = path.rpartition("/")
+    def ftp_delete(self, paths: Iterable[str]) -> None:
+        """Remove several paths over one FTP session.
+
+        One session per file costs a control and a data connection each time,
+        which is most of this suite's wall clock for work that is not under
+        test.
+        """
+        paths = list(paths)
+        if not paths:
+            return
         try:
             with ftp_lib.session(self.args.host, self.args.password) as client:
-                ftp_lib.delete_quietly(client, f"{directory}/{name}")
+                for path in paths:
+                    ftp_lib.delete_quietly(client, path)
         except ftplib.all_errors + (OSError, Failure):
             pass
 
     def alive(self) -> Optional[str]:
-        """None when the device answers, otherwise the reason it did not."""
-        deadline = time.time() + LIVENESS_TIMEOUT_SECONDS
-        last = "no answer"
-        while time.time() < deadline:
-            try:
-                info = self.api.info()
-                if info.product:
-                    return None
-                last = "info answered without a product name"
-            except (Failure, OSError, TimeoutError, urllib.error.URLError) as exc:
-                last = format_exception(exc)
-            time.sleep(1.0)
-        return last
+        return self.api.unreachable_reason(LIVENESS_TIMEOUT_SECONDS)
+
+    def all_paths(self) -> List[str]:
+        paths = [self.remote_path(label, kind) for label, kind, _p, _e in CASES]
+        label, kind, _p, _e = CASES[0]
+        paths.append(self.remote_path(f"{label}-repeat", kind))
+        return paths
 
     # -- checks -------------------------------------------------------------
     def create_case(self, label: str, kind: str, params: dict, expected: int) -> bool:
         path = self.remote_path(label, kind)
-        self.ftp_delete(path)
 
         check_start(f"create {kind} at {path}")
         try:
@@ -134,6 +135,12 @@ class SuiteRunner:
             return False
         check_ok()
 
+        # create_* refuses to overwrite (FA_CREATE_NEW), so a leftover from an
+        # aborted run would fail every case. One session clears them all.
+        check_start("clear leftovers from an earlier run")
+        self.ftp_delete(self.all_paths())
+        check_ok()
+
         all_ok = True
         for label, kind, params, expected in CASES:
             section(label)
@@ -149,10 +156,7 @@ class SuiteRunner:
         return all_ok
 
     def cleanup(self) -> None:
-        for label, kind, _params, _expected in CASES:
-            self.ftp_delete(self.remote_path(label, kind))
-        label, kind, _params, _expected = CASES[0]
-        self.ftp_delete(self.remote_path(f"{label}-repeat", kind))
+        self.ftp_delete(self.all_paths())
 
 
 def main() -> int:

--- a/tests/e2e/api/create_disk_image_test.py
+++ b/tests/e2e/api/create_disk_image_test.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# E2E: Verifies the files:create_* disk-image routes and that the device stays
+# alive afterwards.
+#
+# The liveness check after every create is the point of this suite. A create
+# call that answers HTTP 200 but leaves the device unable to serve the next
+# request is the failure this suite exists to catch: ArgsURI::ClearAll() used to
+# release a strdup()'d string with delete, which reaches heap_4 with an address
+# that is not a block start and stops the whole device inside configASSERT.
+
+import argparse
+import ftplib
+import os
+import sys
+import time
+import urllib.error
+from typing import List, Optional, Tuple
+
+# tests/lib holds the reporting rules every suite shares.
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"))
+import ftp as ftp_lib  # noqa: E402  (needs tests/lib on sys.path first)
+import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
+from api import UltimateApi  # noqa: E402  (needs tests/lib on sys.path first)
+from report import (  # noqa: E402  (needs tests/lib on sys.path first)
+    Failure, check_count, check_fail, check_ok, check_start, detail,
+    format_exception, section, suite_fail, suite_ok)
+
+SUITE = "create_disk_image_test"
+TEST_DIR = "/Temp"
+
+# (label, kind, keyword arguments, expected size in bytes)
+# Sizes are the ones software/api/route_files.cc computes.
+CASES: List[Tuple[str, str, dict, int]] = [
+    ("d64-35", "d64", {"tracks": 35}, 683 * 256),
+    ("d64-40", "d64", {"tracks": 40}, (17 * 5 + 683) * 256),
+    ("d71", "d71", {}, 683 * 2 * 256),
+    ("d81", "d81", {}, 3200 * 256),
+    ("dnp-1", "dnp", {"tracks": 1}, 65536),
+    ("dnp-16", "dnp", {"tracks": 16}, 16 * 65536),
+]
+
+# How long to wait for the device to answer the liveness read after a create.
+# The failure mode this guards against is permanent, so a short budget is
+# enough and keeps a broken build from stalling the run.
+LIVENESS_TIMEOUT_SECONDS = 10.0
+
+
+class SuiteRunner:
+    def __init__(self, args) -> None:
+        self.args = args
+        self.api = UltimateApi(args.host, args.password, args.timeout)
+
+    # -- helpers ------------------------------------------------------------
+    def remote_path(self, label: str, kind: str) -> str:
+        return f"{TEST_DIR}/cdi_{label}.{kind}"
+
+    def ftp_delete(self, path: str) -> None:
+        directory, _, name = path.rpartition("/")
+        try:
+            with ftp_lib.session(self.args.host, self.args.password) as client:
+                ftp_lib.delete_quietly(client, f"{directory}/{name}")
+        except ftplib.all_errors + (OSError, Failure):
+            pass
+
+    def alive(self) -> Optional[str]:
+        """None when the device answers, otherwise the reason it did not."""
+        deadline = time.time() + LIVENESS_TIMEOUT_SECONDS
+        last = "no answer"
+        while time.time() < deadline:
+            try:
+                info = self.api.info()
+                if info.product:
+                    return None
+                last = "info answered without a product name"
+            except (Failure, OSError, TimeoutError, urllib.error.URLError) as exc:
+                last = format_exception(exc)
+            time.sleep(1.0)
+        return last
+
+    # -- checks -------------------------------------------------------------
+    def create_case(self, label: str, kind: str, params: dict, expected: int) -> bool:
+        path = self.remote_path(label, kind)
+        self.ftp_delete(path)
+
+        check_start(f"create {kind} at {path}")
+        try:
+            getattr(self.api.files, f"create_{kind}")(path, **params)
+        except (Failure, OSError, TimeoutError, urllib.error.URLError) as exc:
+            check_fail(f"create_{kind} did not complete: {format_exception(exc)}")
+            return False
+        check_ok()
+
+        # Run this before the size check: when the create takes the device down,
+        # files:info cannot answer either, and the liveness wording says what
+        # actually happened.
+        check_start(f"device still answers after create {kind}")
+        reason = self.alive()
+        if reason:
+            check_fail(
+                f"device stopped answering after create_{kind}: {reason}. "
+                "It needs a power cycle.")
+            return False
+        check_ok()
+
+        check_start(f"{path} is {expected} bytes")
+        try:
+            info = self.api.files.info(path)
+        except (Failure, OSError, TimeoutError, urllib.error.URLError) as exc:
+            check_fail(f"files:info failed: {format_exception(exc)}")
+            return False
+        if info is None:
+            check_fail(f"{path} does not exist after a successful create")
+            return False
+        if info.size != expected:
+            check_fail(f"{path} is {info.size} bytes, expected {expected}")
+            return False
+        check_ok()
+        return True
+
+    def repeat_case(self) -> bool:
+        """A second create in a fresh request proves the first one left the
+        device in a state that can still serve requests, not merely alive."""
+        label, kind, params, expected = CASES[0]
+        section("repeat")
+        return self.create_case(f"{label}-repeat", kind, params, expected)
+
+    def run(self) -> bool:
+        section("preconditions")
+        check_start("device reachable")
+        reason = self.alive()
+        if reason:
+            check_fail(f"device did not answer before the suite started: {reason}")
+            return False
+        check_ok()
+
+        all_ok = True
+        for label, kind, params, expected in CASES:
+            section(label)
+            if not self.create_case(label, kind, params, expected):
+                all_ok = False
+                # Once the device is down every later case reports the same
+                # thing, so stop and say so once.
+                if self.alive():
+                    detail("device is down; skipping the remaining cases")
+                    return False
+        if all_ok:
+            all_ok = self.repeat_case()
+        return all_ok
+
+    def cleanup(self) -> None:
+        for label, kind, _params, _expected in CASES:
+            self.ftp_delete(self.remote_path(label, kind))
+        label, kind, _params, _expected = CASES[0]
+        self.ftp_delete(self.remote_path(f"{label}-repeat", kind))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS"))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "10.0")))
+    args = parser.parse_args()
+
+    runner = SuiteRunner(args)
+    try:
+        passed = runner.run()
+    except Failure as exc:
+        suite_fail(SUITE, format_exception(exc))
+        return 1
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        if rest_lib.looks_unreachable(exc):
+            suite_fail(SUITE, f"connection failure: {format_exception(exc)}")
+        else:
+            suite_fail(SUITE, f"REST failure: {format_exception(exc)}")
+        return 1
+    finally:
+        try:
+            runner.cleanup()
+        except Exception:
+            pass
+
+    if passed:
+        suite_ok(SUITE, f"{check_count()} checks")
+        return 0
+    suite_fail(SUITE, "see the failed check above")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/api/rest_api_coverage_test.py
+++ b/tests/e2e/api/rest_api_coverage_test.py
@@ -1,427 +1,1069 @@
 #!/usr/bin/env python3
-# E2E: Calls every REST endpoint the firmware registers and checks the device
-# survives each one.
+# E2E: Exercises every REST operation the firmware serves, checks what each call
+# actually did, and checks the device survives it.
 #
 # Why this exists. A lockup in files:create_d64 shipped because no suite ever
 # called that route: the API surface was covered by whichever endpoints the
-# feature suites happened to need. So this suite reads the route table out of
-# software/api/*.cc and requires every route to be classified, either with a
-# probe here or with a written reason for not calling it. A new endpoint fails
-# this suite until somebody decides which it is.
+# feature suites happened to need. This suite reads the operation list off the
+# device's own contract and requires every operation to be classified, so a new
+# one fails the suite until somebody decides what to do with it.
 #
-# What a probe is. Most probes deliberately drive the argument or error path
-# rather than the successful one: a nonexistent file, an unknown drive, a
-# missing required argument. That keeps the suite fast and side-effect free,
-# and it is not a weaker check than a happy-path call would be. The bug that
-# prompted this suite was in ArgsURI's destructor, which runs on every request
-# whatever the outcome, so an error-path call catches it exactly as well.
+# Where the operation list comes from. doc/api/rest_api_openapi_*.yaml when it
+# is in the tree, because that is generated from the route table and lists the
+# path-parameter variants that behave differently: the per-category flash
+# operations, and a category read against an item read. Otherwise the API_CALL
+# macros in software/api/*.cc, which name every handler but collapse those
+# variants into one entry.
 #
-# After every probe the device is read back. That read is what turns "the route
-# answered" into "the route answered and the firmware is still running".
+# Side effects. Where a call has an outcome the API can see, the case reads it
+# back: drives:off is followed by a listing that says the drive is off,
+# menu_button by a menu_screen that answers, writemem by a readmem of the byte.
+# Where there is none REST exposes, the case says so instead of letting a status
+# code stand in for a result.
 #
-# Repetition. The lockup this suite exists for did not fire on a cold device on
-# the first call, so every probe runs --repeat times. By default the repetitions
-# are spread across worker threads so that different endpoints are in flight at
-# once, which is the harder case: it overlaps request teardown on one connection
-# with argument parsing on another. --order sequential runs each endpoint's
-# repetitions back to back on one thread instead, which is what you want when a
-# single endpoint is suspect and you need the calls attributable.
+# Calls go through tests/lib/api.py rather than hand-built URLs. That is where
+# the URL shapes live, and building them here is how an earlier version of this
+# suite ended up calling /v1/drives:mount, which is not the route: the drive is
+# a path element, so it answered 400 for the wrong reason and passed.
+#
+# Cost and safety. Negative cases drive the argument path, which is free and
+# leaves nothing behind. Cases that change the machine are exclusive, never run
+# concurrently, record what they found first, and cleanup() puts it back however
+# the run ended.
+#
+# Repetition. The lockup did not fire on a cold device on the first call, so
+# every case runs --repeat times. By default the repetitions are spread across
+# worker threads so different operations are in flight at once, which overlaps
+# request teardown on one connection with argument parsing on another.
+# --order sequential runs each case's repetitions back to back instead, for when
+# one operation is suspect and the calls have to be attributable.
+#
+# Targets: any, including a cartridge. Operations a product does not build are
+# reported SKIP with the reason, not passed over: machine:input answers 501 on a
+# cartridge, machine:debugreg and the streams are not in a cartridge's route
+# table at all, and readmem's zero-length rejection is a firmware fix that
+# tests/lib/machine.py knows some releases lack.
 
 import argparse
-import ftplib
 import os
 import posixpath
 import re
+import socket
 import sys
 import threading
+import time
 import urllib.error
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
-# tests/lib holds the reporting rules and the one shared REST client.
+# tests/lib holds the reporting rules, the typed API and the one REST client;
+# tests/e2e/lib holds the settings fixtures the cfg-* suites share.
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "lib"))
 import ftp as ftp_lib  # noqa: E402  (needs tests/lib on sys.path first)
+import machine as machine_lib  # noqa: E402  (needs tests/lib on sys.path first)
 import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
 from api import UltimateApi  # noqa: E402  (needs tests/lib on sys.path first)
 from report import (  # noqa: E402  (needs tests/lib on sys.path first)
     Failure, check_count, check_fail, check_ok, check_skip, check_start, detail,
-    format_exception, section, suite_fail, suite_ok)
+    format_exception, section, suite_fail, suite_ok, warn)
+from temp_settings import AUTO_CLEANUP_ITEM, CONFIG_CATEGORY  # noqa: E402
 
 SUITE = "rest_api_coverage_test"
-API_SOURCE_DIR = Path(__file__).resolve().parents[3] / "software" / "api"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+API_SOURCE_DIR = REPO_ROOT / "software" / "api"
+OPENAPI_DIR = REPO_ROOT / "doc" / "api"
 API_CALL_RE = re.compile(
     r"^API_CALL\(\s*(\w+)\s*,\s*(\w+)\s*,\s*(\w+)\s*,", re.MULTILINE)
 
-# A scratch directory that exists on every product, cleared on reboot.
+# The category the reset case uses. Printer settings change nothing the harness
+# depends on, unlike User Interface Settings, whose Interface Type defaults to
+# Freeze. See the reset case for why that matters.
+RESETTABLE_CATEGORY = "Printer Settings"
+
 SCRATCH = "/Temp"
-# A path that is guaranteed not to exist, for probes that must not create
-# anything. The directory component does not exist either, so a route that
-# creates a file on the way to failing still creates nothing.
-MISSING = "/Temp/rest_api_coverage_no_such_dir/no_such_file"
+# A path whose parent does not exist either, so a route that creates a file on
+# its way to failing still creates nothing.
+MISSING = f"{SCRATCH}/rest_api_coverage_absent/no_such_file"
+MOUNT_IMAGE = f"{SCRATCH}/rest_api_coverage.d64"
+# Cassette buffer: RAM the C64 is not using at a BASIC prompt.
+SCRATCH_ADDRESS = 0x0334
+# Longer than MAX_WRITEMEM_HEX_BYTES, so api.writemem takes the POST form. That
+# is what gives POST machine:writemem a happy case.
+POST_WRITE_LENGTH = 256
 
 LIVENESS_TIMEOUT_SECONDS = 10.0
-
+# How long the menu may take to appear or go after the button is pressed. The
+# press is handed to the UI task, so it is not done when the call returns.
+MENU_SETTLE_SECONDS = 5.0
 # The firmware serves MAX_HTTP_CLIENT = 4 connections (httpd/c-version/lib/
-# server.h). Each worker holds one for the call and one for the liveness read
-# that follows it, but never both at once, so the ceiling is one per worker.
-# Three leaves a slot free: saturating the last one turns a slow answer into a
-# refused connection, which would read as a device failure rather than as the
-# queueing it is.
+# server.h). A worker holds one for the call and one for the liveness read that
+# follows, never both at once, so the ceiling is one per worker. Three leaves a
+# slot free: saturating the last one turns a slow answer into a refused
+# connection, which reads as a device failure rather than as queueing.
 DEFAULT_WORKERS = 3
 DEFAULT_REPEAT = 3
 
-# Endpoints that are deliberately not called, and why. Anything listed here is
-# still required to exist: if one is removed from the firmware this suite fails,
-# so the list cannot rot into a set of names nobody recognises.
-EXCLUDED: Dict[Tuple[str, str, str], str] = {
-    ("PUT", "machine", "poweroff"):
-        "turns the device off; no test can turn it back on",
-    ("PUT", "machine", "reboot"):
-        "restarts the machine mid-run; exercised by readmem-writemem",
-    ("PUT", "machine", "reset"):
-        "resets the C64 under whatever else is running; exercised by "
-        "readmem-writemem",
-    ("PUT", "configs", "save_to_flash"):
-        "writes the settings store; a run that started in safe mode would "
-        "overwrite the real values with defaults",
-    ("PUT", "configs", "load_from_flash"):
-        "discards the settings the run is using, including the ones a later "
-        "suite set up",
-    ("PUT", "configs", "reset_to_default"):
-        "destroys the operator's settings",
-    ("PUT", "machine", "menu_button"):
-        "leaves the on-screen menu open or closed for every later suite; "
-        "exercised by menu-screen",
+Key = Tuple[str, str]                       # (METHOD, operation path)
+
+# The only operation this suite will not call. Everything else is reachable
+# without leaving the device worse off, given the restore each case does.
+EXCLUDED: Dict[Key, str] = {
+    ("PUT", "/v1/machine:poweroff"):
+        "turns the device off, and no test can turn it back on",
 }
 
+# Operations whose happy path belongs to another suite, named so that "no happy
+# case here" is a decision rather than an omission.
+HAPPY_ELSEWHERE: Dict[Key, str] = {
+    ("PUT", "/v1/files/{path}:create_d64"): "create-disk-image",
+    ("PUT", "/v1/files/{path}:create_d71"): "create-disk-image",
+    ("PUT", "/v1/files/{path}:create_d81"): "create-disk-image",
+    ("PUT", "/v1/files/{path}:create_dnp"): "create-disk-image",
+    ("PUT", "/v1/runners:load_prg"): "prg-load-path-trim",
+    ("PUT", "/v1/runners:run_prg"): "prg-load-path-trim",
+    ("POST", "/v1/runners:load_prg"): "prg-load-path-trim",
+    ("POST", "/v1/runners:run_prg"): "prg-load-path-trim",
+    ("POST", "/v1/machine:input"): "input",
+}
 
-class Probe:
-    """One endpoint, one call, and what counts as an answer.
+# Operations with no happy path anywhere, and why. Printed on every run, so the
+# gaps this suite knows about stay visible instead of passing as covered.
+NEGATIVE_ONLY: Dict[Key, str] = {
+    ("PUT", "/v1/drives/{drive}:load_rom"):
+        "a wrong file leaves the drive with a broken ROM until the next reboot, "
+        "and the tree has no drive ROM to load a good one from",
+    ("POST", "/v1/drives/{drive}:load_rom"): "as the PUT form",
+    ("PUT", "/v1/runners:sidplay"): "needs a SID file and takes over the machine",
+    ("PUT", "/v1/runners:modplay"): "needs a MOD file and takes over the machine",
+    ("PUT", "/v1/runners:run_crt"): "needs a cartridge image and resets the C64",
+    ("POST", "/v1/runners:sidplay"): "as the PUT form",
+    ("POST", "/v1/runners:modplay"): "as the PUT form",
+    ("POST", "/v1/runners:run_crt"): "as the PUT form",
+}
 
-    `accept` is a set of status codes rather than one code because several
-    routes are compiled per product: machine:input is behind #if U64 and
-    answers 501 on a cartridge, and menu_screen answers 404 when no menu is
-    open. A probe that accepted only one of those would fail on half the
-    hardware for a reason that is not a defect.
-    """
+# Maps an API_CALL handler to the operation path the contract gives it, for the
+# fallback gate. Only the routes that take path parameters need an entry.
+HANDLER_PATHS: Dict[Tuple[str, str, str], List[str]] = {
+    ("GET", "files", "info"): ["/v1/files/{path}:info"],
+    ("PUT", "files", "create_d64"): ["/v1/files/{path}:create_d64"],
+    ("PUT", "files", "create_d71"): ["/v1/files/{path}:create_d71"],
+    ("PUT", "files", "create_d81"): ["/v1/files/{path}:create_d81"],
+    ("PUT", "files", "create_dnp"): ["/v1/files/{path}:create_dnp"],
+    ("GET", "configs", "none"): ["/v1/configs", "/v1/configs/{category}",
+                                 "/v1/configs/{category}/{item}"],
+    ("PUT", "configs", "none"): ["/v1/configs/{category}/{item}"],
+    ("POST", "configs", "none"): ["/v1/configs"],
+    ("PUT", "configs", "save_to_flash"): ["/v1/configs:save_to_flash",
+                                          "/v1/configs/{category}:save_to_flash"],
+    ("PUT", "configs", "load_from_flash"): ["/v1/configs:load_from_flash",
+                                            "/v1/configs/{category}:load_from_flash"],
+    ("PUT", "configs", "reset_to_default"): ["/v1/configs:reset_to_default",
+                                             "/v1/configs/{category}:reset_to_default"],
+    ("GET", "drives", "none"): ["/v1/drives"],
+    ("GET", "version", "none"): ["/v1/version"],
+    ("GET", "info", "none"): ["/v1/info"],
+    ("GET", "help", "none"): ["/v1/help"],
+}
+for _action in ("mount", "reset", "remove", "on", "off", "unlink", "load_rom",
+                "set_mode"):
+    HANDLER_PATHS[("PUT", "drives", _action)] = [f"/v1/drives/{{drive}}:{_action}"]
+for _action in ("mount", "load_rom"):
+    HANDLER_PATHS[("POST", "drives", _action)] = [f"/v1/drives/{{drive}}:{_action}"]
+for _action in ("start", "stop"):
+    HANDLER_PATHS[("PUT", "streams", _action)] = [f"/v1/streams/{{stream}}:{_action}"]
 
-    def __init__(self, method: str, group: str, command: str,
-                 path: str, accept: Sequence[int], *,
-                 params: Optional[Dict[str, object]] = None,
-                 body: Optional[bytes] = None,
-                 note: str = "",
-                 exclusive: bool = False) -> None:
-        self.method = method
-        self.group = group
-        self.command = command
-        self.path = path
-        self.accept = set(accept)
-        self.params = params
-        self.body = body
-        self.note = note
-        # An exclusive probe changes machine state that the next probe would
-        # see, so it never runs concurrently with anything, including itself.
+
+class Skip(Exception):
+    """Raised by a case that cannot apply to this device."""
+
+
+class Case:
+    """One thing to call, and what has to be true afterwards."""
+
+    def __init__(self, key: Optional[Key], name: str, kind: str,
+                 run: Callable[["Ctx"], None], *, exclusive: bool = False) -> None:
+        self.key = key                  # None for protocol cases
+        self.name = name
+        self.kind = kind                # happy | negative | protocol
+        self.run = run
         self.exclusive = exclusive
 
     @property
-    def key(self) -> Tuple[str, str, str]:
-        return (self.method, self.group, self.command)
-
-    @property
     def label(self) -> str:
-        name = self.group if self.command == "none" else f"{self.group}:{self.command}"
-        return f"{self.method} {name}"
+        if self.key is None:
+            return f"protocol: {self.name}"
+        return f"{self.key[0]} {self.key[1]} - {self.name}"
 
 
-def _route_path(group: str, command: str) -> str:
-    return f"/v1/{group}" if command == "none" else f"/v1/{group}:{command}"
+class Ctx:
+    """What a case is handed: one thread's client and the suite's fixtures."""
+
+    def __init__(self, api: UltimateApi, suite: "SuiteRunner") -> None:
+        self.api = api
+        self.suite = suite
+
+    def refused(self, method: str, path: str, call, *, allow=(400, 403, 404, 412,
+                                                              500, 501)) -> None:
+        """Assert a call the device should turn down does exactly that.
+
+        The typed API raises Failure carrying the status, so the status is
+        recovered from the message rather than by bypassing the library and
+        rebuilding the URL here.
+        """
+        try:
+            call()
+        except Failure as exc:
+            match = re.search(r"HTTP (\d+)", str(exc))
+            if match and int(match.group(1)) in allow:
+                return
+            raise Failure(f"{method} {path}: {exc}")
+        raise Failure(f"{method} {path} was accepted, expected one of "
+                      f"{sorted(allow)}")
+
+    def require_fix(self, name: str) -> None:
+        """Skip when this machine's firmware predates the behaviour asserted.
+
+        tests/lib/machine.py owns the table of outstanding gaps and the wording,
+        so a backport is one deletion there rather than an edit in every suite.
+        """
+        reason = self.suite.machine.missing_fix(name)
+        if reason:
+            raise Skip(reason)
+
+    def refuse_status(self, method: str, path: str, *,
+                      params: Optional[Dict[str, object]] = None,
+                      allow=(400, 403, 404, 412, 500, 501)) -> None:
+        """Assert a refusal for a call the typed API has no method for.
+
+        Used where the point is a shape the library will not build, such as an
+        unknown drive letter or a missing required argument.
+        """
+        code, _, body = self.api.rest.request(method, path, params=params)
+        if code not in allow:
+            raise Failure(f"{method} {path} answered HTTP {code}, expected one "
+                          f"of {sorted(allow)}: {body[:160]!r}")
 
 
-OK = (200,)
-# A route that refuses the probe's arguments. Which of these a route picks is
-# its own business; the point of the probe is that it answers and stays up.
-REFUSED = (400, 403, 404, 412, 500, 501)
+def build_cases() -> List[Case]:
+    c: List[Case] = []
 
+    def case(key, name, kind, fn, exclusive=False):
+        c.append(Case(key, name, kind, fn, exclusive=exclusive))
 
-def build_probes() -> List[Probe]:
-    p: List[Probe] = []
+    # ---- identity and help ----------------------------------------------
+    def _version(ctx: Ctx) -> None:
+        if not ctx.api.version():
+            raise Failure("no version string in the answer")
+    case(("GET", "/v1/version"), "returns a version", "happy", _version)
 
-    # ---- read-only ------------------------------------------------------
-    p.append(Probe("GET", "version", "none", "/v1/version", OK))
-    p.append(Probe("GET", "info", "none", "/v1/info", OK))
-    p.append(Probe("GET", "help", "none", "/v1/help", OK,
-                   params={"command": "version"}))
-    p.append(Probe("GET", "drives", "none", "/v1/drives", OK))
-    p.append(Probe("GET", "configs", "none", "/v1/configs", OK))
-    p.append(Probe("GET", "files", "info", f"/v1/files{SCRATCH}:info", OK))
-    p.append(Probe("GET", "machine", "readmem", "/v1/machine:readmem", OK,
-                   params={"address": 1024, "length": 16}))
-    p.append(Probe("GET", "machine", "heap", "/v1/machine:heap", OK))
-    # Both debugreg routes are inside #if U64 in route_machine.cc, so on a
-    # product without that register they are not in the route table at all and
-    # the dispatcher answers 404. That is different from machine:input, which
-    # is always registered and answers 501.
-    p.append(Probe("GET", "machine", "debugreg", "/v1/machine:debugreg",
-                   OK + (404,), note="404 where the route is not compiled in"))
-    p.append(Probe("GET", "machine", "menu_screen", "/v1/machine:menu_screen",
-                   OK + (404,), note="404 when no menu is open"))
-    p.append(Probe("GET", "machine", "measure", "/v1/machine:measure",
-                   OK + (501,), note="501 when the FPGA has no bus measurement"))
-    p.append(Probe("GET", "machine", "input", "/v1/machine:input",
-                   OK + (501,), note="501 on products without key injection"))
+    def _info(ctx: Ctx) -> None:
+        info = ctx.api.info()
+        if not info.product or not info.firmware_version:
+            raise Failure(f"product or firmware missing: {info}")
+    case(("GET", "/v1/info"), "names product and firmware", "happy", _info)
 
-    # ---- argument and error paths, no state change ----------------------
-    for kind, extra in (("d64", {"tracks": 35}), ("d71", {}),
-                        ("d81", {}), ("dnp", {"tracks": 1})):
-        p.append(Probe("PUT", "files", f"create_{kind}",
-                       f"/v1/files{MISSING}.{kind}:create_{kind}", REFUSED,
-                       params=extra,
-                       note="unwritable path; the happy path is create-disk-image"))
-    p.append(Probe("PUT", "machine", "writemem", "/v1/machine:writemem", REFUSED,
-                   params={"address": 1024},
-                   note="no data argument; real writes are readmem-writemem"))
-    # debugreg takes any value and answers 200, so there is no argument that
-    # refuses. run() replaces this with the value the register already holds,
-    # which makes the call a no-op, and cleanup() puts it back either way.
-    p.append(Probe("PUT", "machine", "debugreg", "/v1/machine:debugreg",
-                   OK + (404,), params={"value": "0"},
-                   note="writes back the value already in the register, "
-                        "404 where the route is not compiled in"))
-    p.append(Probe("PUT", "drives", "mount", "/v1/drives:mount", REFUSED,
-                   params={"drive": "a", "image": MISSING + ".d64"}))
-    p.append(Probe("PUT", "drives", "load_rom", "/v1/drives:load_rom", REFUSED,
-                   params={"drive": "a", "file": MISSING + ".rom"}))
-    p.append(Probe("PUT", "drives", "set_mode", "/v1/drives:set_mode", REFUSED,
-                   params={"drive": "a", "mode": "no-such-mode"}))
-    p.append(Probe("PUT", "drives", "reset", "/v1/drives:reset", REFUSED,
-                   params={"drive": "z"}, note="unknown drive letter"))
-    p.append(Probe("PUT", "drives", "remove", "/v1/drives:remove", REFUSED,
-                   params={"drive": "z"}))
-    p.append(Probe("PUT", "drives", "unlink", "/v1/drives:unlink", REFUSED,
-                   params={"drive": "z"}))
-    p.append(Probe("PUT", "drives", "on", "/v1/drives:on", REFUSED,
-                   params={"drive": "z"}))
-    p.append(Probe("PUT", "drives", "off", "/v1/drives:off", REFUSED,
-                   params={"drive": "z"}))
-    p.append(Probe("PUT", "configs", "none", "/v1/configs/No%20Such%20Category",
-                   REFUSED, params={"value": "1"},
-                   note="unknown category; real writes are the cfg-* suites"))
-    for command in ("sidplay", "modplay", "load_prg", "run_prg", "run_crt"):
-        p.append(Probe("PUT", "runners", command, f"/v1/runners:{command}", REFUSED,
-                       params={"file": MISSING + ".prg"},
-                       note="nonexistent file, so nothing is launched"))
-    p.append(Probe("PUT", "streams", "start", "/v1/streams:start", REFUSED,
-                   params={"stream": "no-such-stream"}))
-    p.append(Probe("PUT", "streams", "stop", "/v1/streams:stop", REFUSED,
-                   params={"stream": "no-such-stream"}))
+    def _help(ctx: Ctx) -> None:
+        if not ctx.api.help("version"):
+            raise Failure("the help page was empty")
+    case(("GET", "/v1/help"), "answers for a known command", "happy", _help)
 
-    # ---- round trip, state restored immediately -------------------------
-    # These two are the only pair that has to run for real: there is no
-    # argument that makes pause fail without also skipping the code that
-    # freezes the machine. They are adjacent and in this order, and cleanup()
-    # sends a resume as well, so an abort between them cannot leave the C64
-    # paused for the suites that follow.
-    p.append(Probe("PUT", "machine", "pause", "/v1/machine:pause", OK,
-                   exclusive=True))
-    p.append(Probe("PUT", "machine", "resume", "/v1/machine:resume", OK,
-                   exclusive=True))
+    def _help_bad(ctx: Ctx) -> None:
+        # No parameter at all: command="" is still a parameter, and the route
+        # accepts it.
+        ctx.refuse_status("GET", "/v1/help")
+    case(("GET", "/v1/help"), "refuses a missing command", "negative", _help_bad)
 
-    # ---- POST routes ----------------------------------------------------
-    # Every POST route takes its payload as an attachment. Sending none is
-    # refused before the handler runs, which reaches the same request teardown
-    # without uploading anything or starting anything.
-    for group, command in (("configs", "none"), ("drives", "mount"),
-                           ("drives", "load_rom"), ("machine", "writemem"),
-                           ("machine", "input"), ("runners", "sidplay"),
-                           ("runners", "modplay"), ("runners", "load_prg"),
-                           ("runners", "run_prg"), ("runners", "run_crt")):
-        p.append(Probe("POST", group, command, _route_path(group, command), REFUSED,
-                       note="no body, so the handler never runs"))
+    # ---- configuration reads --------------------------------------------
+    def _configs(ctx: Ctx) -> None:
+        if not ctx.api.configs.categories():
+            raise Failure("the configuration listing is empty")
+    case(("GET", "/v1/configs"), "lists categories", "happy", _configs)
 
-    return p
+    def _config_category(ctx: Ctx) -> None:
+        if not ctx.api.configs.category(CONFIG_CATEGORY):
+            raise Failure(f"{CONFIG_CATEGORY} came back empty")
+    case(("GET", "/v1/configs/{category}"), "reads one category", "happy",
+         _config_category)
+
+    def _config_item(ctx: Ctx) -> None:
+        item = ctx.api.configs.item(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        if "current" not in item:
+            raise Failure(f"no current value in {item}")
+    case(("GET", "/v1/configs/{category}/{item}"), "reads one item", "happy",
+         _config_item)
+
+    def _config_unknown(ctx: Ctx) -> None:
+        ctx.refuse_status("GET", "/v1/configs/No%20Such%20Category", allow=(404,))
+    case(("GET", "/v1/configs/{category}"), "refuses an unknown category",
+         "negative", _config_unknown)
+
+    # ---- configuration writes -------------------------------------------
+    def _config_write(ctx: Ctx) -> None:
+        value = ctx.suite.config_value(ctx)
+        ctx.api.configs.set(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM, value)
+        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        if after != value:
+            raise Failure(f"wrote {value!r}, reads {after!r}")
+    case(("PUT", "/v1/configs/{category}/{item}"),
+         "writing the current value back is a no-op", "happy", _config_write,
+         exclusive=True)
+
+    def _config_write_path(ctx: Ctx) -> None:
+        # The other accepted form: the value as a third path element.
+        value = ctx.suite.config_value(ctx)
+        ctx.api.configs.set_by_path(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM, value)
+        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        if after != value:
+            raise Failure(f"wrote {value!r} through the path form, reads {after!r}")
+    case(("PUT", "/v1/configs/{category}/{item}"),
+         "the value-in-path form sets the same item", "happy", _config_write_path,
+         exclusive=True)
+
+    def _config_write_bad(ctx: Ctx) -> None:
+        ctx.refused("PUT", "/v1/configs/{category}/{item}",
+                    lambda: ctx.api.configs.set("No Such Category", "No Such Item", "1"))
+    case(("PUT", "/v1/configs/{category}/{item}"), "refuses an unknown category",
+         "negative", _config_write_bad)
+
+    def _config_apply(ctx: Ctx) -> None:
+        value = ctx.suite.config_value(ctx)
+        ctx.api.configs.apply({CONFIG_CATEGORY: {AUTO_CLEANUP_ITEM: value}})
+        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        if after != value:
+            raise Failure(f"the JSON form wrote {value!r}, reads {after!r}")
+    case(("POST", "/v1/configs"), "the JSON form sets an item", "happy",
+         _config_apply, exclusive=True)
+
+    def _config_apply_bad(ctx: Ctx) -> None:
+        ctx.refused("POST", "/v1/configs",
+                    lambda: ctx.api.configs.apply({"No Such Category": {"x": "1"}}))
+    case(("POST", "/v1/configs"), "refuses an unknown category", "negative",
+         _config_apply_bad)
+
+    # ---- flash-backed settings ------------------------------------------
+    # Saving writes what is already in force, because no case changes a setting
+    # without putting it back first, so the store ends where it started.
+    def _flash_roundtrip(ctx: Ctx) -> None:
+        before = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        ctx.api.configs.save_to_flash()
+        ctx.api.configs.load_from_flash()
+        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        if after != before:
+            raise Failure(f"save then load changed {AUTO_CLEANUP_ITEM} from "
+                          f"{before!r} to {after!r}")
+    case(("PUT", "/v1/configs:save_to_flash"), "save then load leaves the value",
+         "happy", _flash_roundtrip, exclusive=True)
+    case(("PUT", "/v1/configs:load_from_flash"), "covered by the save case above",
+         "happy", _flash_roundtrip, exclusive=True)
+
+    def _flash_roundtrip_category(ctx: Ctx) -> None:
+        before = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        ctx.api.configs.save_to_flash(CONFIG_CATEGORY)
+        ctx.api.configs.load_from_flash(CONFIG_CATEGORY)
+        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        if after != before:
+            raise Failure(f"per-category save then load changed "
+                          f"{AUTO_CLEANUP_ITEM} from {before!r} to {after!r}")
+    case(("PUT", "/v1/configs/{category}:save_to_flash"),
+         "save then load leaves the value", "happy", _flash_roundtrip_category,
+         exclusive=True)
+    case(("PUT", "/v1/configs/{category}:load_from_flash"),
+         "covered by the save case above", "happy", _flash_roundtrip_category,
+         exclusive=True)
+
+    def _reset_to_default(ctx: Ctx) -> None:
+        # Not User Interface Settings: the default for Interface Type there is
+        # Freeze, and a menu opened in Freeze takes down a device whose core
+        # lacks the GideonZ#733 fix. Resetting a category is a real reset even
+        # when it is undone a moment later, so the category has to be one whose
+        # defaults cannot cost the run its device.
+        category = RESETTABLE_CATEGORY
+        snapshot = ctx.suite.snapshot_category(ctx, category)
+        probe = next(iter(snapshot))
+        try:
+            ctx.api.configs.reset_to_default(category)
+        finally:
+            ctx.suite.restore_category(ctx, category, snapshot)
+        after = ctx.api.configs.current(category, probe)
+        if after != snapshot[probe]:
+            raise Failure(f"restoring after the reset left {probe} at {after!r}, "
+                          f"expected {snapshot[probe]!r}")
+    case(("PUT", "/v1/configs/{category}:reset_to_default"),
+         "resets one category and the values restore", "happy", _reset_to_default,
+         exclusive=True)
+
+    # The global form resets every category at once, so it only runs when the
+    # operator asks for it. Skipped otherwise, which still classifies it.
+    case(("PUT", "/v1/configs:reset_to_default"),
+         "resets everything, needs --allow-global-reset", "happy",
+         lambda ctx: ctx.suite.global_reset(ctx), exclusive=True)
+
+    # ---- files -----------------------------------------------------------
+    def _files_info(ctx: Ctx) -> None:
+        if ctx.api.files.info(SCRATCH) is None:
+            raise Failure(f"{SCRATCH} is missing")
+    case(("GET", "/v1/files/{path}:info"), f"describes {SCRATCH}", "happy",
+         _files_info)
+
+    def _files_info_missing(ctx: Ctx) -> None:
+        if ctx.api.files.info(MISSING) is not None:
+            raise Failure(f"{MISSING} was reported as existing")
+    case(("GET", "/v1/files/{path}:info"), "reports a missing path as absent",
+         "negative", _files_info_missing)
+
+    for kind, extra in (("d64", {"tracks": 35}), ("d71", {}), ("d81", {}),
+                        ("dnp", {"tracks": 1})):
+        def _create(ctx: Ctx, kind=kind, extra=extra) -> None:
+            create = getattr(ctx.api.files, f"create_{kind}")
+            ctx.refused("PUT", f"/v1/files/{{path}}:create_{kind}",
+                        lambda: create(f"{MISSING}.{kind}", **extra))
+        case(("PUT", f"/v1/files/{{path}}:create_{kind}"),
+             "refuses an unwritable path", "negative", _create)
+
+    # ---- machine reads ---------------------------------------------------
+    def _readmem(ctx: Ctx) -> None:
+        data = ctx.api.machine.readmem(SCRATCH_ADDRESS, 16)
+        if len(data) != 16:
+            raise Failure(f"asked for 16 bytes, got {len(data)}")
+    case(("GET", "/v1/machine:readmem"), "returns the length asked for", "happy",
+         _readmem)
+
+    def _readmem_bad(ctx: Ctx) -> None:
+        # Raw, because the typed call range-checks the length before sending and
+        # the point here is what the device does with it.
+        ctx.require_fix(machine_lib.READMEM_REJECTS_ZERO_LENGTH)
+        ctx.refuse_status("GET", "/v1/machine:readmem",
+                          params={"address": f"{SCRATCH_ADDRESS:04X}", "length": 0})
+    case(("GET", "/v1/machine:readmem"), "refuses a zero length", "negative",
+         _readmem_bad)
+
+    def _heap(ctx: Ctx) -> None:
+        reading = ctx.api.machine.heap()
+        if reading is None:
+            raise Failure("machine:heap is not on this firmware")
+        if not 0 < int(reading["free"]) <= int(reading["total"]):
+            raise Failure(f"implausible heap reading: {reading}")
+    case(("GET", "/v1/machine:heap"), "reports free within total", "happy", _heap)
+
+    def _measure(ctx: Ctx) -> None:
+        ctx.api.machine.measure()      # None where the FPGA cannot measure
+    case(("GET", "/v1/machine:measure"), "answers, 501 without bus measurement",
+         "happy", _measure)
+
+    def _input_get(ctx: Ctx) -> None:
+        try:
+            ctx.api.machine.input_state()
+        except Failure as exc:
+            if "501" in str(exc):
+                raise Skip("key injection is not built into this product")
+            raise
+    case(("GET", "/v1/machine:input"), "reports the input state", "happy",
+         _input_get)
+
+    def _debugreg_get(ctx: Ctx) -> None:
+        if ctx.api.machine.debugreg() is None:
+            raise Skip("the debug register is not built into this product")
+    case(("GET", "/v1/machine:debugreg"), "reads the register", "happy",
+         _debugreg_get)
+
+    def _debugreg_put(ctx: Ctx) -> None:
+        before = ctx.api.machine.debugreg()
+        if before is None:
+            raise Skip("the debug register is not built into this product")
+        after = ctx.api.machine.set_debugreg(f"0x{before}")
+        if after != before:
+            raise Failure(f"wrote back {before!r}, reads {after!r}")
+    case(("PUT", "/v1/machine:debugreg"), "writing the held value back is a no-op",
+         "happy", _debugreg_put, exclusive=True)
+
+    def _menu_screen(ctx: Ctx) -> None:
+        # Covered for real by the menu_button case, which opens the menu and
+        # reads the screen while it is open. Here only that the closed answer
+        # is the documented 404 rather than a hang.
+        if ctx.api.machine.menu_open():
+            raise Failure("a menu was already open before this suite touched it")
+    case(("GET", "/v1/machine:menu_screen"), "answers 404 with no menu open",
+         "happy", _menu_screen)
+
+    # ---- machine writes --------------------------------------------------
+    def _writemem_put(ctx: Ctx) -> None:
+        before = ctx.api.machine.readmem(SCRATCH_ADDRESS, 1)
+        probe = bytes([before[0] ^ 0x5A])
+        ctx.api.machine.writemem(SCRATCH_ADDRESS, probe)
+        try:
+            after = ctx.api.machine.readmem(SCRATCH_ADDRESS, 1)
+            if after != probe:
+                raise Failure(f"wrote {probe.hex()}, reads {after.hex()}")
+        finally:
+            ctx.api.machine.writemem(SCRATCH_ADDRESS, before)
+    case(("PUT", "/v1/machine:writemem"), "the byte written is the byte read back",
+         "happy", _writemem_put, exclusive=True)
+
+    def _writemem_post(ctx: Ctx) -> None:
+        # Over MAX_WRITEMEM_HEX_BYTES the library uploads instead, which is the
+        # POST form of the same operation.
+        before = ctx.api.machine.readmem(SCRATCH_ADDRESS, POST_WRITE_LENGTH)
+        probe = bytes((b ^ 0xA5) for b in before)
+        ctx.api.machine.writemem(SCRATCH_ADDRESS, probe)
+        try:
+            after = ctx.api.machine.readmem(SCRATCH_ADDRESS, POST_WRITE_LENGTH)
+            if after != probe:
+                raise Failure("the uploaded block is not what reads back")
+        finally:
+            ctx.api.machine.writemem(SCRATCH_ADDRESS, before)
+    case(("POST", "/v1/machine:writemem"), "the uploaded block reads back",
+         "happy", _writemem_post, exclusive=True)
+
+    def _writemem_bad(ctx: Ctx) -> None:
+        ctx.refuse_status("PUT", "/v1/machine:writemem",
+                          params={"address": f"{SCRATCH_ADDRESS:04X}"})
+    case(("PUT", "/v1/machine:writemem"), "refuses a missing data argument",
+         "negative", _writemem_bad)
+
+    def _input_post_bad(ctx: Ctx) -> None:
+        ctx.refuse_status("POST", "/v1/machine:input")
+    case(("POST", "/v1/machine:input"), "refuses an empty event list", "negative",
+         _input_post_bad)
+
+    # ---- machine control -------------------------------------------------
+    def _pause_resume(ctx: Ctx) -> None:
+        # Neither has an outcome REST can see: the VIC keeps running while the
+        # CPU is held, so nothing readable stops changing. Both are in one case
+        # so a failure cannot leave the machine paused.
+        ctx.api.machine.pause()
+        ctx.api.machine.resume()
+    case(("PUT", "/v1/machine:pause"), "pauses and resumes (status only)", "happy",
+         _pause_resume, exclusive=True)
+    case(("PUT", "/v1/machine:resume"), "covered by the pause case above", "happy",
+         _pause_resume, exclusive=True)
+
+    def _menu_button(ctx: Ctx) -> None:
+        # Opening the menu with Interface Type = Freeze stops a device whose
+        # core lacks the fix for GideonZ#733 answering anything at all, and
+        # recovery is physical. tests/lib/machine.py owns that table.
+        ctx.require_fix(machine_lib.FREEZE_MENU_OPENS)
+        ctx.api.machine.menu_button()
+        # Poll rather than read once: the press is queued for the UI task, and
+        # a second press sent while the first is still opening used to take the
+        # device down. Only press again once the menu is actually there.
+        if not ctx.suite.wait_for_menu(ctx, True):
+            raise Failure("the menu did not open")
+        ctx.api.machine.menu_button()
+        if not ctx.suite.wait_for_menu(ctx, False):
+            raise Failure("the menu did not close again")
+    case(("PUT", "/v1/machine:menu_button"), "opens the menu and closes it again",
+         "happy", _menu_button, exclusive=True)
+
+    def _reset(ctx: Ctx) -> None:
+        if not ctx.api.machine.reset(force=True, wait=True):
+            raise Failure("the C64 did not reach the BASIC prompt after a reset")
+    case(("PUT", "/v1/machine:reset"), "the C64 comes back to READY", "happy",
+         _reset, exclusive=True)
+
+    def _reboot(ctx: Ctx) -> None:
+        ctx.api.machine.reboot()
+        if not ctx.api.machine.wait_until_ready():
+            raise Failure("the C64 did not reach the BASIC prompt after a reboot")
+    case(("PUT", "/v1/machine:reboot"), "the C64 comes back to READY", "happy",
+         _reboot, exclusive=True)
+
+    # ---- drives ----------------------------------------------------------
+    def _drives_list(ctx: Ctx) -> None:
+        found = ctx.api.drives.list()
+        for slot in ("a", "b"):
+            if slot not in found:
+                raise Failure(f"drive {slot} missing from the listing: {sorted(found)}")
+    case(("GET", "/v1/drives"), "lists both drive slots", "happy", _drives_list)
+
+    def _drive_on_off(ctx: Ctx) -> None:
+        before = ctx.api.drives.get("a").enabled
+        (ctx.api.drives.off if before else ctx.api.drives.on)("a")
+        if ctx.api.drives.get("a").enabled == before:
+            raise Failure(f"the drive stayed enabled={before}")
+        (ctx.api.drives.on if before else ctx.api.drives.off)("a")
+        if ctx.api.drives.get("a").enabled != before:
+            raise Failure(f"the drive did not go back to enabled={before}")
+    case(("PUT", "/v1/drives/{drive}:on"), "flips the drive and the listing agrees",
+         "happy", _drive_on_off, exclusive=True)
+    case(("PUT", "/v1/drives/{drive}:off"), "covered by the on/off case above",
+         "happy", _drive_on_off, exclusive=True)
+
+    def _drive_mount(ctx: Ctx) -> None:
+        ctx.suite.ensure_mount_image(ctx)
+        ctx.api.drives.mount("a", MOUNT_IMAGE)
+        try:
+            mounted = ctx.api.drives.get("a")
+            if posixpath.basename(MOUNT_IMAGE) not in mounted.image_file:
+                raise Failure(f"mounted {MOUNT_IMAGE}, listing shows "
+                              f"image_file={mounted.image_file!r}")
+        finally:
+            ctx.api.drives.remove("a")
+    case(("PUT", "/v1/drives/{drive}:mount"), "the listing shows the image",
+         "happy", _drive_mount, exclusive=True)
+
+    def _drive_unlink(ctx: Ctx) -> None:
+        # unlink breaks the connection to the file and leaves the disk in the
+        # drive, so the listing still names it. That is the documented
+        # difference from remove, which ejects it, and asserting the opposite
+        # here would be asserting the wrong contract.
+        ctx.suite.ensure_mount_image(ctx)
+        ctx.api.drives.mount("a", MOUNT_IMAGE)
+        try:
+            ctx.api.drives.unlink("a")
+            still = ctx.api.drives.get("a").image_file
+            if posixpath.basename(MOUNT_IMAGE) not in still:
+                raise Failure(f"unlink ejected the disk as well: image_file={still!r}")
+        finally:
+            ctx.api.drives.remove("a")
+    case(("PUT", "/v1/drives/{drive}:unlink"), "keeps the disk, drops the file",
+         "happy", _drive_unlink, exclusive=True)
+
+    def _drive_remove(ctx: Ctx) -> None:
+        ctx.suite.ensure_mount_image(ctx)
+        ctx.api.drives.mount("a", MOUNT_IMAGE)
+        ctx.api.drives.remove("a")
+        left = ctx.api.drives.get("a").image_file
+        if left:
+            raise Failure(f"remove left {left!r} on the drive")
+    case(("PUT", "/v1/drives/{drive}:remove"), "clears the mounted image", "happy",
+         _drive_remove, exclusive=True)
+
+    def _drive_mount_upload(ctx: Ctx) -> None:
+        # The uploaded part needs a name with a usable extension: the default
+        # image type comes from it, and an upload without one is refused with
+        # "Invalid Type".
+        payload, content_type = rest_lib.multipart_body(
+            "file", posixpath.basename(MOUNT_IMAGE),
+            ctx.suite.mount_image_bytes(ctx))
+        code, _, body = ctx.api.rest.request(
+            "POST", "/v1/drives/a:mount", body=payload,
+            headers={"Content-Type": content_type})
+        if code != 200:
+            raise Failure(f"POST drives/a:mount returned HTTP {code}: {body[:160]!r}")
+        try:
+            if not ctx.api.drives.get("a").image_file:
+                raise Failure("the upload mounted nothing")
+        finally:
+            ctx.api.drives.remove("a")
+    case(("POST", "/v1/drives/{drive}:mount"), "an uploaded image mounts", "happy",
+         _drive_mount_upload, exclusive=True)
+
+    def _drive_set_mode(ctx: Ctx) -> None:
+        before = ctx.api.drives.get("a").type
+        ctx.api.drives.set_mode("a", before)
+        after = ctx.api.drives.get("a").type
+        if after != before:
+            raise Failure(f"setting the current mode {before!r} changed it to {after!r}")
+    case(("PUT", "/v1/drives/{drive}:set_mode"), "setting the current mode is a no-op",
+         "happy", _drive_set_mode, exclusive=True)
+
+    def _drive_reset(ctx: Ctx) -> None:
+        # A drive reset has no outcome the API exposes; this exercises the route
+        # and its request teardown.
+        ctx.api.drives.reset("a")
+    case(("PUT", "/v1/drives/{drive}:reset"), "resets the drive (status only)",
+         "happy", _drive_reset, exclusive=True)
+
+    def _drive_unknown(ctx: Ctx) -> None:
+        ctx.refuse_status("PUT", "/v1/drives/z:reset")
+    case(("PUT", "/v1/drives/{drive}:reset"), "refuses an unknown drive letter",
+         "negative", _drive_unknown)
+
+    def _mount_missing(ctx: Ctx) -> None:
+        ctx.refused("PUT", "/v1/drives/{drive}:mount",
+                    lambda: ctx.api.drives.mount("a", MISSING + ".d64"))
+    case(("PUT", "/v1/drives/{drive}:mount"), "refuses a missing image", "negative",
+         _mount_missing)
+
+    def _load_rom_missing(ctx: Ctx) -> None:
+        ctx.refused("PUT", "/v1/drives/{drive}:load_rom",
+                    lambda: ctx.api.drives.load_rom("a", MISSING + ".rom"))
+    case(("PUT", "/v1/drives/{drive}:load_rom"), "refuses a missing ROM file",
+         "negative", _load_rom_missing)
+
+    def _load_rom_post(ctx: Ctx) -> None:
+        ctx.refuse_status("POST", "/v1/drives/a:load_rom")
+    case(("POST", "/v1/drives/{drive}:load_rom"), "refuses a request with no body",
+         "negative", _load_rom_post)
+
+    def _set_mode_bad(ctx: Ctx) -> None:
+        ctx.refused("PUT", "/v1/drives/{drive}:set_mode",
+                    lambda: ctx.api.drives.set_mode("a", "no-such-mode"))
+    case(("PUT", "/v1/drives/{drive}:set_mode"), "refuses an unknown mode",
+         "negative", _set_mode_bad)
+
+    for action in ("remove", "on", "off", "unlink"):
+        def _unknown_drive(ctx: Ctx, action=action) -> None:
+            ctx.refuse_status("PUT", f"/v1/drives/z:{action}")
+        case(("PUT", f"/v1/drives/{{drive}}:{action}"),
+             "refuses an unknown drive letter", "negative", _unknown_drive)
+
+    # ---- runners ---------------------------------------------------------
+    for action in ("sidplay", "modplay", "load_prg", "run_prg", "run_crt"):
+        def _runner_missing(ctx: Ctx, action=action) -> None:
+            call = getattr(ctx.api.runners, action)
+            ctx.refused("PUT", f"/v1/runners:{action}",
+                        lambda: call(MISSING + ".prg"))
+        case(("PUT", f"/v1/runners:{action}"), "refuses a missing file", "negative",
+             _runner_missing)
+
+        def _runner_no_body(ctx: Ctx, action=action) -> None:
+            ctx.refuse_status("POST", f"/v1/runners:{action}")
+        case(("POST", f"/v1/runners:{action}"), "refuses a request with no body",
+             "negative", _runner_no_body)
+
+    # ---- streams ---------------------------------------------------------
+    def _stream_roundtrip(ctx: Ctx) -> None:
+        # The debug stream is the cheap one; the video stream shares a multicast
+        # group with anything else on the network. Sent to this host and stopped
+        # in the same case so nothing keeps streaming afterwards.
+        # A route the product does not build is not in the table and the
+        # dispatcher answers 404 with an empty body. The handler's own refusals
+        # are 404 too but carry a JSON error, so the body is what tells a
+        # missing operation from a rejected one. Anything else is a failure:
+        # mapping every 404 to "not built" once hid a resolver error here.
+        code, _, body = ctx.api.rest.request(
+            "PUT", "/v1/streams/debug:start",
+            params={"ip": ctx.suite.local_ip(ctx)})
+        if code == 404 and not body.strip():
+            raise Skip("this product does not serve the data streams")
+        if code != 200:
+            raise Failure(f"streams/debug:start answered HTTP {code}: {body[:160]!r}")
+        ctx.api.streams.stop("debug")
+    case(("PUT", "/v1/streams/{stream}:start"), "starts and stops the debug stream",
+         "happy", _stream_roundtrip, exclusive=True)
+    case(("PUT", "/v1/streams/{stream}:stop"), "covered by the start case above",
+         "happy", _stream_roundtrip, exclusive=True)
+
+    def _stream_unknown(ctx: Ctx) -> None:
+        ctx.refused("PUT", "/v1/streams/{stream}:start",
+                    lambda: ctx.api.streams.start("no-such-stream", ip="127.0.0.1"))
+    case(("PUT", "/v1/streams/{stream}:start"), "refuses an unknown stream",
+         "negative", _stream_unknown)
+
+    def _stream_stop_unknown(ctx: Ctx) -> None:
+        ctx.refused("PUT", "/v1/streams/{stream}:stop",
+                    lambda: ctx.api.streams.stop("no-such-stream"))
+    case(("PUT", "/v1/streams/{stream}:stop"), "refuses an unknown stream",
+         "negative", _stream_stop_unknown)
+
+    # ---- protocol --------------------------------------------------------
+    def _unknown_route(ctx: Ctx) -> None:
+        code, _, _b = ctx.api.rest.request("GET", "/v1/no_such_group:no_such_command")
+        if code != 404:
+            raise Failure(f"an unknown route answered HTTP {code}, expected 404")
+    case(None, "an unknown route is 404", "protocol", _unknown_route)
+
+    def _wrong_method(ctx: Ctx) -> None:
+        code, _, _b = ctx.api.rest.request("GET", "/v1/machine:pause")
+        if code not in (404, 405):
+            raise Failure(f"GET on a PUT-only command answered HTTP {code}")
+    case(None, "a command asked for with the wrong method does not run", "protocol",
+         _wrong_method)
+
+    def _no_password(ctx: Ctx) -> None:
+        if not ctx.suite.args.password:
+            raise Skip("no password is set on this device")
+        code, _, _b = ctx.api.rest.request("GET", "/v1/info", use_password=False)
+        if code != 403:
+            raise Failure(f"an unauthenticated read answered HTTP {code}, expected 403")
+    case(None, "an unauthenticated read is refused", "protocol", _no_password)
+
+    return c
 
 
 class SuiteRunner:
     def __init__(self, args) -> None:
         self.args = args
         self.api = UltimateApi(args.host, args.password, args.timeout)
-        # The probes assert on status codes, so they go through the transport
-        # rather than the typed API: rest.py returns the status instead of
-        # raising on it.
-        self.rest = self.api.rest
-        self.probes = build_probes()
-        self.debugreg_before: Optional[str] = None
+        self.cases = build_cases()
         self.local = threading.local()
         self.local.api = self.api
-        # Set by the first worker that finds the device gone, so the others
-        # stop rather than each spending the liveness budget discovering it.
+        self.state_lock = threading.Lock()
         self.dead = threading.Event()
+        self._image_ready = False
+        self._image_bytes: Optional[bytes] = None
+        self._config_value: Optional[str] = None
+        self._local_ip: Optional[str] = None
+        self.restore_drive: Optional[Tuple[bool, str, str]] = None
+        self.restore_config: Optional[Dict[str, str]] = None
 
-    # -- helpers ------------------------------------------------------------
-    def alive(self) -> Optional[str]:
-        return self.api.unreachable_reason(LIVENESS_TIMEOUT_SECONDS)
+    # -- fixtures -----------------------------------------------------------
+    def ensure_mount_image(self, ctx: Ctx) -> None:
+        with self.state_lock:
+            if self._image_ready:
+                return
+            if ctx.api.files.info(MOUNT_IMAGE) is None:
+                ctx.api.files.create_d64(MOUNT_IMAGE, diskname="restapi")
+            self._image_ready = True
 
-    def source_routes(self) -> Set[Tuple[str, str, str]]:
-        found: Set[Tuple[str, str, str]] = set()
-        for source in sorted(API_SOURCE_DIR.glob("*.cc")):
-            for method, group, command in API_CALL_RE.findall(
-                    source.read_text(encoding="utf-8", errors="replace")):
-                found.add((method.upper(), group, command))
+    def mount_image_bytes(self, ctx: Ctx) -> bytes:
+        with self.state_lock:
+            if self._image_bytes is not None:
+                return self._image_bytes
+        self.ensure_mount_image(ctx)
+        with ftp_lib.session(self.args.host, self.args.password) as client:
+            data = ftp_lib.retrieve(client, MOUNT_IMAGE)
+        with self.state_lock:
+            self._image_bytes = data
+        return data
+
+    def config_value(self, ctx: Ctx) -> str:
+        """The settings item's value as found, so writes can be no-ops."""
+        with self.state_lock:
+            if self._config_value is not None:
+                return self._config_value
+        value = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        if not value:
+            raise Skip(f"{CONFIG_CATEGORY}/{AUTO_CLEANUP_ITEM} is not on this firmware")
+        with self.state_lock:
+            self._config_value = value
+        return value
+
+    def snapshot_category(self, ctx: Ctx, category: str) -> Dict[str, str]:
+        items = ctx.api.configs.category(category)
+        found: Dict[str, str] = {}
+        for name in items:
+            try:
+                value = ctx.api.configs.current(category, name)
+            except Failure:
+                continue
+            if value:
+                found[name] = value
+        if not found:
+            raise Skip(f"{category} has no readable items")
         return found
 
-    def read_debugreg(self) -> Optional[str]:
+    def restore_category(self, ctx: Ctx, category: str,
+                         snapshot: Dict[str, str]) -> None:
+        for name, value in snapshot.items():
+            try:
+                ctx.api.configs.set(category, name, value)
+            except Failure:
+                pass                    # read-only items cannot be written back
+
+    def global_reset(self, ctx: Ctx) -> None:
+        if not self.args.allow_global_reset:
+            raise Skip("resets every category at once; pass --allow-global-reset")
+        # This one does reach User Interface Settings, so it is opt-in and the
+        # operator is expected to know the device may need its interface type
+        # put back by hand if the restore below cannot run.
+        snapshot = {c: self.snapshot_category(ctx, c)
+                    for c in ctx.api.configs.categories()}
         try:
-            code, _, body = self.rest.request("GET", "/v1/machine:debugreg",
-                                              idempotent=True)
-        except (Failure, OSError, TimeoutError, urllib.error.URLError):
-            return None
-        if code != 200:
-            return None
-        match = re.search(rb'"value"\s*:\s*"([^"]*)"', body)
-        return match.group(1).decode("ascii", "replace") if match else None
+            ctx.api.configs.reset_to_default()
+        finally:
+            for category, items in snapshot.items():
+                self.restore_category(ctx, category, items)
 
-    # -- checks -------------------------------------------------------------
-    def check_coverage(self) -> bool:
-        """Every registered route is probed here or excluded with a reason."""
-        section("coverage")
-        check_start(f"read the route table from {API_SOURCE_DIR.name}/*.cc")
+    def local_ip(self, ctx: Ctx) -> str:
+        with self.state_lock:
+            if self._local_ip:
+                return self._local_ip
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
-            registered = self.source_routes()
-        except OSError as exc:
-            check_fail(f"could not read the API sources: {format_exception(exc)}")
-            return False
-        if not registered:
-            check_fail(f"no API_CALL found under {API_SOURCE_DIR}")
-            return False
-        check_ok(f"{len(registered)} endpoints")
+            probe.connect((ctx.api.rest.host, 80))
+            address = probe.getsockname()[0]
+        finally:
+            probe.close()
+        with self.state_lock:
+            self._local_ip = address
+        return address
 
-        probed = {probe.key for probe in self.probes}
-        classified = probed | set(EXCLUDED)
-
-        check_start("every registered endpoint is probed or excluded")
-        unclassified = sorted(registered - classified)
-        if unclassified:
-            for method, group, command in unclassified:
-                detail(f"unclassified: {method} {_route_path(group, command)}")
-            check_fail(
-                f"{len(unclassified)} endpoint(s) have no probe and no written "
-                "reason to skip. Add a probe, or add one to EXCLUDED saying why "
-                "it must not be called.")
-            return False
-        check_ok(f"{len(probed)} probed, {len(EXCLUDED)} excluded")
-
-        check_start("nothing is classified that the firmware no longer has")
-        stale = sorted(classified - registered)
-        if stale:
-            for method, group, command in stale:
-                detail(f"stale: {method} {_route_path(group, command)}")
-            check_fail(f"{len(stale)} classified endpoint(s) are not registered "
-                       "any more; remove them from this suite")
-            return False
-        check_ok()
-
-        for (method, group, command), reason in sorted(EXCLUDED.items()):
-            detail(f"not called: {method} {_route_path(group, command)} - {reason}")
-        return True
-
-    def call_once(self, api, probe: Probe) -> Optional[str]:
-        """Run one probe once on `api`; None when it passed, else the reason.
-
-        Each worker owns its client, so nothing here touches shared state and
-        the transport's counters stay meaningful per thread.
-        """
-        try:
-            code, _, body = api.rest.request(
-                probe.method, probe.path, params=probe.params, body=probe.body)
-        except (Failure, OSError, TimeoutError, urllib.error.URLError) as exc:
-            return f"did not answer: {format_exception(exc)}"
-        if code not in probe.accept:
-            return (f"answered HTTP {code}, expected one of "
-                    f"{sorted(probe.accept)}: {body[:160]!r}")
-        reason = api.unreachable_reason(LIVENESS_TIMEOUT_SECONDS)
-        if reason:
-            self.dead.set()
-            return (f"the device stopped answering after this call: {reason}. "
-                    "It needs a power cycle.")
-        return None
-
-    def client(self):
-        """One UltimateApi per thread.
-
-        Keyed by thread rather than by task, because the pool decides which
-        thread runs which task: two tasks that happened to pick the same client
-        would share its transport counters across threads.
-        """
+    def client(self) -> UltimateApi:
+        """One UltimateApi per thread: the pool decides which thread runs which
+        case, so a client picked by index would be shared across threads."""
         api = getattr(self.local, "api", None)
         if api is None:
             api = UltimateApi(self.args.host, self.args.password, self.args.timeout)
             self.local.api = api
         return api
 
-    def run_probes(self) -> bool:
-        """Run every probe `repeat` times and report one check per endpoint."""
-        shared = [p for p in self.probes if not p.exclusive]
-        exclusive = [p for p in self.probes if p.exclusive]
-        results: Dict[Tuple[str, str, str], Optional[str]] = {}
+    def wait_for_menu(self, ctx: Ctx, open_: bool,
+                      budget: float = MENU_SETTLE_SECONDS) -> bool:
+        """Whether the menu reaches `open_` within `budget`."""
+        deadline = time.monotonic() + budget
+        while True:
+            if ctx.api.machine.menu_open() == open_:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.2)
+
+    def alive(self) -> Optional[str]:
+        return self.api.unreachable_reason(LIVENESS_TIMEOUT_SECONDS)
+
+    @property
+    def machine(self) -> machine_lib.Machine:
+        """Which machine this is, for the checks that need a firmware fix."""
+        info = self.api.info()
+        return machine_lib.identify(self.api.host,
+                                    lambda: (info.product, info.firmware_version))
+
+    # -- coverage -----------------------------------------------------------
+    def contract_operations(self) -> Tuple[Set[Key], str]:
+        """Every operation the device serves, and where the list came from."""
+        specs = sorted(OPENAPI_DIR.glob("rest_api_openapi_*.yaml"))
+        if specs:
+            try:
+                import yaml                              # noqa: PLC0415
+            except ImportError:
+                specs = []
+        if specs:
+            found: Set[Key] = set()
+            for spec in specs:
+                document = yaml.safe_load(spec.read_text(encoding="utf-8"))
+                for path, item in (document.get("paths") or {}).items():
+                    for method in item:
+                        if method.lower() in ("get", "put", "post", "delete", "patch"):
+                            found.add((method.upper(), path))
+            return found, f"{len(specs)} OpenAPI document(s)"
+
+        found = set()
+        for source in sorted(API_SOURCE_DIR.glob("*.cc")):
+            for method, group, command in API_CALL_RE.findall(
+                    source.read_text(encoding="utf-8", errors="replace")):
+                key = (method.upper(), group, command)
+                for path in HANDLER_PATHS.get(
+                        key, [f"/v1/{group}" if command == "none"
+                              else f"/v1/{group}:{command}"]):
+                    found.add((method.upper(), path))
+        return found, "the API_CALL macros"
+
+    def check_coverage(self) -> bool:
+        section("coverage")
+        check_start("read the operation list")
+        try:
+            registered, where = self.contract_operations()
+        except OSError as exc:
+            check_fail(f"could not read the contract: {format_exception(exc)}")
+            return False
+        if not registered:
+            check_fail("the contract lists no operations")
+            return False
+        check_ok(f"{len(registered)} operations, from {where}")
+
+        exercised = {c.key for c in self.cases if c.key is not None}
+        happy = {c.key for c in self.cases if c.key is not None and c.kind == "happy"}
+
+        check_start("every operation is exercised or excluded")
+        unclassified = sorted(registered - (exercised | set(EXCLUDED)))
+        if unclassified:
+            for method, path in unclassified:
+                detail(f"unclassified: {method} {path}")
+            check_fail(f"{len(unclassified)} operation(s) have no case and no "
+                       "written reason to skip")
+            return False
+        check_ok(f"{len(exercised)} exercised, {len(EXCLUDED)} excluded")
+
+        check_start("nothing is classified that the device does not serve")
+        stale = sorted((exercised | set(EXCLUDED) | set(HAPPY_ELSEWHERE)
+                        | set(NEGATIVE_ONLY)) - registered)
+        if stale:
+            for method, path in stale:
+                detail(f"stale: {method} {path}")
+            check_fail(f"{len(stale)} classified operation(s) are not served; "
+                       "remove them from this suite")
+            return False
+        check_ok()
+
+        check_start("every operation has a happy path somewhere")
+        missing = sorted(registered - (happy | set(EXCLUDED) | set(HAPPY_ELSEWHERE)
+                                       | set(NEGATIVE_ONLY)))
+        if missing:
+            for method, path in missing:
+                detail(f"no happy path: {method} {path}")
+            check_fail(f"{len(missing)} operation(s) are only called with arguments "
+                       "they refuse. Add a happy case, name the suite that has one "
+                       "in HAPPY_ELSEWHERE, or say in NEGATIVE_ONLY why there "
+                       "cannot be one")
+            return False
+        check_ok(f"{len(happy)} here, {len(HAPPY_ELSEWHERE)} elsewhere, "
+                 f"{len(NEGATIVE_ONLY)} with none")
+
+        for (method, path), reason in sorted(EXCLUDED.items()):
+            detail(f"not called: {method} {path} - {reason}")
+        for (method, path), reason in sorted(NEGATIVE_ONLY.items()):
+            detail(f"negative only: {method} {path} - {reason}")
+        return True
+
+    # -- execution ----------------------------------------------------------
+    def run_once(self, case: Case) -> Optional[str]:
+        api = self.client()
+        try:
+            case.run(Ctx(api, self))
+        except Skip as exc:
+            return f"SKIP {exc}"
+        except (Failure, OSError, TimeoutError, urllib.error.URLError) as exc:
+            reason = format_exception(exc)
+            if self.alive():
+                self.dead.set()
+                return f"{reason}, and the device stopped answering. Power cycle it."
+            return reason
+        liveness = api.unreachable_reason(LIVENESS_TIMEOUT_SECONDS)
+        if liveness:
+            self.dead.set()
+            return (f"the device stopped answering after this call: {liveness}. "
+                    "Power cycle it.")
+        return None
+
+    def run_cases(self) -> bool:
+        shared = [c for c in self.cases if not c.exclusive]
+        exclusive = [c for c in self.cases if c.exclusive]
+        results: Dict[int, str] = {}
+        attempted: Set[int] = set()
         lock = threading.Lock()
 
-        def record(probe: Probe, reason: Optional[str]) -> None:
-            if reason is None:
-                return
-            with lock:
-                results.setdefault(probe.key, reason)
-
-        def task(probe: Probe) -> None:
+        def task(case: Case) -> None:
             if self.dead.is_set():
                 return
             with lock:
-                if probe.key in results:
-                    return          # already failed; do not pile on
-            record(probe, self.call_once(self.client(), probe))
+                if id(case) in results:
+                    return              # already failed; do not pile on
+                attempted.add(id(case))
+            outcome = self.run_once(case)
+            if outcome is not None:
+                with lock:
+                    results.setdefault(id(case), outcome)
 
         if self.args.order == "sequential":
-            # a,a,a,b,b,b: one endpoint at a time, on one connection.
-            for probe in shared:
+            for case in shared:
                 for _ in range(self.args.repeat):
-                    task(probe)
+                    task(case)
         else:
-            # a,b,c,...,a,b,c,...: one pass of every endpoint per round, so the
-            # calls in flight together are always different endpoints.
             with ThreadPoolExecutor(max_workers=self.args.workers) as pool:
                 for _ in range(self.args.repeat):
                     if self.dead.is_set():
                         break
                     list(pool.map(task, shared))
 
-        # The exclusive ones are always sequential and always in list order, so
-        # pause is followed by resume however the rest of the suite ran.
+        # Always sequential and always in list order, so a case that changes
+        # state and puts it back is never interleaved with one that reads it.
         for _ in range(self.args.repeat):
             if self.dead.is_set():
                 break
-            for probe in exclusive:
-                task(probe)
+            for case in exclusive:
+                task(case)
 
         ok = True
-        for probe in self.probes:
-            label = probe.label
-            if probe.note:
-                label = f"{label} ({probe.note})"
-            check_start(f"{label} x{self.args.repeat}")
-            reason = results.get(probe.key)
-            if reason is None:
-                if self.dead.is_set() and probe.key not in results:
-                    check_skip("device was already down")
+        for case in self.cases:
+            check_start(f"{case.label} x{self.args.repeat}")
+            outcome = results.get(id(case))
+            if outcome is None:
+                if id(case) not in attempted:
+                    check_skip("the device was already down")
                     ok = False
-                    continue
-                check_ok()
-                continue
-            check_fail(f"{probe.label} {reason}")
-            ok = False
-            if self.dead.is_set():
-                detail("device is down; the remaining endpoints were not called")
-                break
+                else:
+                    check_ok()
+            elif outcome.startswith("SKIP "):
+                check_skip(outcome[5:])
+            else:
+                check_fail(outcome)
+                ok = False
         return ok
 
     def run(self) -> bool:
@@ -436,40 +1078,55 @@ class SuiteRunner:
             return False
         check_ok()
 
-        # Make the debugreg write a no-op by giving it back what it holds.
-        self.debugreg_before = self.read_debugreg()
-        if self.debugreg_before is not None:
-            for probe in self.probes:
-                if probe.key == ("PUT", "machine", "debugreg"):
-                    probe.params = {"value": f"0x{self.debugreg_before}"}
+        check_start("record the state to restore")
+        try:
+            drive = self.api.drives.get("a")
+            self.restore_drive = (drive.enabled, drive.type, drive.image_path)
+            self.restore_config = self.snapshot_category(
+                Ctx(self.api, self), CONFIG_CATEGORY)
+        except (Failure, Skip) as exc:
+            check_fail(f"could not read the starting state: {format_exception(exc)}")
+            return False
+        check_ok(f"drive a: enabled={drive.enabled} type={drive.type!r}, "
+                 f"{len(self.restore_config)} settings")
 
-        section("endpoints")
-        detail(f"{len(self.probes)} endpoints x{self.args.repeat}, "
-               f"{self.args.order}"
-               + (f", {self.args.workers} workers" if self.args.order == "concurrent"
-                  else ""))
-        return self.run_probes()
+        section("operations")
+        detail(f"{len(self.cases)} cases x{self.args.repeat}, {self.args.order}"
+               + (f", {self.args.workers} workers"
+                  if self.args.order == "concurrent" else ""))
+        return self.run_cases()
 
+    # -- cleanup ------------------------------------------------------------
     def cleanup(self) -> None:
-        """The probes are chosen not to leave anything behind. What is left is
-        the pause/resume pair, which must not end paused however the run ended,
-        and the scratch directory in the unlikely case a route created it on its
-        way to failing."""
-        try:
-            self.rest.request("PUT", "/v1/machine:resume")
-        except (Failure, OSError, TimeoutError, urllib.error.URLError):
-            pass
-        if self.debugreg_before is not None:
+        """Put back everything a case could have changed, however the run ended.
+
+        Quiet and best effort: a cleanup failure on a device that has already
+        gone down would bury the reason the suite failed.
+        """
+        def quietly(action) -> None:
             try:
-                self.rest.request("PUT", "/v1/machine:debugreg",
-                                  params={"value": f"0x{self.debugreg_before}"})
-            except (Failure, OSError, TimeoutError, urllib.error.URLError):
+                action()
+            except Exception:                            # noqa: BLE001
                 pass
-        try:
-            with ftp_lib.session(self.args.host, self.args.password) as client:
-                ftp_lib.quietly(lambda: client.rmd(posixpath.dirname(MISSING)))
-        except ftplib.all_errors + (OSError, Failure):
-            pass
+
+        quietly(self.api.machine.resume)
+        quietly(lambda: self.api.rest.request("PUT", "/v1/streams/debug:stop"))
+        quietly(lambda: self.api.drives.unlink("a"))
+        if self.restore_drive is not None:
+            enabled, mode, image = self.restore_drive
+            quietly(lambda: self.api.drives.set_mode("a", mode))
+            quietly(lambda: (self.api.drives.on if enabled else self.api.drives.off)("a"))
+            if image:
+                quietly(lambda: self.api.drives.mount("a", image))
+        if self.restore_config:
+            quietly(lambda: self.restore_category(
+                Ctx(self.api, self), CONFIG_CATEGORY, self.restore_config))
+        quietly(self._remove_scratch)
+
+    def _remove_scratch(self) -> None:
+        with ftp_lib.session(self.args.host, self.args.password) as client:
+            ftp_lib.delete_quietly(client, MOUNT_IMAGE)
+            ftp_lib.quietly(lambda: client.rmd(posixpath.dirname(MISSING)))
 
 
 def main() -> int:
@@ -479,17 +1136,19 @@ def main() -> int:
     parser.add_argument("-t", "--timeout", type=float,
                         default=float(os.environ.get("U64_TIMEOUT", "10.0")))
     parser.add_argument("-r", "--repeat", type=int, default=DEFAULT_REPEAT,
-                        help="how many times each endpoint is called "
-                             "(default: %(default)s)")
+                        help="how many times each case runs (default: %(default)s)")
     parser.add_argument("--order", choices=("concurrent", "sequential"),
                         default="concurrent",
-                        help="concurrent spreads the repetitions across workers "
-                             "so different endpoints overlap; sequential calls "
-                             "each endpoint's repetitions back to back on one "
-                             "thread (default: %(default)s)")
+                        help="concurrent spreads the repetitions across workers so "
+                             "different operations overlap; sequential runs each "
+                             "case's repetitions back to back on one thread "
+                             "(default: %(default)s)")
     parser.add_argument("-w", "--workers", type=int, default=DEFAULT_WORKERS,
-                        help="concurrent workers, at most one HTTP connection "
-                             "each (default: %(default)s)")
+                        help="concurrent workers, one HTTP connection each "
+                             "(default: %(default)s)")
+    parser.add_argument("--allow-global-reset", action="store_true",
+                        help="also call configs:reset_to_default without a "
+                             "category, which resets every category at once")
     args = parser.parse_args()
     if args.repeat < 1:
         parser.error("--repeat must be at least 1")
@@ -511,8 +1170,8 @@ def main() -> int:
     finally:
         try:
             runner.cleanup()
-        except Exception:
-            pass
+        except Exception as exc:                          # noqa: BLE001
+            warn(f"cleanup failed: {format_exception(exc)}")
 
     if passed:
         suite_ok(SUITE, f"{check_count()} checks")

--- a/tests/e2e/api/rest_api_coverage_test.py
+++ b/tests/e2e/api/rest_api_coverage_test.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+# E2E: Calls every REST endpoint the firmware registers and checks the device
+# survives each one.
+#
+# Why this exists. A lockup in files:create_d64 shipped because no suite ever
+# called that route: the API surface was covered by whichever endpoints the
+# feature suites happened to need. So this suite reads the route table out of
+# software/api/*.cc and requires every route to be classified, either with a
+# probe here or with a written reason for not calling it. A new endpoint fails
+# this suite until somebody decides which it is.
+#
+# What a probe is. Most probes deliberately drive the argument or error path
+# rather than the successful one: a nonexistent file, an unknown drive, a
+# missing required argument. That keeps the suite fast and side-effect free,
+# and it is not a weaker check than a happy-path call would be. The bug that
+# prompted this suite was in ArgsURI's destructor, which runs on every request
+# whatever the outcome, so an error-path call catches it exactly as well.
+#
+# After every probe the device is read back. That read is what turns "the route
+# answered" into "the route answered and the firmware is still running".
+
+import argparse
+import ftplib
+import os
+import posixpath
+import re
+import sys
+import urllib.error
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+# tests/lib holds the reporting rules and the one shared REST client.
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"))
+import ftp as ftp_lib  # noqa: E402  (needs tests/lib on sys.path first)
+import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
+from api import UltimateApi  # noqa: E402  (needs tests/lib on sys.path first)
+from report import (  # noqa: E402  (needs tests/lib on sys.path first)
+    Failure, check_count, check_fail, check_ok, check_start, detail,
+    format_exception, section, suite_fail, suite_ok)
+
+SUITE = "rest_api_coverage_test"
+API_SOURCE_DIR = Path(__file__).resolve().parents[3] / "software" / "api"
+API_CALL_RE = re.compile(
+    r"^API_CALL\(\s*(\w+)\s*,\s*(\w+)\s*,\s*(\w+)\s*,", re.MULTILINE)
+
+# A scratch directory that exists on every product, cleared on reboot.
+SCRATCH = "/Temp"
+# A path that is guaranteed not to exist, for probes that must not create
+# anything. The directory component does not exist either, so a route that
+# creates a file on the way to failing still creates nothing.
+MISSING = "/Temp/rest_api_coverage_no_such_dir/no_such_file"
+
+LIVENESS_TIMEOUT_SECONDS = 10.0
+
+# Endpoints that are deliberately not called, and why. Anything listed here is
+# still required to exist: if one is removed from the firmware this suite fails,
+# so the list cannot rot into a set of names nobody recognises.
+EXCLUDED: Dict[Tuple[str, str, str], str] = {
+    ("PUT", "machine", "poweroff"):
+        "turns the device off; no test can turn it back on",
+    ("PUT", "machine", "reboot"):
+        "restarts the machine mid-run; exercised by readmem-writemem",
+    ("PUT", "machine", "reset"):
+        "resets the C64 under whatever else is running; exercised by "
+        "readmem-writemem",
+    ("PUT", "configs", "save_to_flash"):
+        "writes the settings store; a run that started in safe mode would "
+        "overwrite the real values with defaults",
+    ("PUT", "configs", "load_from_flash"):
+        "discards the settings the run is using, including the ones a later "
+        "suite set up",
+    ("PUT", "configs", "reset_to_default"):
+        "destroys the operator's settings",
+    ("PUT", "machine", "menu_button"):
+        "leaves the on-screen menu open or closed for every later suite; "
+        "exercised by menu-screen",
+}
+
+
+class Probe:
+    """One endpoint, one call, and what counts as an answer.
+
+    `accept` is a set of status codes rather than one code because several
+    routes are compiled per product: machine:input is behind #if U64 and
+    answers 501 on a cartridge, and menu_screen answers 404 when no menu is
+    open. A probe that accepted only one of those would fail on half the
+    hardware for a reason that is not a defect.
+    """
+
+    def __init__(self, method: str, group: str, command: str,
+                 path: str, accept: Sequence[int], *,
+                 params: Optional[Dict[str, object]] = None,
+                 body: Optional[bytes] = None,
+                 note: str = "") -> None:
+        self.method = method
+        self.group = group
+        self.command = command
+        self.path = path
+        self.accept = set(accept)
+        self.params = params
+        self.body = body
+        self.note = note
+
+    @property
+    def key(self) -> Tuple[str, str, str]:
+        return (self.method, self.group, self.command)
+
+    @property
+    def label(self) -> str:
+        name = self.group if self.command == "none" else f"{self.group}:{self.command}"
+        return f"{self.method} {name}"
+
+
+def _route_path(group: str, command: str) -> str:
+    return f"/v1/{group}" if command == "none" else f"/v1/{group}:{command}"
+
+
+OK = (200,)
+# A route that refuses the probe's arguments. Which of these a route picks is
+# its own business; the point of the probe is that it answers and stays up.
+REFUSED = (400, 403, 404, 412, 500, 501)
+
+
+def build_probes() -> List[Probe]:
+    p: List[Probe] = []
+
+    # ---- read-only ------------------------------------------------------
+    p.append(Probe("GET", "version", "none", "/v1/version", OK))
+    p.append(Probe("GET", "info", "none", "/v1/info", OK))
+    p.append(Probe("GET", "help", "none", "/v1/help", OK,
+                   params={"command": "version"}))
+    p.append(Probe("GET", "drives", "none", "/v1/drives", OK))
+    p.append(Probe("GET", "configs", "none", "/v1/configs", OK))
+    p.append(Probe("GET", "files", "info", f"/v1/files{SCRATCH}:info", OK))
+    p.append(Probe("GET", "machine", "readmem", "/v1/machine:readmem", OK,
+                   params={"address": 1024, "length": 16}))
+    p.append(Probe("GET", "machine", "heap", "/v1/machine:heap", OK))
+    p.append(Probe("GET", "machine", "debugreg", "/v1/machine:debugreg", OK))
+    p.append(Probe("GET", "machine", "menu_screen", "/v1/machine:menu_screen",
+                   OK + (404,), note="404 when no menu is open"))
+    p.append(Probe("GET", "machine", "measure", "/v1/machine:measure",
+                   OK + (501,), note="501 when the FPGA has no bus measurement"))
+    p.append(Probe("GET", "machine", "input", "/v1/machine:input",
+                   OK + (501,), note="501 on products without key injection"))
+
+    # ---- argument and error paths, no state change ----------------------
+    for kind, extra in (("d64", {"tracks": 35}), ("d71", {}),
+                        ("d81", {}), ("dnp", {"tracks": 1})):
+        p.append(Probe("PUT", "files", f"create_{kind}",
+                       f"/v1/files{MISSING}.{kind}:create_{kind}", REFUSED,
+                       params=extra,
+                       note="unwritable path; the happy path is create-disk-image"))
+    p.append(Probe("PUT", "machine", "writemem", "/v1/machine:writemem", REFUSED,
+                   params={"address": 1024},
+                   note="no data argument; real writes are readmem-writemem"))
+    # debugreg takes any value and answers 200, so there is no argument that
+    # refuses. run() replaces this with the value the register already holds,
+    # which makes the call a no-op, and cleanup() puts it back either way.
+    p.append(Probe("PUT", "machine", "debugreg", "/v1/machine:debugreg", OK,
+                   params={"value": "0"},
+                   note="writes back the value already in the register"))
+    p.append(Probe("PUT", "drives", "mount", "/v1/drives:mount", REFUSED,
+                   params={"drive": "a", "image": MISSING + ".d64"}))
+    p.append(Probe("PUT", "drives", "load_rom", "/v1/drives:load_rom", REFUSED,
+                   params={"drive": "a", "file": MISSING + ".rom"}))
+    p.append(Probe("PUT", "drives", "set_mode", "/v1/drives:set_mode", REFUSED,
+                   params={"drive": "a", "mode": "no-such-mode"}))
+    p.append(Probe("PUT", "drives", "reset", "/v1/drives:reset", REFUSED,
+                   params={"drive": "z"}, note="unknown drive letter"))
+    p.append(Probe("PUT", "drives", "remove", "/v1/drives:remove", REFUSED,
+                   params={"drive": "z"}))
+    p.append(Probe("PUT", "drives", "unlink", "/v1/drives:unlink", REFUSED,
+                   params={"drive": "z"}))
+    p.append(Probe("PUT", "drives", "on", "/v1/drives:on", REFUSED,
+                   params={"drive": "z"}))
+    p.append(Probe("PUT", "drives", "off", "/v1/drives:off", REFUSED,
+                   params={"drive": "z"}))
+    p.append(Probe("PUT", "configs", "none", "/v1/configs/No%20Such%20Category",
+                   REFUSED, params={"value": "1"},
+                   note="unknown category; real writes are the cfg-* suites"))
+    for command in ("sidplay", "modplay", "load_prg", "run_prg", "run_crt"):
+        p.append(Probe("PUT", "runners", command, f"/v1/runners:{command}", REFUSED,
+                       params={"file": MISSING + ".prg"},
+                       note="nonexistent file, so nothing is launched"))
+    p.append(Probe("PUT", "streams", "start", "/v1/streams:start", REFUSED,
+                   params={"stream": "no-such-stream"}))
+    p.append(Probe("PUT", "streams", "stop", "/v1/streams:stop", REFUSED,
+                   params={"stream": "no-such-stream"}))
+
+    # ---- round trip, state restored immediately -------------------------
+    # These two are the only pair that has to run for real: there is no
+    # argument that makes pause fail without also skipping the code that
+    # freezes the machine. They are adjacent and in this order, and cleanup()
+    # sends a resume as well, so an abort between them cannot leave the C64
+    # paused for the suites that follow.
+    p.append(Probe("PUT", "machine", "pause", "/v1/machine:pause", OK))
+    p.append(Probe("PUT", "machine", "resume", "/v1/machine:resume", OK))
+
+    # ---- POST routes ----------------------------------------------------
+    # Every POST route takes its payload as an attachment. Sending none is
+    # refused before the handler runs, which reaches the same request teardown
+    # without uploading anything or starting anything.
+    for group, command in (("configs", "none"), ("drives", "mount"),
+                           ("drives", "load_rom"), ("machine", "writemem"),
+                           ("machine", "input"), ("runners", "sidplay"),
+                           ("runners", "modplay"), ("runners", "load_prg"),
+                           ("runners", "run_prg"), ("runners", "run_crt")):
+        p.append(Probe("POST", group, command, _route_path(group, command), REFUSED,
+                       note="no body, so the handler never runs"))
+
+    return p
+
+
+class SuiteRunner:
+    def __init__(self, args) -> None:
+        self.args = args
+        self.api = UltimateApi(args.host, args.password, args.timeout)
+        # The probes assert on status codes, so they go through the transport
+        # rather than the typed API: rest.py returns the status instead of
+        # raising on it.
+        self.rest = self.api.rest
+        self.probes = build_probes()
+        self.debugreg_before: Optional[str] = None
+
+    # -- helpers ------------------------------------------------------------
+    def alive(self) -> Optional[str]:
+        return self.api.unreachable_reason(LIVENESS_TIMEOUT_SECONDS)
+
+    def source_routes(self) -> Set[Tuple[str, str, str]]:
+        found: Set[Tuple[str, str, str]] = set()
+        for source in sorted(API_SOURCE_DIR.glob("*.cc")):
+            for method, group, command in API_CALL_RE.findall(
+                    source.read_text(encoding="utf-8", errors="replace")):
+                found.add((method.upper(), group, command))
+        return found
+
+    def read_debugreg(self) -> Optional[str]:
+        try:
+            code, _, body = self.rest.request("GET", "/v1/machine:debugreg",
+                                              idempotent=True)
+        except (Failure, OSError, TimeoutError, urllib.error.URLError):
+            return None
+        if code != 200:
+            return None
+        match = re.search(rb'"value"\s*:\s*"([^"]*)"', body)
+        return match.group(1).decode("ascii", "replace") if match else None
+
+    # -- checks -------------------------------------------------------------
+    def check_coverage(self) -> bool:
+        """Every registered route is probed here or excluded with a reason."""
+        section("coverage")
+        check_start(f"read the route table from {API_SOURCE_DIR.name}/*.cc")
+        try:
+            registered = self.source_routes()
+        except OSError as exc:
+            check_fail(f"could not read the API sources: {format_exception(exc)}")
+            return False
+        if not registered:
+            check_fail(f"no API_CALL found under {API_SOURCE_DIR}")
+            return False
+        check_ok(f"{len(registered)} endpoints")
+
+        probed = {probe.key for probe in self.probes}
+        classified = probed | set(EXCLUDED)
+
+        check_start("every registered endpoint is probed or excluded")
+        unclassified = sorted(registered - classified)
+        if unclassified:
+            for method, group, command in unclassified:
+                detail(f"unclassified: {method} {_route_path(group, command)}")
+            check_fail(
+                f"{len(unclassified)} endpoint(s) have no probe and no written "
+                "reason to skip. Add a probe, or add one to EXCLUDED saying why "
+                "it must not be called.")
+            return False
+        check_ok(f"{len(probed)} probed, {len(EXCLUDED)} excluded")
+
+        check_start("nothing is classified that the firmware no longer has")
+        stale = sorted(classified - registered)
+        if stale:
+            for method, group, command in stale:
+                detail(f"stale: {method} {_route_path(group, command)}")
+            check_fail(f"{len(stale)} classified endpoint(s) are not registered "
+                       "any more; remove them from this suite")
+            return False
+        check_ok()
+
+        for (method, group, command), reason in sorted(EXCLUDED.items()):
+            detail(f"not called: {method} {_route_path(group, command)} - {reason}")
+        return True
+
+    def run_probe(self, probe: Probe) -> bool:
+        label = probe.label
+        if probe.note:
+            label = f"{label} ({probe.note})"
+        check_start(label)
+        try:
+            code, _, body = self.rest.request(
+                probe.method, probe.path, params=probe.params, body=probe.body)
+        except (Failure, OSError, TimeoutError, urllib.error.URLError) as exc:
+            check_fail(f"{probe.label} did not answer: {format_exception(exc)}")
+            return False
+        if code not in probe.accept:
+            check_fail(f"{probe.label} answered HTTP {code}, expected one of "
+                       f"{sorted(probe.accept)}: {body[:160]!r}")
+            return False
+        check_ok(f"HTTP {code}")
+
+        check_start(f"device still answers after {probe.label}")
+        reason = self.alive()
+        if reason:
+            check_fail(f"device stopped answering after {probe.label}: {reason}. "
+                       "It needs a power cycle.")
+            return False
+        check_ok()
+        return True
+
+    def run(self) -> bool:
+        if not self.check_coverage():
+            return False
+
+        section("preconditions")
+        check_start("device reachable")
+        reason = self.alive()
+        if reason:
+            check_fail(f"device did not answer before the suite started: {reason}")
+            return False
+        check_ok()
+
+        # Make the debugreg write a no-op by giving it back what it holds.
+        self.debugreg_before = self.read_debugreg()
+        if self.debugreg_before is not None:
+            for probe in self.probes:
+                if probe.key == ("PUT", "machine", "debugreg"):
+                    probe.params = {"value": f"0x{self.debugreg_before}"}
+
+        section("endpoints")
+        for probe in self.probes:
+            if not self.run_probe(probe):
+                # Once the device is down every later probe reports the same
+                # thing, so stop and say so once.
+                if self.alive():
+                    detail("device is down; skipping the remaining endpoints")
+                return False
+        return True
+
+    def cleanup(self) -> None:
+        """The probes are chosen not to leave anything behind. What is left is
+        the pause/resume pair, which must not end paused however the run ended,
+        and the scratch directory in the unlikely case a route created it on its
+        way to failing."""
+        try:
+            self.rest.request("PUT", "/v1/machine:resume")
+        except (Failure, OSError, TimeoutError, urllib.error.URLError):
+            pass
+        if self.debugreg_before is not None:
+            try:
+                self.rest.request("PUT", "/v1/machine:debugreg",
+                                  params={"value": f"0x{self.debugreg_before}"})
+            except (Failure, OSError, TimeoutError, urllib.error.URLError):
+                pass
+        try:
+            with ftp_lib.session(self.args.host, self.args.password) as client:
+                ftp_lib.quietly(lambda: client.rmd(posixpath.dirname(MISSING)))
+        except ftplib.all_errors + (OSError, Failure):
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS"))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "10.0")))
+    args = parser.parse_args()
+
+    runner = SuiteRunner(args)
+    try:
+        passed = runner.run()
+    except Failure as exc:
+        suite_fail(SUITE, format_exception(exc))
+        return 1
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        if rest_lib.looks_unreachable(exc):
+            suite_fail(SUITE, f"connection failure: {format_exception(exc)}")
+        else:
+            suite_fail(SUITE, f"REST failure: {format_exception(exc)}")
+        return 1
+    finally:
+        try:
+            runner.cleanup()
+        except Exception:
+            pass
+
+    if passed:
+        suite_ok(SUITE, f"{check_count()} checks")
+        return 0
+    suite_fail(SUITE, "see the failed check above")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/api/rest_api_coverage_test.py
+++ b/tests/e2e/api/rest_api_coverage_test.py
@@ -18,6 +18,14 @@
 #
 # After every probe the device is read back. That read is what turns "the route
 # answered" into "the route answered and the firmware is still running".
+#
+# Repetition. The lockup this suite exists for did not fire on a cold device on
+# the first call, so every probe runs --repeat times. By default the repetitions
+# are spread across worker threads so that different endpoints are in flight at
+# once, which is the harder case: it overlaps request teardown on one connection
+# with argument parsing on another. --order sequential runs each endpoint's
+# repetitions back to back on one thread instead, which is what you want when a
+# single endpoint is suspect and you need the calls attributable.
 
 import argparse
 import ftplib
@@ -25,7 +33,9 @@ import os
 import posixpath
 import re
 import sys
+import threading
 import urllib.error
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
@@ -36,7 +46,7 @@ import ftp as ftp_lib  # noqa: E402  (needs tests/lib on sys.path first)
 import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
 from api import UltimateApi  # noqa: E402  (needs tests/lib on sys.path first)
 from report import (  # noqa: E402  (needs tests/lib on sys.path first)
-    Failure, check_count, check_fail, check_ok, check_start, detail,
+    Failure, check_count, check_fail, check_ok, check_skip, check_start, detail,
     format_exception, section, suite_fail, suite_ok)
 
 SUITE = "rest_api_coverage_test"
@@ -52,6 +62,15 @@ SCRATCH = "/Temp"
 MISSING = "/Temp/rest_api_coverage_no_such_dir/no_such_file"
 
 LIVENESS_TIMEOUT_SECONDS = 10.0
+
+# The firmware serves MAX_HTTP_CLIENT = 4 connections (httpd/c-version/lib/
+# server.h). Each worker holds one for the call and one for the liveness read
+# that follows it, but never both at once, so the ceiling is one per worker.
+# Three leaves a slot free: saturating the last one turns a slow answer into a
+# refused connection, which would read as a device failure rather than as the
+# queueing it is.
+DEFAULT_WORKERS = 3
+DEFAULT_REPEAT = 3
 
 # Endpoints that are deliberately not called, and why. Anything listed here is
 # still required to exist: if one is removed from the firmware this suite fails,
@@ -92,7 +111,8 @@ class Probe:
                  path: str, accept: Sequence[int], *,
                  params: Optional[Dict[str, object]] = None,
                  body: Optional[bytes] = None,
-                 note: str = "") -> None:
+                 note: str = "",
+                 exclusive: bool = False) -> None:
         self.method = method
         self.group = group
         self.command = command
@@ -101,6 +121,9 @@ class Probe:
         self.params = params
         self.body = body
         self.note = note
+        # An exclusive probe changes machine state that the next probe would
+        # see, so it never runs concurrently with anything, including itself.
+        self.exclusive = exclusive
 
     @property
     def key(self) -> Tuple[str, str, str]:
@@ -136,7 +159,12 @@ def build_probes() -> List[Probe]:
     p.append(Probe("GET", "machine", "readmem", "/v1/machine:readmem", OK,
                    params={"address": 1024, "length": 16}))
     p.append(Probe("GET", "machine", "heap", "/v1/machine:heap", OK))
-    p.append(Probe("GET", "machine", "debugreg", "/v1/machine:debugreg", OK))
+    # Both debugreg routes are inside #if U64 in route_machine.cc, so on a
+    # product without that register they are not in the route table at all and
+    # the dispatcher answers 404. That is different from machine:input, which
+    # is always registered and answers 501.
+    p.append(Probe("GET", "machine", "debugreg", "/v1/machine:debugreg",
+                   OK + (404,), note="404 where the route is not compiled in"))
     p.append(Probe("GET", "machine", "menu_screen", "/v1/machine:menu_screen",
                    OK + (404,), note="404 when no menu is open"))
     p.append(Probe("GET", "machine", "measure", "/v1/machine:measure",
@@ -157,9 +185,10 @@ def build_probes() -> List[Probe]:
     # debugreg takes any value and answers 200, so there is no argument that
     # refuses. run() replaces this with the value the register already holds,
     # which makes the call a no-op, and cleanup() puts it back either way.
-    p.append(Probe("PUT", "machine", "debugreg", "/v1/machine:debugreg", OK,
-                   params={"value": "0"},
-                   note="writes back the value already in the register"))
+    p.append(Probe("PUT", "machine", "debugreg", "/v1/machine:debugreg",
+                   OK + (404,), params={"value": "0"},
+                   note="writes back the value already in the register, "
+                        "404 where the route is not compiled in"))
     p.append(Probe("PUT", "drives", "mount", "/v1/drives:mount", REFUSED,
                    params={"drive": "a", "image": MISSING + ".d64"}))
     p.append(Probe("PUT", "drives", "load_rom", "/v1/drives:load_rom", REFUSED,
@@ -194,8 +223,10 @@ def build_probes() -> List[Probe]:
     # freezes the machine. They are adjacent and in this order, and cleanup()
     # sends a resume as well, so an abort between them cannot leave the C64
     # paused for the suites that follow.
-    p.append(Probe("PUT", "machine", "pause", "/v1/machine:pause", OK))
-    p.append(Probe("PUT", "machine", "resume", "/v1/machine:resume", OK))
+    p.append(Probe("PUT", "machine", "pause", "/v1/machine:pause", OK,
+                   exclusive=True))
+    p.append(Probe("PUT", "machine", "resume", "/v1/machine:resume", OK,
+                   exclusive=True))
 
     # ---- POST routes ----------------------------------------------------
     # Every POST route takes its payload as an attachment. Sending none is
@@ -222,6 +253,11 @@ class SuiteRunner:
         self.rest = self.api.rest
         self.probes = build_probes()
         self.debugreg_before: Optional[str] = None
+        self.local = threading.local()
+        self.local.api = self.api
+        # Set by the first worker that finds the device gone, so the others
+        # stop rather than each spending the liveness budget discovering it.
+        self.dead = threading.Event()
 
     # -- helpers ------------------------------------------------------------
     def alive(self) -> Optional[str]:
@@ -290,31 +326,103 @@ class SuiteRunner:
             detail(f"not called: {method} {_route_path(group, command)} - {reason}")
         return True
 
-    def run_probe(self, probe: Probe) -> bool:
-        label = probe.label
-        if probe.note:
-            label = f"{label} ({probe.note})"
-        check_start(label)
+    def call_once(self, api, probe: Probe) -> Optional[str]:
+        """Run one probe once on `api`; None when it passed, else the reason.
+
+        Each worker owns its client, so nothing here touches shared state and
+        the transport's counters stay meaningful per thread.
+        """
         try:
-            code, _, body = self.rest.request(
+            code, _, body = api.rest.request(
                 probe.method, probe.path, params=probe.params, body=probe.body)
         except (Failure, OSError, TimeoutError, urllib.error.URLError) as exc:
-            check_fail(f"{probe.label} did not answer: {format_exception(exc)}")
-            return False
+            return f"did not answer: {format_exception(exc)}"
         if code not in probe.accept:
-            check_fail(f"{probe.label} answered HTTP {code}, expected one of "
-                       f"{sorted(probe.accept)}: {body[:160]!r}")
-            return False
-        check_ok(f"HTTP {code}")
-
-        check_start(f"device still answers after {probe.label}")
-        reason = self.alive()
+            return (f"answered HTTP {code}, expected one of "
+                    f"{sorted(probe.accept)}: {body[:160]!r}")
+        reason = api.unreachable_reason(LIVENESS_TIMEOUT_SECONDS)
         if reason:
-            check_fail(f"device stopped answering after {probe.label}: {reason}. "
-                       "It needs a power cycle.")
-            return False
-        check_ok()
-        return True
+            self.dead.set()
+            return (f"the device stopped answering after this call: {reason}. "
+                    "It needs a power cycle.")
+        return None
+
+    def client(self):
+        """One UltimateApi per thread.
+
+        Keyed by thread rather than by task, because the pool decides which
+        thread runs which task: two tasks that happened to pick the same client
+        would share its transport counters across threads.
+        """
+        api = getattr(self.local, "api", None)
+        if api is None:
+            api = UltimateApi(self.args.host, self.args.password, self.args.timeout)
+            self.local.api = api
+        return api
+
+    def run_probes(self) -> bool:
+        """Run every probe `repeat` times and report one check per endpoint."""
+        shared = [p for p in self.probes if not p.exclusive]
+        exclusive = [p for p in self.probes if p.exclusive]
+        results: Dict[Tuple[str, str, str], Optional[str]] = {}
+        lock = threading.Lock()
+
+        def record(probe: Probe, reason: Optional[str]) -> None:
+            if reason is None:
+                return
+            with lock:
+                results.setdefault(probe.key, reason)
+
+        def task(probe: Probe) -> None:
+            if self.dead.is_set():
+                return
+            with lock:
+                if probe.key in results:
+                    return          # already failed; do not pile on
+            record(probe, self.call_once(self.client(), probe))
+
+        if self.args.order == "sequential":
+            # a,a,a,b,b,b: one endpoint at a time, on one connection.
+            for probe in shared:
+                for _ in range(self.args.repeat):
+                    task(probe)
+        else:
+            # a,b,c,...,a,b,c,...: one pass of every endpoint per round, so the
+            # calls in flight together are always different endpoints.
+            with ThreadPoolExecutor(max_workers=self.args.workers) as pool:
+                for _ in range(self.args.repeat):
+                    if self.dead.is_set():
+                        break
+                    list(pool.map(task, shared))
+
+        # The exclusive ones are always sequential and always in list order, so
+        # pause is followed by resume however the rest of the suite ran.
+        for _ in range(self.args.repeat):
+            if self.dead.is_set():
+                break
+            for probe in exclusive:
+                task(probe)
+
+        ok = True
+        for probe in self.probes:
+            label = probe.label
+            if probe.note:
+                label = f"{label} ({probe.note})"
+            check_start(f"{label} x{self.args.repeat}")
+            reason = results.get(probe.key)
+            if reason is None:
+                if self.dead.is_set() and probe.key not in results:
+                    check_skip("device was already down")
+                    ok = False
+                    continue
+                check_ok()
+                continue
+            check_fail(f"{probe.label} {reason}")
+            ok = False
+            if self.dead.is_set():
+                detail("device is down; the remaining endpoints were not called")
+                break
+        return ok
 
     def run(self) -> bool:
         if not self.check_coverage():
@@ -336,14 +444,11 @@ class SuiteRunner:
                     probe.params = {"value": f"0x{self.debugreg_before}"}
 
         section("endpoints")
-        for probe in self.probes:
-            if not self.run_probe(probe):
-                # Once the device is down every later probe reports the same
-                # thing, so stop and say so once.
-                if self.alive():
-                    detail("device is down; skipping the remaining endpoints")
-                return False
-        return True
+        detail(f"{len(self.probes)} endpoints x{self.args.repeat}, "
+               f"{self.args.order}"
+               + (f", {self.args.workers} workers" if self.args.order == "concurrent"
+                  else ""))
+        return self.run_probes()
 
     def cleanup(self) -> None:
         """The probes are chosen not to leave anything behind. What is left is
@@ -373,7 +478,23 @@ def main() -> int:
     parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS"))
     parser.add_argument("-t", "--timeout", type=float,
                         default=float(os.environ.get("U64_TIMEOUT", "10.0")))
+    parser.add_argument("-r", "--repeat", type=int, default=DEFAULT_REPEAT,
+                        help="how many times each endpoint is called "
+                             "(default: %(default)s)")
+    parser.add_argument("--order", choices=("concurrent", "sequential"),
+                        default="concurrent",
+                        help="concurrent spreads the repetitions across workers "
+                             "so different endpoints overlap; sequential calls "
+                             "each endpoint's repetitions back to back on one "
+                             "thread (default: %(default)s)")
+    parser.add_argument("-w", "--workers", type=int, default=DEFAULT_WORKERS,
+                        help="concurrent workers, at most one HTTP connection "
+                             "each (default: %(default)s)")
     args = parser.parse_args()
+    if args.repeat < 1:
+        parser.error("--repeat must be at least 1")
+    if args.workers < 1:
+        parser.error("--workers must be at least 1")
 
     runner = SuiteRunner(args)
     try:

--- a/tests/e2e/api/rest_api_coverage_test.py
+++ b/tests/e2e/api/rest_api_coverage_test.py
@@ -79,10 +79,15 @@ OPENAPI_DIR = REPO_ROOT / "doc" / "api"
 API_CALL_RE = re.compile(
     r"^API_CALL\(\s*(\w+)\s*,\s*(\w+)\s*,\s*(\w+)\s*,", re.MULTILINE)
 
-# The category the reset case uses. Printer settings change nothing the harness
-# depends on, unlike User Interface Settings, whose Interface Type defaults to
-# Freeze. See the reset case for why that matters.
-RESETTABLE_CATEGORY = "Printer Settings"
+# Categories the reset case must not touch, whatever the product calls the rest.
+# User Interface Settings holds Interface Type, whose default is Freeze, and a
+# menu opened in Freeze takes down a device whose core lacks the GideonZ#733
+# fix. The network ones re-apply on write and bounce the link the run is using.
+RESET_DENY_LIST = ("User Interface Settings", "Ethernet Settings",
+                   "Network Settings", "WiFi Settings")
+# Tried first when it is present, only so the report names the same category
+# from run to run. Any category outside the deny list will do.
+RESET_PREFERRED = "Printer Settings"
 
 SCRATCH = "/Temp"
 # A path whose parent does not exist either, so a route that creates a file on
@@ -279,7 +284,7 @@ def build_cases() -> List[Case]:
 
     # ---- configuration reads --------------------------------------------
     def _configs(ctx: Ctx) -> None:
-        if not ctx.api.configs.categories():
+        if not ctx.api.configs.category_names():
             raise Failure("the configuration listing is empty")
     case(("GET", "/v1/configs"), "lists categories", "happy", _configs)
 
@@ -303,20 +308,20 @@ def build_cases() -> List[Case]:
 
     # ---- configuration writes -------------------------------------------
     def _config_write(ctx: Ctx) -> None:
-        value = ctx.suite.config_value(ctx)
-        ctx.api.configs.set(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM, value)
-        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        category, item, value = ctx.suite.config_target(ctx)
+        ctx.api.configs.set(category, item, value)
+        after = ctx.api.configs.current(category, item)
         if after != value:
-            raise Failure(f"wrote {value!r}, reads {after!r}")
+            raise Failure(f"wrote {value!r} to {category}/{item}, reads {after!r}")
     case(("PUT", "/v1/configs/{category}/{item}"),
          "writing the current value back is a no-op", "happy", _config_write,
          exclusive=True)
 
     def _config_write_path(ctx: Ctx) -> None:
         # The other accepted form: the value as a third path element.
-        value = ctx.suite.config_value(ctx)
-        ctx.api.configs.set_by_path(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM, value)
-        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        category, item, value = ctx.suite.config_target(ctx)
+        ctx.api.configs.set_by_path(category, item, value)
+        after = ctx.api.configs.current(category, item)
         if after != value:
             raise Failure(f"wrote {value!r} through the path form, reads {after!r}")
     case(("PUT", "/v1/configs/{category}/{item}"),
@@ -330,9 +335,9 @@ def build_cases() -> List[Case]:
          "negative", _config_write_bad)
 
     def _config_apply(ctx: Ctx) -> None:
-        value = ctx.suite.config_value(ctx)
-        ctx.api.configs.apply({CONFIG_CATEGORY: {AUTO_CLEANUP_ITEM: value}})
-        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        category, item, value = ctx.suite.config_target(ctx)
+        ctx.api.configs.apply({category: {item: value}})
+        after = ctx.api.configs.current(category, item)
         if after != value:
             raise Failure(f"the JSON form wrote {value!r}, reads {after!r}")
     case(("POST", "/v1/configs"), "the JSON form sets an item", "happy",
@@ -348,26 +353,28 @@ def build_cases() -> List[Case]:
     # Saving writes what is already in force, because no case changes a setting
     # without putting it back first, so the store ends where it started.
     def _flash_roundtrip(ctx: Ctx) -> None:
-        before = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        category, item, _value = ctx.suite.config_target(ctx)
+        before = ctx.api.configs.current(category, item)
         ctx.api.configs.save_to_flash()
         ctx.api.configs.load_from_flash()
-        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        after = ctx.api.configs.current(category, item)
         if after != before:
-            raise Failure(f"save then load changed {AUTO_CLEANUP_ITEM} from "
-                          f"{before!r} to {after!r}")
+            raise Failure(f"save then load changed {item} from {before!r} to "
+                          f"{after!r}")
     case(("PUT", "/v1/configs:save_to_flash"), "save then load leaves the value",
          "happy", _flash_roundtrip, exclusive=True)
     case(("PUT", "/v1/configs:load_from_flash"), "covered by the save case above",
          "happy", _flash_roundtrip, exclusive=True)
 
     def _flash_roundtrip_category(ctx: Ctx) -> None:
-        before = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
-        ctx.api.configs.save_to_flash(CONFIG_CATEGORY)
-        ctx.api.configs.load_from_flash(CONFIG_CATEGORY)
-        after = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
+        category, item, _value = ctx.suite.config_target(ctx)
+        before = ctx.api.configs.current(category, item)
+        ctx.api.configs.save_to_flash(category)
+        ctx.api.configs.load_from_flash(category)
+        after = ctx.api.configs.current(category, item)
         if after != before:
-            raise Failure(f"per-category save then load changed "
-                          f"{AUTO_CLEANUP_ITEM} from {before!r} to {after!r}")
+            raise Failure(f"per-category save then load changed {item} from "
+                          f"{before!r} to {after!r}")
     case(("PUT", "/v1/configs/{category}:save_to_flash"),
          "save then load leaves the value", "happy", _flash_roundtrip_category,
          exclusive=True)
@@ -381,8 +388,9 @@ def build_cases() -> List[Case]:
         # lacks the GideonZ#733 fix. Resetting a category is a real reset even
         # when it is undone a moment later, so the category has to be one whose
         # defaults cannot cost the run its device.
-        category = RESETTABLE_CATEGORY
+        category = ctx.suite.resettable_category(ctx)
         snapshot = ctx.suite.snapshot_category(ctx, category)
+        ctx.suite.remember_reset_snapshot(snapshot)
         probe = next(iter(snapshot))
         try:
             ctx.api.configs.reset_to_default(category)
@@ -721,10 +729,6 @@ def build_cases() -> List[Case]:
         # The debug stream is the cheap one; the video stream shares a multicast
         # group with anything else on the network. Sent to this host and stopped
         # in the same case so nothing keeps streaming afterwards.
-        # Not a firmware vintage question on every machine: where the device
-        # has two interfaces, the streamer looks the destination up on the
-        # wrong one. tests/lib/machine.py carries that as an open gap.
-        ctx.require_fix(machine_lib.STREAM_FINDS_DESTINATION_MAC)
         # A route the product does not build is not in the table and the
         # dispatcher answers 404 with an empty body. The handler's own refusals
         # are 404 too but carry a JSON error, so the body is what tells a
@@ -735,6 +739,16 @@ def build_cases() -> List[Case]:
             params={"ip": ctx.suite.local_ip(ctx)})
         if code == 404 and not body.strip():
             raise Skip("this product does not serve the data streams")
+        if code == 404 and b"Resolve Error" in body:
+            # DataStreamer::startStream always takes
+            # NetworkInterface::getInterface(0) and looks the destination up in
+            # that interface's ARP table, so a device with both Ethernet and
+            # WiFi can fail to find the MAC of the host it is answering right
+            # now. Detected here rather than keyed to a product, because a
+            # device with one interface resolves it and passes.
+            raise Skip("the data streamer resolves the destination on the first "
+                       "interface only, and this device has another one that "
+                       "carries the traffic")
         if code != 200:
             raise Failure(f"streams/debug:start answered HTTP {code}: {body[:160]!r}")
         ctx.api.streams.stop("debug")
@@ -791,10 +805,13 @@ class SuiteRunner:
         self.dead = threading.Event()
         self._image_ready = False
         self._image_bytes: Optional[bytes] = None
-        self._config_value: Optional[str] = None
+        self._config_target: Optional[Tuple[str, str, str]] = None
+        self._reset_category: Optional[str] = None
         self._local_ip: Optional[str] = None
         self.restore_drive: Optional[Tuple[bool, str, str]] = None
         self.restore_config: Optional[Dict[str, str]] = None
+        self.restore_config_category = CONFIG_CATEGORY
+        self._reset_snapshot: Optional[Dict[str, str]] = None
 
     # -- fixtures -----------------------------------------------------------
     def ensure_mount_image(self, ctx: Ctx) -> None:
@@ -816,17 +833,54 @@ class SuiteRunner:
             self._image_bytes = data
         return data
 
-    def config_value(self, ctx: Ctx) -> str:
-        """The settings item's value as found, so writes can be no-ops."""
+    def config_target(self, ctx: Ctx) -> Tuple[str, str, str]:
+        """A settings item and its current value, so a write can be a no-op.
+
+        The item the cfg-* suites use is preferred, so the report names the same
+        one from run to run, but any readable item will do: a product without
+        that one still gets the write and the read-back exercised.
+        """
         with self.state_lock:
-            if self._config_value is not None:
-                return self._config_value
-        value = ctx.api.configs.current(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)
-        if not value:
-            raise Skip(f"{CONFIG_CATEGORY}/{AUTO_CLEANUP_ITEM} is not on this firmware")
+            if self._config_target is not None:
+                return self._config_target
+        candidates = [(CONFIG_CATEGORY, AUTO_CLEANUP_ITEM)]
+        for category in ctx.api.configs.category_names():
+            if category in RESET_DENY_LIST:
+                continue
+            for item in ctx.api.configs.category(category):
+                candidates.append((category, item))
+        for category, item in candidates:
+            try:
+                value = ctx.api.configs.current(category, item)
+            except Failure:
+                continue
+            if value:
+                with self.state_lock:
+                    self._config_target = (category, item, value)
+                return self._config_target
+        raise Skip("no readable settings item to write back")
+
+    def remember_reset_snapshot(self, snapshot: Dict[str, str]) -> None:
+        """Kept so cleanup() can put the category back if a case is cut short."""
         with self.state_lock:
-            self._config_value = value
-        return value
+            if self._reset_snapshot is None:
+                self._reset_snapshot = dict(snapshot)
+
+    def resettable_category(self, ctx: Ctx) -> str:
+        """A category whose defaults cannot cost the run its device."""
+        with self.state_lock:
+            if self._reset_category is not None:
+                return self._reset_category
+        names = [c for c in ctx.api.configs.category_names()
+                 if c not in RESET_DENY_LIST]
+        if RESET_PREFERRED in names:
+            names.insert(0, names.pop(names.index(RESET_PREFERRED)))
+        for name in names:
+            if ctx.api.configs.category(name):
+                with self.state_lock:
+                    self._reset_category = name
+                return name
+        raise Skip("no category outside the deny list to reset")
 
     def snapshot_category(self, ctx: Ctx, category: str) -> Dict[str, str]:
         items = ctx.api.configs.category(category)
@@ -857,7 +911,7 @@ class SuiteRunner:
         # operator is expected to know the device may need its interface type
         # put back by hand if the restore below cannot run.
         snapshot = {c: self.snapshot_category(ctx, c)
-                    for c in ctx.api.configs.categories()}
+                    for c in ctx.api.configs.category_names()}
         try:
             ctx.api.configs.reset_to_default()
         finally:
@@ -1086,6 +1140,7 @@ class SuiteRunner:
         try:
             drive = self.api.drives.get("a")
             self.restore_drive = (drive.enabled, drive.type, drive.image_path)
+            self.restore_config_category = CONFIG_CATEGORY
             self.restore_config = self.snapshot_category(
                 Ctx(self.api, self), CONFIG_CATEGORY)
         except (Failure, Skip) as exc:
@@ -1124,7 +1179,14 @@ class SuiteRunner:
                 quietly(lambda: self.api.drives.mount("a", image))
         if self.restore_config:
             quietly(lambda: self.restore_category(
-                Ctx(self.api, self), CONFIG_CATEGORY, self.restore_config))
+                Ctx(self.api, self), self.restore_config_category,
+                self.restore_config))
+        if self._config_target is not None:
+            category, item, value = self._config_target
+            quietly(lambda: self.api.configs.set(category, item, value))
+        if self._reset_category is not None and self._reset_snapshot:
+            quietly(lambda: self.restore_category(
+                Ctx(self.api, self), self._reset_category, self._reset_snapshot))
         quietly(self._remove_scratch)
 
     def _remove_scratch(self) -> None:

--- a/tests/e2e/api/rest_api_coverage_test.py
+++ b/tests/e2e/api/rest_api_coverage_test.py
@@ -721,6 +721,10 @@ def build_cases() -> List[Case]:
         # The debug stream is the cheap one; the video stream shares a multicast
         # group with anything else on the network. Sent to this host and stopped
         # in the same case so nothing keeps streaming afterwards.
+        # Not a firmware vintage question on every machine: where the device
+        # has two interfaces, the streamer looks the destination up on the
+        # wrong one. tests/lib/machine.py carries that as an open gap.
+        ctx.require_fix(machine_lib.STREAM_FINDS_DESTINATION_MAC)
         # A route the product does not build is not in the table and the
         # dispatcher answers 404 with an empty body. The handler's own refusals
         # are 404 too but carry a JSON error, so the body is what tells a

--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -610,6 +610,18 @@ class ConfigsApi:
     def categories(self) -> Dict[str, object]:
         return _errors(self._rest.json("/v1/configs"), "configs")
 
+    def category_names(self) -> List[str]:
+        """Just the category names.
+
+        `categories()` hands back the whole answer, whose keys are "categories"
+        and "errors" rather than the names themselves, so iterating it gives
+        neither and the mistake only shows when a request is built from it.
+        """
+        listed = self.categories().get("categories")
+        if not isinstance(listed, list):
+            raise Failure("configs: no category list in the answer")
+        return [str(name) for name in listed]
+
     def category(self, category: str) -> Dict[str, object]:
         payload = _errors(self._rest.json(f"/v1/configs/{_quote(category)}"),
                           f"configs/{category}")

--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -843,6 +843,33 @@ class UltimateApi:
         except Failure:
             return False
 
+    def unreachable_reason(self, budget: float = 10.0,
+                           poll: float = 1.0) -> Optional[str]:
+        """None when the device answers within `budget`, else why it did not.
+
+        `reachable()` answers yes or no, which is all a gate needs. A suite
+        asserting that the device survived the call it just made has to put the
+        reason in the failure, or every lockup reads as the same blank timeout.
+        This is that probe, in one place, so suites that check liveness after
+        each step do not each grow their own poll loop.
+
+        Catches Failure only, deliberately: rest.py raises it when no answer
+        arrived, and a blanket except here would report a coding mistake in the
+        probe as a dead device.
+        """
+        deadline = time.monotonic() + budget
+        last = "no answer"
+        while True:
+            try:
+                if self.version():
+                    return None
+                last = "version answered without a version string"
+            except Failure as exc:
+                last = str(exc)
+            if time.monotonic() >= deadline:
+                return last
+            time.sleep(poll)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -344,6 +344,44 @@ class MachineApi:
             raise Failure(f"writemem ${address:04X} ({len(data)} bytes) returned "
                           f"HTTP {code}: {body[:160]!r}")
 
+    def measure(self) -> Optional[bytes]:
+        """A bus timing capture, or None where the FPGA cannot measure (501)."""
+        code, _, body = self._rest.request("GET", "/v1/machine:measure",
+                                           idempotent=True)
+        if code == 501:
+            return None
+        if code != 200:
+            raise Failure(f"machine:measure returned HTTP {code}: {body[:160]!r}")
+        return body
+
+    def debugreg(self) -> Optional[str]:
+        """The debug register as two hex digits, or None where it does not exist.
+
+        Both debugreg routes sit inside `#if U64`, so on other products they
+        are not in the route table and the dispatcher answers 404. That is a
+        product difference, not a failure, so it is None rather than a raise.
+        """
+        code, _, body = self._rest.request("GET", "/v1/machine:debugreg",
+                                           idempotent=True)
+        if code == 404:
+            return None
+        if code != 200:
+            raise Failure(f"machine:debugreg returned HTTP {code}: {body[:160]!r}")
+        payload = _errors(_json(body, "machine:debugreg"), "machine:debugreg")
+        return str(payload.get("value", ""))
+
+    def set_debugreg(self, value: str) -> Optional[str]:
+        """Set the debug register, returning what it reads back, or None where
+        the route does not exist."""
+        code, _, body = self._rest.request("PUT", "/v1/machine:debugreg",
+                                           params={"value": value})
+        if code == 404:
+            return None
+        if code != 200:
+            raise Failure(f"machine:debugreg returned HTTP {code}: {body[:160]!r}")
+        payload = _errors(_json(body, "machine:debugreg"), "machine:debugreg")
+        return str(payload.get("value", ""))
+
     def heap(self) -> Optional[Dict[str, int]]:
         """Free, low-water and total FreeRTOS heap, or None on firmware without it.
 
@@ -659,6 +697,29 @@ class ConfigsApi:
         if code != 200:
             raise Failure(f"{path}={value!r} returned HTTP {code}: {body[:160]!r}")
 
+    def set_by_path(self, category: str, item: str, value: object) -> None:
+        """Set an item with the value as the third path element.
+
+        The route takes either `?value=` with a two-element path or a
+        three-element path with no query argument (route_configs.cc). Both
+        reach the same code; a suite that only ever used one would not notice
+        the other breaking.
+        """
+        path = (f"/v1/configs/{_quote(category)}/{_quote(item)}"
+                f"/{_quote(str(value))}")
+        code, _, body = self._rest.request("PUT", path)
+        if code != 200:
+            raise Failure(f"{path} returned HTTP {code}: {body[:160]!r}")
+
+    def apply(self, settings: Dict[str, Dict[str, object]]) -> None:
+        """Set several items at once, as the JSON body form of the route."""
+        body = json.dumps(settings).encode("utf-8")
+        code, _, answer = self._rest.request(
+            "POST", "/v1/configs", body=body,
+            headers={"Content-Type": "application/json"})
+        if code != 200:
+            raise Failure(f"POST /v1/configs returned HTTP {code}: {answer[:160]!r}")
+
     def _flash(self, action: str, category: Optional[str]) -> None:
         path = (f"/v1/configs:{action}" if category is None
                 else f"/v1/configs/{_quote(category)}:{action}")
@@ -826,6 +887,15 @@ class UltimateApi:
 
     def version(self) -> str:
         return str(_errors(self.rest.json("/v1/version"), "version").get("version", ""))
+
+    def help(self, command: str) -> bytes:
+        """The help page for one command. Answers HTML, not JSON."""
+        code, _, body = self.rest.request("GET", "/v1/help",
+                                          params={"command": command},
+                                          idempotent=True)
+        if code != 200:
+            raise Failure(f"/v1/help returned HTTP {code}: {body[:160]!r}")
+        return body
 
     def info(self) -> Info:
         payload = _errors(self.rest.json("/v1/info"), "info")

--- a/tests/lib/machine.py
+++ b/tests/lib/machine.py
@@ -161,6 +161,20 @@ READMEM_REJECTS_ZERO_LENGTH = _fix(
     "with an empty body",
     (C64U,))
 
+# What the streams case of tests/e2e/api/rest_api_coverage_test.py asserts:
+# PUT /v1/streams/{stream}:start answers 200 for a destination on the local
+# network. DataStreamer::startStream always takes NetworkInterface
+# ::getInterface(0) and looks the destination up in that interface's ARP table,
+# so on a machine with both Ethernet and WiFi it can fail to find the MAC of a
+# host it is serving HTTP to at that moment, and answers 404 "Network Host
+# Resolve Error". Seen on an Ultimate 64 Elite whose two addresses carry
+# different MACs, one of them the WiFi module's.
+STREAM_FINDS_DESTINATION_MAC = _fix(
+    "stream-finds-destination-mac",
+    "PUT /v1/streams/<stream>:start resolves a destination that is reachable "
+    "on an interface other than the first one",
+    (U64,))
+
 # Measured with tests/e2e/io/c64/freeze_menu_test.py, and the reason that
 # suite must not run without the fix: on firmware without it, opening the menu
 # while Interface Type is Freeze stops the device answering REST, ICMP and FTP

--- a/tests/lib/machine.py
+++ b/tests/lib/machine.py
@@ -161,20 +161,6 @@ READMEM_REJECTS_ZERO_LENGTH = _fix(
     "with an empty body",
     (C64U,))
 
-# What the streams case of tests/e2e/api/rest_api_coverage_test.py asserts:
-# PUT /v1/streams/{stream}:start answers 200 for a destination on the local
-# network. DataStreamer::startStream always takes NetworkInterface
-# ::getInterface(0) and looks the destination up in that interface's ARP table,
-# so on a machine with both Ethernet and WiFi it can fail to find the MAC of a
-# host it is serving HTTP to at that moment, and answers 404 "Network Host
-# Resolve Error". Seen on an Ultimate 64 Elite whose two addresses carry
-# different MACs, one of them the WiFi module's.
-STREAM_FINDS_DESTINATION_MAC = _fix(
-    "stream-finds-destination-mac",
-    "PUT /v1/streams/<stream>:start resolves a destination that is reachable "
-    "on an interface other than the first one",
-    (U64,))
-
 # Measured with tests/e2e/io/c64/freeze_menu_test.py, and the reason that
 # suite must not run without the fix: on firmware without it, opening the menu
 # while Interface Type is Freeze stops the device answering REST, ICMP and FTP


### PR DESCRIPTION
Any `files:create_d64` call took the whole device off the network: no HTTP, no FTP,
no ICMP, power cycle to recover. It shipped because no test ever called that route,
so this PR also adds a suite that calls every REST operation the firmware serves.
That suite found seven more defects.

## The lockup

```
#0  vAssertCalled (fileName="heap_4.c", lineNo=316)
#1  vPortFree (pv=0x41b868)
#2  ArgsURI::ClearAll ()   at software/api/routes.h:224
#3  ArgsURI::~ArgsURI ()
#4  execute_api_v1 ()      at software/api/routes.cc:137
```

The image is written correctly and the response is even sent. The device dies
afterwards, tearing down the request.

`enforce_diskname()` hands a `strdup()`'d string to `args.temporary()`, and
`ClearAll()` released it with `delete`. Since #719 the linker-wrapped `malloc` puts a
size header in front of the pointer the caller gets: `free()` subtracts it, `delete`
is a bare `vPortFree()` and does not. heap_4 is handed an address that is not a block
start, its "is this block allocated" assert fails, and `vAssertCalled` spins with
interrupts off.

Only the four `create_*` routes call `enforce_diskname()`, which is why nothing else
was affected. Firmware 3.14e predates #719 and is fine.

## Fixes

| Defect | Symptom | Fix |
| --- | --- | --- |
| `ClearAll()` freed `strdup()` memory with `delete` | device off the network | free it with `free()` |
| `create_*` returned without closing the `File` when `format()` failed | leaked a `File` and its open handle | scope the file system stack so there is one `fclose()` for both outcomes |
| `C64::freeze()` asserted when already frozen | device off the network; two `menu_button` presses in quick succession reach it | decline the second freeze |
| `C64::unfreeze()` asserted when nothing was frozen | device off the network; a reset issued with the menu open reaches it | decline and clear the flag |
| `GET /v1/configs/<unknown>` | HTTP 200 with an empty body, so a typo reads as an empty category | HTTP 404 |
| `PUT /v1/configs/{cat}/{item}/{value}` | HTTP 400, although `route_configs.cc` implements exactly that form | `value` is `P_OPTIONAL`, so the handler decides instead of the validator |
| `configs:load_from_flash` | reset the caller's connection every time, so success and crash looked identical | re-applying unchanged DHCP settings no longer stops and restarts the client, which cleared the address and made lwIP abort every connection |
| `GET /v1/help` | malformed reply: the status line arrived as body text | `html_response()` frames the reply like `json_response()`, with the header and `Content-Length` in the header buffer |

The three device-killers share one mechanism: `configASSERT` spins with interrupts
off, so an invariant meant to catch a programming mistake takes the machine off the
network instead. Two of the three are reachable with one ordinary REST call issued
twice.

## The coverage gate

`rest-api-coverage` reads the operation list from `doc/api/rest_api_openapi_*.yaml`
when the tree has it (from #801) and from the `API_CALL` macros otherwise, then
**fails while an operation is neither exercised nor written into one of three
tables**: `EXCLUDED`, `HAPPY_ELSEWHERE` or `NEGATIVE_ONLY`. A new endpoint cannot
arrive untested.

Only `machine:poweroff` is excluded. Everything else is called, including `reset`,
`reboot`, `menu_button` and the flash-backed settings operations, each restoring what
it changed. `configs:reset_to_default` without a category is behind
`--allow-global-reset`.

Where a call has an outcome the API can see, the case reads it back: the drive
listing after mounting, the item after writing it, the byte after `writemem`, the
menu screen after `menu_button`. Where there is none, the case says so rather than
letting a 200 stand in for a result.

Each case runs three times, spread across three worker threads so different
operations overlap; `--order sequential` runs the repetitions back to back instead.
Three workers, not four, because the firmware serves `MAX_HTTP_CLIENT = 4` and
saturating the last slot turns queueing into refused connections.

Checking against the OpenAPI documents was worth doing for its own sake. The surface
is 58 operations rather than the 53 handlers the macros list, because the
per-category flash operations and the category and item reads behave differently, and
the documents settled two behaviours I had guessed wrong: `unlink` leaves the disk in
the drive, and an uploaded image needs a filename with an extension.

## Not fixed

`streams:start` fails on a device with two interfaces. `DataStreamer::startStream`
always takes `NetworkInterface::getInterface(0)` and looks the destination up in that
interface's ARP table, so an Ultimate 64 Elite with Ethernet and WiFi answers 404
"Network Host Resolve Error" for the host it is serving HTTP to at that moment.
Pre-existing, and choosing the right interface is a feature change rather than part
of a lockup fix. The case recognises that answer and skips with it as the reason, so
a single-interface device still runs the check.

## Verified

Both suites, both devices, run concurrently. Three consecutive rounds with no
failures. Before the fixes the coverage suite took the device down twice and the
disk-image suite failed on its first create.

| | Ultimate 64 Elite | Ultimate II+L in a C64 Ultimate |
| --- | --- | --- |
| `create-disk-image` | 23/23 in 1.1 s | 23/23 in 2.1 s |
| `rest-api-coverage` | 83/83 in 28 s | 83/83 in 45 s |

77 cases run three times is 462 calls per device per round, each followed by a read
that proves the firmware is still running. No check reaches the ten-second threshold
the E2E README sets.

Skips name their reason: the cartridge builds neither `machine:input`,
`machine:debugreg` nor the data streams, and neither device has a password set for
the authentication case.

Nothing is tied to a particular device. The target comes from `-H` in the usual
`host` or `cartridge@computer` form, the harness's own address is derived from the
route to the device, and the settings item to write and the category to reset are
discovered at runtime. The categories that are never reset are excluded by behaviour,
not by name: User Interface Settings because Interface Type defaults to Freeze, and
the network categories because re-applying them bounces the link the run is using.

`u64`, `u64ii` and `u2pl` all build. The `u2` (MicroBlaze) target does not build in a
linked git worktree for unrelated reasons (`git show HEAD:...` inside the container).
