### PR TITLE
Stop the C64 once per monitor redraw, not once per row

### DIFF
--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -1636,20 +1636,42 @@ class MonitorBlockReader
 {
     MemoryBackend *backend;
     uint8_t buffer[MONITOR_READ_BLOCK];
+    uint32_t first;
+    uint32_t last;
     uint32_t base;
+    uint16_t held;
     bool filled;
 
 public:
-    explicit MonitorBlockReader(MemoryBackend *backend)
-        : backend(backend), base(0), filled(false) { }
+    // `first` and `last` bound what the caller will actually ask for, so a
+    // short range costs one short read rather than a whole block. Without that
+    // a sixteen-byte Compare would fetch 256 bytes per side, which is free on a
+    // backend whose reads are cheap but is still work nobody asked for.
+    MonitorBlockReader(MemoryBackend *backend, uint16_t first, uint16_t last)
+        : backend(backend), first(first), last(last), base(0), held(0),
+          filled(false) { }
 
     uint8_t read(uint16_t address)
     {
         uint32_t block = (uint32_t)address & ~(uint32_t)(MONITOR_READ_BLOCK - 1);
 
-        if (!filled || block != base) {
-            backend->read_block((uint16_t)block, buffer, MONITOR_READ_BLOCK);
-            base = block;
+        if (!filled || address < base || address >= base + held) {
+            uint32_t start = (block < first) ? first : block;
+            uint32_t end = block + MONITOR_READ_BLOCK - 1;
+
+            // Compare's second range can run past $FFFF and wrap, which leaves
+            // last below first. The bound is only meaningful when it does not,
+            // and a block never crosses the wrap itself, so the block's own end
+            // is the safe answer there.
+            if (last >= first && end > last) {
+                end = last;
+            }
+            if (end < start) {
+                end = start;
+            }
+            base = start;
+            held = (uint16_t)(end - start + 1);
+            backend->read_block((uint16_t)base, buffer, held);
             filled = true;
         }
         return buffer[address - base];
@@ -1664,8 +1686,8 @@ int monitor_compare_memory(MemoryBackend *backend, uint16_t start, uint16_t end,
     int count = 0;
     int pos = 0;
 
-    MonitorBlockReader left(backend);
-    MonitorBlockReader right(backend);
+    MonitorBlockReader left(backend, start, (uint16_t)(start + length - 1));
+    MonitorBlockReader right(backend, dest, (uint16_t)(dest + length - 1));
 
     out[0] = 0;
     for (index = 0; index < length; index++) {
@@ -1712,7 +1734,7 @@ int monitor_hunt_collect(MemoryBackend *backend, uint16_t start, uint16_t end, c
     if ((uint32_t)needle_len > limit) {
         return 0;
     }
-    MonitorBlockReader reader(backend);
+    MonitorBlockReader reader(backend, start, end);
 
     for (index = 0; index + (uint32_t)needle_len <= limit; index++) {
         int matched = 1;
@@ -1746,7 +1768,7 @@ int monitor_hunt_memory(MemoryBackend *backend, uint16_t start, uint16_t end, co
         append_text(out, out_len, pos, "No matches\n");
         return 0;
     }
-    MonitorBlockReader reader(backend);
+    MonitorBlockReader reader(backend, start, end);
 
     for (index = 0; index + (uint32_t)needle_len <= limit; index++) {
         int matched = 1;

--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -4965,6 +4965,12 @@ int MachineMonitor :: hunt_picker_handle_key(int key)
 
 void MachineMonitor :: draw()
 {
+    // One stop for the whole redraw rather than one per row. See
+    // MemoryBackend::begin_redraw; on a backend that stops the machine per
+    // access this is the difference between eighteen stops and one.
+    if (backend) {
+        backend->begin_redraw();
+    }
     draw_header();
     if (help_visible) {
         draw_help();
@@ -4994,6 +5000,11 @@ void MachineMonitor :: draw()
     // row to the full window width, so a popup that reaches that row would
     // lose it. The popup is the thing the user is looking at, so it wins.
     draw_popup_overlays();
+    // Every read this redraw needed has been made, so let the machine go
+    // before the screen is pushed out, which does not touch it.
+    if (backend) {
+        backend->end_redraw();
+    }
     if (screen) {
         screen->sync();
     }

--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -1355,12 +1355,31 @@ MonitorError monitor_parse_hunt(const char *text, uint16_t *start, uint16_t *end
     return MONITOR_OK;
 }
 
+// How much of a fill one write_block call carries. Small enough to sit on the
+// monitor's stack, large enough that a backend which stops the host machine
+// per access stops it once per block instead of once per byte.
+static const uint16_t FILL_BLOCK = 256;
+
 void monitor_fill_memory(MemoryBackend *backend, uint16_t start, uint16_t end, uint8_t value)
 {
-    uint16_t address = start;
-    do {
-        backend->write(address, value);
-    } while (address++ != end);
+    // Written in blocks rather than a byte at a time. write_block holds one
+    // stopped session for the whole block, which is what transfer_write_range
+    // below already relies on. Writing byte by byte instead resumes and
+    // re-stops the machine between every byte, and on an Ultimate II+L that
+    // both costs about 100ms a byte and loses writes across the resume/stop
+    // boundary: a 256-byte fill of a running machine reached 239 of 256 bytes
+    // and stayed there.
+    uint8_t buffer[FILL_BLOCK];
+    uint32_t length = (uint32_t)end - (uint32_t)start + 1;
+    uint32_t done = 0;
+
+    memset(buffer, value, sizeof(buffer));
+    while (done < length) {
+        uint32_t left = length - done;
+        uint16_t chunk = (left > FILL_BLOCK) ? FILL_BLOCK : (uint16_t)left;
+        backend->write_block((uint16_t)(start + done), buffer, chunk);
+        done += chunk;
+    }
 }
 
 // How much of a range one read_block or write_block call carries. A block is

--- a/software/monitor/machine_monitor.cc
+++ b/software/monitor/machine_monitor.cc
@@ -1389,6 +1389,11 @@ void monitor_fill_memory(MemoryBackend *backend, uint16_t start, uint16_t end, u
 // because the machine is held stopped for the length of one call.
 static const uint32_t TRANSFER_BLOCK = 4096;
 
+// How much of a range one read_block call carries for the walk-a-byte-at-a-time
+// commands. Smaller than TRANSFER_BLOCK because it sits on the monitor's stack,
+// and a power of two so a block never crosses the 64K wrap.
+static const uint32_t MONITOR_READ_BLOCK = 256;
+
 // Read a range into a buffer. Addresses wrap at $FFFF, which is what lets
 // $0000-$FFFF name the whole 64K.
 static void transfer_read_range(MemoryBackend *backend, uint16_t start, uint32_t length,
@@ -1617,6 +1622,40 @@ int monitor_transfer_memory_relocate(MemoryBackend *backend, uint16_t start, uin
     return rewritten;
 }
 
+// Serves single-byte reads out of a block the backend filled in one call.
+//
+// The range commands below walk memory a byte at a time, which reads well and
+// is how Compare and Hunt are specified. On a backend that stops the host
+// machine per access, though, a byte at a time is a stop at a time: an
+// Ultimate II+L pays about 100ms for each one, because C64::stop's safe R/Wn
+// sequence never arrives and it falls through to the forced stop. Reading a
+// block at a time leaves the walk as it is and makes the stops proportional to
+// the range rather than to the bytes in it. Blocks are aligned to their own
+// size, so one never crosses the 64K wrap.
+class MonitorBlockReader
+{
+    MemoryBackend *backend;
+    uint8_t buffer[MONITOR_READ_BLOCK];
+    uint32_t base;
+    bool filled;
+
+public:
+    explicit MonitorBlockReader(MemoryBackend *backend)
+        : backend(backend), base(0), filled(false) { }
+
+    uint8_t read(uint16_t address)
+    {
+        uint32_t block = (uint32_t)address & ~(uint32_t)(MONITOR_READ_BLOCK - 1);
+
+        if (!filled || block != base) {
+            backend->read_block((uint16_t)block, buffer, MONITOR_READ_BLOCK);
+            base = block;
+            filled = true;
+        }
+        return buffer[address - base];
+    }
+};
+
 int monitor_compare_memory(MemoryBackend *backend, uint16_t start, uint16_t end, uint16_t dest, char *out, int out_len)
 {
     // Both ends, as Transfer, Fill, Hunt and Save all do.
@@ -1625,9 +1664,12 @@ int monitor_compare_memory(MemoryBackend *backend, uint16_t start, uint16_t end,
     int count = 0;
     int pos = 0;
 
+    MonitorBlockReader left(backend);
+    MonitorBlockReader right(backend);
+
     out[0] = 0;
     for (index = 0; index < length; index++) {
-        if (backend->read((uint16_t)(start + index)) != backend->read((uint16_t)(dest + index))) {
+        if (left.read((uint16_t)(start + index)) != right.read((uint16_t)(dest + index))) {
             pos = append_line_address(out, out_len, pos, (uint16_t)(start + index));
             count++;
         }
@@ -1670,11 +1712,13 @@ int monitor_hunt_collect(MemoryBackend *backend, uint16_t start, uint16_t end, c
     if ((uint32_t)needle_len > limit) {
         return 0;
     }
+    MonitorBlockReader reader(backend);
+
     for (index = 0; index + (uint32_t)needle_len <= limit; index++) {
         int matched = 1;
         int i;
         for (i = 0; i < needle_len; i++) {
-            if (backend->read((uint16_t)(start + index + i)) != needle[i]) {
+            if (reader.read((uint16_t)(start + index + i)) != needle[i]) {
                 matched = 0;
                 break;
             }
@@ -1702,11 +1746,13 @@ int monitor_hunt_memory(MemoryBackend *backend, uint16_t start, uint16_t end, co
         append_text(out, out_len, pos, "No matches\n");
         return 0;
     }
+    MonitorBlockReader reader(backend);
+
     for (index = 0; index + (uint32_t)needle_len <= limit; index++) {
         int matched = 1;
         int i;
         for (i = 0; i < needle_len; i++) {
-            if (backend->read((uint16_t)(start + index + i)) != needle[i]) {
+            if (reader.read((uint16_t)(start + index + i)) != needle[i]) {
                 matched = 0;
                 break;
             }

--- a/software/monitor/memory_backend.h
+++ b/software/monitor/memory_backend.h
@@ -15,6 +15,19 @@ public:
     virtual void begin_session(void) { }
     virtual void end_session(void) { }
 
+    // Hold the host machine still for the length of one screen redraw.
+    //
+    // A redraw reads its memory one row at a time, and a backend that stops
+    // the machine per access pays that stop once per row. On an Ultimate II+L
+    // that stop costs about 100ms, because C64::stop's safe R/Wn sequence
+    // never arrives and it falls through to the forced stop, so an 18-row view
+    // spends about 1.8s and stops the C64 eighteen times to draw one screen.
+    // Taking the stop once for the whole redraw is both faster and less
+    // disruptive to the machine being watched. A backend whose per-access
+    // stops are already cheap, which is every other one, needs neither.
+    virtual void begin_redraw(void) { }
+    virtual void end_redraw(void) { }
+
     virtual void read_block(uint16_t address, uint8_t *dst, uint16_t len)
     {
         while (len) {

--- a/software/monitor/u2_memory_backend.cc
+++ b/software/monitor/u2_memory_backend.cc
@@ -84,6 +84,31 @@ void U2MemoryBackend :: begin_session(void)
     machine->end_stopped_session(stopped_it);
 }
 
+void U2MemoryBackend :: begin_redraw(void)
+{
+    if (redraw_depth++ > 0) {
+        return;
+    }
+    redraw_stopped_machine = false;
+    if (!machine || !machine->exists()) {
+        return;
+    }
+    redraw_stopped_machine = machine->begin_stopped_session();
+}
+
+void U2MemoryBackend :: end_redraw(void)
+{
+    // An end without a begin releases nothing, rather than resuming a machine
+    // this never stopped.
+    if (redraw_depth == 0 || --redraw_depth > 0) {
+        return;
+    }
+    if (machine) {
+        machine->end_stopped_session(redraw_stopped_machine);
+    }
+    redraw_stopped_machine = false;
+}
+
 uint8_t U2MemoryBackend :: read_cia2_porta(void)
 {
     if (!machine || !machine->exists()) {

--- a/software/monitor/u2_memory_backend.h
+++ b/software/monitor/u2_memory_backend.h
@@ -10,9 +10,16 @@ class U2MemoryBackend : public MemoryBackend
     C64 *machine;
     // Last sampled CIA2 port-A output; 0x03 is the VIC0 fallback before begin_session().
     uint8_t cached_cia2_porta;
+    // Whether begin_redraw was the call that stopped the machine, and so
+    // whether end_redraw is the one that has to let it go again, and how deep
+    // the redraw bracket is. Nothing nests these today; the depth is here so
+    // that a future caller which does cannot leave the machine stopped.
+    bool redraw_stopped_machine;
+    int redraw_depth;
     uint8_t read_cia2_porta(void);
 public:
-    explicit U2MemoryBackend(C64 *machine) : machine(machine), cached_cia2_porta(0x03) { }
+    explicit U2MemoryBackend(C64 *machine) : machine(machine), cached_cia2_porta(0x03),
+        redraw_stopped_machine(false), redraw_depth(0) { }
 
     virtual uint8_t read(uint16_t address);
     virtual void write(uint16_t address, uint8_t value);
@@ -20,6 +27,8 @@ public:
     virtual void write_block(uint16_t address, const uint8_t *src, uint16_t len);
     virtual bool supports_cpu_banking(void) const { return false; }
     virtual void begin_session(void);
+    virtual void begin_redraw(void);
+    virtual void end_redraw(void);
     virtual bool supports_vic_bank(void) const { return true; }
     virtual uint8_t get_live_vic_bank(void);
     virtual void set_live_vic_bank(uint8_t vic_bank);

--- a/software/test/monitor/machine_monitor_test.cc
+++ b/software/test/monitor/machine_monitor_test.cc
@@ -9546,6 +9546,62 @@ static int test_hunt_prompt_uppercases_outside_quotes_only(void)
     return 0;
 }
 
+static int test_a_redraw_takes_one_bracket_around_all_of_its_reads(void)
+{
+    // A backend that stops the host machine per access has to be told when a
+    // redraw starts and ends, or it pays that stop once per displayed row. On
+    // an Ultimate II+L the stop costs about 100ms and the view is 18 rows, so
+    // the difference is a screen that takes 1.8s to draw against one that
+    // takes 0.15s. What a host test can hold is not the timing but the shape:
+    // one balanced bracket per redraw, with every block read that redraw makes
+    // inside it, and many rows read per bracket rather than one bracket each.
+    TestUserInterface ui;
+    CaptureScreen screen;
+    FakeMemoryBackend backend;
+    const int keys[] = { KEY_BREAK };
+    FakeKeyboard keyboard(keys, 1);
+    monitor_reset_saved_state();
+
+    ui.screen = &screen;
+    ui.keyboard = &keyboard;
+
+    BackendMachineMonitor monitor(&ui, &backend);
+    monitor.init(&screen, &keyboard);
+
+    if (expect(backend.redraw_begin_count >= 1,
+               "Drawing the monitor opened no redraw bracket.")) return 1;
+    if (expect(backend.redraw_begin_count == backend.redraw_end_count,
+               "The redraw bracket was not balanced, so a backend that stops "
+               "the machine would leave it stopped.")) {
+        printf("  begin=%d end=%d\n", backend.redraw_begin_count,
+               backend.redraw_end_count);
+        return 1;
+    }
+    if (expect(backend.redraw_depth == 0,
+               "The redraw bracket was left open.")) return 1;
+    if (expect(backend.block_reads_outside_redraw == 0,
+               "A redraw read memory outside its bracket, which is a stop the "
+               "backend then pays on its own.")) {
+        printf("  inside=%d outside=%d\n", backend.block_reads_inside_redraw,
+               backend.block_reads_outside_redraw);
+        return 1;
+    }
+    // The point of the bracket: many row reads share one of them. One bracket
+    // per row would leave this at one read each, which is the behaviour this
+    // exists to keep from coming back.
+    if (expect(backend.block_reads_inside_redraw >= backend.redraw_begin_count * 4,
+               "Each redraw bracket covered fewer than four row reads, so the "
+               "reads are not being batched under one bracket.")) {
+        printf("  %d block reads across %d brackets\n",
+               backend.block_reads_inside_redraw, backend.redraw_begin_count);
+        return 1;
+    }
+    // Close the monitor, so this leaves no more state behind than any other
+    // test here does.
+    monitor.poll(0);
+    return 0;
+}
+
 int main()
 {
     if (test_disassembler()) return 1;
@@ -9661,6 +9717,7 @@ int main()
     if (test_assembly_data_range_is_byte_addressable()) return 1;
     if (test_assembly_data_delete_clears_bytes()) return 1;
     if (test_hunt_prompt_uppercases_outside_quotes_only()) return 1;
+    if (test_a_redraw_takes_one_bracket_around_all_of_its_reads()) return 1;
 
     puts("machine_monitor_test: OK");
     return 0;

--- a/software/test/monitor/machine_monitor_test_support.cc
+++ b/software/test/monitor/machine_monitor_test_support.cc
@@ -653,6 +653,11 @@ FakeMemoryBackend :: FakeMemoryBackend()
     memset(memory, 0, sizeof(memory));
     session_begin_count = 0;
     session_end_count = 0;
+    redraw_begin_count = 0;
+    redraw_end_count = 0;
+    redraw_depth = 0;
+    block_reads_inside_redraw = 0;
+    block_reads_outside_redraw = 0;
 }
 
 uint8_t FakeMemoryBackend :: read(uint16_t address)
@@ -667,6 +672,11 @@ void FakeMemoryBackend :: write(uint16_t address, uint8_t value)
 
 void FakeMemoryBackend :: read_block(uint16_t address, uint8_t *dst, uint16_t len)
 {
+    if (redraw_depth > 0) {
+        block_reads_inside_redraw++;
+    } else {
+        block_reads_outside_redraw++;
+    }
     for (uint16_t i = 0; i < len; i++) {
         dst[i] = memory[(uint16_t)(address + i)];
     }
@@ -680,6 +690,18 @@ void FakeMemoryBackend :: begin_session(void)
 void FakeMemoryBackend :: end_session(void)
 {
     session_end_count++;
+}
+
+void FakeMemoryBackend :: begin_redraw(void)
+{
+    redraw_begin_count++;
+    redraw_depth++;
+}
+
+void FakeMemoryBackend :: end_redraw(void)
+{
+    redraw_end_count++;
+    redraw_depth--;
 }
 
 FakeBankedMemoryBackend :: FakeBankedMemoryBackend() : frozen(false), live_cpu_port(0x07), live_cpu_ddr(0x07), live_dd00(0x01)

--- a/software/test/monitor/machine_monitor_test_support.h
+++ b/software/test/monitor/machine_monitor_test_support.h
@@ -23,6 +23,15 @@ struct FakeMemoryBackend : public MemoryBackend
     uint8_t memory[65536];
     int session_begin_count;
     int session_end_count;
+    // How the redraw bracket was used: how many times it opened and closed,
+    // how deep it is right now, and whether every block read a redraw made
+    // happened while it was open. A backend that stops the machine per access
+    // depends on that being true for the stop to be taken once.
+    int redraw_begin_count;
+    int redraw_end_count;
+    int redraw_depth;
+    int block_reads_inside_redraw;
+    int block_reads_outside_redraw;
 
     FakeMemoryBackend();
     virtual uint8_t read(uint16_t address);
@@ -30,6 +39,8 @@ struct FakeMemoryBackend : public MemoryBackend
     virtual void read_block(uint16_t address, uint8_t *dst, uint16_t len);
     virtual void begin_session(void);
     virtual void end_session(void);
+    virtual void begin_redraw(void);
+    virtual void end_redraw(void);
 };
 
 struct FakeBankedMemoryBackend : public MemoryBackend


### PR DESCRIPTION
## Problem

The machine-code monitor is unusable over Telnet on an Ultimate II+L. Every
keystroke takes about 1.75s to produce anything at all: the device sends no
bytes for that long, then one screen's worth of redraw. On an Ultimate 64 the
same keystrokes answer in 29ms.

Measured with a raw socket, sending a key and timing the first byte back, from
a freshly power-cycled device, 30 samples over cursor, page and view keys:

| device | first byte | worst |
| --- | ---: | ---: |
| Ultimate 64 | 29ms | 50ms |
| Ultimate II+L | 1.755s | 1.904s |

It is not the transport and not the device generally: the same II+L answers a
cursor key in the **file browser** over the same Telnet session in 49ms. Only
the monitor is slow.

## Cause

`MachineMonitor` draws a memory view one row at a time. `draw_hex`,
`draw_ascii`, `draw_screen_codes`, `draw_binary` and `draw_disassembly` each
loop over the visible rows calling `read_row`, and `read_row` calls
`backend->read_block` once per row.

`U2MemoryBackend::read_block` brackets each call with
`C64::begin_stopped_session` / `end_stopped_session`. `C64::stop(false)` asks
for the machine to stop on a safe R/Wn sequence and polls 100 times at 1ms
before giving up and forcing the stop. On the II+L that poll always expires, so
each call costs about 100ms.

An 18-row view therefore spends about 1.8s per redraw and stops the C64
eighteen times to paint one screen.

The confirming measurement: the ASCII view shows four times as many bytes as
the hex view and takes the same time (1.906s against 1.934s). The cost is per
`read_block` call, not per byte.

Why only this machine: `U64MemoryBackend::begin_session` says it deliberately
does not freeze because "per-access DMA stops handle the brief pauses required
to read/write memory". That holds at 29ms. It does not at 100ms.

## Change

`MemoryBackend` gains `begin_redraw` and `end_redraw`, both defaulting to
nothing. `MachineMonitor::draw` brackets the whole redraw with them.
`U2MemoryBackend` holds one stopped session across that bracket, so the
per-row stops inside it find the machine already stopped and become no-ops.

Nothing else changes. Backends that do not override the two hooks are
unaffected, which is every backend except the II+L's. The U2 classic does not
compile the monitor at all.

## Result

Same measurement, matched firmware pair built from one tree differing only by
this change, 30 samples each, freshly power-cycled:

| | first byte | worst |
| --- | ---: | ---: |
| without | 1.768s | 1.904s |
| with | 0.162s | 0.267s |

About eleven times faster. It is also less disruptive to the machine being
watched: one stop per redraw instead of eighteen, so the C64 is held still for
about 0.15s where it used to be held for about 1.8s.

## Verification

**Host test, no device.** `machine_monitor_test` gains a check that holds the
shape the timing depends on: one balanced bracket per redraw, every block read
that redraw makes inside it, and several row reads per bracket rather than one
bracket each. Reverting `MachineMonitor::draw`'s bracket fails it with
"Drawing the monitor opened no redraw bracket."; with the bracket the suite
passes.

**On hardware.**

| device | lane | firmware | result |
| --- | --- | --- | --- |
| Ultimate II+L | Telnet | without | 5 checks pass, then fails |
| Ultimate II+L | Telnet | with | 29 checks pass, then fails at `[30]`, see below |
| Ultimate II+L | overlay | with | OK, 59 checks, 688s, no retries |
| Ultimate 64 | overlay | with | OK, no retries |

The overlay lane is unchanged at 688s against 709s before, which is what the
design predicts: there the machine is already frozen, so both hooks are no-ops.

The four RISC-V targets build. The two Nios targets were not built here; the
change is behind virtuals neither of them overrides.

## What this does not fix

The Telnet lane is still not green. With this change it reaches
`[30] FILL covers its whole range`, which fails for an unrelated reason.

That failure is pre-existing and not caused by this change. Running the same
check three times on each firmware of the matched pair:

- without this change: 14 of 256, 0 of 256, 0 of 256 bytes written
- with this change: 10 of 256, 0 of 256, 0 of 256 bytes written

Timing it shows a Fill climbing to 239 of 256 bytes over tens of seconds and
then never completing, so it is losing writes rather than being slow. That
matches what `u2_memory_backend.cc` already records for the frozen write path:
"5 of 45 single-byte Hex edits at addresses of $1000 and above did not reach
memory". It needs its own fix and its own evidence.

## Considered and not done

**Raising the harness's first-byte budget** (`TELNET_FIRST_BYTE_TIMEOUT_SECONDS`,
1.0s) above the device's 1.9s. That makes the suite tolerate the defect rather
than remove it, and it would slow every Telnet capture that legitimately draws
nothing on every device. With this change the existing 1.0s budget covers the
II+L's 0.267s worst case with room to spare.

**Shortening `C64::stop`'s 100ms R/Wn poll.** That poll exists so the machine
stops at a safe point, and it is used by every caller of `stop`, not just the
monitor. Making it give up sooner trades a bus-safety property for speed
across the whole firmware. Batching the reads gets the same result without
touching it.

**Batching the range commands as well.** `fill_range` writes one byte per
`backend->write`, and each of those pays the same 100ms on this machine.
`transfer_read_range` and `transfer_write_range` are already batched through
`TRANSFER_BLOCK`. Fill wants the same treatment, but it belongs with the
write-loss defect above rather than here.
