### PR TITLE
Reduce the U2 application image size

### DIFF
--- a/target/u2/riscv/ultimate/Makefile
+++ b/target/u2/riscv/ultimate/Makefile
@@ -192,7 +192,7 @@ SRCS_IEC = iec_code.iec
 SRCS_NANO = nano_minimal.nan
 
 PATH_INC =  $(addprefix -I, $(VPATH))
-OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-div
+OPTIONS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -ffunction-sections -fdata-sections -nostartfiles -mno-div -msave-restore
 OPTIONS += -gdwarf-2 -Os -DRISCV -DU2 -DOS -DIOBASE=0x10000000 -DU2P_IO_BASE=0x10100000 -DCLOCK_FREQ=50000000 -Wno-write-strings
 COPTIONS = $(OPTIONS) -std=gnu99
 CPPOPT   = $(OPTIONS) -std=gnu++11 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive

--- a/target/u2/riscv/ultimate/linker.x
+++ b/target/u2/riscv/ultimate/linker.x
@@ -109,6 +109,17 @@ SECTIONS
   } > memory
 
 
+  /* Call frame information for the hand-written assembly helpers in libgcc,
+     which carry theirs in .eh_frame rather than in .debug_frame. Without
+     KEEP, --gc-sections drops the section and a debugger cannot unwind a
+     stop taken inside one of those helpers. */
+  .eh_frame :
+  {
+    KEEP (*(.eh_frame))
+    . = ALIGN(4);
+  } > memory
+
+
   /* initialized read/write data, accessed in RAM, placed in ROM, copied during boot */
   .data :
   {


### PR DESCRIPTION
## Summary

The U2 has only 2,720 bytes of application space remaining, which is not enough to accommodate meaningful further firmware growth.

This change increases the available space to 77,264 bytes by enabling RISC-V save/restore helpers for the U2 target. The trade-off is that work limited by the U2's CPU becomes approximately 3% slower.

No source files or features change, and no other product is affected.

## Problem

The U2 application image is 808,288 bytes, while its `FLASH_ID_APPL` partition is 811,008 bytes. This leaves only 2,720 bytes free, or 0.34%.

`tools/app_space.py` already reports this as a warning on every build.

Unlike the U2+, U2+L, U64 and U64-II, the U2 has a hardware-fixed partition size (`w25q_flash.cc:25`, `at45_flash.cc:30`). It is therefore within a few kilobytes of being unable to accept any further firmware growth.

## Change

Only two lines change, both for the U2 target:

- `target/u2/riscv/ultimate/Makefile`: add `-msave-restore` to `OPTIONS`.
- `target/u2/riscv/ultimate/linker.x`: add an output section for `.eh_frame`.

No source file changes. No other target changes.

### What `-msave-restore` does

On RISC-V, `ra` and `s0`-`s11` are callee-saved registers. Every non-leaf function normally emits its own prologue to store the registers it uses and its own epilogue to reload them.

With `-msave-restore`, GCC instead:

- replaces the prologue with `jal t0, __riscv_save_<n>`;
- replaces the function's `ret` with a tail jump to `__riscv_restore_<n>`.

These shared helpers live in libgcc. They use `t0` rather than `ra` because `ra` is one of the registers being saved.

In this image:

- 2,017 call sites use a save helper;
- 1,996 call sites tail-jump to a restore helper;
- the entire helper family occupies 188 bytes.

### Why the linker script also changes

The hand-written libgcc assembly helpers store their call frame information in `.eh_frame`, rather than `.debug_frame`.

The link uses `--gc-sections`, and `.eh_frame` was not named in the linker script, so it was discarded. If a debugger stopped with the program counter inside one of these helpers, it would therefore produce an incorrect backtrace rather than no backtrace.

The new output section retains `.eh_frame` at a cost of 612 bytes.

It also restores discoverable unwind information for the following functions, none of which had any before this change:

- `__divdi3`
- `__udivdi3`
- `__moddi3`
- `__umoddi3`
- `crt0`

## Measured size result

Both builds used the same worktree, commit and CI-pinned toolchain: RISC-V GCC 10.2.0, SHA-256 verified as identical to the CI pin.

| Build | Image | `.text` | `.rodata` | `.data` | Free | Free % |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Without change | 808,288 | 651,952 | 147,448 | 8,888 | 2,720 | 0.34% |
| With change | 733,744 | 576,792 | 147,448 | 8,888 | 77,264 | 9.53% |

The image shrinks by 74,544 bytes, equivalent to 11.5% of `.text`. `.rodata` and `.data` are byte-identical.

The local build also reproduces CI closely:

- CI reported 2,656 bytes free on `test-merge`.
- The local build reported 2,720 bytes free.
- The 64-byte difference is the length of the branch-name string in the generated `gitinfo.h`.

## Evidence that behaviour is unchanged

### Symbol sets

Comparing the two ELFs:

- zero symbols were removed;
- 26 symbols were added;
- all 26 additions are `__riscv_save_0..12` and `__riscv_restore_0..12`.

No other symbol changed identity.

### Call frame information

A representative function was compiled both ways and its `.debug_frame` data compared.

Both versions have the same canonical frame address and register rules. Only the program counter offsets at which those rules take effect change.

Backtraces from application code are therefore unaffected.

### Stack usage

Both versions were compiled with `-fstack-usage`, and all 3,088 functions were compared:

- no frame becomes smaller;
- no frame grows by more than 16 bytes;
- 339 frames grow from 0 to 16 bytes;
- total stack usage across all functions increases from 98,176 to 103,600 bytes.

The worst case for a 20-deep call chain is an additional 320 bytes against a 6,400-byte task stack.

`configCHECK_FOR_STACK_OVERFLOW` is `0`, so there is no runtime stack-overflow detection.

### Hazards checked

The following potential hazards were checked and cleared:

- No function in the U2 build is declared `naked` or `interrupt`.
- There is no `setjmp` or `longjmp`.
- C++ is compiled with `-fno-exceptions`, so nothing unwinds through these frames at runtime.
- The only use of `__builtin_return_address` is a diagnostic in `memory_wrap.cc`.

## Measured performance cost

This change trades execution speed for image size. The cost is real and is documented in full below.

### Static cost

The helpers save registers in groups of four because the ABI requires 16-byte stack alignment.

A function that needs to preserve only `ra` therefore calls `__riscv_save_0`, which also writes `s0`, `s1` and `s2`.

Across the 1,984 functions that are present in both builds and converted by the flag, the number of frame-management instructions actually executed per call changes as follows:

- mean increase: 7.52 instructions;
- median increase: 8 instructions;
- range: -45 to +17 instructions;
- before: 12.26 instructions per call;
- after: 19.77 instructions per call;
- 2.9% of functions execute fewer instructions than before.

### On-device cost

The performance cost was measured on real Ultimate II+L hardware built with the same flag because no U2 classic is available on this bench.

#### Method

- Four measurement blocks were run in the order base, changed, base, changed. This interleaving prevents drift across the run from landing entirely on one arm.
- The device was power-cycled before every block, given a fixed 60-second settling period, and had `/Temp` cleaned identically.
- Firmware identity was confirmed before every block by reading the Git hash from the System Information screen.
- Workloads were run round-robin rather than in separate blocks.
- Three warm-up rounds were discarded.
- Twenty-five measured rounds were run.
- Medians are reported rather than means.
- `dnp_delta` is the time required to build a 255-track DNP image minus the time required to build a 128-track image from the same round. This removes the fixed HTTP round-trip and file-creation costs, leaving only work that scales with the firmware's processing.

| Workload | Base median | Changed median | Difference | Block-to-block noise |
| --- | ---: | ---: | ---: | ---: |
| `create_dnp`, 255 tracks | 2.92156 s | 3.01310 s | **+3.13%** | 0.5% |
| `create_dnp`, 128 tracks | 1.49070 s | 1.53010 s | **+2.64%** | 0.16% |
| `dnp_delta` | 1.43564 s | 1.48874 s | **+3.70%** | 1.4% |
| FTP upload, 1 MB to RAM disk | 2.77507 s | 2.77782 s | +0.10% | 1.0% |
| `create_d81` | 0.26717 s | 0.25720 s | -3.73% | 2%, sign flips between blocks |
| `GET /v1/info`, noise floor | 0.02105 s | 0.02144 s | +1.87% | 11% |

Work limited by the firmware's own CPU is approximately **3% slower**.

Network-bound work is unchanged: the FTP upload difference is +0.10%, against 1.0% run-to-run noise.

The two short workloads at the bottom are within their own noise and are included only for completeness. In particular, the `create_d81` result changes sign between blocks and should not be interpreted as an improvement.

The two baseline blocks agree within 0.6% despite an intervening reflash and power cycle. This is what makes the approximately 3% result meaningful.

## Debuggability

Retaining `.eh_frame` prevents the main debugging regression that `-msave-restore` would otherwise introduce. It also improves unwinding for the libgcc assembly helpers generally.

One residual regression remains and is intentionally not addressed here.

`C_exception_handler` in `riscv_main.c:189` prints `mepc` and nothing else. A fault inside a save or restore helper would therefore report an address in the helper rather than in the function whose prologue faulted.

The only fault class affected is a corrupt stack pointer because these helpers do nothing except load and store through `sp`. In that situation, the remainder of the stack is unusable anyway, so the only additional information lost is one function name.

`print_tasks()` still reports every task's stack high-water mark, which is more useful for diagnosing that failure.

Printing `t0` from the trap path would recover the caller identity. However, that would modify code compiled by every target, so it is deliberately outside the scope of this change.

## Why this applies only to the U2

The U2+, U2+L, U64 and U64-II all have at least 30% of their application space free. They gain nothing from this change and would incur the measured CPU cost without any benefit.

Their binaries therefore remain byte-identical to `test-merge`.

The hardware performance measurements above come from a U2+L image built with the flag, even though this pull request does not ship the flag for the U2+L. This is the strongest hardware evidence available without a U2 classic on the bench, and the limitation is stated explicitly.

The helpers use only plain RV32I loads, stores and jumps. There is therefore no mechanism by which the U2's rvlite core should execute them differently from the U2+L's NEORV32.

That is a reasoned argument, not a measurement.

## Verification

- All four RISC-V targets build: `u2` is changed, while `u2pl` and `u64ii` are unchanged and confirmed byte-identical in size to `test-merge`.
- The two Nios targets cannot be built on this bench, but they are unaffected by construction because only files under `target/u2/` change.
- E2E gate and performance-suite results for the changed firmware are being collected and will be added below.
- The machine-code-monitor suite currently fails on both this branch and `test-merge` because of an unrelated test-harness problem. That problem is fixed separately and is not part of this change.

## Alternatives considered and rejected

Every result below comes from a real clean build, not an estimate.

| Option | Measured saving | Reason rejected |
| --- | ---: | --- |
| Link-time optimisation | 71,264 bytes | Merges all 68 global constructors into one and runs them in reverse link order, as confirmed by disassembly. This reverses the task menu order, `FileType` probe order, embedded image probe order, root browser entries and REST route table. Preserving the order would require `init_priority` on 68 globals across 68 files. It also makes `--wrap` fragile and removes 952 function labels from the image. |
| Own `siscanf` | About 15,660 bytes | Nothing in the firmware directly calls `scanf`, but newlib's `_tzset_unlocked_r` does and therefore retains the entire FILE core. Releasing it would require reimplementing four newlib format strings, including a width-limited negated scanset. A subtle mistake would silently break timezone and DST handling. |
| Replace newlib stdio at its three call sites | 5,584 bytes | Worth doing independently, but `software/httpd` is a submodule, so this requires a fork commit and pointer update. It does not belong in this change. |
| Own `strstr` in `small_printf.cc` | 1,696 bytes | Safe and behaviour-preserving, but requires an `#ifdef __NEWLIB__` guard because glibc declares `strstr` as C++ overloads and the PC targets also compile this file. Better handled separately. |
| `--param case-values-threshold=20` | 1,736 bytes | Affects 31 objects, including `iec_drive.o`, `c1541.o` and `cbmdos_parser.o`, which are on IEC timing paths. It has not been validated on hardware and is therefore not proposed. |
| `-msmall-data-limit=32` | 924 bytes | Safe and has no runtime cost, but the saving is too small to justify carrying it alone. |
| Remove `assembly_search.cc` on U2 | 10,729 bytes | It is not dead code. `AssemblyInGui assembly_gui` registers the live **Assembly 64 / New Search** task-menu entry on U2. Only the keyboard shortcut is guarded by `#ifndef U2`. |
| Remove the SID and MUS player cartridges | 22,966 bytes | Removes features. |
| Remove the embedded MOD module | 16,384 bytes | Removes a feature. |
| Drop the 64-bit division helpers | 5,808 bytes | FatFs uses them because `FF_FS_EXFAT 1` makes `FSIZE_t` 64-bit. Removing them would remove exFAT support. |
| `-fmerge-all-constants` | 256 bytes | GCC documents this as producing non-conforming behaviour because distinct constants may share an address. |
| Compressed instructions (`rv32imc`) | Not measured | The U2's rvlite core does not implement the C extension. This would require a hardware change. |

The following options were also measured and rejected as ineffective or worse:

| Option | Size change |
| --- | ---: |
| `-fno-ident` | 0 |
| `-fipa-icf` | Already enabled by `-Os` |
| `-freorder-blocks-algorithm=simple` | 0 |
| `-fno-align-functions` | 0 |
| `-fno-inline-small-functions` | +24 bytes |
| `-Wl,--sort-section=alignment` | +24 bytes |
| `-fconserve-stack` | +136 bytes |
| `-fno-schedule-insns` and `-fno-schedule-insns2` | +664 bytes |

## Trade-off

Without this change, the U2 has only 2,720 bytes of application space remaining and cannot absorb meaningful further growth.

With this change, it has 77,264 bytes free, while firmware work limited by the U2's own CPU becomes approximately 3% slower.

No source file changes, no feature is removed, and no other product is affected.

If the 3% performance cost is unacceptable, the only alternatives with comparable savings are:

- link-time optimisation, which changes global constructor ordering; or
- removing features.

Both are worse trade-offs and are documented above with measurements.
