### PR TITLE
Return a socket read over several reply blocks, and report UDP truncation (#802)

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -247,6 +247,12 @@ SUITES: Sequence[Suite] = (
     # and the file system.
     Suite("e2e", "uci-targets", "tests/e2e/io/command_interface/uci_targets_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"),
+    # The UCI network target's READ_SOCKET: what the requested length does, and
+    # what happens to a datagram larger than it (#802). This host is the
+    # device's network peer, so it binds two ports and needs the device to be
+    # able to reach it; the scenarios that need that skip where it cannot.
+    Suite("e2e", "uci-net-target", "tests/e2e/io/command_interface/net_target_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all"),
     # Two checks that are genuinely about the Telnet transport itself (a
     # concurrent poll-mode connection, per-keystroke output volume) only run
     # under --mode telnet.

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -237,18 +237,37 @@ void NetworkTarget :: read_socket(Message *command, Message **reply, Message **s
 	uint8_t socketnr = command->message[2];
 	uint32_t length = ((uint32_t)command->message[3]) | (((uint32_t)command->message[4]) << 8);
 
-    if (length > (CMD_MAX_REPLY_LEN-2)) {
+    // The reply is a two byte header plus the payload, and the transport can
+    // only deliver a block shorter than the response queue: the FPGA stops the
+    // response pointer at the last byte of the buffer while it still reports
+    // data available, so a block of exactly CMD_MAX_REPLY_LEN never ends and a
+    // client reading on that flag never stops.
+    if (length > (CMD_MAX_REPLY_LEN-3)) {
         *status = &c_status_param_out_of_range;
         *reply = &c_message_empty;
         return;
     }
 
     *reply = &data_message;
-	int ret = lwip_recv(socketnr, &data_message.message[2], length, 0);
+    // lwip_recvmsg rather than lwip_recv: on a datagram socket it returns the
+    // length of the datagram itself and sets MSG_TRUNC when it did not fit,
+    // where lwip_recv reports only what was copied and drops the rest without
+    // a trace. On a stream socket the two behave the same way.
+    struct iovec iov;
+    struct msghdr msg;
+    iov.iov_base = &data_message.message[2];
+    iov.iov_len = length;
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    int ret = lwip_recvmsg(socketnr, &msg, 0);
+    // The header is the number of bytes this reply carries, which is what the
+    // network target document specifies and what existing clients read.
+    int copied = (ret > (int)length) ? (int)length : ret;
     data_message.length = 2;
     data_message.last_part = true;
-    data_message.message[0] = (ret & 0xFF);
-    data_message.message[1] = (ret & 0xFF00) >> 8;
+    data_message.message[0] = (copied & 0xFF);
+    data_message.message[1] = (copied & 0xFF00) >> 8;
 
     // printf("Reading %d bytes from socket %d resulted in %d\n", length, socketnr, ret);
 	if (ret == 0) {
@@ -257,7 +276,18 @@ void NetworkTarget :: read_socket(Message *command, Message **reply, Message **s
 		return;
 	}
 	if (ret > 0) {
-		data_message.length = ret + 2;
+		data_message.length = copied + 2;
+		if (msg.msg_flags & MSG_TRUNC) {
+			// The datagram was longer than the caller asked for and the rest is
+			// gone. Reporting that on the status channel leaves the reply itself
+			// unchanged, so a client that does not look is no worse off than
+			// before, and one that does can tell a short datagram from a
+			// truncated one.
+			*status = &status_message;
+			sprintf((char *)this->status_message.message, "04,DATAGRAM TRUNCATED: %d", ret);
+			this->status_message.length = strlen((char *)this->status_message.message);
+			return;
+		}
 		*status = &c_status_ok;
 		return;
 	}

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -29,6 +29,7 @@ NetworkTarget::NetworkTarget(int id)
     command_targets[id] = this;
     data_message.message = new uint8_t[CMD_MAX_REPLY_LEN];
     status_message.message = new uint8_t[CMD_MAX_STATUS_LEN];
+    discard_read_reply();
 }
 
 NetworkTarget::~NetworkTarget()
@@ -41,6 +42,12 @@ NetworkTarget::~NetworkTarget()
 void NetworkTarget :: parse_command(Message *command, Message **reply, Message **status)
 {
     NetworkInterface *interface;
+
+    // The command interface only accepts a command while it is idle, so a
+    // reply that is still being handed out cannot normally be interrupted by
+    // one. Dropping it here as well means no path into this target can hand a
+    // client bytes left over from an earlier read.
+    discard_read_reply();
 
     switch(command->message[1]) {
         case NET_CMD_IDENTIFY:
@@ -237,32 +244,37 @@ void NetworkTarget :: read_socket(Message *command, Message **reply, Message **s
 	uint8_t socketnr = command->message[2];
 	uint32_t length = ((uint32_t)command->message[3]) | (((uint32_t)command->message[4]) << 8);
 
-    // The reply is a two byte header plus the payload, and the transport can
-    // only deliver a block shorter than the response queue: the FPGA stops the
-    // response pointer at the last byte of the buffer while it still reports
-    // data available, so a block of exactly CMD_MAX_REPLY_LEN never ends and a
-    // client reading on that flag never stops.
-    if (length > (CMD_MAX_REPLY_LEN-3)) {
+    // A complete unfragmented IPv4 UDP datagram is the most this command can
+    // ever return, so that is what it accepts. Anything larger cannot arrive.
+    if (length > NET_MAX_SOCKET_READ) {
         *status = &c_status_param_out_of_range;
         *reply = &c_message_empty;
         return;
     }
 
     *reply = &data_message;
+    // The whole payload is received here, into a buffer that outlives this
+    // call, so that a reply spanning several blocks never has to go back to
+    // the socket. A second receive on a datagram socket would take the next
+    // datagram rather than the rest of this one.
+    //
     // lwip_recvmsg rather than lwip_recv: on a datagram socket it returns the
     // length of the datagram itself and sets MSG_TRUNC when it did not fit,
     // where lwip_recv reports only what was copied and drops the rest without
     // a trace. On a stream socket the two behave the same way.
     struct iovec iov;
     struct msghdr msg;
-    iov.iov_base = &data_message.message[2];
+    iov.iov_base = buffer;
     iov.iov_len = length;
     memset(&msg, 0, sizeof(msg));
     msg.msg_iov = &iov;
     msg.msg_iovlen = 1;
     int ret = lwip_recvmsg(socketnr, &msg, 0);
     // The header is the number of bytes this reply carries, which is what the
-    // network target document specifies and what existing clients read.
+    // network target document specifies and what existing clients read. On a
+    // reply that spans blocks it is still the total, not the part in the first
+    // block, so a client that concatenates the blocks gets exactly the reply a
+    // large enough response queue would have delivered in one.
     int copied = (ret > (int)length) ? (int)length : ret;
     data_message.length = 2;
     data_message.last_part = true;
@@ -276,25 +288,55 @@ void NetworkTarget :: read_socket(Message *command, Message **reply, Message **s
 		return;
 	}
 	if (ret > 0) {
-		data_message.length = copied + 2;
+		Message *result = &c_status_ok;
 		if (msg.msg_flags & MSG_TRUNC) {
 			// The datagram was longer than the caller asked for and the rest is
 			// gone. Reporting that on the status channel leaves the reply itself
 			// unchanged, so a client that does not look is no worse off than
 			// before, and one that does can tell a short datagram from a
 			// truncated one.
-			*status = &status_message;
 			sprintf((char *)this->status_message.message, "04,DATAGRAM TRUNCATED: %d", ret);
 			this->status_message.length = strlen((char *)this->status_message.message);
-			return;
+			result = &status_message;
 		}
-		*status = &c_status_ok;
+		start_read_reply(copied, result, reply, status);
 		return;
 	}
 	*status = &status_message;
 	sprintf((char *)this->status_message.message, "02,NO DATA: %d", errno);
 	this->status_message.length = strlen((char *)this->status_message.message);
 }
+
+void NetworkTarget :: start_read_reply(int payload_length, Message *result, Message **reply, Message **status)
+{
+    read_total = payload_length;
+    read_offset = 0;
+    read_status = result;
+
+    int chunk = (payload_length > NET_FIRST_BLOCK_PAYLOAD) ? NET_FIRST_BLOCK_PAYLOAD : payload_length;
+    memcpy(&data_message.message[2], buffer, chunk);
+    read_offset = chunk;
+    data_message.length = chunk + 2;
+    data_message.last_part = (read_offset >= read_total);
+
+    *reply = &data_message;
+    // The command has one result and reports it once, on the block that ends
+    // the reply. An intermediate block leaves the status queue empty rather
+    // than repeating the text, so a client that appends the status of every
+    // block ends up with exactly the text a single block reply would give it.
+    *status = data_message.last_part ? read_status : &c_message_empty;
+    if (data_message.last_part) {
+        discard_read_reply();
+    }
+}
+
+void NetworkTarget :: discard_read_reply(void)
+{
+    read_total = 0;
+    read_offset = 0;
+    read_status = &c_status_ok;
+}
+
 #include "dump_hex.h"
 void NetworkTarget :: write_socket(Message *command, Message **reply, Message **status)
 {
@@ -337,11 +379,36 @@ void NetworkTarget :: close_socket(Message *command, Message **reply, Message **
 
 void NetworkTarget :: get_more_data(Message **reply, Message **status)
 {
-	*reply = &c_message_empty;
-	*status = &c_status_net_no_data;
+    if (read_offset >= read_total) {
+        // Nothing was left pending, so this is a client asking for a block
+        // that was never announced.
+        *reply = &c_message_empty;
+        *status = &c_status_net_no_data;
+        return;
+    }
+
+    int chunk = read_total - read_offset;
+    if (chunk > NET_MAX_REPLY_BLOCK) {
+        chunk = NET_MAX_REPLY_BLOCK;
+    }
+    // A continuation block is payload only. The header went out with the first
+    // block and already counted these bytes.
+    memcpy(data_message.message, &buffer[read_offset], chunk);
+    read_offset += chunk;
+    data_message.length = chunk;
+    data_message.last_part = (read_offset >= read_total);
+
+    *reply = &data_message;
+    *status = data_message.last_part ? read_status : &c_message_empty;
+    if (data_message.last_part) {
+        discard_read_reply();
+    }
 }
 
-void NetworkTarget :: abort(void)
+void NetworkTarget :: abort(int a)
 {
-
+    // `a` counts the bytes the client took from the block it abandoned. They
+    // are its business; what is left of the payload goes away with the
+    // transaction, which is what a datagram read means anyway.
+    discard_read_reply();
 }

--- a/software/io/network/network_target.h
+++ b/software/io/network/network_target.h
@@ -24,21 +24,58 @@
 
 #define NET_CMD_BUFSIZE 2048
 
+// The largest payload READ_SOCKET accepts, which is the largest UDP payload
+// that can reach the device: 1500 bytes of Ethernet MTU less 20 bytes of IPv4
+// header and 8 bytes of UDP header. IP_REASSEMBLY is 0 in
+// software/network/config/lwipopts.h, so a datagram above this arrives as
+// fragments that are dropped before any socket sees them.
+#define NET_MAX_SOCKET_READ 1472
+
+// The largest reply block the transport can deliver. The FPGA stops the
+// response pointer on the last byte of the response buffer while it still
+// reports data available, so a block of exactly CMD_MAX_REPLY_LEN never ends
+// and a client that reads on that flag never stops. See
+// fpga/io/command_interface/vhdl_source/command_protocol.vhd.
+#define NET_MAX_REPLY_BLOCK (CMD_MAX_REPLY_LEN - 1)
+
+// Payload bytes in the first block, which also carries the two byte header.
+#define NET_FIRST_BLOCK_PAYLOAD (NET_MAX_REPLY_BLOCK - 2)
+
+#if NET_MAX_SOCKET_READ > NET_CMD_BUFSIZE
+#error "the socket read buffer cannot hold the largest accepted read"
+#endif
+
 class NetworkTarget : public CommandTarget {
     Message data_message;
     Message status_message;
     uint8_t buffer[NET_CMD_BUFSIZE];
+
+    // A socket read whose payload does not fit one reply block is handed out
+    // over several, through the command interface's Data More mechanism. The
+    // socket receive happens once, while READ_SOCKET runs, so a later block
+    // never touches the socket again and cannot consume the next datagram.
+    // These describe what is left of that one payload in `buffer`:
+    // read_offset bytes of read_total have been placed in a block already, and
+    // read_status is the result to report on the block that ends the reply.
+    // `buffer` is shared with open_socket's name resolution, which is safe
+    // because parse_command drops any pending reply before it runs a command.
+    int read_total;
+    int read_offset;
+    Message *read_status;
+
     void open_socket(Message *command, Message **reply, Message **status, int);
     void read_socket(Message *command, Message **reply, Message **status);
     void write_socket(Message *command, Message **reply, Message **status);
     void close_socket(Message *command, Message **reply, Message **status);
+    void start_read_reply(int payload_length, Message *result, Message **reply, Message **status);
+    void discard_read_reply(void);
 public:
 	NetworkTarget(int id);
 	virtual ~NetworkTarget();
 
     void parse_command(Message *command, Message **reply, Message **status);
     void get_more_data(Message **reply, Message **status);
-    void abort(void);
+    void abort(int a);
 };
 
 #endif /* IO_NETWORK_NETWORK_TARGET_H_ */

--- a/tests/e2e/av/stream_test.py
+++ b/tests/e2e/av/stream_test.py
@@ -4,21 +4,19 @@
 import argparse
 import math
 import os
-import subprocess
 import sys
-import tempfile
 import time
 from pathlib import Path
 from typing import Iterable, List, Sequence
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parents[2]
-ASSEMBLER = REPO_ROOT / "tools" / "64tass" / "64tass"
 
 sys.path.insert(0, str(REPO_ROOT / "tests" / "lib"))
 sys.path.insert(0, str(REPO_ROOT / "tests" / "e2e" / "lib"))
 
 from api import UltimateApi
+from assembler import assemble
 from av_stream import (
     AUDIO_PACKET_BYTES,
     VIDEO_PACKET_BYTES,
@@ -37,19 +35,6 @@ PAL_AUDIO_RATE = 47982.8869047619
 LADDER_FRAMES_PER_NOTE = 10
 LADDER_FREQUENCIES = (130.8, 146.8, 164.8, 174.6, 196.0, 220.0, 246.9, 261.6,
                       246.9, 220.0, 196.0, 174.6, 164.8, 146.8, 130.8)
-
-
-def assemble(name: str) -> bytes:
-    source = SCRIPT_DIR / name
-    with tempfile.TemporaryDirectory(prefix="av-stream-") as directory:
-        output = Path(directory) / "fixture.prg"
-        result = subprocess.run(
-            [str(ASSEMBLER), "-q", "-o", str(output), str(source)],
-            capture_output=True, text=True, check=False,
-        )
-        if result.returncode:
-            raise Failure(f"64tass failed for {name}: {result.stderr.strip()}")
-        return output.read_bytes()
 
 
 def log_packet_health(capture: AvStreamCapture) -> None:
@@ -98,7 +83,7 @@ def assert_tone_ladder(capture: AvStreamCapture, start: float) -> None:
 
 def run_tone_ladder(device: UltimateApi) -> None:
     device.machine.reset(force=True)
-    program = assemble("tone_ladder.asm")
+    program = assemble(SCRIPT_DIR / "tone_ladder.asm")
     # The handle rather than the host name: for a cartridge target the video,
     # the audio and the request that starts them belong to the computer, and
     # only the handle knows which machine that is.
@@ -120,7 +105,7 @@ def run_tone_ladder(device: UltimateApi) -> None:
 
 def run_key_pop(device: UltimateApi) -> None:
     device.machine.reset(force=True)
-    program = assemble("av_pop_key.asm")
+    program = assemble(SCRIPT_DIR / "av_pop_key.asm")
     with AvStreamCapture(device.target) as capture:
         capture.capture(0.15)
         device.runners.upload("run_prg", program)
@@ -157,7 +142,7 @@ def main() -> int:
         if args.case in ("all", "pop"):
             with check("Space key reaches aligned audio and video pop"):
                 run_key_pop(device)
-    except (Failure, OSError, subprocess.SubprocessError) as exc:
+    except (Failure, OSError) as exc:
         suite_fail("stream_test", str(exc))
         return 1
     suite_ok("stream_test")

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -617,6 +617,15 @@ def run_tcp_lossless(net: Net, peer: Peer) -> bool:
             if bytes(recovered) != pattern(BIG_DATAGRAM):
                 raise Failure(f"recovered {len(recovered)} of {BIG_DATAGRAM} bytes; a stream "
                               f"read that asks for less than is pending must lose nothing")
+
+        with check("a stream read that asks for less than is pending still answers 00,OK"):
+            # Every read above asked for less than the socket held, which is
+            # ordinary on a stream and loses nothing. Nothing that reports
+            # truncation on datagram sockets may report it here.
+            unexpected = [r.status_text for r in chunks if r.payload and r.status_text != STATUS_OK]
+            if unexpected:
+                raise Failure(f"a stream read answered {unexpected!r}; only {STATUS_OK!r} "
+                              f"is correct when no data was lost")
     finally:
         if conn is not None:
             conn.close()

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -72,9 +72,15 @@ STATUS_NO_DATA_PREFIX = b"02,NO DATA"
 # and the length in the command is the only variable.
 NEVER_OPENED = 0x7F
 
-# The largest length READ_SOCKET accepts, measured below: the 896-byte response
-# queue less the two header bytes the reply puts in front of the payload.
-ACCEPTED_MAX = REPLY_QUEUE_BYTES - 2
+# The largest length READ_SOCKET accepts is discovered on the device rather
+# than written down here. A reply is a 2-byte header plus the payload, so the
+# number depends on how large a reply block the transport can deliver, and a
+# suite that hard-codes it asserts today's number instead of the property that
+# matters: whatever length the firmware accepts, its reply has to be readable.
+# The search runs over this range, which spans every plausible answer.
+LENGTH_SEARCH_MAX = 2048
+# A safe length for reads that only have to work, not to probe a boundary.
+SAFE_READ = 512
 
 # Small enough that a full drain is a few seconds, large enough that a
 # truncated read and a complete read differ by an obvious amount.
@@ -201,7 +207,33 @@ class Net:
     def close(self, handle: int):
         return self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_CLOSE_SOCKET, handle]))
 
-    def drain_socket(self, handle: int, maxlen: int = ACCEPTED_MAX, limit: int = 8) -> int:
+    def largest_accepted_length(self) -> int:
+        """The largest length READ_SOCKET accepts, found by bisection.
+
+        Probed against a handle that was never opened, so the socket refuses
+        every one of them and the only thing that separates the answers is the
+        length: an accepted length is answered by the socket
+        ('02,NO DATA'), a refused one by the length check
+        ('82,PARAMETER(S) OUT OF RANGE').
+        """
+        def accepted(length: int) -> bool:
+            return self.read(NEVER_OPENED, length).status_text != STATUS_OUT_OF_RANGE
+
+        low, high = 1, LENGTH_SEARCH_MAX
+        if not accepted(low):
+            raise Failure(f"READ_SOCKET refused a length of {low}")
+        if accepted(high):
+            raise Failure(f"READ_SOCKET accepted a length of {high}, which cannot fit the "
+                          f"{REPLY_QUEUE_BYTES}-byte response queue")
+        while high - low > 1:
+            middle = (low + high) // 2
+            if accepted(middle):
+                low = middle
+            else:
+                high = middle
+        return low
+
+    def drain_socket(self, handle: int, maxlen: int = SAFE_READ, limit: int = 8) -> int:
         """Read until the socket has nothing left, so a case starts clean."""
         drained = 0
         for _ in range(limit):
@@ -282,27 +314,33 @@ def run_read_length_limit(net: Net) -> bool:
     The handle here was never opened, so the socket can only ever refuse. Any
     difference between two rows is therefore the length handling and nothing
     else.
+
+    The boundary is found on the device rather than asserted, because the
+    number is not part of any published contract: the network target document
+    states no maximum for READ_SOCKET, and neither the cap nor the status that
+    reports it is documented. What is asserted is that the boundary is sharp
+    and that both sides of it answer on the status channel.
     """
     section("read-length-limit")
-    ok = True
+    accepted_max = net.largest_accepted_length()
 
-    with check(f"READ_SOCKET accepts a length of {ACCEPTED_MAX}"):
-        result = net.read(NEVER_OPENED, ACCEPTED_MAX, overrun_reads=4)
+    with check(f"READ_SOCKET accepts a length of {accepted_max}"):
+        result = net.read(NEVER_OPENED, accepted_max, overrun_reads=4)
         detail(result.describe())
         if not result.status_text.startswith(STATUS_NO_DATA_PREFIX):
             raise Failure(
-                f"length {ACCEPTED_MAX} answered {result.status_text!r}; the socket was "
+                f"length {accepted_max} answered {result.status_text!r}; the socket was "
                 f"never opened, so the answer has to come from the socket "
                 f"({STATUS_NO_DATA_PREFIX.decode()}), not from the length")
         if result.header != -1:
             raise Failure(f"a refused socket read should report -1 in the reply header, "
                           f"got {result.header}")
 
-    with check(f"READ_SOCKET refuses a length of {ACCEPTED_MAX + 1}"):
-        result = net.read(NEVER_OPENED, ACCEPTED_MAX + 1, overrun_reads=4)
+    with check(f"READ_SOCKET refuses a length of {accepted_max + 1}"):
+        result = net.read(NEVER_OPENED, accepted_max + 1, overrun_reads=4)
         detail(result.describe())
         if result.status_text != STATUS_OUT_OF_RANGE:
-            raise Failure(f"length {ACCEPTED_MAX + 1} answered {result.status_text!r}, "
+            raise Failure(f"length {accepted_max + 1} answered {result.status_text!r}, "
                           f"expected {STATUS_OUT_OF_RANGE!r}")
         if result.reply:
             raise Failure(f"a refused request put {len(result.reply)} bytes in the response "
@@ -316,25 +354,28 @@ def run_read_length_limit(net: Net) -> bool:
                    "2-byte header without checking DATA_AV computes a length of 0 and "
                    "sees a refusal as an empty read")
 
-    with check("the refusal boundary is where the response queue ends"):
-        accepted = net.read(NEVER_OPENED, ACCEPTED_MAX)
-        refused = net.read(NEVER_OPENED, ACCEPTED_MAX + 1)
+    with check("the refusal boundary is sharp"):
+        # Bisection only finds a boundary if the answer is monotonic in the
+        # length. This confirms the two lengths either side of it directly.
+        accepted = net.read(NEVER_OPENED, accepted_max)
+        refused = net.read(NEVER_OPENED, accepted_max + 1)
         if not accepted.status_text.startswith(STATUS_NO_DATA_PREFIX):
-            raise Failure(f"length {ACCEPTED_MAX} was refused: {accepted.status_text!r}")
+            raise Failure(f"length {accepted_max} was refused: {accepted.status_text!r}")
         if refused.status_text != STATUS_OUT_OF_RANGE:
-            raise Failure(f"length {ACCEPTED_MAX + 1} was accepted: {refused.status_text!r}")
-        detail(f"accepted up to {ACCEPTED_MAX}, refused from {ACCEPTED_MAX + 1}: the "
-               f"{REPLY_QUEUE_BYTES}-byte response queue less the 2-byte reply header")
-    return ok
+            raise Failure(f"length {accepted_max + 1} was accepted: {refused.status_text!r}")
+        detail(f"accepted up to {accepted_max}, refused from {accepted_max + 1}; "
+               f"the response queue holds {REPLY_QUEUE_BYTES} bytes and a reply is a "
+               f"2-byte header plus the payload")
+    return True
 
 
 def run_largest_accepted_read_drains(net: Net, peer: Peer) -> bool:
-    """The largest length READ_SOCKET accepts has to produce a reply a client can read.
+    """Whatever length READ_SOCKET accepts, the reply to it has to be readable.
 
-    A reply block is a 2-byte header plus the payload, so a read of 894 bytes
-    builds a block of exactly 896, the size of the response queue. Measured on
-    a U64 Elite: at 893 the queue delivers 895 bytes and DATA_AV clears; at 894
-    DATA_AV never clears and every further read returns the same last byte.
+    A reply block is a 2-byte header plus the payload, and the transport cannot
+    deliver a block of exactly the response queue's size. Measured on a U64
+    Elite: a block of 895 bytes ends and DATA_AV clears, a block of 896 never
+    ends and every further read returns the same last byte.
 
     The mechanism is in fpga/io/command_interface/vhdl_source/command_protocol.vhd.
     response_pointer stops incrementing once it reaches
@@ -348,13 +389,18 @@ def run_largest_accepted_read_drains(net: Net, peer: Peer) -> bool:
     is set, so this is not a slow read or a lost byte: it is an endless one.
     The reference client, ultimateii-dos-lib, does exactly that into a
     fixed-size buffer.
+
+    The length is the one the device accepts, not a number written here, so
+    this stays a statement about the firmware's own boundary rather than about
+    any particular value of it.
     """
     section("largest-accepted-read-drains")
+    accepted_max = net.largest_accepted_length()
     handle = net.open_udp(peer.ip, peer.udp_port)
     try:
         peer.learn_udp_peer(net, handle)
         measured = {}
-        for maxlen in (ACCEPTED_MAX - 1, ACCEPTED_MAX):
+        for maxlen in (accepted_max - 1, accepted_max):
             net.drain_socket(handle)
             peer.send_udp(pattern(FULL_DATAGRAM))
             time.sleep(DELIVERY_SETTLE_SECONDS)
@@ -363,23 +409,26 @@ def run_largest_accepted_read_drains(net: Net, peer: Peer) -> bool:
             detail(f"length {maxlen}: reply block {block} bytes, DATA_AV cleared {cleared}, "
                    f"last bytes {tail.hex(' ')}")
 
-        with check(f"a read of {ACCEPTED_MAX - 1} bytes ends its reply"):
-            block, cleared, _ = measured[ACCEPTED_MAX - 1]
+        with check(f"a read of {accepted_max - 1} bytes ends its reply"):
+            block, cleared, _ = measured[accepted_max - 1]
             if not cleared:
                 raise Failure(f"DATA_AV was still set after {block} bytes")
-            if block != ACCEPTED_MAX + 1:
-                raise Failure(f"expected {ACCEPTED_MAX + 1} bytes (2 header + "
-                              f"{ACCEPTED_MAX - 1} payload), got {block}")
+            if block != accepted_max + 1:
+                raise Failure(f"expected {accepted_max + 1} bytes (2 header + "
+                              f"{accepted_max - 1} payload), got {block}")
 
-        with check(f"a read of {ACCEPTED_MAX} bytes, the largest accepted, ends its reply"):
-            block, cleared, tail = measured[ACCEPTED_MAX]
+        with check(f"a read of {accepted_max} bytes, the largest accepted, ends its reply"):
+            block, cleared, tail = measured[accepted_max]
             if not cleared:
                 raise Failure(
                     f"DATA_AV was still set after {block} bytes and the queue was still "
-                    f"repeating {tail[-1:].hex()}. A read of {ACCEPTED_MAX} bytes builds a "
-                    f"reply block of {ACCEPTED_MAX + 2} bytes, the exact size of the "
+                    f"repeating {tail[-1:].hex()}. A read of {accepted_max} bytes builds a "
+                    f"reply block of {accepted_max + 2} bytes, the exact size of the "
                     f"{REPLY_QUEUE_BYTES}-byte response queue, and that block never ends. "
                     f"A client that reads while DATA_AV is set never stops")
+            if block != accepted_max + 2:
+                raise Failure(f"expected {accepted_max + 2} bytes (2 header + "
+                              f"{accepted_max} payload), got {block}")
     finally:
         net.close(handle)
     return True
@@ -481,7 +530,7 @@ def run_udp_truncation(net: Net, peer: Peer) -> bool:
         peer.send_udp(pattern(BIG_DATAGRAM))
         time.sleep(DELIVERY_SETTLE_SECONDS)
         truncated = net.read(handle, SMALL_READ, overrun_reads=2)
-        follow_up = net.read(handle, ACCEPTED_MAX)
+        follow_up = net.read(handle, SAFE_READ)
 
         with check(f"a {SMALL_READ}-byte datagram read with a length of {SMALL_READ} arrives whole"):
             detail(complete.describe())
@@ -503,6 +552,19 @@ def run_udp_truncation(net: Net, peer: Peer) -> bool:
                  f"retrievable: the first read delivered {len(truncated.payload)} and a "
                  f"further read delivered {len(follow_up.payload)}, status "
                  f"{follow_up.status_text!r}")
+
+        with check("the reply header still reports the bytes the reply carries"):
+            # The network target document defines the header as "the actual
+            # number of bytes read". Anything that reports a datagram's true
+            # length there instead would tell a client how much was lost at the
+            # cost of breaking every client that uses the header to find the
+            # end of the payload, so the contract is asserted on both reads.
+            for label, result in (("complete", complete), ("truncated", truncated)):
+                if result.header != len(result.payload):
+                    raise Failure(
+                        f"the {label} read reported {result.header} in its header while "
+                        f"carrying {len(result.payload)} payload bytes; the header is "
+                        f"specified as the number of bytes read")
 
         with check(f"a {BIG_DATAGRAM}-byte datagram read with a length of {SMALL_READ} "
                    f"is distinguishable from a complete one"):
@@ -572,6 +634,7 @@ def run_oversize_request_keeps_datagram(net: Net, peer: Peer) -> bool:
     """
     section("oversize-request-keeps-the-datagram")
     ok = True
+    over_long = net.largest_accepted_length() + 1
     handle = net.open_udp(peer.ip, peer.udp_port)
     try:
         peer.learn_udp_peer(net, handle)
@@ -579,10 +642,10 @@ def run_oversize_request_keeps_datagram(net: Net, peer: Peer) -> bool:
         peer.send_udp(pattern(SMALL_READ))
         time.sleep(DELIVERY_SETTLE_SECONDS)
 
-        refused = net.read(handle, ACCEPTED_MAX + 1, overrun_reads=2)
+        refused = net.read(handle, over_long, overrun_reads=2)
         after = net.read(handle, SMALL_READ)
 
-        with check(f"a request of {ACCEPTED_MAX + 1} bytes is refused without touching the socket"):
+        with check(f"a request of {over_long} bytes is refused without touching the socket"):
             detail(f"refused read: {refused.describe()}")
             detail(f"next read:    {after.describe()}")
             if refused.status_text != STATUS_OUT_OF_RANGE:

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -971,6 +971,18 @@ def run_tcp_lossless(net: Net, peer: Peer) -> bool:
                               f"{describe_mismatch(bytes(stream), pattern(SPANNING_DATAGRAM, seed=3))}")
 
         with check("a stream read above one block reports its own length and stays 00,OK"):
+            # Without this, the case passes whether or not any read was large
+            # enough to need a second block, and a broken split over TCP would
+            # go unnoticed. lwip_recv_tcp fills the requested length from every
+            # segment already queued, so after the settle above one read takes
+            # the whole run: measured as blocks [895, 527] on both a U64 Elite
+            # and a U2+L.
+            if not any(len(r.payload) > FIRST_BLOCK_PAYLOAD for r in wide):
+                raise Failure(
+                    f"no read returned more than {FIRST_BLOCK_PAYLOAD} bytes, the most one "
+                    f"block carries, so the stream never crossed a block boundary and this "
+                    f"case tested nothing: reads returned "
+                    f"{[len(r.payload) for r in wide]}")
             for result in wide:
                 if not result.payload:
                     continue

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+# E2E: Verifies UCI network target socket reads: length handling and datagram delivery.
+
+"""End-to-end check of the UCI network target's READ_SOCKET command.
+
+Regression guard for GideonZ/1541ultimate#802, reported as "a maxlen above 512
+silently returns no data". Everything here was measured on real hardware
+against the $DF1B-$DF1F registers; nothing is taken from the issue text or from
+the manuals, which are used only as the statement of the intended contract.
+
+This host process is the network peer. It binds a UDP socket and a TCP
+listener, has the device open a socket back to it, learns the device's
+ephemeral source port from the device's own WRITE_SOCKET, and then sends
+payloads of a chosen size. That means the suite needs the device to be able to
+reach this machine on two ports it binds; where it cannot, the scenarios that
+need a peer skip rather than fail.
+
+Payloads are pattern(): byte i is (i mod 251). 251 is prime and below 256, so
+any run of received bytes identifies the offset it came from. That turns "64
+bytes arrived" into "bytes 0-63 arrived", which is what separates truncation
+at the head from anything else.
+
+Reads are kept small on purpose. The response queue is drained one REST DMA
+cycle per byte, so the size of the payload is the cost of the suite, and every
+property under test is visible at 64 bytes as clearly as at 894.
+
+Supported on any Ultimate whose FPGA provides the command interface. The suite
+enables the "Command Interface" setting and restores it on exit.
+"""
+
+import argparse
+import os
+import socket
+import sys
+import time
+from typing import Dict, List, Optional, Tuple
+
+# tests/lib holds the reporting rules and the transport every suite shares.
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "lib"))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"))
+import targets  # noqa: E402
+from api import UltimateApi  # noqa: E402
+from report import (  # noqa: E402
+    FAIL, Failure, OK, SKIP, check, check_ok, check_skip, check_start, detail,
+    format_exception, section, suite_fail, suite_ok, warn)
+from uci import (  # noqa: E402
+    REPLY_QUEUE_BYTES, TARGET_NETWORK, Uci, Wedged, interface_present)
+
+CONFIG_CATEGORY = "C64 and Cartridge Settings"
+CFG_CMD_IF = "Command Interface"
+OWNED_SETTINGS = (CFG_CMD_IF,)
+
+NET_CMD_IDENTIFY = 0x01
+NET_CMD_GET_IPADDR = 0x05
+NET_CMD_OPEN_TCP = 0x07
+NET_CMD_OPEN_UDP = 0x08
+NET_CMD_CLOSE_SOCKET = 0x09
+NET_CMD_READ_SOCKET = 0x10
+NET_CMD_WRITE_SOCKET = 0x11
+
+STATUS_OK = b"00,OK"
+STATUS_CLOSED = b"01,CONNECTION CLOSED BY HOST"
+STATUS_OUT_OF_RANGE = b"82,PARAMETER(S) OUT OF RANGE"
+# Not in the network target document, but what the firmware answers when
+# lwip_recv returns -1. The number is the errno: 9 is EBADF for a handle that
+# was never opened, 11 is EAGAIN for an open socket with nothing pending.
+STATUS_NO_DATA_PREFIX = b"02,NO DATA"
+
+# A handle no OPEN command ever returned, so the socket can never supply data
+# and the length in the command is the only variable.
+NEVER_OPENED = 0x7F
+
+# The largest length READ_SOCKET accepts, measured below: the 896-byte response
+# queue less the two header bytes the reply puts in front of the payload.
+ACCEPTED_MAX = REPLY_QUEUE_BYTES - 2
+
+# Small enough that a full drain is a few seconds, large enough that a
+# truncated read and a complete read differ by an obvious amount.
+SMALL_READ = 64
+BIG_DATAGRAM = 200
+
+# A datagram long enough to fill any read length this suite asks for.
+FULL_DATAGRAM = 1000
+# Where the drain of the largest accepted read gives up. The response queue
+# holds 896 bytes, so anything past that is the queue failing to end rather
+# than a longer reply.
+OVERRUN_LIMIT = REPLY_QUEUE_BYTES + 128
+
+# The device's socket carries SO_RCVTIMEO of 40 ms, so a read finds a datagram
+# that is already queued and does not wait for one in flight.
+DELIVERY_SETTLE_SECONDS = 0.4
+PEER_TIMEOUT_SECONDS = 10.0
+RESET_SETTLE_SECONDS = 3.0
+
+TESTS = [
+    "read-length-limit",
+    "largest-accepted-read-drains",
+    "datagram-size-ceiling",
+    "udp-truncation-is-detectable",
+    "tcp-read-is-lossless",
+    "oversize-request-keeps-the-datagram",
+]
+
+# The largest UDP payload that fits one Ethernet frame: 1500 less 20 bytes of
+# IP header and 8 of UDP header. Anything above it is fragmented on the wire.
+UNFRAGMENTED_MAX = 1472
+
+
+def pattern(size: int, seed: int = 0) -> bytes:
+    """A payload whose every byte identifies its own offset.
+
+    251 is prime and below 256, so a run of bytes fixes the offset it started
+    at for any payload shorter than 251 * 251.
+    """
+    return bytes((i + seed) % 251 for i in range(size))
+
+
+def run_offset(chunk: bytes, seed: int = 0) -> Optional[int]:
+    """Where this run started inside pattern(), or None if it is not a run of it."""
+    if not chunk:
+        return None
+    start = (chunk[0] - seed) % 251
+    for index, byte in enumerate(chunk):
+        if byte != (start + seed + index) % 251:
+            return None
+    return start
+
+
+class ReadResult:
+    """What a client can see after one READ_SOCKET, and nothing more."""
+
+    def __init__(self, transaction) -> None:
+        block = transaction.first
+        self.state = block.state
+        self.state_name = block.state_name
+        self.status_byte = block.status_byte
+        self.reply = block.data
+        self.status_text = transaction.status_text
+        self.overrun = block.overrun
+        self.blocks = len(transaction.blocks)
+        # The reply's own framing: two header bytes, then the payload.
+        self.header = (int.from_bytes(self.reply[:2], "little", signed=True)
+                       if len(self.reply) >= 2 else None)
+        self.payload = self.reply[2:]
+
+    @property
+    def observable(self) -> Tuple:
+        """Everything a client could branch on, as one comparable value.
+
+        Two reads that differ in what was actually delivered but agree here are
+        indistinguishable to any client, however careful it is.
+        """
+        return (self.status_byte, self.header, len(self.payload),
+                self.status_text, self.overrun)
+
+    def describe(self) -> str:
+        return (f"{self.state_name}, header {self.header}, payload {len(self.payload)} bytes"
+                f"{f' from offset {run_offset(self.payload)}' if self.payload else ''}"
+                f", status {self.status_text!r}"
+                + (f", overrun {self.overrun.hex(' ')}" if self.overrun else ""))
+
+
+class Net:
+    """The network target's commands, over the command interface."""
+
+    def __init__(self, uci: Uci) -> None:
+        self.uci = uci
+
+    def identify(self):
+        return self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_IDENTIFY]))
+
+    def ip_address(self) -> Optional[str]:
+        reply = self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_GET_IPADDR, 0])).data
+        return ".".join(str(b) for b in reply[:4]) if len(reply) >= 4 else None
+
+    def _open(self, command: int, ip: str, port: int, what: str) -> int:
+        message = (bytes([TARGET_NETWORK, command, port & 0xFF, (port >> 8) & 0xFF])
+                   + ip.encode("ascii") + b"\x00")
+        result = self.uci.transact(message)
+        if result.status_text != STATUS_OK or len(result.data) != 1:
+            raise Failure(f"{what} {ip}:{port} answered {result.status_text!r} "
+                          f"with reply {result.data!r}")
+        return result.data[0]
+
+    def open_udp(self, ip: str, port: int) -> int:
+        return self._open(NET_CMD_OPEN_UDP, ip, port, "OPEN_UDP")
+
+    def open_tcp(self, ip: str, port: int) -> int:
+        return self._open(NET_CMD_OPEN_TCP, ip, port, "OPEN_TCP")
+
+    def write(self, handle: int, payload: bytes):
+        return self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_WRITE_SOCKET, handle]) + payload)
+
+    def read(self, handle: int, maxlen: int, overrun_reads: int = 0) -> ReadResult:
+        command = bytes([TARGET_NETWORK, NET_CMD_READ_SOCKET, handle,
+                         maxlen & 0xFF, (maxlen >> 8) & 0xFF])
+        return ReadResult(self.uci.transact(command, overrun_reads=overrun_reads))
+
+    def close(self, handle: int):
+        return self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_CLOSE_SOCKET, handle]))
+
+    def drain_socket(self, handle: int, maxlen: int = ACCEPTED_MAX, limit: int = 8) -> int:
+        """Read until the socket has nothing left, so a case starts clean."""
+        drained = 0
+        for _ in range(limit):
+            result = self.read(handle, maxlen)
+            if not result.payload:
+                return drained
+            drained += len(result.payload)
+        raise Failure(f"socket {handle} still had data after {limit} reads")
+
+
+def local_address_towards(device_host: str) -> str:
+    """This machine's address on the route to the device, without guessing.
+
+    A connected UDP socket applies the routing table without sending anything,
+    so getsockname reports the source address the device would see.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect((device_host, 9))
+        return probe.getsockname()[0]
+    finally:
+        probe.close()
+
+
+class Peer:
+    """The host-side endpoints the device opens sockets to."""
+
+    def __init__(self, bind_ip: str) -> None:
+        self.ip = bind_ip
+        self.udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.udp.bind((bind_ip, 0))
+        self.udp_port = self.udp.getsockname()[1]
+        self.udp_peer: Optional[Tuple[str, int]] = None
+        self.tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.tcp.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.tcp.bind((bind_ip, 0))
+        self.tcp.listen(2)
+        self.tcp_port = self.tcp.getsockname()[1]
+        self.tcp_conn: Optional[socket.socket] = None
+
+    def learn_udp_peer(self, net: Net, handle: int) -> Tuple[str, int]:
+        """The device's ephemeral source address, from a datagram it sends.
+
+        The device connects its UDP socket, so it only accepts datagrams from
+        the address it connected to, and a reply has to come from this bound
+        port back to whatever source port the device chose.
+        """
+        net.write(handle, b"PROBE")
+        self.udp.settimeout(PEER_TIMEOUT_SECONDS)
+        _, address = self.udp.recvfrom(2048)
+        self.udp_peer = address
+        return address
+
+    def send_udp(self, payload: bytes) -> None:
+        if self.udp_peer is None:
+            raise Failure("the device's UDP source address is not known yet")
+        self.udp.sendto(payload, self.udp_peer)
+
+    def accept_tcp(self) -> socket.socket:
+        self.tcp.settimeout(PEER_TIMEOUT_SECONDS)
+        conn, _ = self.tcp.accept()
+        conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self.tcp_conn = conn
+        return conn
+
+    def close(self) -> None:
+        for sock in (self.tcp_conn, self.tcp, self.udp):
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+
+
+def run_read_length_limit(net: Net) -> bool:
+    """What the length in the command does, isolated from the socket.
+
+    The handle here was never opened, so the socket can only ever refuse. Any
+    difference between two rows is therefore the length handling and nothing
+    else.
+    """
+    section("read-length-limit")
+    ok = True
+
+    with check(f"READ_SOCKET accepts a length of {ACCEPTED_MAX}"):
+        result = net.read(NEVER_OPENED, ACCEPTED_MAX, overrun_reads=4)
+        detail(result.describe())
+        if not result.status_text.startswith(STATUS_NO_DATA_PREFIX):
+            raise Failure(
+                f"length {ACCEPTED_MAX} answered {result.status_text!r}; the socket was "
+                f"never opened, so the answer has to come from the socket "
+                f"({STATUS_NO_DATA_PREFIX.decode()}), not from the length")
+        if result.header != -1:
+            raise Failure(f"a refused socket read should report -1 in the reply header, "
+                          f"got {result.header}")
+
+    with check(f"READ_SOCKET refuses a length of {ACCEPTED_MAX + 1}"):
+        result = net.read(NEVER_OPENED, ACCEPTED_MAX + 1, overrun_reads=4)
+        detail(result.describe())
+        if result.status_text != STATUS_OUT_OF_RANGE:
+            raise Failure(f"length {ACCEPTED_MAX + 1} answered {result.status_text!r}, "
+                          f"expected {STATUS_OUT_OF_RANGE!r}")
+        if result.reply:
+            raise Failure(f"a refused request put {len(result.reply)} bytes in the response "
+                          f"queue; it must leave it empty")
+        # The client-visible shape of that refusal, which is what #802 reported
+        # as "silently returns no data": the response queue is empty, so
+        # DATA_AV never sets, and a client that reads the two header bytes
+        # regardless of the flag reads back zeros and computes a length of 0.
+        if result.overrun and set(result.overrun) == {0}:
+            detail("an empty response queue reads back $00, so a client that takes the "
+                   "2-byte header without checking DATA_AV computes a length of 0 and "
+                   "sees a refusal as an empty read")
+
+    with check("the refusal boundary is where the response queue ends"):
+        accepted = net.read(NEVER_OPENED, ACCEPTED_MAX)
+        refused = net.read(NEVER_OPENED, ACCEPTED_MAX + 1)
+        if not accepted.status_text.startswith(STATUS_NO_DATA_PREFIX):
+            raise Failure(f"length {ACCEPTED_MAX} was refused: {accepted.status_text!r}")
+        if refused.status_text != STATUS_OUT_OF_RANGE:
+            raise Failure(f"length {ACCEPTED_MAX + 1} was accepted: {refused.status_text!r}")
+        detail(f"accepted up to {ACCEPTED_MAX}, refused from {ACCEPTED_MAX + 1}: the "
+               f"{REPLY_QUEUE_BYTES}-byte response queue less the 2-byte reply header")
+    return ok
+
+
+def run_largest_accepted_read_drains(net: Net, peer: Peer) -> bool:
+    """The largest length READ_SOCKET accepts has to produce a reply a client can read.
+
+    A reply block is a 2-byte header plus the payload, so a read of 894 bytes
+    builds a block of exactly 896, the size of the response queue. Measured on
+    a U64 Elite: at 893 the queue delivers 895 bytes and DATA_AV clears; at 894
+    DATA_AV never clears and every further read returns the same last byte.
+
+    The mechanism is in fpga/io/command_interface/vhdl_source/command_protocol.vhd.
+    response_pointer stops incrementing once it reaches
+    c_cmd_if_response_buffer_end, the last byte of the buffer, while
+    response_valid stays asserted for as long as
+    (response_pointer - buffer_addr) < response_length. At a length of exactly
+    896 the pointer saturates at offset 895 and that comparison stays true, so
+    the two never agree.
+
+    A client written to the protocol reads the response register while DATA_AV
+    is set, so this is not a slow read or a lost byte: it is an endless one.
+    The reference client, ultimateii-dos-lib, does exactly that into a
+    fixed-size buffer.
+    """
+    section("largest-accepted-read-drains")
+    handle = net.open_udp(peer.ip, peer.udp_port)
+    try:
+        peer.learn_udp_peer(net, handle)
+        measured = {}
+        for maxlen in (ACCEPTED_MAX - 1, ACCEPTED_MAX):
+            net.drain_socket(handle)
+            peer.send_udp(pattern(FULL_DATAGRAM))
+            time.sleep(DELIVERY_SETTLE_SECONDS)
+            measured[maxlen] = drain_count(net.uci, handle, maxlen)
+            block, cleared, tail = measured[maxlen]
+            detail(f"length {maxlen}: reply block {block} bytes, DATA_AV cleared {cleared}, "
+                   f"last bytes {tail.hex(' ')}")
+
+        with check(f"a read of {ACCEPTED_MAX - 1} bytes ends its reply"):
+            block, cleared, _ = measured[ACCEPTED_MAX - 1]
+            if not cleared:
+                raise Failure(f"DATA_AV was still set after {block} bytes")
+            if block != ACCEPTED_MAX + 1:
+                raise Failure(f"expected {ACCEPTED_MAX + 1} bytes (2 header + "
+                              f"{ACCEPTED_MAX - 1} payload), got {block}")
+
+        with check(f"a read of {ACCEPTED_MAX} bytes, the largest accepted, ends its reply"):
+            block, cleared, tail = measured[ACCEPTED_MAX]
+            if not cleared:
+                raise Failure(
+                    f"DATA_AV was still set after {block} bytes and the queue was still "
+                    f"repeating {tail[-1:].hex()}. A read of {ACCEPTED_MAX} bytes builds a "
+                    f"reply block of {ACCEPTED_MAX + 2} bytes, the exact size of the "
+                    f"{REPLY_QUEUE_BYTES}-byte response queue, and that block never ends. "
+                    f"A client that reads while DATA_AV is set never stops")
+    finally:
+        net.close(handle)
+    return True
+
+
+def drain_count(uci: Uci, handle: int, maxlen: int) -> Tuple[int, bool, bytes]:
+    """Push one READ_SOCKET and pull bytes until DATA_AV clears or the cap is hit.
+
+    Returns the number of bytes the queue handed out, whether DATA_AV cleared,
+    and the last few bytes, which say whether the queue was repeating itself.
+    """
+    from uci import (CTRL_DATA_ACC, REG_RESPONSE, REG_STATUS, ST_DATA_AV, ST_STAT_AV)
+    uci.release()
+    uci.require_idle("before the largest accepted read")
+    command = bytes([TARGET_NETWORK, NET_CMD_READ_SOCKET, handle,
+                     maxlen & 0xFF, (maxlen >> 8) & 0xFF])
+    uci.push(command)
+    uci.wait_for_reply(command)
+    out = bytearray()
+    while uci.status() & ST_DATA_AV:
+        out.append(uci.peek(REG_RESPONSE))
+        if len(out) >= OVERRUN_LIMIT:
+            break
+    cleared = not (uci.status() & ST_DATA_AV)
+    uci._drain(ST_STAT_AV, REG_STATUS, "status")
+    uci.control(CTRL_DATA_ACC)
+    # Writing DATA_ACC leaves the data state whether or not the queue emptied,
+    # so the interface is usable again even after a block that never ended.
+    uci.release()
+    return len(out), cleared, bytes(out[-6:])
+
+
+def run_datagram_size_ceiling(net: Net, peer: Peer) -> bool:
+    """How large a datagram can reach the device at all, before any read length.
+
+    This is a property of the network stack, not of the command interface, and
+    it bounds anything the command interface could ever deliver. It is measured
+    with a small read length so the reply drain stays short: whether a datagram
+    arrived is visible from the first byte of it, and the payload identifies its
+    own offset.
+    """
+    section("datagram-size-ceiling")
+    handle = net.open_udp(peer.ip, peer.udp_port)
+    try:
+        peer.learn_udp_peer(net, handle)
+        arrivals: Dict[int, int] = {}
+        for size in (SMALL_READ, BIG_DATAGRAM, UNFRAGMENTED_MAX, UNFRAGMENTED_MAX + 1, 1500):
+            net.drain_socket(handle)
+            peer.send_udp(pattern(size))
+            time.sleep(DELIVERY_SETTLE_SECONDS)
+            result = net.read(handle, SMALL_READ)
+            arrivals[size] = len(result.payload)
+            detail(f"{size:>4}-byte datagram: {result.describe()}")
+
+        with check(f"a datagram of up to {UNFRAGMENTED_MAX} bytes reaches the device"):
+            missing = [size for size in (SMALL_READ, BIG_DATAGRAM, UNFRAGMENTED_MAX)
+                       if arrivals[size] == 0]
+            if missing:
+                raise Failure(f"no part of a datagram of {missing} bytes arrived, "
+                              f"though each fits one Ethernet frame")
+
+        with check(f"a datagram above {UNFRAGMENTED_MAX} bytes does not reach the device"):
+            arrived = [size for size in (UNFRAGMENTED_MAX + 1, 1500) if arrivals[size] > 0]
+            if arrived:
+                raise Failure(f"a datagram of {arrived} bytes arrived; IP_REASSEMBLY is 0 in "
+                              f"software/network/config/lwipopts.h, so a fragmented datagram "
+                              f"should be dropped before any socket sees it")
+            detail("IP reassembly is off for the whole device (lwipopts.h IP_REASSEMBLY 0), "
+                   "so this bounds every network service, not just the command interface")
+    finally:
+        net.close(handle)
+    return True
+
+
+def run_udp_truncation(net: Net, peer: Peer) -> bool:
+    """A datagram larger than the requested length must not vanish in silence.
+
+    The property under test is detectability, not delivery: whatever the
+    firmware does with the bytes that do not fit, a client has to be able to
+    tell that they existed. Today a 200-byte datagram read with a length of 64
+    and a genuine 64-byte datagram produce byte-for-byte identical replies, so
+    a protocol with per-datagram integrity sees an authentication failure with
+    nothing to attribute it to.
+    """
+    section("udp-truncation-is-detectable")
+    ok = True
+    handle = net.open_udp(peer.ip, peer.udp_port)
+    detail(f"UDP socket handle {handle}")
+    try:
+        address = peer.learn_udp_peer(net, handle)
+        detail(f"device source address {address[0]}:{address[1]}")
+
+        net.drain_socket(handle)
+        peer.send_udp(pattern(SMALL_READ))
+        time.sleep(DELIVERY_SETTLE_SECONDS)
+        complete = net.read(handle, SMALL_READ, overrun_reads=2)
+
+        net.drain_socket(handle)
+        peer.send_udp(pattern(BIG_DATAGRAM))
+        time.sleep(DELIVERY_SETTLE_SECONDS)
+        truncated = net.read(handle, SMALL_READ, overrun_reads=2)
+        follow_up = net.read(handle, ACCEPTED_MAX)
+
+        with check(f"a {SMALL_READ}-byte datagram read with a length of {SMALL_READ} arrives whole"):
+            detail(complete.describe())
+            if complete.payload != pattern(SMALL_READ):
+                raise Failure(f"expected the whole {SMALL_READ}-byte payload, got "
+                              f"{len(complete.payload)} bytes from offset "
+                              f"{run_offset(complete.payload)}")
+            if complete.status_text != STATUS_OK:
+                raise Failure(f"expected {STATUS_OK!r}, got {complete.status_text!r}")
+
+        # Delivery, as opposed to detectability, is recorded rather than gated:
+        # whether the bytes that did not fit are queued for a further read or
+        # discarded is a design decision, and a signal-only fix leaves them
+        # discarded on purpose. Recorded before the check below, which ends the
+        # scenario when it fails.
+        recovered = len(truncated.payload) + len(follow_up.payload)
+        if recovered < BIG_DATAGRAM:
+            warn(f"{BIG_DATAGRAM - recovered} of {BIG_DATAGRAM} datagram bytes were not "
+                 f"retrievable: the first read delivered {len(truncated.payload)} and a "
+                 f"further read delivered {len(follow_up.payload)}, status "
+                 f"{follow_up.status_text!r}")
+
+        with check(f"a {BIG_DATAGRAM}-byte datagram read with a length of {SMALL_READ} "
+                   f"is distinguishable from a complete one"):
+            detail(f"truncated read: {truncated.describe()}")
+            detail(f"a further read returned {len(follow_up.payload)} bytes, "
+                   f"status {follow_up.status_text!r}")
+            if truncated.observable == complete.observable:
+                raise Failure(
+                    f"reading a {BIG_DATAGRAM}-byte datagram with a length of {SMALL_READ} "
+                    f"is byte-for-byte identical to reading a genuine {SMALL_READ}-byte "
+                    f"datagram: both report header {complete.header}, "
+                    f"{len(complete.payload)} payload bytes and status "
+                    f"{complete.status_text!r}. {BIG_DATAGRAM - len(truncated.payload)} bytes "
+                    f"were dropped and no field a client can read says so")
+
+    finally:
+        net.close(handle)
+    return ok
+
+
+def run_tcp_lossless(net: Net, peer: Peer) -> bool:
+    """The same command over TCP loses nothing, which is the control for UDP.
+
+    read_socket() never looks at the socket type, so this runs the identical
+    firmware path with the identical length. Anything UDP loses here is lost by
+    the socket layer under it, not by the command interface or by the length.
+    """
+    section("tcp-read-is-lossless")
+    ok = True
+    handle = net.open_tcp(peer.ip, peer.tcp_port)
+    detail(f"TCP socket handle {handle}")
+    conn = None
+    try:
+        conn = peer.accept_tcp()
+        conn.sendall(pattern(BIG_DATAGRAM))
+        time.sleep(DELIVERY_SETTLE_SECONDS)
+        chunks: List[ReadResult] = []
+        recovered = bytearray()
+        for _ in range(8):
+            result = net.read(handle, SMALL_READ)
+            chunks.append(result)
+            if not result.payload:
+                break
+            recovered += result.payload
+            if len(recovered) >= BIG_DATAGRAM:
+                break
+        with check(f"{BIG_DATAGRAM} bytes sent over TCP are recovered by reads of "
+                   f"{SMALL_READ} bytes"):
+            detail(" ".join(f"{len(c.payload)}@{run_offset(c.payload)}" for c in chunks))
+            if bytes(recovered) != pattern(BIG_DATAGRAM):
+                raise Failure(f"recovered {len(recovered)} of {BIG_DATAGRAM} bytes; a stream "
+                              f"read that asks for less than is pending must lose nothing")
+    finally:
+        if conn is not None:
+            conn.close()
+        net.close(handle)
+    return ok
+
+
+def run_oversize_request_keeps_datagram(net: Net, peer: Peer) -> bool:
+    """A refused request must not consume the datagram it refused to deliver.
+
+    #802's client asked for 1024 bytes and got nothing. If the refusal also
+    threw the pending datagram away, the data would be gone as well as
+    undelivered, and a client that lowered its length afterwards would still
+    see nothing.
+    """
+    section("oversize-request-keeps-the-datagram")
+    ok = True
+    handle = net.open_udp(peer.ip, peer.udp_port)
+    try:
+        peer.learn_udp_peer(net, handle)
+        net.drain_socket(handle)
+        peer.send_udp(pattern(SMALL_READ))
+        time.sleep(DELIVERY_SETTLE_SECONDS)
+
+        refused = net.read(handle, ACCEPTED_MAX + 1, overrun_reads=2)
+        after = net.read(handle, SMALL_READ)
+
+        with check(f"a request of {ACCEPTED_MAX + 1} bytes is refused without touching the socket"):
+            detail(f"refused read: {refused.describe()}")
+            detail(f"next read:    {after.describe()}")
+            if refused.status_text != STATUS_OUT_OF_RANGE:
+                raise Failure(f"expected {STATUS_OUT_OF_RANGE!r}, got {refused.status_text!r}")
+            if after.payload != pattern(SMALL_READ):
+                raise Failure(
+                    f"the datagram was pending when the over-long request was refused, and a "
+                    f"following read of {SMALL_READ} bytes recovered {len(after.payload)} "
+                    f"bytes instead of {SMALL_READ}: the refusal consumed it")
+    finally:
+        net.close(handle)
+    return ok
+
+
+def restore_settings(device, original: Dict[str, str], keep: bool) -> bool:
+    if keep or not original:
+        return True
+    ok = True
+    for item, value in original.items():
+        with check(f"restore {item!r} to {value!r}"):
+            device.configs.set(CONFIG_CATEGORY, item, value)
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify how the UCI network target's READ_SOCKET handles the requested "
+                    "length and datagrams larger than it (GideonZ/1541ultimate#802)."
+    )
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS"))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "30.0")))
+    parser.add_argument("-b", "--busy-timeout", type=float, default=15.0,
+                        help="How long one command may stay in Command Busy before it "
+                             "counts as wedged.")
+    parser.add_argument("--test", action="append", choices=["all"] + TESTS)
+    parser.add_argument("--keep-config", action="store_true",
+                        help="Don't restore the original Command Interface setting on exit.")
+    args = parser.parse_args()
+
+    selected = TESTS if not args.test or "all" in args.test else [t for t in TESTS if t in args.test]
+    target = targets.parse(args.host)
+    device = UltimateApi(target.device, args.password, args.timeout)
+    # The command interface registers are decoded on the C64 expansion bus, so
+    # the machine that reads them back has to be the one driving that bus. On a
+    # single-machine target these are the same host; on cartridge@computer they
+    # are not. See tests/lib/targets.py.
+    computer = UltimateApi(target.computer, args.password, args.timeout)
+    uci = Uci(computer.machine, args.busy_timeout)
+    net = Net(uci)
+
+    original: Dict[str, str] = {}
+    results: Dict[str, bool] = {}
+    peer: Optional[Peer] = None
+    interface_enabled = False
+    cleanup_ok = True
+
+    def run(name: str, fn, *fn_args) -> None:
+        """Run one scenario; a failed check ends that scenario, not the run.
+
+        report.check re-raises, so the first failing check leaves its scenario
+        immediately. The others still have to run: this suite is measuring
+        several independent properties of the same command, and stopping at the
+        first one would hide the rest.
+        """
+        if name not in selected:
+            return
+        results[name] = False  # so an aborted scenario reports FAIL, not "not reached"
+        try:
+            results[name] = fn(*fn_args)
+        except Wedged:
+            # The interface is stuck for every target; nothing after this can run.
+            raise
+        except Failure as exc:
+            detail(f"{name} stopped: {format_exception(exc)}")
+
+    try:
+        with check(f"read {CONFIG_CATEGORY!r}"):
+            config = device.configs.category(CONFIG_CATEGORY)
+            if CFG_CMD_IF not in config:
+                raise Failure(f"this device has no {CFG_CMD_IF!r} setting; it cannot run this suite")
+            original = {CFG_CMD_IF: str(config[CFG_CMD_IF])}
+            detail(f"current: {original}")
+
+        with check("enable the Command Interface registers at $DF1B-$DF1F"):
+            device.configs.set(CONFIG_CATEGORY, CFG_CMD_IF, "Enabled")
+            interface_enabled = True
+            uci.release()
+
+        if not interface_present(uci):
+            check_start("this machine answers at the Command Interface registers")
+            check_skip("$DF1B-$DF1F all read $FF, so no command interface is present "
+                       "at those addresses on this machine")
+            suite_ok("net_target_test")
+            return 0
+
+        with check("the network target identifies itself"):
+            result = net.identify()
+            if result.status_text != STATUS_OK or not result.data:
+                raise Failure(f"NET_CMD_IDENTIFY answered {result.status_text!r} "
+                              f"with reply {result.data!r}")
+            detail(result.data.decode("latin-1"))
+
+        run("read-length-limit", run_read_length_limit, net)
+
+        needs_peer = [name for name in
+                      ("largest-accepted-read-drains", "datagram-size-ceiling",
+                       "udp-truncation-is-detectable",
+                       "tcp-read-is-lossless", "oversize-request-keeps-the-datagram")
+                      if name in selected]
+        if needs_peer:
+            check_start("this host can act as the device's network peer")
+            try:
+                peer = Peer(local_address_towards(target.device))
+                # Proves the route in the direction that matters: the device
+                # opening a socket back to this process and its datagram
+                # arriving here.
+                handle = net.open_udp(peer.ip, peer.udp_port)
+                try:
+                    peer.learn_udp_peer(net, handle)
+                finally:
+                    net.close(handle)
+                check_ok(f"{peer.ip} UDP {peer.udp_port}, TCP {peer.tcp_port}")
+            except (Failure, OSError, socket.timeout) as exc:
+                check_skip(f"the device could not reach this host: {format_exception(exc)}")
+                if peer is not None:
+                    peer.close()
+                peer = None
+
+        if peer is not None:
+            run("largest-accepted-read-drains", run_largest_accepted_read_drains, net, peer)
+            run("datagram-size-ceiling", run_datagram_size_ceiling, net, peer)
+            run("udp-truncation-is-detectable", run_udp_truncation, net, peer)
+            run("tcp-read-is-lossless", run_tcp_lossless, net, peer)
+            run("oversize-request-keeps-the-datagram",
+                run_oversize_request_keeps_datagram, net, peer)
+        else:
+            for name in needs_peer:
+                results.setdefault(name, None)
+
+    except Failure as exc:
+        suite_fail("net_target_test", format_exception(exc))
+    finally:
+        if peer is not None:
+            peer.close()
+        # A failed scenario can leave the interface holding a reply, so hand the
+        # data back before the setting goes home.
+        released = uci.release() if interface_enabled else True
+        if not released:
+            warn("the command interface did not return to Idle")
+        restored = restore_settings(device, original, args.keep_config)
+        cleanup_ok = released and restored
+
+    section("summary")
+    all_ok = cleanup_ok
+    for name in selected:
+        outcome = results.get(name)
+        state = OK if outcome else (FAIL if outcome is False else SKIP)
+        if outcome is False:
+            all_ok = False
+        detail(f"{name}: {state}")
+    detail(f"cleanup: {OK if cleanup_ok else FAIL}")
+
+    if all_ok:
+        suite_ok("net_target_test")
+        return 0
+    suite_fail("net_target_test", "see the summary above")
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as exc:
+        suite_fail("net_target_test", format_exception(exc))
+        raise SystemExit(1)

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -62,7 +62,8 @@ from report import (  # noqa: E402
     FAIL, Failure, OK, SKIP, check, check_ok, check_skip, check_start, detail,
     format_exception, section, suite_fail, suite_ok, warn)
 from uci import (  # noqa: E402
-    REPLY_QUEUE_BYTES, TARGET_NETWORK, Uci, Wedged, interface_present)
+    MAX_BLOCK_BYTES, REPLY_QUEUE_BYTES, TARGET_NETWORK, Uci, Wedged,
+    interface_present)
 from uci_native import NativeUci  # noqa: E402
 
 CONFIG_CATEGORY = "C64 and Cartridge Settings"
@@ -88,13 +89,27 @@ STATUS_NO_DATA_PREFIX = b"02,NO DATA"
 # and the length in the command is the only variable.
 NEVER_OPENED = 0x7F
 
-# The largest length READ_SOCKET accepts is discovered on the device rather
-# than written down here. A reply is a 2-byte header plus the payload, so the
-# number depends on how large a reply block the transport can deliver, and a
-# suite that hard-codes it asserts today's number instead of the property that
-# matters: whatever length the firmware accepts, its reply has to be readable.
-# The search runs over this range, which spans every plausible answer.
+# The largest UDP payload that fits one Ethernet frame: 1500 less 20 bytes of
+# IPv4 header and 8 of UDP header. Anything above it is sent as fragments, and
+# IP_REASSEMBLY is 0 in software/network/config/lwipopts.h, so nothing larger
+# reaches a socket on the device at all.
+UNFRAGMENTED_MAX = 1472
+
+# The largest length READ_SOCKET accepts. A complete unfragmented IPv4 UDP
+# datagram is the most the command can ever return, so the two are the same
+# number. This is asserted rather than only discovered, because it is now a
+# deliberate limit of the command rather than a side effect of how large a
+# reply block the transport happens to be able to carry.
+MAX_READ = UNFRAGMENTED_MAX
+# The search for the boundary runs over this range, which spans every
+# plausible answer, and is what turns "the limit is 1472" into a measurement.
 LENGTH_SEARCH_MAX = 2048
+
+# What one reply block can carry. A block of exactly REPLY_QUEUE_BYTES never
+# ends, so a block holds at most MAX_BLOCK_BYTES, and the first block of a
+# reply spends two of them on the length header.
+FIRST_BLOCK_PAYLOAD = MAX_BLOCK_BYTES - 2
+
 # A safe length for reads that only have to work, not to probe a boundary.
 SAFE_READ = 512
 
@@ -103,11 +118,20 @@ SAFE_READ = 512
 SMALL_READ = 64
 BIG_DATAGRAM = 200
 
-# A datagram long enough to fill any read length this suite asks for.
-FULL_DATAGRAM = 1000
-# Where the drain of the largest accepted read gives up. The response queue
-# holds 896 bytes, so anything past that is the queue failing to end rather
-# than a longer reply.
+# One payload that needs more than one reply block and is not a round number
+# of blocks either way, so a payload placed at the wrong offset in the second
+# block shows up as wrong data rather than as the right data shifted by zero.
+# Used as a datagram over UDP and as a run of stream bytes over TCP.
+SPANNING_DATAGRAM = 1420
+
+# A truncated read whose returned part still needs more than one block: the
+# datagram is larger than the request, and the request is larger than a block.
+TRUNCATED_REQUEST = 1000
+TRUNCATED_DATAGRAM = 1200
+
+# Where the drain of one reply block gives up. The response queue holds 896
+# bytes, so anything past that is the queue failing to end rather than a
+# longer block.
 OVERRUN_LIMIT = REPLY_QUEUE_BYTES + 128
 
 # The device's socket carries SO_RCVTIMEO of 40 ms, so a read finds a datagram
@@ -120,16 +144,15 @@ ROUTES = ["rest", "native"]
 
 TESTS = [
     "read-length-limit",
-    "largest-accepted-read-drains",
+    "reply-blocks-are-drainable",
+    "datagram-spans-reply-blocks",
     "datagram-size-ceiling",
     "udp-truncation-is-detectable",
+    "truncation-spans-reply-blocks",
     "tcp-read-is-lossless",
     "oversize-request-keeps-the-datagram",
+    "multi-block-state-does-not-leak",
 ]
-
-# The largest UDP payload that fits one Ethernet frame: 1500 less 20 bytes of
-# IP header and 8 of UDP header. Anything above it is fragmented on the wire.
-UNFRAGMENTED_MAX = 1472
 
 
 def pattern(size: int, seed: int = 0) -> bytes:
@@ -160,11 +183,17 @@ class ReadResult:
         self.state = block.state
         self.state_name = block.state_name
         self.status_byte = block.status_byte
-        self.reply = block.data
+        # The logical reply, which is every block's data in order. A reply that
+        # fits one block is that block; one that does not is announced as Data
+        # More and continues in the next, and a client that concatenates them
+        # holds exactly what a single block would have carried.
+        self.reply = transaction.data
         self.status_text = transaction.status_text
         self.overrun = block.overrun
+        self.block_lengths = [len(b.data) for b in transaction.blocks]
         self.blocks = len(transaction.blocks)
-        # The reply's own framing: two header bytes, then the payload.
+        # The reply's own framing: two header bytes, then the payload. The
+        # header counts the whole payload, not the part in the first block.
         self.header = (int.from_bytes(self.reply[:2], "little", signed=True)
                        if len(self.reply) >= 2 else None)
         self.payload = self.reply[2:]
@@ -182,8 +211,30 @@ class ReadResult:
     def describe(self) -> str:
         return (f"{self.state_name}, header {self.header}, payload {len(self.payload)} bytes"
                 f"{f' from offset {run_offset(self.payload)}' if self.payload else ''}"
+                f", blocks {self.block_lengths}"
                 f", status {self.status_text!r}"
                 + (f", overrun {self.overrun.hex(' ')}" if self.overrun else ""))
+
+
+def describe_mismatch(actual: bytes, expected: bytes) -> str:
+    """Where two payloads first differ, and what is there instead.
+
+    A reply assembled from several blocks can go wrong by dropping bytes,
+    repeating them, or starting the second block at the wrong offset. All three
+    show up as the first differing position plus the offset the bytes there
+    actually came from, because pattern() makes every byte name its own offset.
+    """
+    if len(actual) != len(expected):
+        return (f"got {len(actual)} bytes, expected {len(expected)}"
+                + (f"; the bytes it does have start at offset {run_offset(actual)}"
+                   if run_offset(actual) is not None else ""))
+    for index, (got, want) in enumerate(zip(actual, expected)):
+        if got != want:
+            tail = actual[index:index + 16]
+            return (f"first difference at offset {index}: got ${got:02X}, expected "
+                    f"${want:02X}; the run starting there came from offset "
+                    f"{run_offset(tail)}")
+    return "identical"
 
 
 class Net:
@@ -221,13 +272,25 @@ class Net:
         return bytes([TARGET_NETWORK, NET_CMD_READ_SOCKET, handle,
                       maxlen & 0xFF, (maxlen >> 8) & 0xFF])
 
-    def read(self, handle: int, maxlen: int, overrun_reads: int = 0) -> ReadResult:
+    def read(self, handle: int, maxlen: int, overrun_reads: int = 0,
+             single_part: bool = True) -> ReadResult:
+        """One READ_SOCKET, followed through however many blocks it takes.
+
+        `single_part` asserts that the reply arrives in one block, announced as
+        Data Last, which is what every reply short enough to fit one has to do.
+        Pass False for a read whose payload cannot fit one block.
+        """
         return ReadResult(self.uci.transact(self.read_command(handle, maxlen),
+                                            single_part=single_part,
                                             overrun_reads=overrun_reads))
 
     def probe_read(self, handle: int, maxlen: int) -> Tuple[int, bool, bytes]:
-        """One read, drained to a cap rather than to the DATA_AV flag."""
+        """One read, its first block drained to a cap rather than to DATA_AV."""
         return self.uci.probe_drain(self.read_command(handle, maxlen), OVERRUN_LIMIT)
+
+    def abort_read(self, handle: int, maxlen: int) -> Tuple[int, bool]:
+        """One read whose reply is abandoned after its first block."""
+        return self.uci.probe_abort(self.read_command(handle, maxlen))
 
     def close(self, handle: int):
         return self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_CLOSE_SOCKET, handle]))
@@ -239,7 +302,8 @@ class Net:
         every one of them and the only thing that separates the answers is the
         length: an accepted length is answered by the socket
         ('02,NO DATA'), a refused one by the length check
-        ('82,PARAMETER(S) OUT OF RANGE').
+        ('82,PARAMETER(S) OUT OF RANGE'). No reply carries a payload, so this
+        costs a handful of register accesses per probe whatever the length.
         """
         def accepted(length: int) -> bool:
             return self.read(NEVER_OPENED, length).status_text != STATUS_OUT_OF_RANGE
@@ -248,8 +312,8 @@ class Net:
         if not accepted(low):
             raise Failure(f"READ_SOCKET refused a length of {low}")
         if accepted(high):
-            raise Failure(f"READ_SOCKET accepted a length of {high}, which cannot fit the "
-                          f"{REPLY_QUEUE_BYTES}-byte response queue")
+            raise Failure(f"READ_SOCKET accepted a length of {high}, which is larger than "
+                          f"any datagram that can reach the device")
         while high - low > 1:
             middle = (low + high) // 2
             if accepted(middle):
@@ -340,14 +404,23 @@ def run_read_length_limit(net: Net) -> bool:
     difference between two rows is therefore the length handling and nothing
     else.
 
-    The boundary is found on the device rather than asserted, because the
-    number is not part of any published contract: the network target document
-    states no maximum for READ_SOCKET, and neither the cap nor the status that
-    reports it is documented. What is asserted is that the boundary is sharp
-    and that both sides of it answer on the status channel.
+    The boundary is found on the device by bisection and then compared against
+    MAX_READ. It is asserted rather than only recorded because it is now a
+    deliberate limit of the command: a complete unfragmented IPv4 UDP datagram
+    is the most READ_SOCKET can return, so 1472 is the most it accepts. A reply
+    longer than one transport block is split across blocks rather than refused,
+    so the limit no longer follows from the size of the response queue.
     """
     section("read-length-limit")
     accepted_max = net.largest_accepted_length()
+
+    with check(f"READ_SOCKET accepts lengths up to {MAX_READ} and no further"):
+        detail(f"bisection found the boundary at {accepted_max}")
+        if accepted_max != MAX_READ:
+            raise Failure(
+                f"READ_SOCKET accepts up to {accepted_max}, expected {MAX_READ}: "
+                f"1500 bytes of Ethernet MTU less 20 of IPv4 header and 8 of UDP "
+                f"header, which is the largest datagram that can reach the device")
 
     with check(f"READ_SOCKET accepts a length of {accepted_max}"):
         result = net.read(NEVER_OPENED, accepted_max, overrun_reads=4)
@@ -388,17 +461,15 @@ def run_read_length_limit(net: Net) -> bool:
             raise Failure(f"length {accepted_max} was refused: {accepted.status_text!r}")
         if refused.status_text != STATUS_OUT_OF_RANGE:
             raise Failure(f"length {accepted_max + 1} was accepted: {refused.status_text!r}")
-        detail(f"accepted up to {accepted_max}, refused from {accepted_max + 1}; "
-               f"the response queue holds {REPLY_QUEUE_BYTES} bytes and a reply is a "
-               f"2-byte header plus the payload")
+        detail(f"accepted up to {accepted_max}, refused from {accepted_max + 1}")
     return True
 
 
-def run_largest_accepted_read_drains(net: Net, peer: Peer) -> bool:
-    """Whatever length READ_SOCKET accepts, the reply to it has to be readable.
+def run_reply_blocks_are_drainable(net: Net, peer: Peer) -> bool:
+    """Every reply block the firmware builds has to end.
 
-    A reply block is a 2-byte header plus the payload, and the transport cannot
-    deliver a block of exactly the response queue's size. Measured on a U64
+    A reply block is delivered through the response queue, and the transport
+    cannot deliver a block of exactly the queue's size. Measured on a U64
     Elite: a block of 895 bytes ends and DATA_AV clears, a block of 896 never
     ends and every further read returns the same last byte.
 
@@ -415,45 +486,143 @@ def run_largest_accepted_read_drains(net: Net, peer: Peer) -> bool:
     The reference client, ultimateii-dos-lib, does exactly that into a
     fixed-size buffer.
 
-    The length is the one the device accepts, not a number written here, so
-    this stays a statement about the firmware's own boundary rather than about
-    any particular value of it.
+    This measures the first block of a reply directly, at three lengths: the
+    largest payload that fits one block, one byte more than that, and the
+    largest read the command accepts. The second is the case that used to build
+    a 896-byte block. It is now the first block of a reply that continues, and
+    it still has to end.
     """
-    section("largest-accepted-read-drains")
-    accepted_max = net.largest_accepted_length()
+    section("reply-blocks-are-drainable")
     handle = net.open_udp(peer.ip, peer.udp_port)
     try:
         peer.learn_udp_peer(net, handle)
         measured = {}
-        for maxlen in (accepted_max - 1, accepted_max):
+        for maxlen in (FIRST_BLOCK_PAYLOAD, FIRST_BLOCK_PAYLOAD + 1, MAX_READ):
             net.drain_socket(handle)
-            peer.send_udp(pattern(FULL_DATAGRAM))
+            peer.send_udp(pattern(MAX_READ))
             time.sleep(DELIVERY_SETTLE_SECONDS)
             measured[maxlen] = net.probe_read(handle, maxlen)
             block, cleared, tail = measured[maxlen]
-            detail(f"length {maxlen}: reply block {block} bytes, DATA_AV cleared {cleared}, "
+            detail(f"length {maxlen}: first block {block} bytes, DATA_AV cleared {cleared}, "
                    f"last bytes {tail.hex(' ')}")
 
-        with check(f"a read of {accepted_max - 1} bytes ends its reply"):
-            block, cleared, _ = measured[accepted_max - 1]
+        with check(f"a read of {FIRST_BLOCK_PAYLOAD} bytes ends its reply in one block"):
+            block, cleared, _ = measured[FIRST_BLOCK_PAYLOAD]
             if not cleared:
                 raise Failure(f"DATA_AV was still set after {block} bytes")
-            if block != accepted_max + 1:
-                raise Failure(f"expected {accepted_max + 1} bytes (2 header + "
-                              f"{accepted_max - 1} payload), got {block}")
+            if block != FIRST_BLOCK_PAYLOAD + 2:
+                raise Failure(f"expected {FIRST_BLOCK_PAYLOAD + 2} bytes (2 header + "
+                              f"{FIRST_BLOCK_PAYLOAD} payload), got {block}")
 
-        with check(f"a read of {accepted_max} bytes, the largest accepted, ends its reply"):
-            block, cleared, tail = measured[accepted_max]
-            if not cleared:
-                raise Failure(
-                    f"DATA_AV was still set after {block} bytes and the queue was still "
-                    f"repeating {tail[-1:].hex()}. A read of {accepted_max} bytes builds a "
-                    f"reply block of {accepted_max + 2} bytes, the exact size of the "
-                    f"{REPLY_QUEUE_BYTES}-byte response queue, and that block never ends. "
-                    f"A client that reads while DATA_AV is set never stops")
-            if block != accepted_max + 2:
-                raise Failure(f"expected {accepted_max + 2} bytes (2 header + "
-                              f"{accepted_max} payload), got {block}")
+        for maxlen in (FIRST_BLOCK_PAYLOAD + 1, MAX_READ):
+            with check(f"the first block of a read of {maxlen} bytes ends"):
+                block, cleared, tail = measured[maxlen]
+                if not cleared:
+                    raise Failure(
+                        f"DATA_AV was still set after {block} bytes and the queue was still "
+                        f"repeating {tail[-1:].hex()}. A block of exactly "
+                        f"{REPLY_QUEUE_BYTES} bytes, the size of the response queue, never "
+                        f"ends, and a client that reads while DATA_AV is set never stops")
+                if block > MAX_BLOCK_BYTES:
+                    raise Failure(
+                        f"the first block carried {block} bytes; a block may carry at most "
+                        f"{MAX_BLOCK_BYTES}, because one of {REPLY_QUEUE_BYTES} never ends")
+                if block == 0:
+                    raise Failure(
+                        f"a read of {maxlen} bytes put nothing in the response queue, so it "
+                        f"was refused rather than answered; a datagram of {MAX_READ} bytes "
+                        f"was pending and the command accepts lengths up to {MAX_READ}")
+
+        with check(f"no block of any of these replies reaches {REPLY_QUEUE_BYTES} bytes"):
+            sizes = {maxlen: block for maxlen, (block, _, _) in measured.items()}
+            detail(f"first block sizes: {sizes}")
+            oversized = {maxlen: block for maxlen, block in sizes.items()
+                         if block >= REPLY_QUEUE_BYTES}
+            if oversized:
+                raise Failure(f"reads of {sorted(oversized)} built a block of "
+                              f"{sorted(oversized.values())} bytes")
+    finally:
+        net.close(handle)
+    return True
+
+
+def run_datagram_spans_reply_blocks(net: Net, peer: Peer) -> bool:
+    """A datagram larger than one reply block still arrives complete.
+
+    The reply is a 2-byte length header followed by the payload. When that does
+    not fit one block, the firmware announces Data More and continues in the
+    next, and a client that concatenates the blocks holds exactly the reply a
+    large enough response queue would have delivered in one. The header stays
+    the total number of payload bytes rather than the number in the first
+    block, which is what a client uses to find the end of the payload.
+
+    Four sizes: the largest payload that fits one block, one byte more than
+    that, a size in the middle of the second block, and the largest datagram
+    that can reach the device at all. The payload identifies its own offset, so
+    a second block written from the wrong offset, or one that repeats or drops
+    bytes, shows up as wrong data rather than as a plausible reply.
+    """
+    section("datagram-spans-reply-blocks")
+    handle = net.open_udp(peer.ip, peer.udp_port)
+    try:
+        peer.learn_udp_peer(net, handle)
+        # (datagram size, requested length, whether it can fit one block)
+        cases = [
+            (FIRST_BLOCK_PAYLOAD, FIRST_BLOCK_PAYLOAD, True),
+            (FIRST_BLOCK_PAYLOAD + 1, MAX_READ, False),
+            (SPANNING_DATAGRAM, MAX_READ, False),
+            (MAX_READ, MAX_READ, False),
+        ]
+        measured = []
+        for size, maxlen, one_block in cases:
+            net.drain_socket(handle)
+            peer.send_udp(pattern(size))
+            time.sleep(DELIVERY_SETTLE_SECONDS)
+            result = net.read(handle, maxlen, single_part=one_block)
+            measured.append((size, maxlen, one_block, result))
+            detail(f"{size}-byte datagram read at {maxlen}: {result.describe()}")
+            if not one_block and len(result.payload) > FIRST_BLOCK_PAYLOAD:
+                # What a wrong split looks like in the payload: the first byte
+                # of the second block has to continue the run the first block
+                # ended with. The equality check below is what fails on it;
+                # this records the bytes so the failure reads directly.
+                edge = FIRST_BLOCK_PAYLOAD
+                around = result.payload[edge - 4:edge + 4]
+                detail(f"  bytes {edge - 4} to {edge + 3}, spanning the block boundary: "
+                       f"{around.hex(' ')}, a run from offset {run_offset(around)}")
+
+        for size, maxlen, one_block, result in measured:
+            with check(f"a {size}-byte datagram read with a length of {maxlen} arrives whole"):
+                if result.status_text != STATUS_OK:
+                    raise Failure(f"expected {STATUS_OK!r}, got {result.status_text!r}")
+                if result.header != size:
+                    raise Failure(
+                        f"the header reports {result.header} while the datagram was {size} "
+                        f"bytes; the header is the total number of payload bytes the reply "
+                        f"carries, not the number in its first block")
+                if result.payload != pattern(size):
+                    raise Failure(f"the payload is not the datagram that was sent: "
+                                  f"{describe_mismatch(result.payload, pattern(size))}")
+
+            with check(f"the reply to a {size}-byte read is delivered in "
+                       f"{'one block' if one_block else 'blocks that each end'}"):
+                detail(f"block sizes {result.block_lengths}")
+                if one_block and result.blocks != 1:
+                    raise Failure(
+                        f"a payload of {size} bytes fits one block, so it must arrive in "
+                        f"one rather than in {result.blocks}; splitting it would break a "
+                        f"client that does not follow Data More")
+                if not one_block and result.blocks < 2:
+                    raise Failure(
+                        f"a payload of {size} bytes cannot fit one block, because a block "
+                        f"carries at most {MAX_BLOCK_BYTES} bytes, yet the reply arrived "
+                        f"in {result.blocks}")
+                oversized = [b for b in result.block_lengths if b > MAX_BLOCK_BYTES]
+                if oversized:
+                    raise Failure(
+                        f"blocks of {oversized} bytes were built; a block of "
+                        f"{REPLY_QUEUE_BYTES} bytes never ends, so no block may exceed "
+                        f"{MAX_BLOCK_BYTES}")
     finally:
         net.close(handle)
     return True
@@ -583,12 +752,167 @@ def run_udp_truncation(net: Net, peer: Peer) -> bool:
     return ok
 
 
+def run_truncation_spans_reply_blocks(net: Net, peer: Peer) -> bool:
+    """Truncation and continuation are independent, and have to compose.
+
+    A 1200-byte datagram read with a length of 1000: the request is smaller
+    than the datagram, so the read is truncated, and it is larger than one
+    reply block, so what is returned still has to be split. The firmware must
+    return exactly the requested number of bytes, report the true datagram
+    length on the status channel, and keep the header at the number of bytes
+    the reply carries.
+    """
+    section("truncation-spans-reply-blocks")
+    handle = net.open_udp(peer.ip, peer.udp_port)
+    try:
+        peer.learn_udp_peer(net, handle)
+        net.drain_socket(handle)
+        peer.send_udp(pattern(TRUNCATED_DATAGRAM))
+        time.sleep(DELIVERY_SETTLE_SECONDS)
+        result = net.read(handle, TRUNCATED_REQUEST, single_part=False)
+        follow_up = net.read(handle, SAFE_READ)
+        detail(f"{TRUNCATED_DATAGRAM}-byte datagram read at {TRUNCATED_REQUEST}: "
+               f"{result.describe()}")
+
+        with check(f"exactly {TRUNCATED_REQUEST} bytes of a {TRUNCATED_DATAGRAM}-byte "
+                   f"datagram are returned"):
+            if result.header != TRUNCATED_REQUEST:
+                raise Failure(
+                    f"the header reports {result.header}; it is the number of bytes the "
+                    f"reply carries, which is the requested {TRUNCATED_REQUEST}, not the "
+                    f"datagram's {TRUNCATED_DATAGRAM}")
+            if result.payload != pattern(TRUNCATED_REQUEST):
+                raise Failure(f"the payload is not the head of the datagram: "
+                              f"{describe_mismatch(result.payload, pattern(TRUNCATED_REQUEST))}")
+            if result.blocks < 2:
+                raise Failure(f"the reply arrived in {result.blocks} block(s); "
+                              f"{TRUNCATED_REQUEST} payload bytes cannot fit one block of at "
+                              f"most {MAX_BLOCK_BYTES}")
+            oversized = [b for b in result.block_lengths if b > MAX_BLOCK_BYTES]
+            if oversized:
+                raise Failure(f"blocks of {oversized} bytes were built; no block may exceed "
+                              f"{MAX_BLOCK_BYTES}, because one of {REPLY_QUEUE_BYTES} never "
+                              f"ends")
+
+        with check("the true datagram length is reported on the status channel"):
+            expected = f"04,DATAGRAM TRUNCATED: {TRUNCATED_DATAGRAM}".encode("ascii")
+            if result.status_text != expected:
+                raise Failure(f"expected {expected!r}, got {result.status_text!r}")
+
+        with check("the rest of the truncated datagram is gone, not left in the socket"):
+            # UDP semantics: what did not fit is discarded with the datagram.
+            # Recorded as a check rather than a warning because a following
+            # read that returned the remainder would mean the read had queued
+            # part of a datagram, which no client can ask about.
+            detail(f"a further read returned {len(follow_up.payload)} bytes, "
+                   f"status {follow_up.status_text!r}")
+            if follow_up.payload:
+                raise Failure(f"a further read returned {len(follow_up.payload)} bytes from "
+                              f"offset {run_offset(follow_up.payload)}; the remainder of a "
+                              f"truncated datagram is discarded, so it must return nothing")
+    finally:
+        net.close(handle)
+    return True
+
+
+def run_multi_block_state_does_not_leak(net: Net, peer: Peer) -> bool:
+    """A reply that spans blocks must not outlive its own command.
+
+    The firmware holds the received payload between blocks, so there is state
+    that a client could leave behind: by abandoning the reply part way through,
+    or simply by finishing it. Neither may show up in the next command, and
+    neither may leave the target unable to answer one.
+
+    Abandoning is the documented way out of a reply a client no longer wants:
+    the abort bit in the control register, which the Ultimate answers by
+    resetting the exchange.
+    """
+    section("multi-block-state-does-not-leak")
+    handle = net.open_udp(peer.ip, peer.udp_port)
+    try:
+        peer.learn_udp_peer(net, handle)
+
+        net.drain_socket(handle)
+        peer.send_udp(pattern(MAX_READ))
+        time.sleep(DELIVERY_SETTLE_SECONDS)
+        first_block, idle = net.abort_read(handle, MAX_READ)
+        detail(f"abandoned after {first_block} bytes, interface idle {idle}")
+
+        with check("a reply abandoned after its first block returns the interface to Idle"):
+            # A payload of MAX_READ bytes cannot fit one block, so a first
+            # block within the block limit says the reply had more to come and
+            # the abort really did abandon one part way through.
+            if not 0 < first_block <= MAX_BLOCK_BYTES:
+                raise Failure(f"the first block carried {first_block} bytes; a block carries "
+                              f"between 1 and {MAX_BLOCK_BYTES}, and a {MAX_READ}-byte "
+                              f"payload needs more than one, so this reply was not one that "
+                              f"could be abandoned part way through")
+            if not idle:
+                raise Failure("the interface did not return to Idle after the abort")
+
+        with check("the next command after an abandoned reply is answered normally"):
+            # NET_CMD_IDENTIFY has a fixed reply of its own, so anything left
+            # over from the abandoned read would show up as extra bytes, as a
+            # reply announced as Data More, or as no reply at all.
+            identity = net.identify()
+            detail(f"{identity.data!r}, {len(identity.blocks)} block(s), "
+                   f"status {identity.status_text!r}")
+            if identity.status_text != STATUS_OK:
+                raise Failure(f"NET_CMD_IDENTIFY answered {identity.status_text!r}")
+            if len(identity.blocks) != 1:
+                raise Failure(f"NET_CMD_IDENTIFY replied in {len(identity.blocks)} blocks; "
+                              f"its reply fits one, so the abandoned read left the target "
+                              f"still handing out blocks")
+            if not identity.data.startswith(b"ULTIMATE"):
+                raise Failure(f"NET_CMD_IDENTIFY replied {identity.data!r}, which is not its "
+                              f"identification string")
+
+        with check("a read after an abandoned reply returns the next datagram, not the old one"):
+            net.drain_socket(handle)
+            peer.send_udp(pattern(SMALL_READ, seed=7))
+            time.sleep(DELIVERY_SETTLE_SECONDS)
+            result = net.read(handle, SAFE_READ)
+            detail(result.describe())
+            if result.payload != pattern(SMALL_READ, seed=7):
+                raise Failure(f"expected the {SMALL_READ}-byte datagram sent after the "
+                              f"abort, got {len(result.payload)} bytes: "
+                              f"{describe_mismatch(result.payload, pattern(SMALL_READ, seed=7))}")
+
+        with check("the command after a completed multi-block reply is answered normally"):
+            net.drain_socket(handle)
+            peer.send_udp(pattern(MAX_READ))
+            time.sleep(DELIVERY_SETTLE_SECONDS)
+            completed = net.read(handle, MAX_READ, single_part=False)
+            detail(f"completed: {completed.describe()}")
+            if completed.payload != pattern(MAX_READ):
+                raise Failure(f"the multi-block read itself failed: "
+                              f"{describe_mismatch(completed.payload, pattern(MAX_READ))}")
+            identity = net.identify()
+            detail(f"{identity.data!r}, {len(identity.blocks)} block(s), "
+                   f"status {identity.status_text!r}")
+            if len(identity.blocks) != 1 or not identity.data.startswith(b"ULTIMATE"):
+                raise Failure(f"NET_CMD_IDENTIFY replied {identity.data!r} in "
+                              f"{len(identity.blocks)} block(s); a finished reply must leave "
+                              f"nothing behind")
+    finally:
+        net.close(handle)
+    return True
+
+
 def run_tcp_lossless(net: Net, peer: Peer) -> bool:
     """The same command over TCP loses nothing, which is the control for UDP.
 
     read_socket() never looks at the socket type, so this runs the identical
     firmware path with the identical length. Anything UDP loses here is lost by
     the socket layer under it, not by the command interface or by the length.
+
+    The second half reads a stream with a length above what one reply block can
+    carry. read_socket() splits a reply over blocks whatever the socket type,
+    so a stream read can now return more than one block's worth in a single
+    command. A stream has no datagram boundaries, so how many bytes any one
+    read returns is up to the socket; what the test fixes is that repeated
+    reads recover every byte in order, that nothing is reported as truncated,
+    and that no block exceeds what the transport can deliver.
     """
     section("tcp-read-is-lossless")
     ok = True
@@ -624,6 +948,43 @@ def run_tcp_lossless(net: Net, peer: Peer) -> bool:
             if unexpected:
                 raise Failure(f"a stream read answered {unexpected!r}; only {STATUS_OK!r} "
                               f"is correct when no data was lost")
+
+        conn.sendall(pattern(SPANNING_DATAGRAM, seed=3))
+        time.sleep(DELIVERY_SETTLE_SECONDS)
+        wide: List[ReadResult] = []
+        stream = bytearray()
+        for _ in range(8):
+            result = net.read(handle, MAX_READ, single_part=False)
+            wide.append(result)
+            if not result.payload:
+                break
+            stream += result.payload
+            if len(stream) >= SPANNING_DATAGRAM:
+                break
+
+        with check(f"{SPANNING_DATAGRAM} bytes sent over TCP are recovered by reads of "
+                   f"{MAX_READ} bytes"):
+            detail(" ".join(f"{len(r.payload)}@{run_offset(r.payload, seed=3)}"
+                            f"{r.block_lengths}" for r in wide))
+            if bytes(stream) != pattern(SPANNING_DATAGRAM, seed=3):
+                raise Failure(f"recovered {len(stream)} of {SPANNING_DATAGRAM} bytes: "
+                              f"{describe_mismatch(bytes(stream), pattern(SPANNING_DATAGRAM, seed=3))}")
+
+        with check("a stream read above one block reports its own length and stays 00,OK"):
+            for result in wide:
+                if not result.payload:
+                    continue
+                if result.header != len(result.payload):
+                    raise Failure(f"a read reported {result.header} in its header while "
+                                  f"carrying {len(result.payload)} payload bytes")
+                if result.status_text != STATUS_OK:
+                    raise Failure(f"a stream read answered {result.status_text!r}; a stream "
+                                  f"has no datagram to truncate, so only {STATUS_OK!r} is "
+                                  f"correct")
+                oversized = [b for b in result.block_lengths if b > MAX_BLOCK_BYTES]
+                if oversized:
+                    raise Failure(f"blocks of {oversized} bytes were built; no block may "
+                                  f"exceed {MAX_BLOCK_BYTES}")
     finally:
         if conn is not None:
             conn.close()
@@ -730,6 +1091,7 @@ def main() -> int:
     interface_enabled = False
     native_started = False
     cleanup_ok = True
+    setup_failed = False
 
     def run(route: str, name: str, fn, *fn_args) -> None:
         """Run one scenario on one route; a failed check ends that scenario only.
@@ -771,11 +1133,8 @@ def main() -> int:
             suite_ok("net_target_test")
             return 0
 
-        needs_peer = [name for name in
-                      ("largest-accepted-read-drains", "datagram-size-ceiling",
-                       "udp-truncation-is-detectable",
-                       "tcp-read-is-lossless", "oversize-request-keeps-the-datagram")
-                      if name in selected]
+        needs_peer = [name for name in TESTS
+                      if name != "read-length-limit" and name in selected]
         if needs_peer:
             check_start("this host can act as the device's network peer")
             try:
@@ -837,14 +1196,23 @@ def main() -> int:
                 for name in needs_peer:
                     results.setdefault(f"{name} [{route}]", None)
                 continue
-            run(route, "largest-accepted-read-drains", run_largest_accepted_read_drains, net, peer)
+            run(route, "reply-blocks-are-drainable", run_reply_blocks_are_drainable, net, peer)
+            run(route, "datagram-spans-reply-blocks", run_datagram_spans_reply_blocks, net, peer)
             run(route, "datagram-size-ceiling", run_datagram_size_ceiling, net, peer)
             run(route, "udp-truncation-is-detectable", run_udp_truncation, net, peer)
+            run(route, "truncation-spans-reply-blocks",
+                run_truncation_spans_reply_blocks, net, peer)
             run(route, "tcp-read-is-lossless", run_tcp_lossless, net, peer)
             run(route, "oversize-request-keeps-the-datagram",
                 run_oversize_request_keeps_datagram, net, peer)
+            run(route, "multi-block-state-does-not-leak",
+                run_multi_block_state_does_not_leak, net, peer)
 
     except Failure as exc:
+        # Setup and route initialisation raise rather than recording a result,
+        # so without this the summary below would find an empty results map, see
+        # a clean cleanup, and report the run as passing.
+        setup_failed = True
         suite_fail("net_target_test", format_exception(exc))
     finally:
         if peer is not None:
@@ -863,7 +1231,7 @@ def main() -> int:
         cleanup_ok = released and restored
 
     section("summary")
-    all_ok = cleanup_ok
+    all_ok = cleanup_ok and not setup_failed
     for label, outcome in results.items():
         state = OK if outcome else (FAIL if outcome is False else SKIP)
         if outcome is False:

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -20,9 +20,25 @@ any run of received bytes identifies the offset it came from. That turns "64
 bytes arrived" into "bytes 0-63 arrived", which is what separates truncation
 at the head from anything else.
 
-Reads are kept small on purpose. The response queue is drained one REST DMA
-cycle per byte, so the size of the payload is the cost of the suite, and every
-property under test is visible at 64 bytes as clearly as at 894.
+Every scenario runs twice, once down each way of reaching the registers. The
+"rest" route uses machine:readmem / machine:writemem, which are DMA cycles the
+Ultimate issues on the cartridge bus. The "native" route runs a small 6502 agent
+on the C64 itself, which is how a program actually uses the interface: its
+register accesses are microseconds apart rather than tens of milliseconds, and
+no DMA is involved. Both were measured to agree in every field, which is what
+says a finding is a property of the interface rather than of how it was
+observed.
+
+The native route runs only on a target that is one machine. On
+cartridge@computer the host's own command interface answers its 6510 at
+$DF1B-$DF1F, so a program there would measure the host instead of the cartridge
+under test, and the suite skips the route rather than report on the wrong
+device.
+
+Reads are kept small on purpose. Over the REST route the response queue is
+drained one DMA cycle per byte, so the size of the payload is the cost of the
+suite, and every property under test is visible at 64 bytes as clearly as at
+894.
 
 Supported on any Ultimate whose FPGA provides the command interface. The suite
 enables the "Command Interface" setting and restores it on exit.
@@ -47,6 +63,7 @@ from report import (  # noqa: E402
     format_exception, section, suite_fail, suite_ok, warn)
 from uci import (  # noqa: E402
     REPLY_QUEUE_BYTES, TARGET_NETWORK, Uci, Wedged, interface_present)
+from uci_native import NativeUci  # noqa: E402
 
 CONFIG_CATEGORY = "C64 and Cartridge Settings"
 CFG_CMD_IF = "Command Interface"
@@ -61,7 +78,6 @@ NET_CMD_READ_SOCKET = 0x10
 NET_CMD_WRITE_SOCKET = 0x11
 
 STATUS_OK = b"00,OK"
-STATUS_CLOSED = b"01,CONNECTION CLOSED BY HOST"
 STATUS_OUT_OF_RANGE = b"82,PARAMETER(S) OUT OF RANGE"
 # Not in the network target document, but what the firmware answers when
 # lwip_recv returns -1. The number is the errno: 9 is EBADF for a handle that
@@ -98,7 +114,9 @@ OVERRUN_LIMIT = REPLY_QUEUE_BYTES + 128
 # that is already queued and does not wait for one in flight.
 DELIVERY_SETTLE_SECONDS = 0.4
 PEER_TIMEOUT_SECONDS = 10.0
-RESET_SETTLE_SECONDS = 3.0
+
+# The two ways of reaching the registers, described at the top of this file.
+ROUTES = ["rest", "native"]
 
 TESTS = [
     "read-length-limit",
@@ -199,10 +217,17 @@ class Net:
     def write(self, handle: int, payload: bytes):
         return self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_WRITE_SOCKET, handle]) + payload)
 
+    def read_command(self, handle: int, maxlen: int) -> bytes:
+        return bytes([TARGET_NETWORK, NET_CMD_READ_SOCKET, handle,
+                      maxlen & 0xFF, (maxlen >> 8) & 0xFF])
+
     def read(self, handle: int, maxlen: int, overrun_reads: int = 0) -> ReadResult:
-        command = bytes([TARGET_NETWORK, NET_CMD_READ_SOCKET, handle,
-                         maxlen & 0xFF, (maxlen >> 8) & 0xFF])
-        return ReadResult(self.uci.transact(command, overrun_reads=overrun_reads))
+        return ReadResult(self.uci.transact(self.read_command(handle, maxlen),
+                                            overrun_reads=overrun_reads))
+
+    def probe_read(self, handle: int, maxlen: int) -> Tuple[int, bool, bytes]:
+        """One read, drained to a cap rather than to the DATA_AV flag."""
+        return self.uci.probe_drain(self.read_command(handle, maxlen), OVERRUN_LIMIT)
 
     def close(self, handle: int):
         return self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_CLOSE_SOCKET, handle]))
@@ -404,7 +429,7 @@ def run_largest_accepted_read_drains(net: Net, peer: Peer) -> bool:
             net.drain_socket(handle)
             peer.send_udp(pattern(FULL_DATAGRAM))
             time.sleep(DELIVERY_SETTLE_SECONDS)
-            measured[maxlen] = drain_count(net.uci, handle, maxlen)
+            measured[maxlen] = net.probe_read(handle, maxlen)
             block, cleared, tail = measured[maxlen]
             detail(f"length {maxlen}: reply block {block} bytes, DATA_AV cleared {cleared}, "
                    f"last bytes {tail.hex(' ')}")
@@ -432,33 +457,6 @@ def run_largest_accepted_read_drains(net: Net, peer: Peer) -> bool:
     finally:
         net.close(handle)
     return True
-
-
-def drain_count(uci: Uci, handle: int, maxlen: int) -> Tuple[int, bool, bytes]:
-    """Push one READ_SOCKET and pull bytes until DATA_AV clears or the cap is hit.
-
-    Returns the number of bytes the queue handed out, whether DATA_AV cleared,
-    and the last few bytes, which say whether the queue was repeating itself.
-    """
-    from uci import (CTRL_DATA_ACC, REG_RESPONSE, REG_STATUS, ST_DATA_AV, ST_STAT_AV)
-    uci.release()
-    uci.require_idle("before the largest accepted read")
-    command = bytes([TARGET_NETWORK, NET_CMD_READ_SOCKET, handle,
-                     maxlen & 0xFF, (maxlen >> 8) & 0xFF])
-    uci.push(command)
-    uci.wait_for_reply(command)
-    out = bytearray()
-    while uci.status() & ST_DATA_AV:
-        out.append(uci.peek(REG_RESPONSE))
-        if len(out) >= OVERRUN_LIMIT:
-            break
-    cleared = not (uci.status() & ST_DATA_AV)
-    uci._drain(ST_STAT_AV, REG_STATUS, "status")
-    uci.control(CTRL_DATA_ACC)
-    # Writing DATA_ACC leaves the data state whether or not the queue emptied,
-    # so the interface is usable again even after a block that never ended.
-    uci.release()
-    return len(out), cleared, bytes(out[-6:])
 
 
 def run_datagram_size_ceiling(net: Net, peer: Peer) -> bool:
@@ -679,6 +677,15 @@ def restore_settings(device, original: Dict[str, str], keep: bool) -> bool:
     return ok
 
 
+def build_driver(route: str, computer, busy_timeout: float):
+    """The driver for one route, ready to use."""
+    if route == "rest":
+        return Uci(computer.machine, busy_timeout)
+    agent = NativeUci(computer.machine, computer.runners, busy_timeout)
+    agent.start()
+    return agent
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Verify how the UCI network target's READ_SOCKET handles the requested "
@@ -692,29 +699,40 @@ def main() -> int:
                         help="How long one command may stay in Command Busy before it "
                              "counts as wedged.")
     parser.add_argument("--test", action="append", choices=["all"] + TESTS)
+    parser.add_argument("--route", action="append", choices=["all"] + ROUTES,
+                        help="How to reach $DF1C-$DF1F: 'rest' for DMA cycles the "
+                             "Ultimate issues, 'native' for 6502 code running on the "
+                             "C64. Both by default.")
     parser.add_argument("--keep-config", action="store_true",
                         help="Don't restore the original Command Interface setting on exit.")
     args = parser.parse_args()
 
     selected = TESTS if not args.test or "all" in args.test else [t for t in TESTS if t in args.test]
+    routes = ROUTES if not args.route or "all" in args.route else [r for r in ROUTES if r in args.route]
     target = targets.parse(args.host)
     device = UltimateApi(target.device, args.password, args.timeout)
     # The command interface registers are decoded on the C64 expansion bus, so
     # the machine that reads them back has to be the one driving that bus. On a
     # single-machine target these are the same host; on cartridge@computer they
-    # are not. See tests/lib/targets.py.
+    # are not, and the 6502 agent runs on the computer while the network stack
+    # under test is the cartridge's. See tests/lib/targets.py.
     computer = UltimateApi(target.computer, args.password, args.timeout)
-    uci = Uci(computer.machine, args.busy_timeout)
-    net = Net(uci)
+    # The REST driver is also the suite's frame: it decides whether this machine
+    # has a command interface at all, and it is what hands data back when a
+    # scenario leaves a reply pending. Neither is something the 6502 agent can
+    # do, since it needs a working interface in order to report anything and it
+    # owns the CPU while it runs.
+    rest_uci = Uci(computer.machine, args.busy_timeout)
 
     original: Dict[str, str] = {}
-    results: Dict[str, bool] = {}
+    results: Dict[str, Optional[bool]] = {}
     peer: Optional[Peer] = None
     interface_enabled = False
+    native_started = False
     cleanup_ok = True
 
-    def run(name: str, fn, *fn_args) -> None:
-        """Run one scenario; a failed check ends that scenario, not the run.
+    def run(route: str, name: str, fn, *fn_args) -> None:
+        """Run one scenario on one route; a failed check ends that scenario only.
 
         report.check re-raises, so the first failing check leaves its scenario
         immediately. The others still have to run: this suite is measuring
@@ -723,14 +741,15 @@ def main() -> int:
         """
         if name not in selected:
             return
-        results[name] = False  # so an aborted scenario reports FAIL, not "not reached"
+        label = f"{name} [{route}]"
+        results[label] = False  # so an aborted scenario reports FAIL, not "not reached"
         try:
-            results[name] = fn(*fn_args)
+            results[label] = fn(*fn_args)
         except Wedged:
             # The interface is stuck for every target; nothing after this can run.
             raise
         except Failure as exc:
-            detail(f"{name} stopped: {format_exception(exc)}")
+            detail(f"{label} stopped: {format_exception(exc)}")
 
     try:
         with check(f"read {CONFIG_CATEGORY!r}"):
@@ -743,23 +762,14 @@ def main() -> int:
         with check("enable the Command Interface registers at $DF1B-$DF1F"):
             device.configs.set(CONFIG_CATEGORY, CFG_CMD_IF, "Enabled")
             interface_enabled = True
-            uci.release()
+            rest_uci.release()
 
-        if not interface_present(uci):
+        if not interface_present(rest_uci):
             check_start("this machine answers at the Command Interface registers")
             check_skip("$DF1B-$DF1F all read $FF, so no command interface is present "
                        "at those addresses on this machine")
             suite_ok("net_target_test")
             return 0
-
-        with check("the network target identifies itself"):
-            result = net.identify()
-            if result.status_text != STATUS_OK or not result.data:
-                raise Failure(f"NET_CMD_IDENTIFY answered {result.status_text!r} "
-                              f"with reply {result.data!r}")
-            detail(result.data.decode("latin-1"))
-
-        run("read-length-limit", run_read_length_limit, net)
 
         needs_peer = [name for name in
                       ("largest-accepted-read-drains", "datagram-size-ceiling",
@@ -773,11 +783,12 @@ def main() -> int:
                 # Proves the route in the direction that matters: the device
                 # opening a socket back to this process and its datagram
                 # arriving here.
-                handle = net.open_udp(peer.ip, peer.udp_port)
+                probe = Net(rest_uci)
+                handle = probe.open_udp(peer.ip, peer.udp_port)
                 try:
-                    peer.learn_udp_peer(net, handle)
+                    peer.learn_udp_peer(probe, handle)
                 finally:
-                    net.close(handle)
+                    probe.close(handle)
                 check_ok(f"{peer.ip} UDP {peer.udp_port}, TCP {peer.tcp_port}")
             except (Failure, OSError, socket.timeout) as exc:
                 check_skip(f"the device could not reach this host: {format_exception(exc)}")
@@ -785,16 +796,53 @@ def main() -> int:
                     peer.close()
                 peer = None
 
-        if peer is not None:
-            run("largest-accepted-read-drains", run_largest_accepted_read_drains, net, peer)
-            run("datagram-size-ceiling", run_datagram_size_ceiling, net, peer)
-            run("udp-truncation-is-detectable", run_udp_truncation, net, peer)
-            run("tcp-read-is-lossless", run_tcp_lossless, net, peer)
-            run("oversize-request-keeps-the-datagram",
+        for route in routes:
+            section(f"route: {route}")
+            if route == "native" and target.split:
+                # Measured on a U2+L in a C64 Ultimate: the host's own command
+                # interface claims $DF1B-$DF1F from its 6510, so a program there
+                # reaches the host's target, not the cartridge's. Turning the
+                # host's interface off does not hand the range over: the 6510
+                # then reads $FF. DMA is the asymmetry, since a readmem issued
+                # by the host does reach the cartridge. So on a split target
+                # this route cannot address the device under test at all.
+                check_start(f"the network target answers over the {route} route")
+                check_skip(f"{target.device} is a cartridge in {target.computer}, and 6502 "
+                           f"code on {target.computer} reaches its own command interface "
+                           f"rather than the cartridge's")
+                for name in selected:
+                    results.setdefault(f"{name} [{route}]", None)
+                continue
+            # A route that cannot be reached fails the run rather than skipping
+            # it: both are expected to work on any device with a command
+            # interface, so one that does not is a finding, not a limitation.
+            with check(f"the network target answers over the {route} route"):
+                if route == "native":
+                    # run_prg needs the machine at a BASIC prompt, and the agent
+                    # keeps the CPU for itself until the machine is reset.
+                    # force=True because MachineApi.reset skips one it believes
+                    # cannot change anything, and this one has to happen.
+                    computer.machine.reset(force=True)
+                    native_started = True
+                driver = build_driver(route, computer, args.busy_timeout)
+                net = Net(driver)
+                identity = net.identify()
+                if identity.status_text != STATUS_OK or not identity.data:
+                    raise Failure(f"NET_CMD_IDENTIFY answered {identity.status_text!r} "
+                                  f"with reply {identity.data!r}")
+                detail(identity.data.decode("latin-1"))
+
+            run(route, "read-length-limit", run_read_length_limit, net)
+            if peer is None:
+                for name in needs_peer:
+                    results.setdefault(f"{name} [{route}]", None)
+                continue
+            run(route, "largest-accepted-read-drains", run_largest_accepted_read_drains, net, peer)
+            run(route, "datagram-size-ceiling", run_datagram_size_ceiling, net, peer)
+            run(route, "udp-truncation-is-detectable", run_udp_truncation, net, peer)
+            run(route, "tcp-read-is-lossless", run_tcp_lossless, net, peer)
+            run(route, "oversize-request-keeps-the-datagram",
                 run_oversize_request_keeps_datagram, net, peer)
-        else:
-            for name in needs_peer:
-                results.setdefault(name, None)
 
     except Failure as exc:
         suite_fail("net_target_test", format_exception(exc))
@@ -803,20 +851,24 @@ def main() -> int:
             peer.close()
         # A failed scenario can leave the interface holding a reply, so hand the
         # data back before the setting goes home.
-        released = uci.release() if interface_enabled else True
+        released = rest_uci.release() if interface_enabled else True
         if not released:
             warn("the command interface did not return to Idle")
+        if native_started:
+            # The agent runs with interrupts off and never returns, so the
+            # machine has to be reset before anything else can use it.
+            with check("reset the C64 so the 6502 agent releases the machine"):
+                computer.machine.reset(force=True)
         restored = restore_settings(device, original, args.keep_config)
         cleanup_ok = released and restored
 
     section("summary")
     all_ok = cleanup_ok
-    for name in selected:
-        outcome = results.get(name)
+    for label, outcome in results.items():
         state = OK if outcome else (FAIL if outcome is False else SKIP)
         if outcome is False:
             all_ok = False
-        detail(f"{name}: {state}")
+        detail(f"{label}: {state}")
     detail(f"cleanup: {OK if cleanup_ok else FAIL}")
 
     if all_ok:

--- a/tests/e2e/io/command_interface/uci_agent.asm
+++ b/tests/e2e/io/command_interface/uci_agent.asm
@@ -20,7 +20,10 @@
 ;   OPT_CAP     how much to pull before giving up, which turns a reply that
 ;               never ends into a measurement instead of a hang
 ;   OPT_OVR     how many bytes to read past DATA_AV
-;   $C009-$C00F and $C440-$C4FF are reserved for further options and results.
+;   OPT_ABRT    abandon the reply after the first block, which is what a
+;               client does when it gives up part way through a Data More
+;               reply
+;   $C00A-$C00F and $C440-$C4FF are reserved for further options and results.
 ; New behaviour, as opposed to a new value, belongs in a reserved option byte,
 ; where zero has to keep meaning what the agent does today: the host writes the
 ; whole option block at once, so an older host leaves zeroes there.
@@ -44,9 +47,11 @@ STATR   = $DF1F                 ; read: status data queue
 
 CTRL_PUSH = $01
 CTRL_ACC  = $02
+CTRL_ABRT = $04
 CTRL_CLR  = $08
 
 ST_STATE  = $30
+ST_IDLE   = $00
 ST_LAST   = $20
 ST_MORE   = $30
 ST_STAT   = $40
@@ -60,7 +65,9 @@ OPT_OVR  = $C004                ; bytes to read from RESP after DATA_AV clears
 OPT_MAXB = $C005                ; how many reply blocks to follow, at least 1
 OPT_CAP  = $C006                ; 16 bit cap on the data drain
 READY    = $C008                ; agent writes $A5 here once it is running
-;          $C009-$C00F          ; reserved for further options
+OPT_ABRT = $C009                ; non-zero: abandon the reply after the first
+                                ; block by writing the abort bit
+;          $C00A-$C00F          ; reserved for further options
 CMDBUF   = $C010                ; command bytes, up to 896
 
 ; ------------------------------------------------------------- result block --
@@ -107,6 +114,7 @@ start
         lda #$00
         sta GO
         sta SEQ
+        sta OPT_ABRT            ; so a host that never sets it gets the default
         lda #$A5
         sta READY
 main_wait
@@ -196,6 +204,12 @@ block_loop
         jsr drain_status
         jsr record_block
 
+        ; Abandon the transaction rather than accept it, if asked to. The
+        ; abort bit is the documented way out of a reply a client no longer
+        ; wants, and the Ultimate answers it by resetting the exchange.
+        lda OPT_ABRT
+        bne transact_abort
+
         ; Follow a Data More reply into its next block, up to OPT_MAXB.
         lda zstat
         and #ST_STATE
@@ -211,7 +225,33 @@ block_loop
         jmp block_loop
 
 blocks_done
+        ; Whether the Ultimate still had blocks to send when the agent stopped
+        ; following them, which is what OPT_MAXB does.
+        ldx #$00
+        lda zstat
+        and #ST_STATE
+        cmp #ST_MORE
+        bne blocks_accept
+        ldx #$01
+blocks_accept
         lda #CTRL_ACC
+        sta CTRL
+        lda CTRL
+        sta R_FINAL
+        cpx #$00
+        beq blocks_end
+        ; The reply was left part way through, so the rest of it has to be
+        ; taken before anything else can use the interface. R_FINAL above still
+        ; records the state that first accept produced.
+        jsr release_to_idle
+blocks_end
+        rts
+
+transact_abort
+        lda #CTRL_ABRT
+        sta CTRL
+        jsr wait_idle
+        lda #CTRL_CLR
         sta CTRL
         lda CTRL
         sta R_FINAL
@@ -221,6 +261,54 @@ transact_timeout
         lda CTRL
         sta R_FIRST
         sta R_FINAL
+        rts
+
+; ---------------------------------------------------------- release_to_idle ---
+; Accepts the remaining blocks of a reply the agent stopped following, waiting
+; for the Ultimate to produce each one, until the exchange is back to Idle.
+; Bounded by the number of blocks it will accept and by wait_reply's own
+; timeout, so an exchange that will not end is recorded rather than hung on.
+release_to_idle
+        ldy #$08
+rti_loop
+        lda CTRL
+        and #ST_STATE
+        beq rti_done
+        jsr wait_reply
+        bcs rti_done
+        lda #CTRL_ACC
+        sta CTRL
+        dey
+        bne rti_loop
+rti_done
+        rts
+
+; --------------------------------------------------------------- wait_idle ---
+; Waits for the state bits to return to Idle after an abort. Bounded the same
+; way wait_reply is, and records the same flag when it gives up, so a state
+; that will not clear is a measurement rather than a hang.
+wait_idle
+        lda #$00
+        sta ztmo
+        sta ztmo+1
+        sta ztmo+2
+idle_loop
+        lda CTRL
+        and #ST_STATE
+        cmp #ST_IDLE
+        beq idle_ok
+        inc ztmo
+        bne idle_loop
+        inc ztmo+1
+        bne idle_loop
+        inc ztmo+2
+        lda ztmo+2
+        cmp #WAIT_WRAPS
+        bne idle_loop
+        lda R_FLAGS
+        ora #$01
+        sta R_FLAGS
+idle_ok
         rts
 
 ; -------------------------------------------------------------- wait_reply ---

--- a/tests/e2e/io/command_interface/uci_agent.asm
+++ b/tests/e2e/io/command_interface/uci_agent.asm
@@ -1,0 +1,363 @@
+; uci_agent.asm - a resident 6502 agent that drives the Ultimate Command
+; Interface from the C64 side, for the E2E suites under tests/e2e.
+;
+; A test can also reach $DF1C-$DF1F through REST machine:readmem and
+; machine:writemem, which are DMA cycles the Ultimate issues on the cartridge
+; bus. This agent is the other path, and the one a real program takes: ordinary
+; loads and stores executed by the 6510, microseconds apart rather than tens of
+; milliseconds, with no DMA involved. It is also much cheaper, because one
+; transaction costs a handful of REST calls however large the reply.
+;
+; The agent knows nothing about any target. It pushes whatever command bytes it
+; is given and records everything the reply exposes: the state byte per block,
+; the data, the status text, the bytes a client would read past DATA_AV, and how
+; many blocks arrived. A test for Ultimate DOS, SoftIEC, the control target or
+; the HTTP target needs different bytes in CMDBUF, not a change here.
+;
+; Extension points, so that most new tests need none:
+;   CMDBUF      any command for any target, up to the 896-byte queue
+;   OPT_MAXB    how far to follow a Data More reply
+;   OPT_CAP     how much to pull before giving up, which turns a reply that
+;               never ends into a measurement instead of a hang
+;   OPT_OVR     how many bytes to read past DATA_AV
+;   $C009-$C00F and $C440-$C4FF are reserved for further options and results.
+; New behaviour, as opposed to a new value, belongs in a reserved option byte,
+; where zero has to keep meaning what the agent does today: the host writes the
+; whole option block at once, so an older host leaves zeroes there.
+;
+; Protocol with the host
+;   1. host writes the command to CMDBUF and its length to CMDLEN, sets the
+;      options, then writes a non-zero value to GO
+;   2. agent runs the transaction, writes the results, clears GO, bumps SEQ
+;   3. host waits for SEQ to change, then reads the result block
+;
+; The agent runs with interrupts disabled and never calls the KERNAL, so nothing
+; else touches the zero page locations it uses. The host side is
+; tests/e2e/lib/uci_native.py, which assembles this with the repository's own
+; 64tass and starts it over runners:run_prg.
+
+; ---------------------------------------------------------------- registers --
+CTRL    = $DF1C                 ; write: control, read: status
+CMDREG  = $DF1D                 ; write: command byte queue
+RESP    = $DF1E                 ; read: response data queue
+STATR   = $DF1F                 ; read: status data queue
+
+CTRL_PUSH = $01
+CTRL_ACC  = $02
+CTRL_CLR  = $08
+
+ST_STATE  = $30
+ST_LAST   = $20
+ST_MORE   = $30
+ST_STAT   = $40
+ST_DATA   = $80
+
+; ------------------------------------------------------------ control block --
+GO       = $C000                ; host sets non-zero to start, agent clears
+SEQ      = $C001                ; incremented after each completed transaction
+CMDLEN   = $C002                ; 16 bit, low byte first
+OPT_OVR  = $C004                ; bytes to read from RESP after DATA_AV clears
+OPT_MAXB = $C005                ; how many reply blocks to follow, at least 1
+OPT_CAP  = $C006                ; 16 bit cap on the data drain
+READY    = $C008                ; agent writes $A5 here once it is running
+;          $C009-$C00F          ; reserved for further options
+CMDBUF   = $C010                ; command bytes, up to 896
+
+; ------------------------------------------------------------- result block --
+R_FIRST  = $C400                ; CTRL as the first reply block arrived
+R_BLOCKS = $C401                ; blocks collected
+R_DLEN   = $C402                ; 16 bit total bytes pulled from RESP
+R_SLEN   = $C404                ; status text length
+R_FINAL  = $C405                ; CTRL after the last DATA_ACC
+R_FLAGS  = $C406                ; 1 wait timed out, 2 drain cap hit, 4 status cap
+R_OVRN   = $C410                ; up to 16 bytes read past DATA_AV
+R_BSTAT  = $C420                ; CTRL per block, up to 8
+R_BLEN   = $C430                ; running total after each block, 8 x 16 bit
+;          $C440-$C4FF          ; reserved for further results
+STATBUF  = $C500                ; status text, up to 255 bytes
+DATABUF  = $2000                ; response data
+
+; -------------------------------------------------------------- zero page ----
+zsrc    = $FB                   ; command read pointer
+zdst    = $FD                   ; data write pointer
+zcnt    = $03                   ; 16 bit scratch counter
+zcap    = $05                   ; 16 bit remaining drain allowance
+ztmo    = $07                   ; 24 bit wait counter
+zblk    = $0A                   ; block index
+zstat   = $0B                   ; CTRL as the current block arrived
+
+; The wait gives up after this many wraps of a 16 bit counter. Each pass is
+; about a dozen cycles, so $08 is roughly six seconds on a 1 MHz 6510: longer
+; than any command takes, shorter than the host's own timeout.
+WAIT_WRAPS = $08
+
+        * = $0801
+
+; BASIC line "10 SYS 2061", so the host can start this with runners:run_prg.
+        .word basic_end, 10
+        .byte $9e
+        .text "2061"
+        .byte 0
+basic_end
+        .word 0
+
+; --------------------------------------------------------------------- main --
+start
+        sei
+        lda #$00
+        sta GO
+        sta SEQ
+        lda #$A5
+        sta READY
+main_wait
+        lda GO
+        beq main_wait
+        jsr transact
+        lda #$00
+        sta GO
+        inc SEQ
+        jmp main_wait
+
+; ---------------------------------------------------------------- transact ---
+; Runs one command end to end and fills the result block.
+transact
+        lda #$00
+        sta R_FLAGS
+        sta R_BLOCKS
+        sta R_SLEN
+        sta R_DLEN
+        sta R_DLEN+1
+        sta zblk
+
+        ; Hand back anything still pending and clear a stale error, so the
+        ; interface is idle before the command goes in. Bounded, because a
+        ; state that will not clear must not hang the agent.
+        ldx #$20
+release_loop
+        lda #CTRL_ACC
+        sta CTRL
+        lda #CTRL_CLR
+        sta CTRL
+        lda CTRL
+        and #ST_STATE
+        beq release_done
+        dex
+        bne release_loop
+release_done
+
+        ; Write the command bytes into the command queue, one at a time.
+        lda #<CMDBUF
+        sta zsrc
+        lda #>CMDBUF
+        sta zsrc+1
+        lda CMDLEN
+        sta zcnt
+        lda CMDLEN+1
+        sta zcnt+1
+push_loop
+        lda zcnt
+        ora zcnt+1
+        beq push_done
+        ldy #$00
+        lda (zsrc),y
+        sta CMDREG
+        inc zsrc
+        bne push_nohi
+        inc zsrc+1
+push_nohi
+        lda zcnt
+        bne push_nodec
+        dec zcnt+1
+push_nodec
+        dec zcnt
+        jmp push_loop
+push_done
+        lda #CTRL_PUSH
+        sta CTRL
+
+        jsr wait_reply
+        bcs transact_timeout
+        lda zstat
+        sta R_FIRST
+
+        ; Where the payload goes, and how much of it is allowed.
+        lda #<DATABUF
+        sta zdst
+        lda #>DATABUF
+        sta zdst+1
+        lda OPT_CAP
+        sta zcap
+        lda OPT_CAP+1
+        sta zcap+1
+
+block_loop
+        jsr drain_data
+        jsr read_overrun
+        jsr drain_status
+        jsr record_block
+
+        ; Follow a Data More reply into its next block, up to OPT_MAXB.
+        lda zstat
+        and #ST_STATE
+        cmp #ST_MORE
+        bne blocks_done
+        lda zblk
+        cmp OPT_MAXB
+        bcs blocks_done
+        lda #CTRL_ACC
+        sta CTRL
+        jsr wait_reply
+        bcs blocks_done
+        jmp block_loop
+
+blocks_done
+        lda #CTRL_ACC
+        sta CTRL
+        lda CTRL
+        sta R_FINAL
+        rts
+
+transact_timeout
+        lda CTRL
+        sta R_FIRST
+        sta R_FINAL
+        rts
+
+; -------------------------------------------------------------- wait_reply ---
+; Waits for the state bits to reach Data Last or Data More. Leaves CTRL in
+; zstat and returns carry clear. On giving up it sets bit 0 of R_FLAGS and
+; returns carry set.
+wait_reply
+        lda #$00
+        sta ztmo
+        sta ztmo+1
+        sta ztmo+2
+wait_loop
+        lda CTRL
+        sta zstat
+        and #ST_STATE
+        cmp #ST_LAST
+        beq wait_ok
+        cmp #ST_MORE
+        beq wait_ok
+        inc ztmo
+        bne wait_loop
+        inc ztmo+1
+        bne wait_loop
+        inc ztmo+2
+        lda ztmo+2
+        cmp #WAIT_WRAPS
+        bne wait_loop
+        lda R_FLAGS
+        ora #$01
+        sta R_FLAGS
+        sec
+        rts
+wait_ok
+        clc
+        rts
+
+; -------------------------------------------------------------- drain_data ---
+; Pulls bytes from the response queue for as long as DATA_AV is set, which is
+; what the protocol tells a client to do, stopping at OPT_CAP so that a queue
+; which never clears cannot hang the machine. Hitting the cap sets bit 1 of
+; R_FLAGS, and that is the whole point of the cap: it is a measurement, not a
+; safety net.
+drain_data
+        lda CTRL
+        and #ST_DATA
+        beq drain_done
+        lda zcap
+        ora zcap+1
+        bne drain_room
+        lda R_FLAGS
+        ora #$02
+        sta R_FLAGS
+        rts
+drain_room
+        lda RESP
+        ldy #$00
+        sta (zdst),y
+        inc zdst
+        bne drain_nohi
+        inc zdst+1
+drain_nohi
+        inc R_DLEN
+        bne drain_nocarry
+        inc R_DLEN+1
+drain_nocarry
+        lda zcap
+        bne drain_nodec
+        dec zcap+1
+drain_nodec
+        dec zcap
+        jmp drain_data
+drain_done
+        rts
+
+; ------------------------------------------------------------ read_overrun ---
+; Reads OPT_OVR further bytes from the response queue after DATA_AV has gone
+; away, on the first block only. That is what a client sees if it reads a fixed
+; count instead of following the flag.
+read_overrun
+        lda zblk
+        bne overrun_done
+        ldx #$00
+overrun_loop
+        cpx OPT_OVR
+        beq overrun_done
+        cpx #$10
+        beq overrun_done
+        lda RESP
+        sta R_OVRN,x
+        inx
+        jmp overrun_loop
+overrun_done
+        rts
+
+; ------------------------------------------------------------ drain_status ---
+; Appends this block's status text. Stops storing at 255 bytes and records that
+; in bit 2 of R_FLAGS; the DATA_ACC that ends the transaction resets the queue.
+drain_status
+        ldx R_SLEN
+status_loop
+        lda CTRL
+        and #ST_STAT
+        beq status_done
+        cpx #$FF
+        beq status_full
+        lda STATR
+        sta STATBUF,x
+        inx
+        jmp status_loop
+status_full
+        lda R_FLAGS
+        ora #$04
+        sta R_FLAGS
+status_done
+        stx R_SLEN
+        rts
+
+; ------------------------------------------------------------ record_block ---
+; Stores this block's status byte and the running data total, then advances the
+; block index. The totals are cumulative; the host differences them. Blocks past
+; the eight the result block has room for are counted but not stored, so a host
+; that asks for more than that cannot make this write outside it.
+record_block
+        ldx zblk
+        cpx #$08
+        bcs record_count
+        lda zstat
+        sta R_BSTAT,x
+        txa
+        asl a
+        tay
+        lda R_DLEN
+        sta R_BLEN,y
+        lda R_DLEN+1
+        sta R_BLEN+1,y
+record_count
+        inc zblk
+        lda zblk
+        sta R_BLOCKS
+        rts

--- a/tests/e2e/lib/assembler.py
+++ b/tests/e2e/lib/assembler.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Assemble a 6502 source into a .prg, using the assembler in this repository.
+
+Several suites run small C64 programs as their stimulus. They build them here
+rather than committing the assembled binary, so the source beside the test is
+the thing that runs and the two cannot drift apart.
+
+`tools/64tass/64tass` is committed and is also built by `make -C tools`, which
+every firmware build runs, so a checkout that can build firmware can run these
+suites. There is no fallback to another assembler on purpose: a different 64tass
+would be a different fixture, and a suite that quietly assembled with one would
+be reporting on something other than what the repository contains.
+
+tests/e2e/io/printer takes the other approach and commits its .prg with a
+Makefile to regenerate it, so that suite needs no assembler at all. Both are
+reasonable; this is for the ones that would rather not commit a binary.
+"""
+
+import os
+import subprocess
+import tempfile
+from typing import Union
+
+from report import Failure
+
+REPO_ROOT = os.path.abspath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+ASSEMBLER = os.path.join(REPO_ROOT, "tools", "64tass", "64tass")
+ASSEMBLE_TIMEOUT_SECONDS = 120.0
+
+
+def assemble(source: Union[str, "os.PathLike[str]"]) -> bytes:
+    """Return the assembled program, with its two-byte load address in front."""
+    source = os.path.abspath(os.fspath(source))
+    if not os.path.exists(source):
+        raise Failure(f"no such 6502 source: {source}")
+    if not os.path.exists(ASSEMBLER):
+        raise Failure(f"{ASSEMBLER} is missing; run `make -C tools` to build it")
+    name = os.path.basename(source)
+    with tempfile.TemporaryDirectory(prefix="c64-asm-") as directory:
+        output = os.path.join(directory, "fixture.prg")
+        try:
+            result = subprocess.run(
+                [ASSEMBLER, "-q", "--cbm-prg", "-o", output, source],
+                capture_output=True, text=True, timeout=ASSEMBLE_TIMEOUT_SECONDS)
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise Failure(f"could not run {ASSEMBLER}: {exc}") from exc
+        if result.returncode:
+            raise Failure(f"64tass failed for {name}: "
+                          f"{(result.stderr or result.stdout).strip()[:400]}")
+        with open(output, "rb") as handle:
+            program = handle.read()
+    if len(program) < 3:
+        raise Failure(f"64tass produced {len(program)} bytes for {name}, which is not a program")
+    return program

--- a/tests/e2e/lib/uci.py
+++ b/tests/e2e/lib/uci.py
@@ -64,6 +64,13 @@ CMD_QUEUE_BYTES = 896
 REPLY_QUEUE_BYTES = 896
 STATUS_QUEUE_BYTES = 256
 
+# The largest reply block that can actually be read back. A block of exactly
+# REPLY_QUEUE_BYTES never ends: command_protocol.vhd stops response_pointer on
+# the last byte of the buffer while response_valid stays asserted, so DATA_AV
+# never clears and the queue repeats that byte. Measured on a U64 Elite, and
+# the reason a longer reply has to be split over several blocks.
+MAX_BLOCK_BYTES = REPLY_QUEUE_BYTES - 1
+
 BUSY_TIMEOUT_SECONDS = 15.0
 BUSY_POLL_SECONDS = 0.05
 ABORT_TIMEOUT_SECONDS = 5.0
@@ -235,8 +242,34 @@ class Uci:
                               f"{bytes(out)[:80]!r}")
         return bytes(out)
 
+    def _drain_response(self) -> bytes:
+        """The response queue, one readmem per byte instead of two.
+
+        $DF1C, $DF1D and $DF1E in one call: the control register, the
+        identification byte, and one byte off the response queue. readmem walks
+        an ascending span as separate DMA cycles, and reading $DF1D has no side
+        effect, because command_protocol.vhd advances a pointer only for the
+        response and status registers. So this is the same "check DATA_AV, then
+        take a byte" that _drain does, at half the REST calls, which halves the
+        cost of the replies this suite now reads back in kilobytes.
+
+        The final call reads $DF1E once with DATA_AV already clear, and that
+        byte is discarded. It costs nothing: the response queue answers $00
+        past the end of a reply, and the read pointer is reset when the next
+        reply's length is written.
+        """
+        out = bytearray()
+        while True:
+            status, _, value = self.machine.readmem(REG_CONTROL, 3)
+            if not (status & ST_DATA_AV):
+                return bytes(out)
+            out.append(value)
+            if len(out) >= DRAIN_LIMIT_BYTES:
+                raise Failure(f"response queue did not drain within {DRAIN_LIMIT_BYTES} "
+                              f"bytes: {bytes(out)[:80]!r}")
+
     def drain(self) -> Tuple[bytes, bytes]:
-        return (self._drain(ST_DATA_AV, REG_RESPONSE, "response"),
+        return (self._drain_response(),
                 self._drain(ST_STAT_AV, REG_STATUS, "status"))
 
     def probe_drain(self, command: bytes, cap: int) -> Tuple[int, bool, bytes]:
@@ -267,6 +300,26 @@ class Uci:
         self.control(CTRL_DATA_ACC)
         self.release()
         return len(out), cleared, bytes(out[-6:])
+
+    def probe_abort(self, command: bytes) -> Tuple[int, bool]:
+        """Push one command, take its first reply block, then abandon it.
+
+        Returns how many bytes that first block carried and whether the
+        interface came back to Idle. This is what a client does when it gives
+        up part way through a Data More reply, and it is the path on which a
+        target that holds continuation state has to let go of it.
+
+        uci_native.NativeUci offers the same method, taken by the 6510 rather
+        than by DMA, so a test can make this measurement down either route.
+        """
+        self.release()
+        self.require_idle("before the abort probe")
+        self.push(command)
+        self.wait_for_reply(command)
+        data = self._drain_response()
+        self._drain(ST_STAT_AV, REG_STATUS, "status")
+        idle = self.abort_to_idle()
+        return len(data), idle
 
     # -- one command --------------------------------------------------------
 
@@ -299,7 +352,7 @@ class Uci:
 
         blocks: List[Reply] = []
         while True:
-            data = self._drain(ST_DATA_AV, REG_RESPONSE, "response")
+            data = self._drain_response()
             overrun = bytes(self.peek(REG_RESPONSE) for _ in range(overrun_reads)) if not blocks else b""
             text = self._drain(ST_STAT_AV, REG_STATUS, "status")
             blocks.append(Reply(status, data, text, overrun))

--- a/tests/e2e/lib/uci.py
+++ b/tests/e2e/lib/uci.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""The Ultimate Command Interface transport, driven over REST DMA cycles.
+
+The registers live at $DF1B-$DF1F on the cartridge bus and are reached through
+machine:readmem / machine:writemem, so no 6502 code is involved.
+
+  $DF1C  write: control (bit 0 PUSH_CMD, bit 1 DATA_ACC, bit 2 ABORT, bit 3 CLR_ERR)
+         read:  status  (bit 0 CMD_BUSY, bit 1 DATA_ACC, bit 2 ABORT_P, bit 3 ERROR,
+                         bits 4-5 state, bit 6 STAT_AV, bit 7 DATA_AV)
+  $DF1D  write: command byte queue;  read: identification ($C9, or $49 on IRQ)
+  $DF1E  read:  response data queue
+  $DF1F  read:  status data queue
+
+Command bytes go into $DF1D one request at a time on purpose, and only $DF1C is
+polled. machine:readmem and machine:writemem walk an ascending span of
+addresses, so a multi-byte access starting at $DF1D or $DF1E would spill onto
+the next register. Measured on a U64 Elite: a length-8 read at $DF1E returned
+one response byte, then one status byte from $DF1F, then the Ultimate audio
+registers at $DF20 upwards.
+"""
+
+import time
+from typing import Dict, List, Optional, Tuple
+
+from report import Failure, detail
+
+REG_IDENT = 0xDF1B
+REG_CONTROL = 0xDF1C
+REG_COMMAND = 0xDF1D
+REG_RESPONSE = 0xDF1E
+REG_STATUS = 0xDF1F
+
+CTRL_PUSH_CMD = 0x01
+CTRL_DATA_ACC = 0x02
+CTRL_ABORT = 0x04
+CTRL_CLR_ERR = 0x08
+
+ST_CMD_BUSY = 0x01
+ST_DATA_ACC = 0x02
+ST_ABORT_P = 0x04
+ST_ERROR = 0x08
+ST_STATE_MASK = 0x30
+ST_STATE_IDLE = 0x00
+ST_STATE_BUSY = 0x10
+ST_STATE_DATA_LAST = 0x20
+ST_STATE_DATA_MORE = 0x30
+ST_STAT_AV = 0x40
+ST_DATA_AV = 0x80
+
+STATE_NAMES = {ST_STATE_IDLE: "Idle", ST_STATE_BUSY: "Command Busy",
+               ST_STATE_DATA_LAST: "Data Last", ST_STATE_DATA_MORE: "Data More"}
+STATUS_FLAGS = ((ST_CMD_BUSY, "CMD_BUSY"), (ST_DATA_ACC, "DATA_ACC"),
+                (ST_ABORT_P, "ABORT_P"), (ST_ERROR, "ERROR"),
+                (ST_STAT_AV, "STAT_AV"), (ST_DATA_AV, "DATA_AV"))
+
+# The dispatcher takes the target from the low nibble of the first command byte.
+TARGET_NETWORK = 0x03
+
+# The three FPGA queues, from "Ultimate Command Interface - Register API",
+# section "Queues". They bound one command and one reply block.
+CMD_QUEUE_BYTES = 896
+REPLY_QUEUE_BYTES = 896
+STATUS_QUEUE_BYTES = 256
+
+BUSY_TIMEOUT_SECONDS = 15.0
+BUSY_POLL_SECONDS = 0.05
+ABORT_TIMEOUT_SECONDS = 5.0
+RELEASE_TIMEOUT_SECONDS = 5.0
+# A drain stops here rather than looping forever if DATA_AV never clears. Set
+# above the queue size so an over-long reply is reported as a measurement
+# instead of being silently cut to the expected length.
+DRAIN_LIMIT_BYTES = 4096
+# How many blocks of a Data More reply are collected before giving up.
+MAX_REPLY_BLOCKS = 8
+
+
+class Wedged(Failure):
+    """The command interface never left Command Busy: issue #740's failure mode."""
+
+
+def describe_status(status: int) -> str:
+    state = STATE_NAMES[status & ST_STATE_MASK]
+    flags = [name for bit, name in STATUS_FLAGS if status & bit]
+    return f"${status:02X} {state}" + (f" [{', '.join(flags)}]" if flags else "")
+
+
+class Reply:
+    """One block of a reply: what a client can observe after it arrives."""
+
+    def __init__(self, status_byte: int, data: bytes, status_text: bytes,
+                 overrun: bytes = b"") -> None:
+        self.status_byte = status_byte
+        self.state = status_byte & ST_STATE_MASK
+        self.data = data
+        self.status_text = status_text
+        # Bytes read from the response queue after DATA_AV went away, which is
+        # what a client sees if it reads a fixed count instead of following the
+        # flag.
+        self.overrun = overrun
+
+    @property
+    def state_name(self) -> str:
+        return STATE_NAMES[self.state]
+
+    def __repr__(self) -> str:
+        return (f"Reply({describe_status(self.status_byte)}, {len(self.data)} data bytes, "
+                f"status {self.status_text!r})")
+
+
+class Transaction:
+    """Every observable of one command: its reply blocks and the final state."""
+
+    def __init__(self, command: bytes, blocks: List[Reply], final_status: int,
+                 elapsed: float) -> None:
+        self.command = command
+        self.blocks = blocks
+        self.final_status = final_status
+        self.elapsed = elapsed
+
+    @property
+    def first(self) -> Reply:
+        return self.blocks[0]
+
+    @property
+    def data(self) -> bytes:
+        """Every data byte of the reply, blocks concatenated in order."""
+        return b"".join(block.data for block in self.blocks)
+
+    @property
+    def status_text(self) -> bytes:
+        """The status text of the last block, which is the command's result."""
+        return self.blocks[-1].status_text
+
+
+class Uci:
+    """The $DF1C-$DF1F transport, one REST DMA cycle per register access."""
+
+    def __init__(self, machine, busy_timeout: float = BUSY_TIMEOUT_SECONDS) -> None:
+        # `machine` is a tests/lib/api.py MachineApi: readmem / writemem.
+        self.machine = machine
+        self.busy_timeout = busy_timeout
+
+    # -- register access ----------------------------------------------------
+
+    def peek(self, address: int) -> int:
+        return self.machine.readmem(address, 1)[0]
+
+    def poke(self, address: int, value: int) -> None:
+        self.machine.writemem(address, bytes([value]))
+
+    def status(self) -> int:
+        # Reading $DF1C has no side effect, unlike the response and status queues.
+        return self.peek(REG_CONTROL)
+
+    def control(self, bits: int) -> None:
+        self.poke(REG_CONTROL, bits)
+
+    def state(self) -> int:
+        return self.status() & ST_STATE_MASK
+
+    # -- state machine ------------------------------------------------------
+
+    def release(self, timeout: float = RELEASE_TIMEOUT_SECONDS) -> bool:
+        """Accept any pending data and clear a stale error, until the state is Idle.
+
+        Accepting data from "Data More" returns to Command Busy while the target
+        prepares the next block, so this has to keep trying rather than assume one
+        write is enough.
+        """
+        deadline = time.time() + timeout
+        while True:
+            self.control(CTRL_DATA_ACC)
+            self.control(CTRL_CLR_ERR)
+            if self.state() == ST_STATE_IDLE:
+                return True
+            if time.time() > deadline:
+                return False
+            time.sleep(BUSY_POLL_SECONDS)
+
+    def abort_to_idle(self) -> bool:
+        """Ask the Ultimate to abandon the exchange, the documented way back to Idle."""
+        self.control(CTRL_ABORT)
+        if not self.wait_for_state(ST_STATE_IDLE, ABORT_TIMEOUT_SECONDS):
+            return False
+        self.control(CTRL_CLR_ERR)
+        return True
+
+    def wait_for_state(self, wanted: int, timeout: float) -> bool:
+        deadline = time.time() + timeout
+        while True:
+            if self.state() == wanted:
+                return True
+            if time.time() > deadline:
+                return False
+            time.sleep(BUSY_POLL_SECONDS)
+
+    def require_idle(self, when: str) -> None:
+        status = self.status()
+        if (status & ST_STATE_MASK) != ST_STATE_IDLE:
+            raise Failure(f"command interface is not idle {when}: {describe_status(status)}")
+        if status & ST_ERROR:
+            raise Failure(f"command interface reports a command error {when}: {describe_status(status)}")
+
+    def push(self, command: bytes) -> None:
+        """Queue the command bytes and hand them to the Ultimate."""
+        for byte in command:
+            self.poke(REG_COMMAND, byte)
+        self.control(CTRL_PUSH_CMD)
+
+    def wait_for_reply(self, command: bytes) -> int:
+        started = time.time()
+        while True:
+            status = self.status()
+            if (status & ST_STATE_MASK) in (ST_STATE_DATA_LAST, ST_STATE_DATA_MORE):
+                return status
+            if time.time() - started > self.busy_timeout:
+                raise Wedged(
+                    f"command {command.hex(' ') or '<empty>'} never left Command Busy after "
+                    f"{self.busy_timeout:.0f}s: {describe_status(status)}. The command "
+                    f"interface is now wedged for every target (issue #740) and only a "
+                    f"firmware restart or power cycle releases it."
+                )
+            time.sleep(BUSY_POLL_SECONDS)
+
+    # -- queues -------------------------------------------------------------
+
+    def _drain(self, available_bit: int, register: int, what: str) -> bytes:
+        out = bytearray()
+        while self.status() & available_bit:
+            out.append(self.peek(register))
+            if len(out) >= DRAIN_LIMIT_BYTES:
+                raise Failure(f"{what} queue did not drain within {DRAIN_LIMIT_BYTES} bytes: "
+                              f"{bytes(out)[:80]!r}")
+        return bytes(out)
+
+    def drain(self) -> Tuple[bytes, bytes]:
+        return (self._drain(ST_DATA_AV, REG_RESPONSE, "response"),
+                self._drain(ST_STAT_AV, REG_STATUS, "status"))
+
+    # -- one command --------------------------------------------------------
+
+    def transact(self, command: bytes, single_part: bool = True,
+                 overrun_reads: int = 0) -> Transaction:
+        """Push one command and collect everything the reply exposes.
+
+        `single_part` asserts what most replies are: one block, announced as
+        Data Last. A single-part reply announced as Data More makes a client
+        that follows the protocol accept the data and then wait for a block
+        that never comes. Pass False for a command whose reply may span blocks;
+        this then follows the protocol through them.
+
+        `overrun_reads` pulls that many further bytes from the response queue
+        after DATA_AV has gone away, recording what a client that reads a fixed
+        count regardless of the flag would see.
+        """
+        self.release()
+        self.require_idle("before pushing a command")
+        started = time.time()
+        self.push(command)
+        status = self.wait_for_reply(command)
+        elapsed = time.time() - started
+
+        if single_part and (status & ST_STATE_MASK) != ST_STATE_DATA_LAST:
+            raise Failure(
+                f"command {command.hex(' ')} replied in state {describe_status(status)}; "
+                f"this reply is sent in one part, so the state has to be Data Last"
+            )
+
+        blocks: List[Reply] = []
+        while True:
+            data = self._drain(ST_DATA_AV, REG_RESPONSE, "response")
+            overrun = bytes(self.peek(REG_RESPONSE) for _ in range(overrun_reads)) if not blocks else b""
+            text = self._drain(ST_STAT_AV, REG_STATUS, "status")
+            blocks.append(Reply(status, data, text, overrun))
+            if (status & ST_STATE_MASK) != ST_STATE_DATA_MORE:
+                break
+            if len(blocks) >= MAX_REPLY_BLOCKS:
+                raise Failure(f"reply to {command.hex(' ')} still said Data More after "
+                              f"{MAX_REPLY_BLOCKS} blocks")
+            self.control(CTRL_DATA_ACC)
+            status = self.wait_for_reply(command)
+
+        self.control(CTRL_DATA_ACC)
+        final = self.status()
+        self.require_idle("after accepting the reply")
+        detail(f"{command.hex(' ') or '<empty>'} -> {elapsed:.2f}s, "
+               f"{len(blocks)} block(s), data {blocks[0].data[:32]!r}"
+               f"{'...' if len(blocks[0].data) > 32 else ''}, "
+               f"status {blocks[-1].status_text!r}")
+        return Transaction(command, blocks, final, elapsed)
+
+
+def interface_present(uci: Uci) -> bool:
+    """False when nothing answers at $DF1B-$DF1F.
+
+    Measured on a C64 Ultimate 1.2.0: the "Command Interface" setting reads
+    Enabled while the whole register window reads $FF, which is the bus
+    floating because nothing answers there. An Ultimate 64 answers
+    $02 $FF $02 $02 $02 at the same five addresses even with the setting off.
+    """
+    return not all(uci.peek(REG_IDENT + offset) == 0xFF for offset in range(5))

--- a/tests/e2e/lib/uci.py
+++ b/tests/e2e/lib/uci.py
@@ -2,7 +2,9 @@
 """The Ultimate Command Interface transport, driven over REST DMA cycles.
 
 The registers live at $DF1B-$DF1F on the cartridge bus and are reached through
-machine:readmem / machine:writemem, so no 6502 code is involved.
+machine:readmem / machine:writemem, so no 6502 code is involved. uci_native.py
+drives the same registers from 6502 code running on the C64 and offers the same
+`transact` and `probe_drain`, so a test can run down either route.
 
   $DF1C  write: control (bit 0 PUSH_CMD, bit 1 DATA_ACC, bit 2 ABORT, bit 3 CLR_ERR)
          read:  status  (bit 0 CMD_BUSY, bit 1 DATA_ACC, bit 2 ABORT_P, bit 3 ERROR,
@@ -236,6 +238,35 @@ class Uci:
     def drain(self) -> Tuple[bytes, bytes]:
         return (self._drain(ST_DATA_AV, REG_RESPONSE, "response"),
                 self._drain(ST_STAT_AV, REG_STATUS, "status"))
+
+    def probe_drain(self, command: bytes, cap: int) -> Tuple[int, bool, bytes]:
+        """Push one command and pull bytes until DATA_AV clears or `cap` is hit.
+
+        Returns how many bytes the queue handed out, whether DATA_AV cleared,
+        and the last few of them, which say whether the queue was repeating
+        itself. `transact` cannot be used for this: it drains on the flag, so a
+        reply that never ends would never come back.
+
+        uci_native.NativeUci offers the same method, taken by the 6510 rather
+        than by DMA, so a test can make this measurement down either route.
+        """
+        self.release()
+        self.require_idle("before the probe read")
+        self.push(command)
+        self.wait_for_reply(command)
+        out = bytearray()
+        while self.status() & ST_DATA_AV:
+            out.append(self.peek(REG_RESPONSE))
+            if len(out) >= cap:
+                break
+        cleared = not (self.status() & ST_DATA_AV)
+        self._drain(ST_STAT_AV, REG_STATUS, "status")
+        # Writing DATA_ACC leaves the data state whether or not the queue
+        # emptied, so the interface is usable again even after a block that
+        # never ended.
+        self.control(CTRL_DATA_ACC)
+        self.release()
+        return len(out), cleared, bytes(out[-6:])
 
     # -- one command --------------------------------------------------------
 

--- a/tests/e2e/lib/uci_native.py
+++ b/tests/e2e/lib/uci_native.py
@@ -36,6 +36,7 @@ OPT_OVR = 0xC004
 OPT_MAXB = 0xC005
 OPT_CAP = 0xC006
 READY = 0xC008
+OPT_ABRT = 0xC009
 CMDBUF = 0xC010
 
 RESULT_BASE = 0xC400
@@ -110,15 +111,19 @@ class NativeUci:
 
     # -- one command --------------------------------------------------------
 
-    def _run(self, command: bytes, overrun_reads: int, cap: int) -> Tuple[bytes, bytes]:
+    def _run(self, command: bytes, overrun_reads: int, cap: int,
+             max_blocks: int = MAX_BLOCKS, abort_first: bool = False) -> Tuple[bytes, bytes]:
         """Hand one command to the agent and return (result block, payload)."""
         if len(command) > CMD_QUEUE_BYTES:
             raise Failure(f"a command of {len(command)} bytes does not fit the command queue")
         self.machine.writemem(CMDBUF, command)
         self.machine.writemem(CMDLEN, bytes([
             len(command) & 0xFF, (len(command) >> 8) & 0xFF,
-            min(overrun_reads, MAX_OVERRUN_READS), MAX_BLOCKS,
+            min(overrun_reads, MAX_OVERRUN_READS), max_blocks,
             cap & 0xFF, (cap >> 8) & 0xFF]))
+        # Outside the option block above, so it is written every time rather
+        # than left over from the previous transaction.
+        self.machine.writemem(OPT_ABRT, bytes([0x01 if abort_first else 0x00]))
         self.machine.writemem(GO, bytes([0x01]))
 
         deadline = time.time() + self.busy_timeout
@@ -222,11 +227,32 @@ class NativeUci:
         Returns how many bytes the queue handed out, whether DATA_AV cleared,
         and the last few of them, which say whether the queue was repeating
         itself. This is the same measurement uci.Uci.probe_drain makes, taken
-        by the 6510 instead of by DMA.
+        by the 6510 instead of by DMA, and like that one it measures the first
+        reply block: the agent is told to follow no further one, so a reply
+        announced as Data More is counted here as the block it started with.
         """
-        block, payload = self._run(command, 0, cap)
+        block, payload = self._run(command, 0, cap, max_blocks=1)
         flags = self._byte(block, R_FLAGS)
         if flags & FLAG_WAIT_TIMEOUT:
             raise Failure(f"command {command.hex(' ')} never left Command Busy")
         cleared = not (flags & FLAG_DRAIN_CAP)
         return len(payload), cleared, payload[-6:]
+
+    # -- abort --------------------------------------------------------------
+
+    def probe_abort(self, command: bytes) -> Tuple[int, bool]:
+        """Push one command, take its first reply block, then abandon it.
+
+        The same measurement uci.Uci.probe_abort makes: how many bytes that
+        first block carried, and whether the interface came back to Idle.
+        """
+        block, payload = self._run(command, 0, DEFAULT_DRAIN_CAP,
+                                   max_blocks=1, abort_first=True)
+        flags = self._byte(block, R_FLAGS)
+        if flags & FLAG_WAIT_TIMEOUT:
+            raise Failure(f"command {command.hex(' ')} never left Command Busy, or the "
+                          f"interface never returned to Idle after the abort; CTRL was "
+                          f"{describe_status(self._byte(block, R_FINAL))}")
+        final = self._byte(block, R_FINAL)
+        idle = (final & ST_STATE_MASK) == ST_STATE_IDLE and not (final & ST_ERROR)
+        return len(payload), idle

--- a/tests/e2e/lib/uci_native.py
+++ b/tests/e2e/lib/uci_native.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Drive the Ultimate Command Interface from 6502 code running on the C64.
+
+`uci.Uci` reaches $DF1C-$DF1F through machine:readmem / machine:writemem, which
+are DMA cycles the Ultimate issues on the cartridge bus. This module reaches the
+same registers the way a real program does: ordinary loads and stores executed
+by the 6510, at bus speed, with no DMA involved.
+
+The 6502 side is `tests/e2e/io/command_interface/uci_agent.asm`, assembled here
+with the repository's own 64tass and started over runners:run_prg. The host
+writes a command block into C64 memory, sets one byte to start it, polls one
+byte until it finishes, and reads the whole result back in one bulk readmem.
+That is a handful of REST calls per command however large the reply, where the
+DMA route costs one call per byte of it.
+
+`NativeUci` exposes the same `transact` and `probe_drain` as `uci.Uci`, so a
+test can run the same scenario down either route.
+"""
+
+import os
+import time
+from typing import List, Optional, Tuple
+
+from assembler import assemble
+from report import Failure, detail
+from uci import (BUSY_TIMEOUT_SECONDS, CMD_QUEUE_BYTES, Reply, ST_ERROR,
+                 ST_STATE_DATA_LAST, ST_STATE_IDLE, ST_STATE_MASK, Transaction,
+                 describe_status)
+
+# These mirror uci_agent.asm. They are the interface between the two halves and
+# have to be changed together.
+GO = 0xC000
+SEQ = 0xC001
+CMDLEN = 0xC002
+OPT_OVR = 0xC004
+OPT_MAXB = 0xC005
+OPT_CAP = 0xC006
+READY = 0xC008
+CMDBUF = 0xC010
+
+RESULT_BASE = 0xC400
+RESULT_BYTES = 0x200            # covers the result block and the status text
+R_FIRST = 0xC400
+R_BLOCKS = 0xC401
+R_DLEN = 0xC402
+R_SLEN = 0xC404
+R_FINAL = 0xC405
+R_FLAGS = 0xC406
+R_OVRN = 0xC410
+R_BSTAT = 0xC420
+R_BLEN = 0xC430
+STATBUF = 0xC500
+DATABUF = 0x2000
+
+FLAG_WAIT_TIMEOUT = 0x01
+FLAG_DRAIN_CAP = 0x02
+FLAG_STATUS_CAP = 0x04
+
+AGENT_READY = 0xA5
+# What the agent is allowed to pull from the response queue when the caller has
+# no opinion. Above the 896-byte queue, so an over-long reply shows up as a
+# measurement rather than being cut to the expected size.
+DEFAULT_DRAIN_CAP = 4096
+# How many reply blocks and overrun bytes the result block has room for.
+MAX_BLOCKS = 8
+MAX_OVERRUN_READS = 16
+
+AGENT_SOURCE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..", "io", "command_interface", "uci_agent.asm")
+
+START_TIMEOUT_SECONDS = 20.0
+POLL_SECONDS = 0.02
+
+
+class NativeUci:
+    """The command interface as the C64 sees it, driven by the resident agent."""
+
+    def __init__(self, machine, runners,
+                 busy_timeout: float = BUSY_TIMEOUT_SECONDS) -> None:
+        # `machine` and `runners` are tests/lib/api.py MachineApi and RunnersApi
+        # for the machine whose bus the registers are on.
+        self.machine = machine
+        self.runners = runners
+        self.busy_timeout = busy_timeout
+        self._sequence = 0
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self) -> None:
+        """Assemble the agent, run it, and wait for it to say it is alive."""
+        prg = assemble(AGENT_SOURCE)
+        detail(f"assembled uci_agent.asm: {len(prg)} bytes, load address "
+               f"${int.from_bytes(prg[:2], 'little'):04X}")
+        status, _, body = self.runners.upload("run_prg", prg)
+        if status != 200:
+            raise Failure(f"runners:run_prg returned HTTP {status}: {body[:160]!r}")
+        deadline = time.time() + START_TIMEOUT_SECONDS
+        while True:
+            if self.machine.readmem(READY, 1)[0] == AGENT_READY:
+                break
+            if time.time() > deadline:
+                raise Failure(
+                    f"the 6502 agent did not report ready within "
+                    f"{START_TIMEOUT_SECONDS:.0f}s; ${READY:04X} never became "
+                    f"${AGENT_READY:02X}")
+            time.sleep(POLL_SECONDS)
+        self._sequence = self.machine.readmem(SEQ, 1)[0]
+        detail("the 6502 agent is resident and idle")
+
+    # -- one command --------------------------------------------------------
+
+    def _run(self, command: bytes, overrun_reads: int, cap: int) -> Tuple[bytes, bytes]:
+        """Hand one command to the agent and return (result block, payload)."""
+        if len(command) > CMD_QUEUE_BYTES:
+            raise Failure(f"a command of {len(command)} bytes does not fit the command queue")
+        self.machine.writemem(CMDBUF, command)
+        self.machine.writemem(CMDLEN, bytes([
+            len(command) & 0xFF, (len(command) >> 8) & 0xFF,
+            min(overrun_reads, MAX_OVERRUN_READS), MAX_BLOCKS,
+            cap & 0xFF, (cap >> 8) & 0xFF]))
+        self.machine.writemem(GO, bytes([0x01]))
+
+        deadline = time.time() + self.busy_timeout
+        while True:
+            sequence = self.machine.readmem(SEQ, 1)[0]
+            if sequence != self._sequence:
+                self._sequence = sequence
+                break
+            if time.time() > deadline:
+                raise Failure(
+                    f"the 6502 agent did not finish {command.hex(' ')} within "
+                    f"{self.busy_timeout:.0f}s. It is either wedged in the command "
+                    f"interface or no longer running; ${READY:04X} reads "
+                    f"${self.machine.readmem(READY, 1)[0]:02X}")
+            time.sleep(POLL_SECONDS)
+
+        block = self.machine.readmem(RESULT_BASE, RESULT_BYTES)
+        length = int.from_bytes(self._at(block, R_DLEN, 2), "little")
+        payload = self.machine.readmem(DATABUF, length) if length else b""
+        return block, payload
+
+    @staticmethod
+    def _at(block: bytes, address: int, count: int = 1) -> bytes:
+        """The `count` bytes the agent wrote at `address`."""
+        start = address - RESULT_BASE
+        return block[start:start + count]
+
+    def _byte(self, block: bytes, address: int) -> int:
+        return self._at(block, address)[0]
+
+    def transact(self, command: bytes, single_part: bool = True,
+                 overrun_reads: int = 0) -> Transaction:
+        """Push one command and collect everything the reply exposes.
+
+        The same contract as uci.Uci.transact. The agent already followed a
+        Data More reply through its blocks, so this only unpacks what it
+        recorded.
+        """
+        started = time.time()
+        block, payload = self._run(command, overrun_reads, DEFAULT_DRAIN_CAP)
+        elapsed = time.time() - started
+        flags = self._byte(block, R_FLAGS)
+        if flags & FLAG_WAIT_TIMEOUT:
+            raise Failure(f"command {command.hex(' ') or '<empty>'} never left Command Busy: "
+                          f"the agent gave up waiting, CTRL was "
+                          f"{describe_status(self._byte(block, R_FIRST))}")
+        if flags & FLAG_DRAIN_CAP:
+            raise Failure(
+                f"the response queue did not stop after {len(payload)} bytes; DATA_AV was "
+                f"still set when the agent reached its cap. Use probe_drain to measure that")
+        if flags & FLAG_STATUS_CAP:
+            raise Failure(f"the status text of {command.hex(' ')} was longer than the "
+                          f"agent's buffer, so what it reported is truncated")
+
+        # The agent counts every block it saw but only has room to describe
+        # MAX_BLOCKS of them, so reading further would be reading the reserved
+        # area rather than a block.
+        count = min(self._byte(block, R_BLOCKS), MAX_BLOCKS)
+        if count == 0:
+            raise Failure(f"the agent recorded no reply block for {command.hex(' ')}")
+        first_status = self._byte(block, R_FIRST)
+        if single_part and (first_status & ST_STATE_MASK) != ST_STATE_DATA_LAST:
+            raise Failure(
+                f"command {command.hex(' ')} replied in state {describe_status(first_status)}; "
+                f"this reply is sent in one part, so the state has to be Data Last")
+
+        text = self._at(block, STATBUF, self._byte(block, R_SLEN))
+        overrun = self._at(block, R_OVRN, min(overrun_reads, MAX_OVERRUN_READS))
+
+        blocks: List[Reply] = []
+        previous = 0
+        for index in range(count):
+            cumulative = int.from_bytes(self._at(block, R_BLEN + index * 2, 2), "little")
+            status_byte = self._byte(block, R_BSTAT + index)
+            # The agent appends every block's status text to one buffer, so the
+            # whole text belongs to the transaction rather than to a block. It
+            # is reported on the last one, which is where uci.Transaction reads
+            # a command's result from.
+            last = index == count - 1
+            blocks.append(Reply(status_byte, payload[previous:cumulative],
+                                text if last else b"",
+                                overrun if index == 0 else b""))
+            previous = cumulative
+
+        # The same assertion uci.Uci.transact makes with require_idle: a reply
+        # that has been accepted must leave the interface idle and unflagged.
+        final = self._byte(block, R_FINAL)
+        if (final & ST_STATE_MASK) != ST_STATE_IDLE or (final & ST_ERROR):
+            raise Failure(f"the interface was {describe_status(final)} after the reply to "
+                          f"{command.hex(' ')} was accepted, expected Idle")
+        detail(f"{command.hex(' ') or '<empty>'} -> {elapsed:.2f}s, {count} block(s), "
+               f"data {blocks[0].data[:32]!r}{'...' if len(blocks[0].data) > 32 else ''}, "
+               f"status {blocks[-1].status_text!r}")
+        return Transaction(command, blocks, final, elapsed)
+
+    # -- raw drain ----------------------------------------------------------
+
+    def probe_drain(self, command: bytes, cap: int) -> Tuple[int, bool, bytes]:
+        """Push one command and pull bytes until DATA_AV clears or `cap` is hit.
+
+        Returns how many bytes the queue handed out, whether DATA_AV cleared,
+        and the last few of them, which say whether the queue was repeating
+        itself. This is the same measurement uci.Uci.probe_drain makes, taken
+        by the 6510 instead of by DMA.
+        """
+        block, payload = self._run(command, 0, cap)
+        flags = self._byte(block, R_FLAGS)
+        if flags & FLAG_WAIT_TIMEOUT:
+            raise Failure(f"command {command.hex(' ')} never left Command Busy")
+        cleared = not (flags & FLAG_DRAIN_CAP)
+        return len(payload), cleared, payload[-6:]


### PR DESCRIPTION
Fixes the two defects behind #802 in `NetworkTarget::read_socket()`, and returns a complete UDP datagram of up to 1472 bytes by splitting the reply across UCI response blocks. An end-to-end suite fails against the current firmware and passes with this change on both an Ultimate 64 Elite and an Ultimate II+L.

The original report says that `SOCKET_READ` with `maxlen = 1024` returns no data, while the same datagram arrives with `maxlen = 512`. Testing the command directly through `$DF1B-$DF1F` on real hardware showed that two separate bugs are involved.

## What is broken

### 1. The largest accepted read never ends

A reply consists of a two-byte header followed by the payload. A read of 894 bytes therefore produces a 896-byte reply, exactly filling the response queue.

At this size, an FPGA boundary bug causes the response pointer to stop on the final byte while `response_valid` remains asserted. As a result:

- `DATA_AV` never clears.
- Every additional read returns the same final byte.
- A client that drains the response while `DATA_AV` is set loops forever.

The mechanism is in `fpga/io/command_interface/vhdl_source/command_protocol.vhd`. `response_pointer` stops incrementing once it reaches `c_cmd_if_response_buffer_end`, the last byte of the buffer, while `response_valid` stays asserted for as long as `(response_pointer - buffer_addr) < response_length`. At a length of exactly 896 the pointer saturates at offset 895 and that comparison stays true, so the two never agree.

At 893 bytes, the reply is 895 bytes long and drains normally.

Requests of 895 bytes or more were already rejected with:

```text
82,PARAMETER(S) OUT OF RANGE
```

The pending datagram is not consumed. Because the response queue remains empty, a client that reads two header bytes without first checking `DATA_AV` sees two zeroes and interprets them as a zero-length response. That explains the reported "no data" result at 1024 bytes.

The boundary before this change was therefore:

| Requested length | Result |
|---:|---|
| 0-893 | Reply drains normally |
| 894 | Reply never ends |
| 895 or more | Request is rejected on the status channel |

The length limit is not currently documented, which should be corrected separately in the manual.

### 2. Truncated UDP datagrams are reported as successful

When a UDP datagram is larger than the requested length, `lwip_recvfrom()` copies only the requested bytes and discards the rest of the datagram.

For example, reading a 200-byte datagram with a length of 64 previously returned:

- a header containing 64;
- the first 64 payload bytes;
- `00,OK`.

A genuine 64-byte datagram produced exactly the same result. The remaining 136 bytes from the larger datagram are gone, and the next read reports no data.

TCP does not have this problem because it is a stream. The same 200 bytes requested in blocks of 64 are returned as 64, 64, 64 and 8 bytes without loss.

For protocols that require the complete datagram, such as the reporter's WireGuard implementation, silent truncation makes a valid but oversized datagram indistinguishable from a corrupted one.

## What this change does

The firmware change is limited to `NetworkTarget::read_socket()` and the three fields of continuation state it needs.

### Return a datagram larger than one response block

`SOCKET_READ` now accepts lengths up to 1472 bytes. That is the largest UDP payload that can reach the device: 1500 bytes of Ethernet MTU less 20 bytes of IPv4 header and 8 bytes of UDP header. `IP_REASSEMBLY` is 0 in `software/network/config/lwipopts.h`, so a larger datagram arrives as fragments that are dropped before any socket sees them.

A reply whose payload does not fit one response block is handed back over the command interface's existing `Data More` mechanism, rather than by enlarging the FPGA response queue. The first block carries the two-byte header and the first 893 payload bytes; the continuation block carries the remaining payload and nothing else. The two-byte header is the total number of payload bytes the command returns, not the number in the first block, so a client that concatenates the blocks holds exactly the reply a large enough queue would have delivered in one.

For a 1420-byte datagram read with `maxlen = 1472`, the blocks measured on hardware are 895 and 527 bytes.

The whole payload is received once, while `SOCKET_READ` runs, into a buffer that outlives the call. A continuation block never goes back to the socket, because a second receive on a datagram socket would take the next datagram rather than the rest of this one.

### Keep every response block short enough to drain

No block the firmware builds exceeds 895 bytes:

- the first block is `2 + min(payload, 893)` bytes, so at most 895;
- a continuation block is at most 895 payload bytes;
- the largest accepted read is 1472 bytes, which is two blocks of 895 and 579.

Requests above 1472 continue to return:

```text
82,PARAMETER(S) OUT OF RANGE
```

### Report UDP truncation

`lwip_recv()` is replaced with `lwip_recvmsg()` using a single `iovec`.

For UDP sockets, `lwip_recvmsg()` reports the original datagram length and sets `MSG_TRUNC` when the supplied buffer is too small. The command still copies no more than the requested number of bytes, but now reports:

```text
04,DATAGRAM TRUNCATED: <original length>
```

For TCP sockets, the new call resolves to the same underlying TCP receive path as before.

Truncation and continuation compose. A 1200-byte datagram read with `maxlen = 1000` returns exactly 1000 payload bytes, split over two blocks, with a header of 1000 and status `04,DATAGRAM TRUNCATED: 1200`. The header stays the number of bytes the reply carries; the datagram's original length is reported only in the status text.

## Continuation state and abort

`NetworkTarget` holds three fields: the total payload length, how much of it has already been placed in a block, and the status to report on the block that ends the reply. There is no per-socket state.

- `parse_command()` drops any pending reply before it runs a command, so no path into this target can hand a client bytes left over from an earlier read.
- `get_more_data()` serves the next block from the buffer and clears the state when it emits the last one. With nothing pending it returns the existing `03,MORE DATA NOT SUPPORTED`, which is what a client asking for a block that was never announced used to get in every case.
- `abort()` discards the state.

`abort()` also changes signature. `CommandTarget` declares `abort(int)`, and `NetworkTarget` declared `abort(void)`, which overloads rather than overrides. A client's abort therefore reached the base class no-op and never reached this target. It now takes the `int` and overrides.

The status channel carries one result per command rather than one per block: an intermediate block leaves the status queue empty, and the block that ends the reply carries the text. A client that appends the status of every block ends up with exactly the text a single-block reply would have given it.

The command interface only accepts a command while it is idle, so a reply that is still being handed out cannot be interrupted by a new one. `parse_command()` clears the state anyway, which covers the one path that ends an exchange without an abort: a command sent with the no-reply bit set, where `run_task()` writes `HANDSHAKE_RESET` instead of a reply.

## Backwards compatibility

Requests up to 893 bytes are unchanged. The reply is a single block announced as `Data Last`, byte for byte what it was before, and a client that does not understand `Data More` never sees it.

Requests above 893 did not previously constitute a working operation, so introducing `Data More` for 894-1472 does not break a single-block contract that anyone could have relied on:

- 894 produced a reply that never terminates, which no protocol-compliant client can consume;
- 895 and above were rejected on the status channel.

The reference client, `ultimateii-dos-lib`, requests 892 bytes (`DATA_QUEUE_SZ - 4`) and is unaffected.

There are two intentional differences in behaviour:

1. A request of 894 to 1472 bytes now returns data across two blocks, where 894 used to hang and 895 and above were rejected.
2. A truncated UDP datagram now returns status `04` instead of incorrectly returning `00,OK`. Status code `04` was previously unused, so a client that ignores the status text receives the same payload bytes as before.

The header format is deliberately unchanged. `uci/network_target.rst` defines it as the number of bytes actually read, and existing clients use that value to locate the end of the returned payload.

## TCP

`read_socket()` does not look at the socket type, so a stream read is split over blocks by the same code. A TCP read with a length above 893 now returns up to that many bytes in one command instead of being rejected. Measured on both devices: 1420 bytes sent over TCP and read with `maxlen = 1472` come back in one command as blocks of 895 and 527.

Nothing else about TCP changes. `MSG_TRUNC` is never set on a stream, so a stream read is never reported as truncated, and repeated reads of less than is pending still lose nothing.

The 1472-byte ceiling applies to TCP as well, although a stream has no datagram size to derive it from. That is deliberate: the limit is what one receive buffer holds, TCP previously stopped at 893, and raising the stream case further would need a larger buffer and more blocks without a bound to justify the number.

## Alternatives considered

### Report the original datagram length in the reply header

This would avoid introducing a new status code, but it would change the meaning of the header. A header larger than the returned payload could also cause existing clients to read beyond the available data.

The header therefore remains the number of bytes actually returned.

### Clamp oversized requests

A request above the supported limit could be silently reduced to 1472 bytes. This was rejected because the interface already reports an explicit out-of-range error and leaves the pending datagram untouched.

Clamping would silently change the meaning of the caller's request and could cause the datagram to be truncated instead.

### Fix the response queue in the FPGA

The endless reply originates in the shared FPGA command interface. Fixing it there would allow a 896-byte block.

However, that requires a new bitstream for every affected product, and devices already in the field would retain the bug until reflashed. There is also no existing testbench for this block.

The software invariant that no block exceeds 895 bytes protects all devices immediately. The underlying FPGA issue should still be fixed separately.

### Support datagrams above 1472 bytes

Datagrams up to 1472 bytes reach the device, while 1473-byte datagrams do not, because IP reassembly is disabled in lwIP. Enabling it affects every network service on the device rather than only `SOCKET_READ`, so it is outside the scope of this change. Fragmented datagrams and 64 KiB datagrams remain unsupported.

### Per-socket continuation state

Continuation is transaction-level rather than per-socket. The command interface serves one exchange at a time and will not accept a command while a reply is outstanding, so a second socket cannot have a reply in flight concurrently. Per-socket state would add bookkeeping with nothing to track.

### Fix the similar HTTP target case here

Code inspection shows that `http_target.cc` can also produce response blocks of exactly 896 bytes and may therefore reach the same FPGA boundary.

That path has not yet been measured on hardware. It is being reported separately rather than expanding this focused fix based only on code inspection.

## How it was tested

The end-to-end suite `tests/e2e/io/command_interface/net_target_test.py` is registered in `run-tests` as `uci-net-target`.

Every scenario runs twice, once down each way of reaching the registers:

- **rest**: `machine:readmem` and `machine:writemem`, which the Ultimate performs as DMA cycles on the cartridge bus.
- **native**: a small resident 6502 agent, `uci_agent.asm`, assembled on the fly with `tools/64tass` and started over `runners:run_prg`. It writes commands to `$DF1D` and drains the queues through ordinary 6510 loads from `$DF1E` and `$DF1F`.

The native route is how a program actually uses the interface. Its register accesses are microseconds apart rather than tens of milliseconds, so it exercises a timing envelope the DMA route cannot reach. The agent already followed a `Data More` reply through its blocks; this change adds an option that abandons a reply after its first block, so both routes can make the same abort measurement.

The host acts as the device's network peer:

1. It opens a UDP socket and TCP listener.
2. The device opens sockets back to the host.
3. The device sends a packet so the test can discover its ephemeral source port.
4. The host returns payloads in which every byte identifies its own offset.
5. The suite verifies the returned length, payload, status and queue state.

Because every byte names its own offset, a continuation block written from the wrong offset, or one that repeats or drops bytes, shows up as wrong data rather than as a plausible reply.

### Scenarios

| Scenario | What it establishes |
|---|---|
| `read-length-limit` | The accepted maximum, found by bisection, is 1472; 1473 is refused on the status channel and the boundary is sharp |
| `reply-blocks-are-drainable` | The first block of a read of 893, 894 and 1472 bytes ends, and no block reaches 896 |
| `datagram-spans-reply-blocks` | Datagrams of 893, 894, 1420 and 1472 bytes arrive complete with `00,OK`; 893 arrives in one block, the rest in blocks that each end |
| `datagram-size-ceiling` | Datagrams up to 1472 bytes reach the device and larger ones do not |
| `udp-truncation-is-detectable` | A 200-byte datagram read at 64 is distinguishable from a genuine 64-byte one |
| `truncation-spans-reply-blocks` | A 1200-byte datagram read at 1000 returns exactly 1000 bytes over two blocks with `04,DATAGRAM TRUNCATED: 1200`, and the remainder is gone |
| `tcp-read-is-lossless` | Stream reads below and above one block lose nothing, cross a block boundary, and are never reported as truncated |
| `oversize-request-keeps-the-datagram` | A refused request of 1473 does not consume the pending datagram |
| `multi-block-state-does-not-leak` | A reply abandoned after its first block returns the interface to Idle, and the next command is answered normally; so is the command after a reply that completed |

### Red/green hardware results

Both halves compare builds of this branch: one containing the suite but not the firmware change, one containing both.

| Device | Routes | Without the change | With the change |
|---|---|---|---|
| Ultimate 64 Elite, firmware 3.15, FPGA 123, core 1.4E | rest and native | 6 of 9 scenarios fail on each route, 176s | 73 checks pass, 330s |
| Ultimate II+L, firmware 3.15, FPGA 123, in a C64 Ultimate | rest only | 5 of 9 scenarios fail, 157s | 39 checks pass, 313s |

The failing scenarios without the change are `read-length-limit`, `reply-blocks-are-drainable`, `datagram-spans-reply-blocks`, `truncation-spans-reply-blocks`, `multi-block-state-does-not-leak`, and on the Ultimate 64 also `tcp-read-is-lossless`.

The three that pass both before and after are `datagram-size-ceiling`, `udp-truncation-is-detectable` and `oversize-request-keeps-the-datagram`. They bound what the change is allowed to alter: the truncation reporting from the earlier commits on this branch still works, the network stack's own datagram ceiling is unchanged, and a refused request still leaves the pending datagram alone.

The Ultimate II+L red run was recorded before the `tcp-read-is-lossless` scenario gained its stream-above-one-block phase, which is why it shows five failures rather than six. That phase fails without the change for the same reason on both devices: a read of 1472 bytes is rejected.

### The native route is skipped on cartridge targets

On a `cartridge@computer` target the two routes reach different devices, which was measured rather than assumed.

Running both routes against a U2+L in a C64 Ultimate showed the REST route reporting the patched cartridge and the native route reporting an unpatched interface. The host's own command interface claims `$DF1B-$DF1F` from its 6510, so a program running there measures the host rather than the cartridge under test. Disabling the host's command interface does not hand the range over either: the 6510 then reads `$FF`.

DMA is the asymmetry. A `readmem` issued by the host does reach the cartridge, which is why the REST route works on these targets.

The suite therefore runs the native route only on a target that is a single machine, and records the reason when it skips it.

### Other checks

- `uci-targets`, the other suite that shares the `tests/e2e/lib/uci.py` transport, passes unchanged on the Ultimate 64: 37 checks in 33s. The REST response drain now reads `$DF1C-$DF1E` in one `readmem` instead of polling and reading separately, which halves its cost; `$DF1D` has no read side effect in `command_protocol.vhd`, so the drain still gates each byte on `DATA_AV`.
- `network_target.cc` compiles for all four toolchains: Nios II for u64 and u2plus, RISC-V for u64ii and u2pl. On the Ultimate 64 the change costs 504 bytes of text and 12 bytes of BSS.

## Known limitation

If a client sets the data-accepted bit and the abort bit close enough together that the firmware sees both in one interrupt, `CommandInterface::run_task()` runs the abort and then still calls `get_more_data()`, which publishes an empty `Data Last` reply carrying `03,MORE DATA NOT SUPPORTED` instead of leaving the interface idle. This is in the shared command interface, applies to every target, and produces exactly the same reply as before this change, because `get_more_data()` returned that unconditionally. It is not addressed here.
