### PR TITLE
Close the UCI network target's sockets on a C64 reset (#808)

### DIFF
--- a/software/io/command_interface/command_intf.cc
+++ b/software/io/command_interface/command_intf.cc
@@ -125,9 +125,14 @@ void CommandInterface :: run_task(void)
 #endif
 		// Checked on every event rather than only on the abort the reset
 		// interrupt posts, so a reset whose post did not fit the queue is
-		// still acted on by the next event that does.
-		if (c64_reset_pending) {
-			c64_reset_pending = false;
+		// still acted on by the next event that does. Read and cleared as one
+		// step, because a reset landing between the two would otherwise be
+		// cleared without ever being told to the targets.
+		portENTER_CRITICAL();
+		bool reset_seen = c64_reset_pending;
+		c64_reset_pending = false;
+		portEXIT_CRITICAL();
+		if (reset_seen) {
 			for(int i=0;i<=CMD_IF_MAX_TARGET;i++)
 				command_targets[i]->c64_reset();
 		}

--- a/software/io/command_interface/command_intf.cc
+++ b/software/io/command_interface/command_intf.cc
@@ -18,6 +18,10 @@ CommandTarget *command_targets[CMD_IF_MAX_TARGET+1];
 
 // Semaphore set by interrupt
 static SemaphoreHandle_t resetSemaphore;
+// Set by the reset interrupt for the server task, which tells the targets on
+// its own thread rather than the reset task's, so a target never hears of the
+// reset while it is in the middle of a command.
+static volatile bool c64_reset_pending;
 
 #define CMD_IF_DEBUG 0
 
@@ -27,6 +31,7 @@ void ResetInterruptHandlerCmdIf()
 {
     BaseType_t woken;
     uint8_t new_flags = CMD_ABORT_DATA;
+    c64_reset_pending = true;
     xSemaphoreGiveFromISR(resetSemaphore, &woken);
     xQueueSendFromISR(cmd_if.queue, &new_flags, &woken);
 }
@@ -126,6 +131,11 @@ void CommandInterface :: run_task(void)
 			}
 			CMD_IF_HANDSHAKE_OUT = HANDSHAKE_RESET;
 			CMD_IF_IRQMASK_CLEAR = CMD_ABORT_DATA;
+			if (c64_reset_pending) {
+				c64_reset_pending = false;
+				for(int i=0;i<=CMD_IF_MAX_TARGET;i++)
+					command_targets[i]->c64_reset();
+			}
 		}
 		if(status_byte & CMD_DATA_ACCEPTED) {
 			if (target != CMD_TARGET_NONE) {

--- a/software/io/command_interface/command_intf.cc
+++ b/software/io/command_interface/command_intf.cc
@@ -18,9 +18,8 @@ CommandTarget *command_targets[CMD_IF_MAX_TARGET+1];
 
 // Semaphore set by interrupt
 static SemaphoreHandle_t resetSemaphore;
-// Set by the reset interrupt for the server task, which tells the targets on
-// its own thread rather than the reset task's, so a target never hears of the
-// reset while it is in the middle of a command.
+// Set by the reset ISR for the server task, so a target is told about the
+// reset between commands rather than during one.
 static volatile bool c64_reset_pending;
 
 #define CMD_IF_DEBUG 0
@@ -123,11 +122,9 @@ void CommandInterface :: run_task(void)
 #if CMD_IF_DEBUG
 		printf("{%b}", status_byte);
 #endif
-		// Checked on every event rather than only on the abort the reset
-		// interrupt posts, so a reset whose post did not fit the queue is
-		// still acted on by the next event that does. Read and cleared as one
-		// step, because a reset landing between the two would otherwise be
-		// cleared without ever being told to the targets.
+		// Checked on every event, so a reset whose queue post was dropped is
+		// still acted on. Read and cleared as one step: a reset landing
+		// between the two would be cleared without ever reaching the targets.
 		portENTER_CRITICAL();
 		bool reset_seen = c64_reset_pending;
 		c64_reset_pending = false;

--- a/software/io/command_interface/command_intf.cc
+++ b/software/io/command_interface/command_intf.cc
@@ -123,6 +123,14 @@ void CommandInterface :: run_task(void)
 #if CMD_IF_DEBUG
 		printf("{%b}", status_byte);
 #endif
+		// Checked on every event rather than only on the abort the reset
+		// interrupt posts, so a reset whose post did not fit the queue is
+		// still acted on by the next event that does.
+		if (c64_reset_pending) {
+			c64_reset_pending = false;
+			for(int i=0;i<=CMD_IF_MAX_TARGET;i++)
+				command_targets[i]->c64_reset();
+		}
 		if(status_byte & CMD_ABORT_DATA) {
 			//printf("Abort received.\n");
 			if (target != CMD_TARGET_NONE) {
@@ -131,11 +139,6 @@ void CommandInterface :: run_task(void)
 			}
 			CMD_IF_HANDSHAKE_OUT = HANDSHAKE_RESET;
 			CMD_IF_IRQMASK_CLEAR = CMD_ABORT_DATA;
-			if (c64_reset_pending) {
-				c64_reset_pending = false;
-				for(int i=0;i<=CMD_IF_MAX_TARGET;i++)
-					command_targets[i]->c64_reset();
-			}
 		}
 		if(status_byte & CMD_DATA_ACCEPTED) {
 			if (target != CMD_TARGET_NONE) {

--- a/software/io/command_interface/command_target.h
+++ b/software/io/command_interface/command_target.h
@@ -44,6 +44,10 @@ public:
     }
     
     virtual void abort(int a) { }
+
+    // The C64 was reset, so whatever program was talking to this target is
+    // gone and can never finish what it started.
+    virtual void c64_reset(void) { }
 };
 
 extern CommandTarget *command_targets[];

--- a/software/io/command_interface/command_target.h
+++ b/software/io/command_interface/command_target.h
@@ -45,8 +45,7 @@ public:
     
     virtual void abort(int a) { }
 
-    // The C64 was reset, so whatever program was talking to this target is
-    // gone and can never finish what it started.
+    // The C64 was reset, so the program talking to this target is gone.
     virtual void c64_reset(void) { }
 };
 

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -209,10 +209,8 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
 		return;
 	}
 
-	// The client's own limit, refused rather than enforced by taking a socket
-	// back: a socket the client still believes it holds must not go away
-	// underneath it. 85 is already what a client sees when there is no socket
-	// to give, so this adds no status a client has to learn.
+	// The client's own limit. Refused rather than reclaimed, with the answer
+	// an exhausted pool already gives. See NET_MAX_SOCKETS.
 	if (socket_count >= NET_MAX_SOCKETS) {
 		*status = &c_status_no_socket;
 		return;
@@ -447,11 +445,9 @@ void NetworkTarget :: close_all_sockets(void)
 
 void NetworkTarget :: c64_reset(void)
 {
-    // The reply is dropped here as well as in abort(), because this hook runs
-    // for a reset whose CMD_ABORT_DATA post did not fit the queue, and that is
-    // exactly the case where abort() is never called. Without it the next
-    // program asking for a further block over Data More would be handed what
-    // is left of the previous program's read.
+    // abort() also drops the reply, but it does not run when the reset's
+    // queue post was dropped. Without this the next program could be handed
+    // what is left of the previous one's read over Data More.
     discard_read_reply();
     close_all_sockets();
 }

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -29,11 +29,13 @@ NetworkTarget::NetworkTarget(int id)
     command_targets[id] = this;
     data_message.message = new uint8_t[CMD_MAX_REPLY_LEN];
     status_message.message = new uint8_t[CMD_MAX_STATUS_LEN];
+    socket_count = 0;
     discard_read_reply();
 }
 
 NetworkTarget::~NetworkTarget()
 {
+    close_all_sockets();
     delete[] data_message.message;
     delete[] status_message.message;
 }
@@ -207,6 +209,14 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
 		return;
 	}
 
+	// Freed before the new socket is taken, so the client never sees the
+	// pool run out before its own limit does.
+	if (socket_count == NET_MAX_SOCKETS) {
+		int oldest = sockets[0];
+		untrack_socket(oldest);
+		lwip_close(oldest);
+	}
+
 	int socket = socket(AF_INET, type, 0);
 	if (socket < 0) {
 		*status = &c_status_no_socket;
@@ -228,6 +238,7 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
         return;
 	}
 
+	track_socket(socket);
 	*reply = &data_message;
 	this->data_message.message[0] = (uint8_t)socket;
 	this->data_message.length = 1;
@@ -283,6 +294,7 @@ void NetworkTarget :: read_socket(Message *command, Message **reply, Message **s
 
     // printf("Reading %d bytes from socket %d resulted in %d\n", length, socketnr, ret);
 	if (ret == 0) {
+		untrack_socket(socketnr);
 		lwip_close(socketnr);
 		*status = &c_status_socket_closed;
 		return;
@@ -366,7 +378,13 @@ void NetworkTarget :: write_socket(Message *command, Message **reply, Message **
 void NetworkTarget :: close_socket(Message *command, Message **reply, Message **status)
 {
     uint8_t socketnr = command->message[2];
-    int result = lwip_close(socketnr);
+    int result = -1;
+    if (owns_socket(socketnr)) {
+        untrack_socket(socketnr);
+        result = lwip_close(socketnr);
+    } else {
+        errno = EBADF;
+    }
     *reply = &c_message_empty;
     if (result < 0) {
         *status = &status_message;
@@ -375,6 +393,47 @@ void NetworkTarget :: close_socket(Message *command, Message **reply, Message **
     } else {
         *status = &c_status_ok;
     }
+}
+
+void NetworkTarget :: track_socket(int socketnr)
+{
+    sockets[socket_count++] = socketnr;
+}
+
+void NetworkTarget :: untrack_socket(int socketnr)
+{
+    for (int i = 0; i < socket_count; i++) {
+        if (sockets[i] == socketnr) {
+            socket_count--;
+            for (; i < socket_count; i++) {
+                sockets[i] = sockets[i + 1];
+            }
+            return;
+        }
+    }
+}
+
+bool NetworkTarget :: owns_socket(int socketnr)
+{
+    for (int i = 0; i < socket_count; i++) {
+        if (sockets[i] == socketnr) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void NetworkTarget :: close_all_sockets(void)
+{
+    for (int i = 0; i < socket_count; i++) {
+        lwip_close(sockets[i]);
+    }
+    socket_count = 0;
+}
+
+void NetworkTarget :: c64_reset(void)
+{
+    close_all_sockets();
 }
 
 void NetworkTarget :: get_more_data(Message **reply, Message **status)

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -8,6 +8,7 @@
 #include "network_target.h"
 #include "network_interface.h"
 #include "socket.h"
+#include "lwip/opt.h"
 #include "netdb.h"
 #include <errno.h>
 #include <stdio.h>
@@ -209,13 +210,6 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
 		return;
 	}
 
-	// The client's own limit. Refused rather than reclaimed, with the answer
-	// an exhausted pool already gives. See NET_MAX_SOCKETS.
-	if (socket_count >= NET_MAX_SOCKETS) {
-		*status = &c_status_no_socket;
-		return;
-	}
-
 	int socket = socket(AF_INET, type, 0);
 	if (socket < 0) {
 		*status = &c_status_no_socket;
@@ -237,8 +231,14 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
         return;
 	}
 
-	// The cap above left room, so this is within the table.
-	track_socket(socket);
+	// The table has room for every socket lwip can create, so this cannot
+	// fail. Refusing rather than writing past the table keeps that a check
+	// instead of an assumption.
+	if (!track_socket(socket)) {
+		*status = &c_status_no_socket;
+		lwip_close(socket);
+		return;
+	}
 	*reply = &data_message;
 	this->data_message.message[0] = (uint8_t)socket;
 	this->data_message.length = 1;
@@ -407,9 +407,20 @@ void NetworkTarget :: close_socket(Message *command, Message **reply, Message **
     }
 }
 
-void NetworkTarget :: track_socket(int socketnr)
+// A socket handed to the client without a table entry would survive a C64
+// reset, which is the defect in #808, so the table must cover every descriptor
+// lwip can return. lwip's NUM_SOCKETS is MEMP_NUM_NETCONN, tested here rather
+// than including lwip's private socket header.
+static_assert(NET_MAX_SOCKETS >= MEMP_NUM_NETCONN,
+              "the socket table is smaller than the number of lwip sockets");
+
+bool NetworkTarget :: track_socket(int socketnr)
 {
+    if (socket_count >= NET_MAX_SOCKETS) {
+        return false;
+    }
     sockets[socket_count++] = socketnr;
+    return true;
 }
 
 void NetworkTarget :: untrack_socket(int socketnr)

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -209,23 +209,22 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
 		return;
 	}
 
-	// Freed before the new socket is taken, so the client never sees the
-	// pool run out before its own limit does. An open that then fails has
-	// still cost the client its oldest socket: the slot only exists once
-	// something has been closed.
-	//
-	// A loop rather than a single test so that track_socket() below is
-	// provably within the table. sockets[NET_MAX_SOCKETS] would be
-	// socket_count itself, so a count that ever exceeded the table would
-	// overwrite the count rather than fail where it could be seen.
-	// untrack_socket() removes exactly the entry named, so this terminates.
-	while (socket_count >= NET_MAX_SOCKETS) {
-		int oldest = sockets[0];
-		untrack_socket(oldest);
-		lwip_close(oldest);
-	}
-
+	// A socket is given up only for one that is going to be handed out, so an
+	// open that fails costs the client nothing. This matters for TCP, where a
+	// refused or unanswered connect() is the ordinary error path rather than
+	// an edge case: a client retrying a connection to a host that is down
+	// would otherwise lose every socket it holds, one per attempt.
 	int socket = socket(AF_INET, type, 0);
+	if (socket < 0 && socket_count >= NET_MAX_SOCKETS) {
+		// The pool is out while this client holds its full share of it, so
+		// the client gives up its oldest and tries once more. Once only: a
+		// second refusal is the rest of the device using the pool rather than
+		// this client, and retrying would close everything the client has for
+		// nothing. Below the cap the answer stays 85, because a pool the
+		// firmware itself filled is not the client's to pay for.
+		close_oldest_socket();
+		socket = socket(AF_INET, type, 0);
+	}
 	if (socket < 0) {
 		*status = &c_status_no_socket;
 		return;
@@ -246,6 +245,18 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
         return;
 	}
 
+	// The cap, applied now that the socket exists and is about to be handed
+	// out. Between socket() above and here the client holds one more than the
+	// cap, which only happens when the pool had room to spare: had it not,
+	// socket() would have failed and taken the evict-and-retry branch.
+	//
+	// A loop rather than a single test so that track_socket() is provably
+	// within the table. sockets[NET_MAX_SOCKETS] would be socket_count
+	// itself, so a count that ever exceeded the table would overwrite the
+	// count rather than fail where it could be seen.
+	while (socket_count >= NET_MAX_SOCKETS) {
+		close_oldest_socket();
+	}
 	track_socket(socket);
 	*reply = &data_message;
 	this->data_message.message[0] = (uint8_t)socket;
@@ -441,6 +452,18 @@ bool NetworkTarget :: owns_socket(int socketnr)
         }
     }
     return false;
+}
+
+void NetworkTarget :: close_oldest_socket(void)
+{
+    // untrack_socket() removes exactly the entry named, so a caller that
+    // loops on socket_count terminates.
+    if (socket_count == 0) {
+        return;
+    }
+    int oldest = sockets[0];
+    untrack_socket(oldest);
+    lwip_close(oldest);
 }
 
 void NetworkTarget :: close_all_sockets(void)

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -213,7 +213,13 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
 	// pool run out before its own limit does. An open that then fails has
 	// still cost the client its oldest socket: the slot only exists once
 	// something has been closed.
-	if (socket_count == NET_MAX_SOCKETS) {
+	//
+	// A loop rather than a single test so that track_socket() below is
+	// provably within the table. sockets[NET_MAX_SOCKETS] would be
+	// socket_count itself, so a count that ever exceeded the table would
+	// overwrite the count rather than fail where it could be seen.
+	// untrack_socket() removes exactly the entry named, so this terminates.
+	while (socket_count >= NET_MAX_SOCKETS) {
 		int oldest = sockets[0];
 		untrack_socket(oldest);
 		lwip_close(oldest);
@@ -447,6 +453,12 @@ void NetworkTarget :: close_all_sockets(void)
 
 void NetworkTarget :: c64_reset(void)
 {
+    // The reply is dropped here as well as in abort(), because this hook runs
+    // for a reset whose CMD_ABORT_DATA post did not fit the queue, and that is
+    // exactly the case where abort() is never called. Without it the next
+    // program asking for a further block over Data More would be handed what
+    // is left of the previous program's read.
+    discard_read_reply();
     close_all_sockets();
 }
 

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -209,22 +209,16 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
 		return;
 	}
 
-	// A socket is given up only for one that is going to be handed out, so an
-	// open that fails costs the client nothing. This matters for TCP, where a
-	// refused or unanswered connect() is the ordinary error path rather than
-	// an edge case: a client retrying a connection to a host that is down
-	// would otherwise lose every socket it holds, one per attempt.
-	int socket = socket(AF_INET, type, 0);
-	if (socket < 0 && socket_count >= NET_MAX_SOCKETS) {
-		// The pool is out while this client holds its full share of it, so
-		// the client gives up its oldest and tries once more. Once only: a
-		// second refusal is the rest of the device using the pool rather than
-		// this client, and retrying would close everything the client has for
-		// nothing. Below the cap the answer stays 85, because a pool the
-		// firmware itself filled is not the client's to pay for.
-		close_oldest_socket();
-		socket = socket(AF_INET, type, 0);
+	// The client's own limit, refused rather than enforced by taking a socket
+	// back: a socket the client still believes it holds must not go away
+	// underneath it. 85 is already what a client sees when there is no socket
+	// to give, so this adds no status a client has to learn.
+	if (socket_count >= NET_MAX_SOCKETS) {
+		*status = &c_status_no_socket;
+		return;
 	}
+
+	int socket = socket(AF_INET, type, 0);
 	if (socket < 0) {
 		*status = &c_status_no_socket;
 		return;
@@ -245,18 +239,7 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
         return;
 	}
 
-	// The cap, applied now that the socket exists and is about to be handed
-	// out. Between socket() above and here the client holds one more than the
-	// cap, which only happens when the pool had room to spare: had it not,
-	// socket() would have failed and taken the evict-and-retry branch.
-	//
-	// A loop rather than a single test so that track_socket() is provably
-	// within the table. sockets[NET_MAX_SOCKETS] would be socket_count
-	// itself, so a count that ever exceeded the table would overwrite the
-	// count rather than fail where it could be seen.
-	while (socket_count >= NET_MAX_SOCKETS) {
-		close_oldest_socket();
-	}
+	// The cap above left room, so this is within the table.
 	track_socket(socket);
 	*reply = &data_message;
 	this->data_message.message[0] = (uint8_t)socket;
@@ -452,18 +435,6 @@ bool NetworkTarget :: owns_socket(int socketnr)
         }
     }
     return false;
-}
-
-void NetworkTarget :: close_oldest_socket(void)
-{
-    // untrack_socket() removes exactly the entry named, so a caller that
-    // loops on socket_count terminates.
-    if (socket_count == 0) {
-        return;
-    }
-    int oldest = sockets[0];
-    untrack_socket(oldest);
-    lwip_close(oldest);
 }
 
 void NetworkTarget :: close_all_sockets(void)

--- a/software/io/network/network_target.cc
+++ b/software/io/network/network_target.cc
@@ -210,7 +210,9 @@ void NetworkTarget :: open_socket(Message *command, Message **reply, Message **s
 	}
 
 	// Freed before the new socket is taken, so the client never sees the
-	// pool run out before its own limit does.
+	// pool run out before its own limit does. An open that then fails has
+	// still cost the client its oldest socket: the slot only exists once
+	// something has been closed.
 	if (socket_count == NET_MAX_SOCKETS) {
 		int oldest = sockets[0];
 		untrack_socket(oldest);
@@ -280,7 +282,13 @@ void NetworkTarget :: read_socket(Message *command, Message **reply, Message **s
     memset(&msg, 0, sizeof(msg));
     msg.msg_iov = &iov;
     msg.msg_iovlen = 1;
-    int ret = lwip_recvmsg(socketnr, &msg, 0);
+    int ret;
+    if (owns_socket(socketnr)) {
+        ret = lwip_recvmsg(socketnr, &msg, 0);
+    } else {
+        errno = EBADF;
+        ret = -1;
+    }
     // The header is the number of bytes this reply carries, which is what the
     // network target document specifies and what existing clients read. On a
     // reply that spans blocks it is still the total, not the part in the first
@@ -356,7 +364,13 @@ void NetworkTarget :: write_socket(Message *command, Message **reply, Message **
     uint8_t *src = &command->message[3];
 
     int length = command->length - 3;
-    int ret = lwip_send(socketnr, src, length, 0);
+    int ret;
+    if (owns_socket(socketnr)) {
+        ret = lwip_send(socketnr, src, length, 0);
+    } else {
+        errno = EBADF;
+        ret = -1;
+    }
     // printf("Writing %d bytes to socket %d resulted in %d\n", length, socketnr, ret);
     // dump_hex_relative(src, length);
 

--- a/software/io/network/network_target.h
+++ b/software/io/network/network_target.h
@@ -28,9 +28,16 @@
 // and never closes otherwise stays open until the device is power cycled, and
 // lwip has 8 UDP control blocks and 16 sockets in total for everything on the
 // device, so a client that loses its handles takes the whole network target
-// down. Opening one more than this closes the oldest, and the target only
-// reads, writes and closes sockets in its table, so a handle that has gone
-// stale cannot reach a socket the firmware opened for itself.
+// down. Opening one more than this is refused with 85, which is the same
+// answer an exhausted pool already gives, and the same shape as
+// TELNET_MAX_SESSIONS in software/network/socket_gui.cc, FTPD_MAX_SESSIONS in
+// software/network/ftpd.cc and MAX_HTTP_CLIENT in the http server.
+//
+// Refused rather than reclaimed on purpose. A client that leaks handles has a
+// bug, and the open it cannot complete is where that bug is: reporting it
+// there is what lets the author find it. Closing the oldest socket instead
+// would keep the leaking client running and move the symptom to some later
+// read or write of a socket it still believed it held.
 // See GideonZ/1541ultimate#808.
 #define NET_MAX_SOCKETS 4
 
@@ -73,14 +80,15 @@ class NetworkTarget : public CommandTarget {
     int read_offset;
     Message *read_status;
 
-    // The sockets this target opened for its client, oldest first. It closes
-    // only these: a handle the client has lost track of may by now be a socket
-    // the firmware opened for itself.
+    // The sockets this target opened for its client, oldest first. It reads,
+    // writes and closes only these: a handle the client has lost track of may
+    // by now be a socket the firmware opened for itself. Any command that
+    // hands the client a socket must therefore track it, or owns_socket()
+    // will refuse the client its own handle.
     int sockets[NET_MAX_SOCKETS];
     int socket_count;
 
     void track_socket(int socketnr);
-    void close_oldest_socket(void);
     void untrack_socket(int socketnr);
     bool owns_socket(int socketnr);
     void close_all_sockets(void);

--- a/software/io/network/network_target.h
+++ b/software/io/network/network_target.h
@@ -80,6 +80,7 @@ class NetworkTarget : public CommandTarget {
     int socket_count;
 
     void track_socket(int socketnr);
+    void close_oldest_socket(void);
     void untrack_socket(int socketnr);
     bool owns_socket(int socketnr);
     void close_all_sockets(void);

--- a/software/io/network/network_target.h
+++ b/software/io/network/network_target.h
@@ -24,10 +24,11 @@
 
 #define NET_CMD_BUFSIZE 2048
 
-// How many sockets one client can hold. Opening past this is refused with 85,
-// as an exhausted lwip pool already answers, so a leak shows on the open that
-// caused it rather than later. Same shape as TELNET_MAX_SESSIONS. See #808.
-#define NET_MAX_SOCKETS 4
+// Room for every socket lwip can hand out, so the table holds whatever this
+// target opens and no client ever meets a limit of its own. lwip's NUM_SOCKETS
+// is MEMP_NUM_NETCONN, which is 16 in software/network/config/lwipopts.h;
+// network_target.cc checks that the two still agree. See #808.
+#define NET_MAX_SOCKETS 16
 
 // The largest payload READ_SOCKET accepts, which is the largest UDP payload
 // that can reach the device: 1500 bytes of Ethernet MTU less 20 bytes of IPv4
@@ -74,7 +75,7 @@ class NetworkTarget : public CommandTarget {
     int sockets[NET_MAX_SOCKETS];
     int socket_count;
 
-    void track_socket(int socketnr);
+    bool track_socket(int socketnr);
     void untrack_socket(int socketnr);
     bool owns_socket(int socketnr);
     void close_all_sockets(void);

--- a/software/io/network/network_target.h
+++ b/software/io/network/network_target.h
@@ -26,9 +26,12 @@
 
 // How many sockets a client can hold open at once. A socket a client opens
 // and never closes otherwise stays open until the device is power cycled, and
-// lwip has MEMP_NUM_UDP_PCB (8) of them for everything on the device, so a
-// client that loses its handles takes the whole network target down. Opening
-// one more than this closes the oldest. See GideonZ/1541ultimate#808.
+// lwip has 8 UDP control blocks and 16 sockets in total for everything on the
+// device, so a client that loses its handles takes the whole network target
+// down. Opening one more than this closes the oldest, and the target only
+// reads, writes and closes sockets in its table, so a handle that has gone
+// stale cannot reach a socket the firmware opened for itself.
+// See GideonZ/1541ultimate#808.
 #define NET_MAX_SOCKETS 4
 
 // The largest payload READ_SOCKET accepts, which is the largest UDP payload

--- a/software/io/network/network_target.h
+++ b/software/io/network/network_target.h
@@ -24,21 +24,9 @@
 
 #define NET_CMD_BUFSIZE 2048
 
-// How many sockets a client can hold open at once. A socket a client opens
-// and never closes otherwise stays open until the device is power cycled, and
-// lwip has 8 UDP control blocks and 16 sockets in total for everything on the
-// device, so a client that loses its handles takes the whole network target
-// down. Opening one more than this is refused with 85, which is the same
-// answer an exhausted pool already gives, and the same shape as
-// TELNET_MAX_SESSIONS in software/network/socket_gui.cc, FTPD_MAX_SESSIONS in
-// software/network/ftpd.cc and MAX_HTTP_CLIENT in the http server.
-//
-// Refused rather than reclaimed on purpose. A client that leaks handles has a
-// bug, and the open it cannot complete is where that bug is: reporting it
-// there is what lets the author find it. Closing the oldest socket instead
-// would keep the leaking client running and move the symptom to some later
-// read or write of a socket it still believed it held.
-// See GideonZ/1541ultimate#808.
+// How many sockets one client can hold. Opening past this is refused with 85,
+// as an exhausted lwip pool already answers, so a leak shows on the open that
+// caused it rather than later. Same shape as TELNET_MAX_SESSIONS. See #808.
 #define NET_MAX_SOCKETS 4
 
 // The largest payload READ_SOCKET accepts, which is the largest UDP payload
@@ -80,11 +68,9 @@ class NetworkTarget : public CommandTarget {
     int read_offset;
     Message *read_status;
 
-    // The sockets this target opened for its client, oldest first. It reads,
-    // writes and closes only these: a handle the client has lost track of may
-    // by now be a socket the firmware opened for itself. Any command that
-    // hands the client a socket must therefore track it, or owns_socket()
-    // will refuse the client its own handle.
+    // The sockets this target opened, oldest first. It reads, writes and
+    // closes only these, so a stale handle cannot reach a socket the firmware
+    // opened for itself. Any command handing out a socket must track it here.
     int sockets[NET_MAX_SOCKETS];
     int socket_count;
 

--- a/software/io/network/network_target.h
+++ b/software/io/network/network_target.h
@@ -24,6 +24,13 @@
 
 #define NET_CMD_BUFSIZE 2048
 
+// How many sockets a client can hold open at once. A socket a client opens
+// and never closes otherwise stays open until the device is power cycled, and
+// lwip has MEMP_NUM_UDP_PCB (8) of them for everything on the device, so a
+// client that loses its handles takes the whole network target down. Opening
+// one more than this closes the oldest. See GideonZ/1541ultimate#808.
+#define NET_MAX_SOCKETS 4
+
 // The largest payload READ_SOCKET accepts, which is the largest UDP payload
 // that can reach the device: 1500 bytes of Ethernet MTU less 20 bytes of IPv4
 // header and 8 bytes of UDP header. IP_REASSEMBLY is 0 in
@@ -63,6 +70,17 @@ class NetworkTarget : public CommandTarget {
     int read_offset;
     Message *read_status;
 
+    // The sockets this target opened for its client, oldest first. It closes
+    // only these: a handle the client has lost track of may by now be a socket
+    // the firmware opened for itself.
+    int sockets[NET_MAX_SOCKETS];
+    int socket_count;
+
+    void track_socket(int socketnr);
+    void untrack_socket(int socketnr);
+    bool owns_socket(int socketnr);
+    void close_all_sockets(void);
+
     void open_socket(Message *command, Message **reply, Message **status, int);
     void read_socket(Message *command, Message **reply, Message **status);
     void write_socket(Message *command, Message **reply, Message **status);
@@ -76,6 +94,7 @@ public:
     void parse_command(Message *command, Message **reply, Message **status);
     void get_more_data(Message **reply, Message **status);
     void abort(int a);
+    void c64_reset(void);
 };
 
 #endif /* IO_NETWORK_NETWORK_TARGET_H_ */

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -138,6 +138,9 @@ OVERRUN_LIMIT = REPLY_QUEUE_BYTES + 128
 # that is already queued and does not wait for one in flight.
 DELIVERY_SETTLE_SECONDS = 0.4
 PEER_TIMEOUT_SECONDS = 10.0
+# How often a lost probe datagram is sent again before the socket is judged
+# unable to reach this host.
+PROBE_ATTEMPTS = 3
 
 # GideonZ/1541ultimate#808: sockets a client opens and never closes. lwip has
 # MEMP_NUM_UDP_PCB = 8 protocol control blocks in total (lwipopts.h), and the
@@ -382,12 +385,24 @@ class Peer:
         The device connects its UDP socket, so it only accepts datagrams from
         the address it connected to, and a reply has to come from this bound
         port back to whatever source port the device chose.
+
+        The probe is a datagram, so it can be lost; seen once in a dozen runs
+        on a wired LAN, with WRITE_SOCKET reporting the bytes as sent. A lost
+        probe is sent again rather than counted against the firmware.
         """
-        net.write(handle, b"PROBE")
-        self.udp.settimeout(PEER_TIMEOUT_SECONDS)
-        _, address = self.udp.recvfrom(2048)
-        self.udp_peer = address
-        return address
+        for attempt in range(PROBE_ATTEMPTS):
+            net.write(handle, b"PROBE")
+            self.udp.settimeout(PEER_TIMEOUT_SECONDS)
+            try:
+                _, address = self.udp.recvfrom(2048)
+            except socket.timeout:
+                detail(f"probe datagram {attempt + 1} of {PROBE_ATTEMPTS} did not arrive "
+                       f"within {PEER_TIMEOUT_SECONDS:.0f}s")
+                continue
+            self.udp_peer = address
+            return address
+        raise Failure(f"no probe datagram arrived from handle {handle} in "
+                      f"{PROBE_ATTEMPTS} attempts")
 
     def send_udp(self, payload: bytes) -> None:
         if self.udp_peer is None:

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -148,6 +148,11 @@ PROBE_ATTEMPTS = 3
 # CLOSE_SOCKET exhausts the pool on firmware that keeps every socket for ever.
 # On firmware that bounds what a client can hold open, every one succeeds.
 ABANDONED_SOCKETS = 8
+# NET_MAX_SOCKETS in software/io/network/network_target.h: how many sockets
+# the target keeps for a client before opening one more closes the oldest.
+# Repeated here rather than discovered, so that changing the cap in the
+# firmware has to be a deliberate change to this test as well.
+SOCKET_CAP = 4
 # How many sockets a reset has to release before opening ABANDONED_SOCKETS
 # more can succeed only if the reset closed them.
 SOCKETS_LEFT_OPEN_AT_RESET = 4
@@ -403,6 +408,17 @@ class Peer:
             return address
         raise Failure(f"no probe datagram arrived from handle {handle} in "
                       f"{PROBE_ATTEMPTS} attempts")
+
+    def drain_udp(self) -> None:
+        """Discard datagrams already queued here, so the next read is this one's."""
+        self.udp.setblocking(False)
+        try:
+            while True:
+                self.udp.recvfrom(2048)
+        except OSError:
+            pass
+        finally:
+            self.udp.setblocking(True)
 
     def send_udp(self, payload: bytes) -> None:
         if self.udp_peer is None:
@@ -1100,6 +1116,27 @@ def open_abandoned(net: Net, peer: Peer, count: int, handles: List[int],
             detail(f"handle {handle}, source port {port}")
 
 
+def source_port(net: Net, peer: Peer, handle: int) -> Optional[int]:
+    """The source port of a datagram written to `handle`, or None if none arrives.
+
+    Drains first, so a datagram left over from an earlier write is never read
+    as this one's, and repeats a lost datagram the way learn_udp_peer does.
+    None means the socket behind the handle did not put a datagram on the
+    wire: either WRITE_SOCKET refused the handle, or the socket is gone.
+    """
+    peer.drain_udp()
+    for _ in range(PROBE_ATTEMPTS):
+        if net.write(handle, b"WHICH").status_text != STATUS_OK:
+            return None
+        peer.udp.settimeout(DELIVERY_SETTLE_SECONDS)
+        try:
+            _, (_, port) = peer.udp.recvfrom(2048)
+        except socket.timeout:
+            continue
+        return port
+    return None
+
+
 def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
     """A client that never closes its sockets cannot exhaust the device.
 
@@ -1108,8 +1145,8 @@ def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
     loses track of its handles, or is simply restarted, takes the network
     target down for everyone until the device is power cycled. A bounded
     target keeps at most a fixed number of client sockets and lets a new one
-    in by closing the oldest, so an OPEN_UDP always succeeds and the first
-    socket opened is gone by the time the pool would have run out.
+    in by closing the oldest, so an OPEN_UDP always succeeds and only the
+    newest SOCKET_CAP sockets are still live afterwards.
     """
     section("abandoned-sockets-are-bounded")
     handles: List[int] = []
@@ -1117,23 +1154,42 @@ def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
     try:
         open_abandoned(net, peer, ABANDONED_SOCKETS, handles, ports)
 
-        with check(f"the first of {ABANDONED_SOCKETS} abandoned sockets has been closed"):
-            # Its handle number may by now belong to a newer socket, so the
-            # test is not "the write fails" but "nothing arrives from the
-            # port the first socket had".
-            result = net.write(handles[0], b"STALE")
-            detail(f"WRITE_SOCKET on handle {handles[0]} answered {result.status_text!r}")
-            if result.status_text == STATUS_OK:
-                peer.udp.settimeout(DELIVERY_SETTLE_SECONDS)
-                try:
-                    _, (_, port) = peer.udp.recvfrom(2048)
-                except socket.timeout:
-                    port = None
-                detail(f"datagram source port {port}, first socket had {ports[0]}")
-                if port == ports[0]:
-                    raise Failure(f"the first socket opened is still live after "
-                                  f"{ABANDONED_SOCKETS} opens without a close; the "
-                                  f"target keeps every socket a client abandons")
+        with check(f"exactly the newest {SOCKET_CAP} of {ABANDONED_SOCKETS} "
+                   f"abandoned sockets are still live"):
+            # A handle number is not the identity of a socket here: lwip hands
+            # the number of a closed socket to the next one opened, so a write
+            # to an evicted socket's handle reaches whichever socket holds
+            # that number now. A source port is the identity, because two live
+            # sockets never share one. Writing to every handle and collecting
+            # the source ports that arrive therefore bounds the live set from
+            # both sides.
+            arrived = [source_port(net, peer, handle) for handle in handles]
+            detail(", ".join(f"#{n + 1} handle {handles[n]} port {ports[n]} "
+                             f"-> {arrived[n]}" for n in range(len(handles))))
+
+            # No port from an evicted socket may answer. This is what fails on
+            # firmware that keeps every socket, and also on firmware whose cap
+            # is larger than SOCKET_CAP.
+            evicted = set(ports[:ABANDONED_SOCKETS - SOCKET_CAP])
+            still_live = sorted(evicted.intersection(p for p in arrived if p is not None))
+            if still_live:
+                raise Failure(f"source ports {still_live} still answer after "
+                              f"{ABANDONED_SOCKETS} opens without a close, so the "
+                              f"target keeps more than {SOCKET_CAP} of a client's "
+                              f"sockets")
+
+            # And every port of the newest SOCKET_CAP has to answer. Their
+            # handles are the ones the target still holds, so each is a
+            # distinct live socket. This is what fails on firmware whose cap
+            # is smaller than SOCKET_CAP, or that evicts the newest rather
+            # than the oldest.
+            newest = set(ports[-SOCKET_CAP:])
+            reached = set(arrived[-SOCKET_CAP:])
+            missing = sorted(newest - reached)
+            if missing:
+                raise Failure(f"source ports {missing} did not answer, so the target "
+                              f"closed a socket that is not among the "
+                              f"{ABANDONED_SOCKETS - SOCKET_CAP} oldest")
     finally:
         close_quietly(net, handles)
     return True

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -84,9 +84,6 @@ STATUS_OUT_OF_RANGE = b"82,PARAMETER(S) OUT OF RANGE"
 # lwip_recv returns -1. The number is the errno: 9 is EBADF for a handle that
 # was never opened, 11 is EAGAIN for an open socket with nothing pending.
 STATUS_NO_DATA_PREFIX = b"02,NO DATA"
-# What OPEN_* answers when there is no socket to give: the client is at
-# NET_MAX_SOCKETS, or lwip's pool is out. Not in the network target document.
-STATUS_NO_SOCKET = b"85,ERROR OPENING SOCKET"
 
 # A handle no OPEN command ever returned, so the socket can never supply data
 # and the length in the command is the only variable.
@@ -145,13 +142,11 @@ PEER_TIMEOUT_SECONDS = 10.0
 # unreachable.
 PROBE_ATTEMPTS = 3
 
-# NET_MAX_SOCKETS in software/io/network/network_target.h: how many sockets the
-# target lets one client hold. Repeated rather than discovered, so changing the
-# cap in the firmware has to be a deliberate change here too. See #808.
-SOCKET_CAP = 4
-# Sockets left open at the reset. Refilling the cap afterwards says the reset
-# released them: had it not, the client would still be at its cap.
-SOCKETS_LEFT_OPEN_AT_RESET = SOCKET_CAP
+# How many sockets the scenario leaks before the reset. Any number the device
+# can spare will do: four is enough to be obvious in lwip's pool and leaves
+# room for the sockets the firmware opens for itself. Opening the same number
+# again after the reset says they were released rather than merely forgotten.
+SOCKETS_LEFT_OPEN_AT_RESET = 4
 RESET_CYCLES = 3
 
 # The two ways of reaching the registers, described at the top of this file.
@@ -167,7 +162,6 @@ TESTS = [
     "tcp-read-is-lossless",
     "oversize-request-keeps-the-datagram",
     "multi-block-state-does-not-leak",
-    "abandoned-sockets-are-bounded",
     "reset-closes-uci-sockets",
 ]
 
@@ -1108,62 +1102,6 @@ def open_abandoned(net: Net, peer: Peer, count: int, handles: List[int],
             detail(f"handle {handle}, source port {port}")
 
 
-def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
-    """A client cannot hold more sockets than the target's cap.
-
-    GideonZ/1541ultimate#808: nothing but the client's own CLOSE_SOCKET ever
-    gave a socket back, so a client that lost its handles took the network
-    target down for everyone until the device was power cycled.
-    """
-    section("abandoned-sockets-are-bounded")
-    handles: List[int] = []
-    ports: List[int] = []
-    try:
-        open_abandoned(net, peer, SOCKET_CAP, handles, ports)
-
-        with check(f"OPEN_UDP past the cap of {SOCKET_CAP} is refused"):
-            result = net.uci.transact(
-                net.open_command(NET_CMD_OPEN_UDP, peer.ip, peer.udp_port))
-            detail(f"OPEN_UDP #{SOCKET_CAP + 1} answered {result.status_text!r}")
-            if result.status_text != STATUS_NO_SOCKET:
-                # It succeeded, so this client can hold more than the cap.
-                # Hand the socket back before reporting that.
-                if result.status_text == STATUS_OK and len(result.data) == 1:
-                    close_quietly(net, [result.data[0]])
-                raise Failure(f"OPEN_UDP #{SOCKET_CAP + 1} answered "
-                              f"{result.status_text!r} rather than "
-                              f"{STATUS_NO_SOCKET.decode()!r}, so a client can hold "
-                              f"more than {SOCKET_CAP} sockets at once")
-
-        with check(f"the {SOCKET_CAP} sockets already open are untouched"):
-            # Nothing is closed on the client's behalf, so a target that made
-            # room by closing one of these fails here.
-            for number, handle in enumerate(handles, start=1):
-                answer = net.write(handle, b"STILL")
-                if answer.status_text != STATUS_OK:
-                    raise Failure(f"WRITE_SOCKET on handle {handle}, socket {number} "
-                                  f"of {SOCKET_CAP}, answered {answer.status_text!r}; "
-                                  f"the refused open cost the client a socket it "
-                                  f"already held")
-
-        with check("closing one socket makes room for another"):
-            # The cap counts live sockets, so a client that closes what it
-            # opens never meets it. Unlike the refusal above, this holds
-            # whatever the rest of the device is doing with the pool.
-            closed = handles.pop(0)
-            ports.pop(0)
-            answer = net.close(closed)
-            if answer.status_text != STATUS_OK:
-                raise Failure(f"CLOSE_SOCKET on handle {closed} answered "
-                              f"{answer.status_text!r}")
-            handle = net.open_udp(peer.ip, peer.udp_port)
-            handles.append(handle)
-            detail(f"closed handle {closed}, opened handle {handle}")
-    finally:
-        close_quietly(net, handles)
-    return True
-
-
 def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
     """A C64 reset releases every socket a client left open.
 
@@ -1190,9 +1128,10 @@ def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
                     raise Failure(f"handles {still_open} were still open after the reset; "
                                   f"the program that opened them is gone, so nothing "
                                   f"else can ever close them")
-            # Refilling the cap says the reset released the sockets rather
-            # than forgetting them: had they still been open, this would be 85.
-            open_abandoned(net, peer, SOCKET_CAP, handles, ports)
+            # Opening as many again says the reset released the sockets rather
+            # than merely forgetting them: had they still been held, lwip would
+            # have that many fewer to give and this would answer 85.
+            open_abandoned(net, peer, SOCKETS_LEFT_OPEN_AT_RESET, handles, ports)
             close_quietly(net, handles)
             handles.clear()
         heap_after = free_heap(device)
@@ -1391,8 +1330,6 @@ def main() -> int:
                 run_oversize_request_keeps_datagram, net, peer)
             run(route, "multi-block-state-does-not-leak",
                 run_multi_block_state_does_not_leak, net, peer)
-            run(route, "abandoned-sockets-are-bounded",
-                run_abandoned_sockets_are_bounded, net, peer)
 
             def reset_and_reopen(route=route):
                 """Reset the C64 and hand back a driver that reaches the target."""

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -391,7 +391,20 @@ class Peer:
 
         The probe is a datagram, so it can be lost; seen once in a dozen runs.
         A lost one is resent rather than counted against the firmware.
+
+        Anything already queued here is discarded first. A datagram left over
+        from an earlier scenario is read as this probe otherwise, and the
+        address learned is then a socket that is already closed, so every
+        send_udp that follows goes nowhere and the device reads report no data.
         """
+        self.udp.setblocking(False)
+        try:
+            while True:
+                self.udp.recvfrom(2048)
+        except OSError:
+            pass
+        finally:
+            self.udp.setblocking(True)
         for attempt in range(PROBE_ATTEMPTS):
             net.write(handle, b"PROBE")
             self.udp.settimeout(PEER_TIMEOUT_SECONDS)

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -157,6 +157,10 @@ SOCKET_CAP = 4
 # more can succeed only if the reset closed them.
 SOCKETS_LEFT_OPEN_AT_RESET = 4
 RESET_CYCLES = 3
+# How long this host is given to refuse a connection to a closed TCP port of
+# its own. A host that drops instead of refusing would leave the device
+# blocked in connect(), which the command interface reports as a wedge.
+REFUSAL_TIMEOUT_SECONDS = 1.0
 
 # The two ways of reaching the registers, described at the top of this file.
 ROUTES = ["rest", "native"]
@@ -172,6 +176,7 @@ TESTS = [
     "oversize-request-keeps-the-datagram",
     "multi-block-state-does-not-leak",
     "abandoned-sockets-are-bounded",
+    "failed-open-keeps-existing-sockets",
     "reset-closes-uci-sockets",
 ]
 
@@ -419,6 +424,35 @@ class Peer:
             pass
         finally:
             self.udp.setblocking(True)
+
+    def refused_tcp_port(self) -> Optional[int]:
+        """A TCP port on this host that refuses a connection at once, or None.
+
+        Bound and released, so the number is almost certainly free, and then
+        tried from this host. What the caller needs is not that the port is
+        closed but that connecting to it comes back quickly: a host that
+        silently drops would leave the device blocked in connect() for as
+        long as lwip retries, and the command interface reports that as a
+        wedge for every target. A caller that gets None skips.
+        """
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            probe.bind((self.ip, 0))
+            port = probe.getsockname()[1]
+        finally:
+            probe.close()
+        attempt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        attempt.settimeout(REFUSAL_TIMEOUT_SECONDS)
+        try:
+            attempt.connect((self.ip, port))
+        except ConnectionRefusedError:
+            return port
+        except OSError:
+            return None
+        finally:
+            attempt.close()
+        # Something accepted, so the port is not closed after all.
+        return None
 
     def send_udp(self, payload: bytes) -> None:
         if self.udp_peer is None:
@@ -1195,6 +1229,60 @@ def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
     return True
 
 
+def run_failed_open_keeps_sockets(net: Net, peer: Peer) -> Optional[bool]:
+    """An open that fails must not cost the client a socket it already holds.
+
+    The target closes its oldest socket to let a new one in. If it does that
+    before the new socket is known to be usable, a TCP connect that fails
+    destroys a live socket and creates nothing, and for TCP a refused or
+    unanswered connect is the ordinary outcome when a host is down rather
+    than an edge case: a client retrying a connection loses everything it
+    holds, one socket per attempt.
+
+    Run with the client at its cap, because that is the only state in which
+    the target has a reason to close anything.
+    """
+    section("failed-open-keeps-existing-sockets")
+    dead_port = peer.refused_tcp_port()
+    if dead_port is None:
+        check_start("this host refuses a connection on a closed TCP port")
+        check_skip("this host does not refuse a connection on a closed TCP port of its "
+                   "own, so a failing OPEN_TCP would block the device in connect() "
+                   "rather than come back with an error")
+        return None
+
+    handles: List[int] = []
+    ports: List[int] = []
+    try:
+        open_abandoned(net, peer, SOCKET_CAP, handles, ports)
+
+        with check(f"OPEN_TCP to closed port {dead_port} fails"):
+            try:
+                handle = net.open_tcp(peer.ip, dead_port)
+            except Failure as exc:
+                detail(f"OPEN_TCP answered {format_exception(exc)}")
+            else:
+                # It succeeded, so this port is not closed and the scenario
+                # never exercised a failing open. Give the socket back.
+                close_quietly(net, [handle])
+                raise Failure(f"OPEN_TCP to port {dead_port} succeeded, so nothing on "
+                              f"this host refused it and the failing open this "
+                              f"scenario needs did not happen")
+
+        with check(f"the {SOCKET_CAP} sockets already open survived the failed open"):
+            arrived = [source_port(net, peer, handle) for handle in handles]
+            detail(", ".join(f"handle {handles[n]} port {ports[n]} -> {arrived[n]}"
+                             for n in range(len(handles))))
+            lost = sorted(set(ports) - set(arrived))
+            if lost:
+                raise Failure(f"source ports {lost} stopped answering after an OPEN_TCP "
+                              f"that failed, so the target gave up a live socket for one "
+                              f"it never handed out")
+    finally:
+        close_quietly(net, handles)
+    return True
+
+
 def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
     """A C64 reset releases every socket a client left open.
 
@@ -1426,6 +1514,8 @@ def main() -> int:
                 run_multi_block_state_does_not_leak, net, peer)
             run(route, "abandoned-sockets-are-bounded",
                 run_abandoned_sockets_are_bounded, net, peer)
+            run(route, "failed-open-keeps-existing-sockets",
+                run_failed_open_keeps_sockets, net, peer)
 
             def reset_and_reopen(route=route):
                 """Reset the C64 and hand back a driver that reaches the target."""

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -84,6 +84,11 @@ STATUS_OUT_OF_RANGE = b"82,PARAMETER(S) OUT OF RANGE"
 # lwip_recv returns -1. The number is the errno: 9 is EBADF for a handle that
 # was never opened, 11 is EAGAIN for an open socket with nothing pending.
 STATUS_NO_DATA_PREFIX = b"02,NO DATA"
+# What OPEN_TCP/OPEN_UDP answer when the target has no socket to give: the
+# client is at NET_MAX_SOCKETS, or lwip's pool is out. The network target
+# document lists no failure at all for OPEN_UDP, so this is measured from the
+# firmware rather than taken from the contract.
+STATUS_NO_SOCKET = b"85,ERROR OPENING SOCKET"
 
 # A handle no OPEN command ever returned, so the socket can never supply data
 # and the length in the command is the only variable.
@@ -142,25 +147,21 @@ PEER_TIMEOUT_SECONDS = 10.0
 # unable to reach this host.
 PROBE_ATTEMPTS = 3
 
-# GideonZ/1541ultimate#808: sockets a client opens and never closes. lwip has
-# MEMP_NUM_UDP_PCB = 8 protocol control blocks in total (lwipopts.h), and the
-# firmware's own UDP users hold some of them, so this many opens without a
-# CLOSE_SOCKET exhausts the pool on firmware that keeps every socket for ever.
-# On firmware that bounds what a client can hold open, every one succeeds.
-ABANDONED_SOCKETS = 8
+# GideonZ/1541ultimate#808: sockets a client opens and never closes. Nothing
+# but the client's own CLOSE_SOCKET ever gave one back, so a client that lost
+# its handles exhausted lwip's pools and took the network target down for
+# everyone until the device was power cycled.
+#
 # NET_MAX_SOCKETS in software/io/network/network_target.h: how many sockets
-# the target keeps for a client before opening one more closes the oldest.
-# Repeated here rather than discovered, so that changing the cap in the
-# firmware has to be a deliberate change to this test as well.
+# the target lets one client hold. Repeated here rather than discovered, so
+# that changing the cap in the firmware has to be a deliberate change to this
+# test as well.
 SOCKET_CAP = 4
-# How many sockets a reset has to release before opening ABANDONED_SOCKETS
-# more can succeed only if the reset closed them.
-SOCKETS_LEFT_OPEN_AT_RESET = 4
+# Sockets left open when the C64 is reset. Filling the cap and then requiring
+# the same number of opens to succeed afterwards is what says the reset
+# released them: had it not, the client would still be at its cap.
+SOCKETS_LEFT_OPEN_AT_RESET = SOCKET_CAP
 RESET_CYCLES = 3
-# How long this host is given to refuse a connection to a closed TCP port of
-# its own. A host that drops instead of refusing would leave the device
-# blocked in connect(), which the command interface reports as a wedge.
-REFUSAL_TIMEOUT_SECONDS = 1.0
 
 # The two ways of reaching the registers, described at the top of this file.
 ROUTES = ["rest", "native"]
@@ -176,7 +177,6 @@ TESTS = [
     "oversize-request-keeps-the-datagram",
     "multi-block-state-does-not-leak",
     "abandoned-sockets-are-bounded",
-    "failed-open-keeps-existing-sockets",
     "reset-closes-uci-sockets",
 ]
 
@@ -276,10 +276,12 @@ class Net:
         reply = self.uci.transact(bytes([TARGET_NETWORK, NET_CMD_GET_IPADDR, 0])).data
         return ".".join(str(b) for b in reply[:4]) if len(reply) >= 4 else None
 
+    def open_command(self, command: int, ip: str, port: int) -> bytes:
+        return (bytes([TARGET_NETWORK, command, port & 0xFF, (port >> 8) & 0xFF])
+                + ip.encode("ascii") + b"\x00")
+
     def _open(self, command: int, ip: str, port: int, what: str) -> int:
-        message = (bytes([TARGET_NETWORK, command, port & 0xFF, (port >> 8) & 0xFF])
-                   + ip.encode("ascii") + b"\x00")
-        result = self.uci.transact(message)
+        result = self.uci.transact(self.open_command(command, ip, port))
         if result.status_text != STATUS_OK or len(result.data) != 1:
             raise Failure(f"{what} {ip}:{port} answered {result.status_text!r} "
                           f"with reply {result.data!r}")
@@ -413,46 +415,6 @@ class Peer:
             return address
         raise Failure(f"no probe datagram arrived from handle {handle} in "
                       f"{PROBE_ATTEMPTS} attempts")
-
-    def drain_udp(self) -> None:
-        """Discard datagrams already queued here, so the next read is this one's."""
-        self.udp.setblocking(False)
-        try:
-            while True:
-                self.udp.recvfrom(2048)
-        except OSError:
-            pass
-        finally:
-            self.udp.setblocking(True)
-
-    def refused_tcp_port(self) -> Optional[int]:
-        """A TCP port on this host that refuses a connection at once, or None.
-
-        Bound and released, so the number is almost certainly free, and then
-        tried from this host. What the caller needs is not that the port is
-        closed but that connecting to it comes back quickly: a host that
-        silently drops would leave the device blocked in connect() for as
-        long as lwip retries, and the command interface reports that as a
-        wedge for every target. A caller that gets None skips.
-        """
-        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            probe.bind((self.ip, 0))
-            port = probe.getsockname()[1]
-        finally:
-            probe.close()
-        attempt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        attempt.settimeout(REFUSAL_TIMEOUT_SECONDS)
-        try:
-            attempt.connect((self.ip, port))
-        except ConnectionRefusedError:
-            return port
-        except OSError:
-            return None
-        finally:
-            attempt.close()
-        # Something accepted, so the port is not closed after all.
-        return None
 
     def send_udp(self, payload: bytes) -> None:
         if self.udp_peer is None:
@@ -1150,134 +1112,65 @@ def open_abandoned(net: Net, peer: Peer, count: int, handles: List[int],
             detail(f"handle {handle}, source port {port}")
 
 
-def source_port(net: Net, peer: Peer, handle: int) -> Optional[int]:
-    """The source port of a datagram written to `handle`, or None if none arrives.
-
-    Drains first, so a datagram left over from an earlier write is never read
-    as this one's, and repeats a lost datagram the way learn_udp_peer does.
-    None means the socket behind the handle did not put a datagram on the
-    wire: either WRITE_SOCKET refused the handle, or the socket is gone.
-    """
-    peer.drain_udp()
-    for _ in range(PROBE_ATTEMPTS):
-        if net.write(handle, b"WHICH").status_text != STATUS_OK:
-            return None
-        peer.udp.settimeout(DELIVERY_SETTLE_SECONDS)
-        try:
-            _, (_, port) = peer.udp.recvfrom(2048)
-        except socket.timeout:
-            continue
-        return port
-    return None
-
-
 def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
-    """A client that never closes its sockets cannot exhaust the device.
+    """A client cannot hold more sockets than the target's cap.
 
     GideonZ/1541ultimate#808: every OPEN_* takes a lwip socket, and nothing
-    but the client's own CLOSE_SOCKET ever gives it back, so a client that
-    loses track of its handles, or is simply restarted, takes the network
-    target down for everyone until the device is power cycled. A bounded
-    target keeps at most a fixed number of client sockets and lets a new one
-    in by closing the oldest, so an OPEN_UDP always succeeds and only the
-    newest SOCKET_CAP sockets are still live afterwards.
+    but the client's own CLOSE_SOCKET ever gave it back, so a client that
+    lost track of its handles, or was simply restarted, took the network
+    target down for everyone until the device was power cycled.
+
+    A capped target refuses the open past its cap. What that establishes,
+    beyond the pool no longer being reachable from one client: the refusal
+    lands on the open, which is where the client's leak is, and the sockets
+    the client already holds are untouched.
     """
     section("abandoned-sockets-are-bounded")
     handles: List[int] = []
     ports: List[int] = []
     try:
-        open_abandoned(net, peer, ABANDONED_SOCKETS, handles, ports)
-
-        with check(f"exactly the newest {SOCKET_CAP} of {ABANDONED_SOCKETS} "
-                   f"abandoned sockets are still live"):
-            # A handle number is not the identity of a socket here: lwip hands
-            # the number of a closed socket to the next one opened, so a write
-            # to an evicted socket's handle reaches whichever socket holds
-            # that number now. A source port is the identity, because two live
-            # sockets never share one. Writing to every handle and collecting
-            # the source ports that arrive therefore bounds the live set from
-            # both sides.
-            arrived = [source_port(net, peer, handle) for handle in handles]
-            detail(", ".join(f"#{n + 1} handle {handles[n]} port {ports[n]} "
-                             f"-> {arrived[n]}" for n in range(len(handles))))
-
-            # No port from an evicted socket may answer. This is what fails on
-            # firmware that keeps every socket, and also on firmware whose cap
-            # is larger than SOCKET_CAP.
-            evicted = set(ports[:ABANDONED_SOCKETS - SOCKET_CAP])
-            still_live = sorted(evicted.intersection(p for p in arrived if p is not None))
-            if still_live:
-                raise Failure(f"source ports {still_live} still answer after "
-                              f"{ABANDONED_SOCKETS} opens without a close, so the "
-                              f"target keeps more than {SOCKET_CAP} of a client's "
-                              f"sockets")
-
-            # And every port of the newest SOCKET_CAP has to answer. Their
-            # handles are the ones the target still holds, so each is a
-            # distinct live socket. This is what fails on firmware whose cap
-            # is smaller than SOCKET_CAP, or that evicts the newest rather
-            # than the oldest.
-            newest = set(ports[-SOCKET_CAP:])
-            reached = set(arrived[-SOCKET_CAP:])
-            missing = sorted(newest - reached)
-            if missing:
-                raise Failure(f"source ports {missing} did not answer, so the target "
-                              f"closed a socket that is not among the "
-                              f"{ABANDONED_SOCKETS - SOCKET_CAP} oldest")
-    finally:
-        close_quietly(net, handles)
-    return True
-
-
-def run_failed_open_keeps_sockets(net: Net, peer: Peer) -> Optional[bool]:
-    """An open that fails must not cost the client a socket it already holds.
-
-    The target closes its oldest socket to let a new one in. If it does that
-    before the new socket is known to be usable, a TCP connect that fails
-    destroys a live socket and creates nothing, and for TCP a refused or
-    unanswered connect is the ordinary outcome when a host is down rather
-    than an edge case: a client retrying a connection loses everything it
-    holds, one socket per attempt.
-
-    Run with the client at its cap, because that is the only state in which
-    the target has a reason to close anything.
-    """
-    section("failed-open-keeps-existing-sockets")
-    dead_port = peer.refused_tcp_port()
-    if dead_port is None:
-        check_start("this host refuses a connection on a closed TCP port")
-        check_skip("this host does not refuse a connection on a closed TCP port of its "
-                   "own, so a failing OPEN_TCP would block the device in connect() "
-                   "rather than come back with an error")
-        return None
-
-    handles: List[int] = []
-    ports: List[int] = []
-    try:
         open_abandoned(net, peer, SOCKET_CAP, handles, ports)
 
-        with check(f"OPEN_TCP to closed port {dead_port} fails"):
-            try:
-                handle = net.open_tcp(peer.ip, dead_port)
-            except Failure as exc:
-                detail(f"OPEN_TCP answered {format_exception(exc)}")
-            else:
-                # It succeeded, so this port is not closed and the scenario
-                # never exercised a failing open. Give the socket back.
-                close_quietly(net, [handle])
-                raise Failure(f"OPEN_TCP to port {dead_port} succeeded, so nothing on "
-                              f"this host refused it and the failing open this "
-                              f"scenario needs did not happen")
+        with check(f"OPEN_UDP past the cap of {SOCKET_CAP} is refused"):
+            result = net.uci.transact(
+                net.open_command(NET_CMD_OPEN_UDP, peer.ip, peer.udp_port))
+            detail(f"OPEN_UDP #{SOCKET_CAP + 1} answered {result.status_text!r}")
+            if result.status_text != STATUS_NO_SOCKET:
+                # It succeeded, so this client can hold more than the cap.
+                # Hand the socket back before reporting that.
+                if result.status_text == STATUS_OK and len(result.data) == 1:
+                    close_quietly(net, [result.data[0]])
+                raise Failure(f"OPEN_UDP #{SOCKET_CAP + 1} answered "
+                              f"{result.status_text!r} rather than "
+                              f"{STATUS_NO_SOCKET.decode()!r}, so a client can hold "
+                              f"more than {SOCKET_CAP} sockets at once")
 
-        with check(f"the {SOCKET_CAP} sockets already open survived the failed open"):
-            arrived = [source_port(net, peer, handle) for handle in handles]
-            detail(", ".join(f"handle {handles[n]} port {ports[n]} -> {arrived[n]}"
-                             for n in range(len(handles))))
-            lost = sorted(set(ports) - set(arrived))
-            if lost:
-                raise Failure(f"source ports {lost} stopped answering after an OPEN_TCP "
-                              f"that failed, so the target gave up a live socket for one "
-                              f"it never handed out")
+        with check(f"the {SOCKET_CAP} sockets already open are untouched"):
+            # Nothing is closed on the client's behalf, so every handle it was
+            # given still reaches the socket it was given. A target that made
+            # room by closing one of these would fail here.
+            for number, handle in enumerate(handles, start=1):
+                answer = net.write(handle, b"STILL")
+                if answer.status_text != STATUS_OK:
+                    raise Failure(f"WRITE_SOCKET on handle {handle}, socket {number} "
+                                  f"of {SOCKET_CAP}, answered {answer.status_text!r}; "
+                                  f"the refused open cost the client a socket it "
+                                  f"already held")
+
+        with check("closing one socket makes room for another"):
+            # The cap counts what the client holds now, so a client that
+            # closes what it opens never meets it. This holds whatever the
+            # rest of the device is doing with the pool, which the refusal
+            # above does not.
+            closed = handles.pop(0)
+            ports.pop(0)
+            answer = net.close(closed)
+            if answer.status_text != STATUS_OK:
+                raise Failure(f"CLOSE_SOCKET on handle {closed} answered "
+                              f"{answer.status_text!r}")
+            handle = net.open_udp(peer.ip, peer.udp_port)
+            handles.append(handle)
+            detail(f"closed handle {closed}, opened handle {handle}")
     finally:
         close_quietly(net, handles)
     return True
@@ -1313,7 +1206,11 @@ def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
                     raise Failure(f"handles {still_open} were still open after the reset; "
                                   f"the program that opened them is gone, so nothing "
                                   f"else can ever close them")
-            open_abandoned(net, peer, ABANDONED_SOCKETS, handles, ports)
+            # Filling the cap again is what says the reset released the
+            # sockets rather than merely forgetting them: had they still been
+            # open, the client would still be at its cap and the first of
+            # these opens would answer 85.
+            open_abandoned(net, peer, SOCKET_CAP, handles, ports)
             close_quietly(net, handles)
             handles.clear()
         heap_after = free_heap(device)
@@ -1514,8 +1411,6 @@ def main() -> int:
                 run_multi_block_state_does_not_leak, net, peer)
             run(route, "abandoned-sockets-are-bounded",
                 run_abandoned_sockets_are_bounded, net, peer)
-            run(route, "failed-open-keeps-existing-sockets",
-                run_failed_open_keeps_sockets, net, peer)
 
             def reset_and_reopen(route=route):
                 """Reset the C64 and hand back a driver that reaches the target."""

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -1142,9 +1142,18 @@ def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
             with check(f"cycle {cycle + 1}: reset the C64 with "
                        f"{SOCKETS_LEFT_OPEN_AT_RESET} sockets open"):
                 net = reset()
-            # Only a reset that closed the sockets left behind lets this many
-            # more open: the sockets from every cycle so far would otherwise
-            # add up past the pool.
+            with check(f"cycle {cycle + 1}: the reset closed the sockets left open"):
+                # A socket the reset closed answers CLOSE_SOCKET with an error;
+                # one it left open closes now, and answers OK. This is what
+                # tells a reset that closes sockets from a cap that merely
+                # makes room for the next opens.
+                still_open = [handle for handle in handles
+                              if net.close(handle).status_text == STATUS_OK]
+                handles.clear()
+                if still_open:
+                    raise Failure(f"handles {still_open} were still open after the reset; "
+                                  f"the program that opened them is gone, so nothing "
+                                  f"else can ever close them")
             open_abandoned(net, peer, ABANDONED_SOCKETS, handles, ports)
             close_quietly(net, handles)
             handles.clear()
@@ -1355,6 +1364,8 @@ def main() -> int:
                     native_started = True
                     return Net(build_driver(route, computer, args.busy_timeout))
                 return Net(rest_uci)
+            # Last on purpose: on the native route the reset inside it ends
+            # the 6502 agent that `net` wraps, so nothing can follow it here.
             run(route, "reset-closes-uci-sockets",
                 run_reset_closes_uci_sockets, net, peer, reset_and_reopen, device)
 

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -139,6 +139,17 @@ OVERRUN_LIMIT = REPLY_QUEUE_BYTES + 128
 DELIVERY_SETTLE_SECONDS = 0.4
 PEER_TIMEOUT_SECONDS = 10.0
 
+# GideonZ/1541ultimate#808: sockets a client opens and never closes. lwip has
+# MEMP_NUM_UDP_PCB = 8 protocol control blocks in total (lwipopts.h), and the
+# firmware's own UDP users hold some of them, so this many opens without a
+# CLOSE_SOCKET exhausts the pool on firmware that keeps every socket for ever.
+# On firmware that bounds what a client can hold open, every one succeeds.
+ABANDONED_SOCKETS = 8
+# How many sockets a reset has to release before opening ABANDONED_SOCKETS
+# more can succeed only if the reset closed them.
+SOCKETS_LEFT_OPEN_AT_RESET = 4
+RESET_CYCLES = 3
+
 # The two ways of reaching the registers, described at the top of this file.
 ROUTES = ["rest", "native"]
 
@@ -152,6 +163,8 @@ TESTS = [
     "tcp-read-is-lossless",
     "oversize-request-keeps-the-datagram",
     "multi-block-state-does-not-leak",
+    "abandoned-sockets-are-bounded",
+    "reset-closes-uci-sockets",
 ]
 
 
@@ -1040,6 +1053,118 @@ def run_oversize_request_keeps_datagram(net: Net, peer: Peer) -> bool:
     return ok
 
 
+def close_quietly(net: Net, handles: List[int]) -> None:
+    """Close every handle a scenario opened, tolerating ones already gone.
+
+    A handle the firmware closed on its own answers CLOSE_SOCKET with an
+    error, which is the expected outcome for some of them and never a reason
+    to leave the rest open.
+    """
+    for handle in handles:
+        try:
+            net.close(handle)
+        except Failure:
+            pass
+
+
+def open_abandoned(net: Net, peer: Peer, count: int, handles: List[int],
+                   ports: List[int]) -> None:
+    """OPEN_UDP `count` times without a CLOSE_SOCKET, recording each socket.
+
+    Each socket announces itself with one datagram, which tells this host the
+    ephemeral source port lwip gave it. Two live sockets never share a port,
+    so a port is the identity of a socket where a handle number is not: lwip
+    hands the number of a closed socket to the next one opened.
+    """
+    for n in range(count):
+        with check(f"OPEN_UDP #{n + 1} without closing the previous ones"):
+            handle = net.open_udp(peer.ip, peer.udp_port)
+            handles.append(handle)
+            _, port = peer.learn_udp_peer(net, handle)
+            ports.append(port)
+            detail(f"handle {handle}, source port {port}")
+
+
+def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
+    """A client that never closes its sockets cannot exhaust the device.
+
+    GideonZ/1541ultimate#808: every OPEN_* takes a lwip socket, and nothing
+    but the client's own CLOSE_SOCKET ever gives it back, so a client that
+    loses track of its handles, or is simply restarted, takes the network
+    target down for everyone until the device is power cycled. A bounded
+    target keeps at most a fixed number of client sockets and lets a new one
+    in by closing the oldest, so an OPEN_UDP always succeeds and the first
+    socket opened is gone by the time the pool would have run out.
+    """
+    section("abandoned-sockets-are-bounded")
+    handles: List[int] = []
+    ports: List[int] = []
+    try:
+        open_abandoned(net, peer, ABANDONED_SOCKETS, handles, ports)
+
+        with check(f"the first of {ABANDONED_SOCKETS} abandoned sockets has been closed"):
+            # Its handle number may by now belong to a newer socket, so the
+            # test is not "the write fails" but "nothing arrives from the
+            # port the first socket had".
+            result = net.write(handles[0], b"STALE")
+            detail(f"WRITE_SOCKET on handle {handles[0]} answered {result.status_text!r}")
+            if result.status_text == STATUS_OK:
+                peer.udp.settimeout(DELIVERY_SETTLE_SECONDS)
+                try:
+                    _, (_, port) = peer.udp.recvfrom(2048)
+                except socket.timeout:
+                    port = None
+                detail(f"datagram source port {port}, first socket had {ports[0]}")
+                if port == ports[0]:
+                    raise Failure(f"the first socket opened is still live after "
+                                  f"{ABANDONED_SOCKETS} opens without a close; the "
+                                  f"target keeps every socket a client abandons")
+    finally:
+        close_quietly(net, handles)
+    return True
+
+
+def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
+    """A C64 reset releases every socket a client left open.
+
+    A program that opened sockets is gone after a reset, and with it any
+    chance of those sockets ever being closed by their owner. `reset` resets
+    the C64 and returns a Net that reaches the target afterwards; on the
+    native route that is a freshly started 6502 agent.
+    """
+    section("reset-closes-uci-sockets")
+    handles: List[int] = []
+    ports: List[int] = []
+    heap_before = free_heap(device)
+    try:
+        for cycle in range(RESET_CYCLES):
+            open_abandoned(net, peer, SOCKETS_LEFT_OPEN_AT_RESET, handles, ports)
+            with check(f"cycle {cycle + 1}: reset the C64 with "
+                       f"{SOCKETS_LEFT_OPEN_AT_RESET} sockets open"):
+                net = reset()
+            # Only a reset that closed the sockets left behind lets this many
+            # more open: the sockets from every cycle so far would otherwise
+            # add up past the pool.
+            open_abandoned(net, peer, ABANDONED_SOCKETS, handles, ports)
+            close_quietly(net, handles)
+            handles.clear()
+        heap_after = free_heap(device)
+        if heap_before is not None and heap_after is not None:
+            detail(f"free heap {heap_before} -> {heap_after} over {RESET_CYCLES} cycles")
+    finally:
+        close_quietly(net, handles)
+    return True
+
+
+def free_heap(device) -> Optional[int]:
+    """Free FreeRTOS heap, for the record; lwip's pools are static and do not show here."""
+    try:
+        heap = device.machine.heap()
+    except Failure:
+        return None
+    return heap["free"] if heap else None
+
+
 def restore_settings(device, original: Dict[str, str], keep: bool) -> bool:
     if keep or not original:
         return True
@@ -1219,6 +1344,19 @@ def main() -> int:
                 run_oversize_request_keeps_datagram, net, peer)
             run(route, "multi-block-state-does-not-leak",
                 run_multi_block_state_does_not_leak, net, peer)
+            run(route, "abandoned-sockets-are-bounded",
+                run_abandoned_sockets_are_bounded, net, peer)
+
+            def reset_and_reopen(route=route):
+                """Reset the C64 and hand back a driver that reaches the target."""
+                nonlocal native_started
+                computer.machine.reset(force=True)
+                if route == "native":
+                    native_started = True
+                    return Net(build_driver(route, computer, args.busy_timeout))
+                return Net(rest_uci)
+            run(route, "reset-closes-uci-sockets",
+                run_reset_closes_uci_sockets, net, peer, reset_and_reopen, device)
 
     except Failure as exc:
         # Setup and route initialisation raise rather than recording a result,

--- a/tests/e2e/io/command_interface/net_target_test.py
+++ b/tests/e2e/io/command_interface/net_target_test.py
@@ -84,10 +84,8 @@ STATUS_OUT_OF_RANGE = b"82,PARAMETER(S) OUT OF RANGE"
 # lwip_recv returns -1. The number is the errno: 9 is EBADF for a handle that
 # was never opened, 11 is EAGAIN for an open socket with nothing pending.
 STATUS_NO_DATA_PREFIX = b"02,NO DATA"
-# What OPEN_TCP/OPEN_UDP answer when the target has no socket to give: the
-# client is at NET_MAX_SOCKETS, or lwip's pool is out. The network target
-# document lists no failure at all for OPEN_UDP, so this is measured from the
-# firmware rather than taken from the contract.
+# What OPEN_* answers when there is no socket to give: the client is at
+# NET_MAX_SOCKETS, or lwip's pool is out. Not in the network target document.
 STATUS_NO_SOCKET = b"85,ERROR OPENING SOCKET"
 
 # A handle no OPEN command ever returned, so the socket can never supply data
@@ -143,22 +141,15 @@ OVERRUN_LIMIT = REPLY_QUEUE_BYTES + 128
 # that is already queued and does not wait for one in flight.
 DELIVERY_SETTLE_SECONDS = 0.4
 PEER_TIMEOUT_SECONDS = 10.0
-# How often a lost probe datagram is sent again before the socket is judged
-# unable to reach this host.
+# How often a lost probe datagram is resent before the socket is judged
+# unreachable.
 PROBE_ATTEMPTS = 3
 
-# GideonZ/1541ultimate#808: sockets a client opens and never closes. Nothing
-# but the client's own CLOSE_SOCKET ever gave one back, so a client that lost
-# its handles exhausted lwip's pools and took the network target down for
-# everyone until the device was power cycled.
-#
-# NET_MAX_SOCKETS in software/io/network/network_target.h: how many sockets
-# the target lets one client hold. Repeated here rather than discovered, so
-# that changing the cap in the firmware has to be a deliberate change to this
-# test as well.
+# NET_MAX_SOCKETS in software/io/network/network_target.h: how many sockets the
+# target lets one client hold. Repeated rather than discovered, so changing the
+# cap in the firmware has to be a deliberate change here too. See #808.
 SOCKET_CAP = 4
-# Sockets left open when the C64 is reset. Filling the cap and then requiring
-# the same number of opens to succeed afterwards is what says the reset
+# Sockets left open at the reset. Refilling the cap afterwards says the reset
 # released them: had it not, the client would still be at its cap.
 SOCKETS_LEFT_OPEN_AT_RESET = SOCKET_CAP
 RESET_CYCLES = 3
@@ -398,9 +389,8 @@ class Peer:
         the address it connected to, and a reply has to come from this bound
         port back to whatever source port the device chose.
 
-        The probe is a datagram, so it can be lost; seen once in a dozen runs
-        on a wired LAN, with WRITE_SOCKET reporting the bytes as sent. A lost
-        probe is sent again rather than counted against the firmware.
+        The probe is a datagram, so it can be lost; seen once in a dozen runs.
+        A lost one is resent rather than counted against the firmware.
         """
         for attempt in range(PROBE_ATTEMPTS):
             net.write(handle, b"PROBE")
@@ -1081,12 +1071,7 @@ def run_oversize_request_keeps_datagram(net: Net, peer: Peer) -> bool:
 
 
 def close_quietly(net: Net, handles: List[int]) -> None:
-    """Close every handle a scenario opened, tolerating ones already gone.
-
-    A handle the firmware closed on its own answers CLOSE_SOCKET with an
-    error, which is the expected outcome for some of them and never a reason
-    to leave the rest open.
-    """
+    """Close every handle a scenario opened; an error means it was already gone."""
     for handle in handles:
         try:
             net.close(handle)
@@ -1098,10 +1083,8 @@ def open_abandoned(net: Net, peer: Peer, count: int, handles: List[int],
                    ports: List[int]) -> None:
     """OPEN_UDP `count` times without a CLOSE_SOCKET, recording each socket.
 
-    Each socket announces itself with one datagram, which tells this host the
-    ephemeral source port lwip gave it. Two live sockets never share a port,
-    so a port is the identity of a socket where a handle number is not: lwip
-    hands the number of a closed socket to the next one opened.
+    Each announces itself with a datagram, so this host learns the source port
+    lwip gave it. Two live sockets never share a port, so it identifies one.
     """
     for n in range(count):
         with check(f"OPEN_UDP #{n + 1} without closing the previous ones"):
@@ -1115,15 +1098,9 @@ def open_abandoned(net: Net, peer: Peer, count: int, handles: List[int],
 def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
     """A client cannot hold more sockets than the target's cap.
 
-    GideonZ/1541ultimate#808: every OPEN_* takes a lwip socket, and nothing
-    but the client's own CLOSE_SOCKET ever gave it back, so a client that
-    lost track of its handles, or was simply restarted, took the network
+    GideonZ/1541ultimate#808: nothing but the client's own CLOSE_SOCKET ever
+    gave a socket back, so a client that lost its handles took the network
     target down for everyone until the device was power cycled.
-
-    A capped target refuses the open past its cap. What that establishes,
-    beyond the pool no longer being reachable from one client: the refusal
-    lands on the open, which is where the client's leak is, and the sockets
-    the client already holds are untouched.
     """
     section("abandoned-sockets-are-bounded")
     handles: List[int] = []
@@ -1146,9 +1123,8 @@ def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
                               f"more than {SOCKET_CAP} sockets at once")
 
         with check(f"the {SOCKET_CAP} sockets already open are untouched"):
-            # Nothing is closed on the client's behalf, so every handle it was
-            # given still reaches the socket it was given. A target that made
-            # room by closing one of these would fail here.
+            # Nothing is closed on the client's behalf, so a target that made
+            # room by closing one of these fails here.
             for number, handle in enumerate(handles, start=1):
                 answer = net.write(handle, b"STILL")
                 if answer.status_text != STATUS_OK:
@@ -1158,10 +1134,9 @@ def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
                                   f"already held")
 
         with check("closing one socket makes room for another"):
-            # The cap counts what the client holds now, so a client that
-            # closes what it opens never meets it. This holds whatever the
-            # rest of the device is doing with the pool, which the refusal
-            # above does not.
+            # The cap counts live sockets, so a client that closes what it
+            # opens never meets it. Unlike the refusal above, this holds
+            # whatever the rest of the device is doing with the pool.
             closed = handles.pop(0)
             ports.pop(0)
             answer = net.close(closed)
@@ -1179,10 +1154,8 @@ def run_abandoned_sockets_are_bounded(net: Net, peer: Peer) -> bool:
 def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
     """A C64 reset releases every socket a client left open.
 
-    A program that opened sockets is gone after a reset, and with it any
-    chance of those sockets ever being closed by their owner. `reset` resets
-    the C64 and returns a Net that reaches the target afterwards; on the
-    native route that is a freshly started 6502 agent.
+    The program that opened them is gone, so nothing else ever can. `reset`
+    resets the C64 and returns a Net that reaches the target afterwards.
     """
     section("reset-closes-uci-sockets")
     handles: List[int] = []
@@ -1195,10 +1168,8 @@ def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
                        f"{SOCKETS_LEFT_OPEN_AT_RESET} sockets open"):
                 net = reset()
             with check(f"cycle {cycle + 1}: the reset closed the sockets left open"):
-                # A socket the reset closed answers CLOSE_SOCKET with an error;
-                # one it left open closes now, and answers OK. This is what
-                # tells a reset that closes sockets from a cap that merely
-                # makes room for the next opens.
+                # A socket the reset closed answers CLOSE_SOCKET with an
+                # error; one it left open closes now, and answers OK.
                 still_open = [handle for handle in handles
                               if net.close(handle).status_text == STATUS_OK]
                 handles.clear()
@@ -1206,10 +1177,8 @@ def run_reset_closes_uci_sockets(net: Net, peer: Peer, reset, device) -> bool:
                     raise Failure(f"handles {still_open} were still open after the reset; "
                                   f"the program that opened them is gone, so nothing "
                                   f"else can ever close them")
-            # Filling the cap again is what says the reset released the
-            # sockets rather than merely forgetting them: had they still been
-            # open, the client would still be at its cap and the first of
-            # these opens would answer 85.
+            # Refilling the cap says the reset released the sockets rather
+            # than forgetting them: had they still been open, this would be 85.
             open_abandoned(net, peer, SOCKET_CAP, handles, ports)
             close_quietly(net, handles)
             handles.clear()


### PR DESCRIPTION
Fixes #808. A UCI client that opens sockets and never closes them holds them until the device is power cycled, because nothing but the client's own `CLOSE_SOCKET` ever returns one. `NetworkTarget` now records the sockets it opens, reads, writes and closes only those, and closes all of them when the C64 resets. A C64 reset therefore recovers the network target, which is the recovery path #808 asks for.

## What is broken

Measured through `$DF1B-$DF1F` on an Ultimate 64 Elite running unpatched `test-merge`:

- A C64 reset releases nothing. With sockets left open, they are still open afterwards and can still be closed by handle, so the reset did not touch them. The program that opened them is gone, so nothing can ever close them.
- Only the client's own `CLOSE_SOCKET` returns a socket. `NetworkTarget::open_socket()` in `software/io/network/network_target.cc` calls `socket()` and `connect()` and hands the raw lwip descriptor to the client. Nothing records it.
- Repeated `OPEN_UDP` without `CLOSE_SOCKET` therefore exhausts the pool and further opens answer `85,ERROR OPENING SOCKET`. `MEMP_NUM_UDP_PCB` is 8 in `software/network/config/lwipopts.h` and the firmware's own UDP users hold the rest, so how many opens a client gets depends on what the firmware has open at the time. It was 5 on one device and 4 on another.
- lwip reuses a closed descriptor's number for the next socket anyone opens, including sockets the firmware opens for itself. A client still using a stale handle reaches whichever socket took that number.

## What this change does

All inside `NetworkTarget`, plus a reset hook in the command interface.

### A record of the sockets this target opened

`NetworkTarget` keeps `int sockets[NET_MAX_SOCKETS]` and `socket_count`. `OPEN_TCP` and `OPEN_UDP` add to it. `CLOSE_SOCKET` and the existing auto-close on `recv() == 0` remove from it.

`NET_MAX_SOCKETS` is 16, which is lwip's `MEMP_NUM_NETCONN` in `software/network/config/lwipopts.h` and therefore the number of sockets lwip can create at all. The table can hold every socket this target could ever be given, so it cannot overflow and no client meets a limit of its own. An open is refused only when lwip refuses it, with the same `85,ERROR OPENING SOCKET` as before this change.

`track_socket()` is bounds checked and returns false rather than writing past the table. A `static_assert(NET_MAX_SOCKETS >= MEMP_NUM_NETCONN)` fails the build if `lwipopts.h` ever outgrows the table. Without that check an untracked socket would be handed to a client, survive a reset, and reintroduce this issue with no test able to detect it.

### Only owned sockets are touched

`READ_SOCKET`, `WRITE_SOCKET` and `CLOSE_SOCKET` refuse a handle that is not in the table by setting `errno = EBADF`, which produces the status texts an unknown handle already produced: `02,NO DATA: 9`, `12,SEND ERROR: 9` and `12,ERROR ON CLOSE: 9`.

This is required by the reset hook below. Closing sockets on a reset returns their descriptor numbers to lwip, which reuses them, so without this gate a program running after a reset could read from or write to a socket the firmware opened for itself.

### Close everything on a C64 reset

The reset interrupt (`ResetInterruptHandlerCmdIf` in `software/io/command_interface/command_intf.cc`) already posts a `CMD_ABORT_DATA` event to the command interface's server task. It now also sets a `c64_reset_pending` flag. The server task reads and clears that flag as one step on every event it dequeues, and calls a new `CommandTarget::c64_reset()` on every target. `NetworkTarget` implements it as close-all plus discarding any pending read reply; the base class is a no-op.

Running this on the server task means a target is never told about the reset while it is in the middle of a command. Checking the flag on every event rather than only on the abort means a reset whose queue post did not fit is still acted on by the next event that does.

## Backwards compatibility

Intentional differences:

- After a C64 reset every UCI socket is closed. A program that survives a reset and expects its sockets to survive with it would break. The reset also aborts any UCI transaction in flight today.
- `READ_SOCKET` and `WRITE_SOCKET` on a handle not obtained from `OPEN_*`, or already closed, now fail with `... : 9` (EBADF) instead of acting on whatever socket lwip gave that number to. A handle that was never valid already failed that way.

Unchanged: the socket id format, the status returned by every command including `OPEN_*` at pool exhaustion, `lwipopts.h`, and the FPGA. There is no new status code and no change to the UCI protocol, so no documentation change is required.

Cost is 48 bytes of bss.

## Alternatives considered

- **A cap on how many sockets one client may hold.** Tried, and removed. On a device whose spare UDP control block count equals the cap, both builds refuse at the same open with the same status, so the cap changes nothing a client can observe and no test can distinguish it from pool exhaustion. The effective limit is `min(cap, free pool)` and the second term moves at runtime: one run refused at 3 rather than 4, failing a scenario on correct firmware. It does not reserve headroom for the firmware's own UDP users either, since a cap of 4 against a pool of 8 with a firmware baseline near 4 still lets a client take every remaining control block.
- **Giving the cap a status of its own** so that it becomes observable and testable. This is the only way a cap could be regression tested, but it adds UCI protocol surface that cannot be withdrawn once clients depend on it, and it needs a matching change in `GideonZ/1541u-documentation`. Days before 3.15 the smaller change is preferred. The table added here is what any later cap or idle reaper would be built on, so nothing is foreclosed.
- **Hooking the reset in `run_reset_task()`**, the task that wakes on the reset semaphore and resets the sampler. It runs on a different FreeRTOS task from `parse_command()`, so closing sockets there races a command in progress. Rejected for the flag on the server task.
- **Tagging the reset as a bit in the queued status byte.** Bit 7 of the hardware status byte is `DATA_AV` and `command_interface_irq()` passes bits 3 to 7 straight into the queue, so any spare bit collides. Rejected.
- **An idle reaper.** Needs a timer and a policy on what counts as idle. Close-on-reset already turns the failure from "power cycle" into "self healing". Not done.

## Not addressed

A client that leaks sockets and never resets is not bounded. It still exhausts the pool and still receives `85,ERROR OPENING SOCKET`, as it does today. What changes is that any C64 reset now recovers the interface, rather than only a mains power cycle.

## How it was tested

One scenario, `reset-closes-uci-sockets`, added to `tests/e2e/io/command_interface/net_target_test.py` (`run-tests` id `uci-net-target`), running on both the REST route (DMA on the registers) and the native route (6502 agent on the C64). It opens four sockets, resets the C64, and requires that `CLOSE_SOCKET` on each answers an error because the reset already closed them. It then opens four more, which must succeed, since sockets still held would leave lwip that many fewer to give. Three cycles. It always closes what it opened, so the device is left clean even on failing firmware.

Red and green on an Ultimate 64 Elite (core 1.4F), two builds differing only by this change, both carrying the same test file. Baseline is `test-merge` `fcc2502d`.

| Run | baseline REST | baseline native | with change REST | with change native |
|---|---|---|---|---|
| 1 | FAIL | FAIL | OK | OK |
| 2 | FAIL | FAIL | OK | OK |
| 3 | FAIL | FAIL | OK | OK |
| 4 | FAIL | FAIL | OK | OK |
| 5 | FAIL | FAIL | OK | OK |
| 6 | FAIL | FAIL | OK | OK |
| 7 | FAIL | FAIL | OK | OK |
| 8 | FAIL | FAIL | OK | OK |
| 9 | FAIL | FAIL | OK | OK |
| 10 | FAIL | FAIL | OK | OK |
| **total** | **10/10 FAIL** | **10/10 FAIL** | **10/10 OK** | **10/10 OK** |

The baseline failure is the same on every run:

```
reset-closes-uci-sockets [rest] stopped: handles [8, 9, 10, 11] were still open
after the reset; the program that opened them is gone, so nothing else can ever
close them
```

Whole `uci-net-target` suite, both routes, on the same two builds:

| Build | Result |
|---|---|
| baseline `fcc2502d`, run 1 | 19 scenarios OK, `reset-closes-uci-sockets` FAIL on both routes |
| baseline `fcc2502d`, run 2 | 19 scenarios OK, `reset-closes-uci-sockets` FAIL on both routes |
| with this change, run 1 | 21 of 21 scenarios OK, 133 checks, 403 s |
| with this change, run 2 | 21 of 21 scenarios OK, 133 checks, 403 s |

### A defect in the test harness, fixed in `16d42416`

`Peer.learn_udp_peer()` took whatever datagram arrived next as its probe reply. A datagram left queued at the host by an earlier scenario was read as the current socket's, so the learned source port belonged to a socket that had already been closed, and every later host to device datagram went to a port nothing was listening on. The device then answered a truthful `02,NO DATA: 11` while its own probe still reached the host.

This produced seven failures on whichever route ran second, on both patched and unpatched builds, and none when a route ran alone. It was reported as a device-side flake before being traced. `16d42416` drains the host socket before probing. The nine scenarios unrelated to this change now pass on both routes on both builds.
