### PR TITLE
Measure whether the monitor's UI holds the C64, rather than infer it

### DIFF
--- a/tests/e2e/monitor/monitor_test.py
+++ b/tests/e2e/monitor/monitor_test.py
@@ -2189,12 +2189,7 @@ def run_freeze_toggle_test(session: MonitorSession, live_host: str) -> None:
     usable afterwards in both cases.
     """
     def jiffy_advances() -> bool:
-        first = read_rest_memory(live_host, 0x00A2, 1)[0]
-        for _ in range(12):
-            time.sleep(0.1)
-            if read_rest_memory(live_host, 0x00A2, 1)[0] != first:
-                return True
-        return False
+        return jiffy_clock_advances(live_host)
 
     # Settled, because the branch taken below is decided from this capture.
     # An unsettled one can be read before the refusal popup has drawn, and then
@@ -3581,24 +3576,83 @@ def set_u2_vic_bank(session: MonitorSession, target: int) -> Snapshot:
     raise Failure(f"U2 VIC bank did not reach VIC{target}")
 
 
-def ui_freezes_machine(device_host: str, mode: str) -> bool:
-    """Whether this device stops the C64 while its monitor is on screen.
+JIFFY_POLLS = 12
+JIFFY_POLL_INTERVAL = 0.1
 
-    Asked of the device rather than inferred from its name. A device that
-    offers the `Interface Type` setting can draw its UI as an overlay on a
-    running machine, and does so unless --mode freeze says otherwise. A
-    cartridge has no such setting: its UI is the freezer, whatever the flag
-    says, so every check that depends on a running machine or on a
-    second view of memory has to treat it as frozen.
+
+def jiffy_clock_advances(host: str) -> bool:
+    """Whether the KERNAL jiffy clock at $00A2 is still counting.
+
+    The KERNAL raster interrupt increments it about 60 times a second on a
+    running machine and not at all on a stopped one, so it reports whether the
+    C64 is executing rather than what any setting says it should be doing.
     """
-    if mode == MODE_FREEZE:
-        return True
+    first = read_rest_memory(host, 0x00A2, 1)[0]
+    for _ in range(JIFFY_POLLS):
+        time.sleep(JIFFY_POLL_INTERVAL)
+        if read_rest_memory(host, 0x00A2, 1)[0] != first:
+            return True
+    return False
+
+
+def wait_for_running_machine(host: str, timeout: float = 10.0) -> bool:
+    """Wait for the jiffy clock to start counting after a machine reset.
+
+    `reset_rest_machine` returns as soon as the device accepts the reset, and
+    the KERNAL takes a moment after that to reach the interrupt that drives the
+    clock. Sampling once straight after the reset therefore reads a machine
+    that is running but has not started counting yet.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if jiffy_clock_advances(host):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+
+
+def offers_overlay_setting(device_host: str) -> bool:
+    """Whether the device has an `Interface Type` setting at all."""
     try:
         rest_api(device_host).configs.item("User Interface Settings",
                                            "Interface Type")
     except Failure:
-        return True  # no such setting, so the UI is the freezer
-    return False
+        return False
+    return True
+
+
+def ui_freezes_machine(device_host: str, mode: str,
+                       machine_was_running: bool) -> bool:
+    """Whether this user interface stops the C64 while the monitor is up.
+
+    Measured on the machine rather than inferred from a setting. Owning the
+    `Interface Type` setting only says the device *can* draw its UI over a
+    running machine; whether it actually does also depends on the hardware it
+    finds. An Ultimate 64 draws the overlay only while a display asserts HDMI
+    hot-plug detect (software/application/ultimate/ultimate.cc), and falls back
+    to the freezer without one, so a device set to `Overlay on HDMI` with no
+    display attached holds the machine while the setting says it does not.
+    Every check that needs a running machine, or a second view of memory, then
+    runs against a stopped one.
+
+    The jiffy clock is read through the device's own DMA. That works whether or
+    not the device is holding the machine, while a cartridge's companion
+    computer reads open bus for as long as the cartridge has it.
+
+    `machine_was_running` is the control sample taken before the UI came up. A
+    machine whose KERNAL interrupt was not counting to begin with cannot answer
+    the question, so the old inference is used and the reason is reported.
+    """
+    if mode == MODE_FREEZE:
+        return True
+    if not machine_was_running:
+        inferred = not offers_overlay_setting(device_host)
+        detail(f"the jiffy clock at $00A2 was not counting before the user "
+               f"interface came up, so whether it holds the machine could not "
+               f"be measured; assuming {'frozen' if inferred else 'running'} "
+               f"from the Interface Type setting instead")
+        return inferred
+    return not jiffy_clock_advances(device_host)
 
 
 def run_tests(session: MonitorSession, rest_host: str, mode: str, is_u2: bool,
@@ -3922,8 +3976,9 @@ def run_tests(session: MonitorSession, rest_host: str, mode: str, is_u2: bool,
             run_go_visible_state_test(session, rest_host)
 
     with check("G keeps the monitor open"):
-        if mode == MODE_FREEZE:
-            check_skip("Freeze hands the machine back, which closes the whole user interface")
+        if frozen:
+            check_skip("this user interface holds the machine, and handing it "
+                       "back on G closes the whole user interface")
         else:
             run_go_keeps_monitor_open_test(session, rest_host)
 
@@ -4662,10 +4717,11 @@ def main() -> int:
     # is the only one that can read the memory the monitor is showing: the
     # computer's own DMA reads open bus. Otherwise the computer's live view is
     # the independent oracle.
-    frozen = ui_freezes_machine(device_host, args.mode)
-    memory_host = device_host if frozen else live_host
-
     reset_rest_machine(control, args.password)
+
+    # The control sample for the freeze measurement below, taken while no user
+    # interface is up and the machine is therefore running.
+    machine_was_running = wait_for_running_machine(device_host)
 
     session = None
     try:
@@ -4673,7 +4729,9 @@ def main() -> int:
             args.mode, target.token, args.password, args.timeout,
             telnet_host=device_host, telnet_port=args.port,
         )
-        session = MonitorSession(backend)
+        session = MonitorSession(backend)  # opens the menu and enters the monitor
+        frozen = ui_freezes_machine(device_host, args.mode, machine_was_running)
+        memory_host = device_host if frozen else live_host
         run_tests(session, memory_host, args.mode, is_u2, control,
                   live_host, device_host, live_host, frozen, device_host)
     except Failure as exc:


### PR DESCRIPTION
## Symptom

`machine-code-monitor` fails check `[46] G keeps the monitor open` on both devices
on the bench, deterministically, on all three attempts:

```
[46] G keeps the monitor open ... FAIL (1.754s)
monitor_test: FAIL (menu screen unavailable after ENTER, 487s)
```

## This is not a firmware regression

The check passed on 2026-08-18 against the U64 in both overlay and telnet mode,
during the development of #785. Establishing why it stopped:

- `software/monitor/run_machine_monitor.cc` is byte-identical between that tree and
  test-merge. So is `software/application/ultimate/ultimate.cc`,
  `software/userinterface/userinterface.cc`, `software/io/c64/c64.h`,
  `software/monitor/machine_monitor.cc` and `software/api/route_machine.cc`.
- The only firmware file in that path that differs is `software/io/c64/c64.cc`,
  changed by #805. The U64 build under test does not contain #805, and fails anyway.
- The HDMI condition this turns on has been in `ultimate.cc` since 2018 (`7ccb6c96`).

## Root cause

Measured on the U64 with `Interface Type` set to `Overlay on HDMI`, reading the
KERNAL jiffy clock at `$00A2`:

```
menu closed   jiffy 00a2a7 -> 00a2e4   RUNNING
menu open     jiffy 00a2e6 -> 00a2e6   STOPPED
```

Opening the menu stops the C64, so the hardware overlay is not engaging. The
firmware needs two things to use it (`ultimate.cc:183`): `U64_HDMI_HPD_CURRENT`,
and `getPreferredType() == 1`. The second is satisfied, since
`itype[] = { "Freeze", "Overlay on HDMI" }` (`userinterface.cc:117`) and the device
reports the second value; both `UserInterface` objects share one config store, because
`register_store` returns an existing store by name (`config.cc:103`). So the overlay
is falling back to the freezer.

With the machine frozen, `C64::is_accessible()` is true, and
`run_machine_monitor.cc` deliberately calls `release_host()` and
`release_ownership()` on a Go, which tears the user interface down. That is the
documented, intended behaviour. The suite was asserting against it.

## The defects, in the harness

**1. Frozen-ness was inferred, not measured.** `ui_freezes_machine()` asked whether
the `Interface Type` config item exists. Owning the setting only says the device
*can* draw its menu over a running machine, not that it does. This also mis-selected
`memory_host`, which is the oracle a dozen other checks read memory from.

**2. The check was gated on the mode flag, not on the result.** It skipped only under
`--mode freeze`, while `run_tests()` already carried a `frozen` parameter it did not
consult. On a cartridge, whose menu is always the freezer, the check could not pass
in any mode.

**3. The control sample was taken too early.** `reset_rest_machine()` returns as soon
as the device accepts the reset, and the KERNAL takes longer than that to reach the
interrupt that drives the jiffy clock. A single sample straight after the reset reads
a running machine as stopped. The wait is now bounded and explicit.

## Change

One file. The suite measures the machine rather than reading a setting, using the
same `$00A2` oracle that check `[41]` already trusts, hoisted into a shared helper so
there is one implementation rather than two. Where the measurement cannot speak,
because the clock was not counting to begin with, it falls back to the old inference
and says so in the run rather than silently.

## Verification

Four full runs, each on the firmware named, with the device power-cycled first:

| device | mode | result | `[46]` |
| --- | --- | --- | --- |
| U64 | overlay | OK, 47 checks, 458s, no retries | SKIP, machine measured frozen |
| U64 | telnet | OK, 47 checks, 2185s, no retries | **PASS (7.291s)** |
| U2+L | overlay | OK, 59 checks, 709s, no retries | SKIP, machine measured frozen |
| U2+L | telnet | fails, see below | not reached |

The U64 telnet run is the one that matters most: it shows the check still runs and
passes wherever the machine genuinely keeps running, so this does not skip the
coverage away. The two skips are correct, and each now states why.

## Known limitation, not addressed here

The U2+L telnet lane fails independently of this change, and did so before it. With
this change stashed, three attempts gave `[04]` "Snapshot mismatch after A" and twice
`[03]` "Memory stability failed after PGUP"; with it, `[02]` and `[03]`. It fails both
ways, so it is not caused by this change and not fixed by it.

Root cause established separately: on a U2+L over Telnet the device answers a
keystroke with an echo burst, pauses, and only then redraws. The Assembly view key
was measured taking **2.35s** to repaint, against `TELNET_IDLE_GAP_SECONDS` of 0.15s,
so any check that decides from the snapshot a keystroke returns can read the screen
as it was before the keystroke. Four instances were confirmed on hardware
(`goto()` returning its own prompt box or a pre-jump header, `[03]`'s page keys,
`[04]`'s view key, `[08]`'s cursor move), and the pattern is used at dozens of
assertion sites. That is a transport-level fix rather than a per-check one, so it is
deliberately not bundled in here. The default gate mode is overlay, which is green on
both devices.
