### PR TITLE
Follow the browser's dark setting in the API explorer, and offer a way back

### DIFF
--- a/html/api.html
+++ b/html/api.html
@@ -80,8 +80,8 @@
 </style>
 </head>
 <body>
-<!-- The two icons are copied verbatim from html/index.html, so that both pages
-     offer the same control. Keep them in step if that page's icons change. -->
+<!-- Icons copied from index.html; keep in step. Sharing them would save
+     under 2 KB and cost a new asset type in seven makefiles. -->
 <div id="page-controls">
     <a id="home-link" href="index.html" title="Back to the Ultimate home page">Home</a>
     <a id="darkmode-button" href="#" title="Switch to dark mode"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M320 64C178.6 64 64 178.6 64 320C64 461.4 178.6 576 320 576C388.8 576 451.3 548.8 497.3 504.6C504.6 497.6 506.7 486.7 502.6 477.5C498.5 468.3 488.9 462.6 478.8 463.4C473.9 463.8 469 464 464 464C362.4 464 280 381.6 280 280C280 207.9 321.5 145.4 382.1 115.2C391.2 110.7 396.4 100.9 395.2 90.8C394 80.7 386.6 72.5 376.7 70.3C358.4 66.2 339.4 64 320 64z"/></svg></a>

--- a/html/api.html
+++ b/html/api.html
@@ -29,7 +29,7 @@
 -->
 <meta http-equiv="Content-Security-Policy" content="
     default-src 'none';
-    script-src 'sha256-MbbxGLnf0+hcHG4EyZkflTUx/Y6JjKwXOJWeTY6Re8s=' https://unpkg.com/swagger-ui-dist@5.32.14/;
+    script-src 'sha256-jG/elDqAeYYU5kU5fxHvBLgsUPuUbQEjzMVi0CC3Rz0=' https://unpkg.com/swagger-ui-dist@5.32.14/;
     style-src 'unsafe-inline' https://unpkg.com/swagger-ui-dist@5.32.14/;
     img-src 'self' data:;
     font-src 'self' data:;
@@ -46,9 +46,47 @@
     body { margin: 0; font-family: sans-serif; }
     #notice { margin: 2em; color: #444; }
     #notice code { background: #eee; padding: 0 0.3em; }
+    /* Swagger UI 5.31 and later carry a dark theme in the stylesheet above,
+       keyed on this class. It defines no prefers-color-scheme rule of its own,
+       so the class is set by the script below rather than by a media query. */
+    /* The page is reached from index.html's navigation, which is a single page
+       and so is left behind on arrival. This is the way back to it. */
+    #page-controls { position: fixed; top: 0.6em; right: 0.8em; z-index: 10; }
+    #page-controls svg { width: 1.4em; height: 1.4em; vertical-align: middle; }
+    #home-link {
+        display: inline-block;
+        margin-right: 0.8em;
+        padding: 0.3em 0.85em;
+        border: 1px solid #d9dde3;
+        border-radius: 4px;
+        background: #fff;
+        color: #3b4151;
+        font-size: 0.8em;
+        font-weight: 600;
+        text-decoration: none;
+        vertical-align: middle;
+    }
+    #home-link:hover { background: #f0f2f5; }
+    html.dark-mode #home-link { background: #2a2f31; border-color: #3f4749; color: #d8d8d8; }
+    html.dark-mode #home-link:hover { background: #363c3f; }
+    #darkmode-button, #lightmode-button { display: none; }
+    html:not(.dark-mode) #darkmode-button { display: inline; }
+    html.dark-mode #lightmode-button { display: inline; }
+    /* The notice is what shows when the bundle cannot be reached, so it needs
+       its own dark colours: nothing from the stylesheet above has loaded. */
+    html.dark-mode body { background: #1c2022; color: #d8d8d8; }
+    html.dark-mode #notice { color: #d8d8d8; }
+    html.dark-mode #notice code { background: #33383a; }
 </style>
 </head>
 <body>
+<!-- The two icons are copied verbatim from html/index.html, so that both pages
+     offer the same control. Keep them in step if that page's icons change. -->
+<div id="page-controls">
+    <a id="home-link" href="index.html" title="Back to the Ultimate home page">Home</a>
+    <a id="darkmode-button" href="#" title="Switch to dark mode"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M320 64C178.6 64 64 178.6 64 320C64 461.4 178.6 576 320 576C388.8 576 451.3 548.8 497.3 504.6C504.6 497.6 506.7 486.7 502.6 477.5C498.5 468.3 488.9 462.6 478.8 463.4C473.9 463.8 469 464 464 464C362.4 464 280 381.6 280 280C280 207.9 321.5 145.4 382.1 115.2C391.2 110.7 396.4 100.9 395.2 90.8C394 80.7 386.6 72.5 376.7 70.3C358.4 66.2 339.4 64 320 64z"/></svg></a>
+    <a id="lightmode-button" href="#" title="Switch to light mode"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path fill="rgb(116, 192, 252)" d="M320 32C328 32 335.4 36 339.9 42.6L398.7 130L502.1 109.8C509.9 108.3 518 110.7 523.7 116.4C529.4 122.1 531.8 130.2 530.3 138L510 241.3L597.4 300.1C604 304.5 608 312 608 320C608 328 604 335.4 597.4 339.9L510 398.7L530.2 502C531.7 509.8 529.3 517.9 523.6 523.6C517.9 529.3 509.8 531.7 502 530.2L398.7 510L339.9 597.4C335.4 604 328 608 320 608C312 608 304.6 604 300.1 597.4L241.3 510L137.9 530.2C130.1 531.7 122 529.3 116.3 523.6C110.6 517.9 108.2 509.8 109.7 502L130 398.7L42.6 339.9C36 335.4 32 328 32 320C32 312 36 304.6 42.6 300.1L130 241.3L109.8 137.9C108.3 130.1 110.7 122 116.4 116.3C122.1 110.6 130.2 108.2 138 109.7L241.3 129.9L300.1 42.5L301.9 40.2C306.4 35 313 32 320 32zM272.2 170C266.8 178 257.2 182 247.7 180.2L163.7 163.8L180.1 247.8C181.9 257.3 177.9 266.9 169.9 272.3L99 320L170 367.8C178 373.2 182 382.8 180.2 392.3L163.8 476.3L247.8 459.9L251.3 459.5C259.6 459.1 267.6 463.1 272.3 470.1L320.1 541.1L367.9 470.1L370.1 467.3C375.7 461.2 384.1 458.3 392.4 460L476.4 476.4L460 392.4C458.2 382.9 462.2 373.3 470.2 367.9L541.2 320.1L470.2 272.3C462.2 266.9 458.2 257.3 460 247.8L476.4 163.8L392.4 180.2C382.9 182 373.3 178 367.9 170L320.1 99L272.3 170zM320 440C253.7 440 200 386.3 200 320C200 253.7 253.7 200 320 200C386.3 200 440 253.7 440 320C440 386.3 386.3 440 320 440zM320 248C280.2 248 248 280.2 248 320C248 359.8 280.2 392 320 392C359.8 392 392 359.8 392 320C392 280.2 359.8 248 320 248z"/></svg></a>
+</div>
 <div id="notice">
     <h1>Ultimate REST API</h1>
     <p>Loading Swagger UI from <code>unpkg.com</code>. If this page stays as it is, this
@@ -64,6 +102,16 @@
         crossorigin="anonymous"
         referrerpolicy="no-referrer"></script>
 <script>
+// Follows the browser's setting on load and switches for the session, which is
+// what html/index.html does. Outside window.onload below, so the offline notice
+// is themed too, on a page where the bundle never arrives.
+function setDarkMode(dark) {
+    document.documentElement.classList.toggle("dark-mode", dark);
+}
+setDarkMode(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches);
+document.getElementById("darkmode-button").onclick = function (e) { e.preventDefault(); setDarkMode(true); };
+document.getElementById("lightmode-button").onclick = function (e) { e.preventDefault(); setDarkMode(false); };
+
 window.onload = function () {
     if (typeof SwaggerUIBundle === "undefined") {
         return;


### PR DESCRIPTION
`html/api.html` is the API Explorer page the updater writes to the device's flash disk. This change makes it follow the browser's dark setting, adds buttons to switch, and adds a link back to the home page. Only that one file changes.

## Before

The page was always light. `html/index.html` has followed the browser's setting since it was written, so the two pages disagreed for a viewer whose browser is set to dark.

The page is also reached from the navigation in `html/index.html`, which is a single-page app: its other navigation entries are `href="#"` and swap the visible section in place, while the API Explorer entry at `html/index.html:1690` is `href="api.html"` and is a real page navigation. Arriving at the explorer therefore left the navigation behind, and the only way back was the browser's own back button.

## Now

The page follows the browser's setting on load and the two buttons switch it for the session. Nothing is persisted, which matches `initDisplayMode` in `html/index.html:865-866`. A `Home` link next to the buttons returns to `index.html`.

Swagger UI gained an official dark theme in 5.31.0, and this page already pins 5.32.14, so the theme CSS is in the stylesheet the page already loads. I checked the published stylesheets directly:

| `swagger-ui.css` | bytes | occurrences of `dark-mode` | occurrences of `prefers-color-scheme` |
| --- | --- | --- | --- |
| 5.30.3 (the release before) | 155,212 | 0 | 0 |
| 5.31.0 | 177,183 | 244 | 0 |
| 5.32.14 (pinned by this page) | 185,784 | 262 | 0 |

The theme is keyed on an `html.dark-mode` class (256 of the 262 occurrences in 5.32.14 are `html.dark-mode` selectors) and the stylesheet declares no `prefers-color-scheme` rule anywhere. CSS alone therefore cannot pick the theme up: there is no media query in the vendored stylesheet to trigger it, and a page-level `@media (prefers-color-scheme: dark)` block cannot add a class to `<html>`. A few lines of JavaScript read `matchMedia("(prefers-color-scheme: dark)")` and set the class, which is the same mechanism `html/index.html` uses.

The wiring sits outside `window.onload` on purpose. When the Swagger UI bundle cannot be reached, the page falls back to a plain notice, and that notice should be themed as well. The notice carries its own dark colours because none of Swagger's CSS has loaded at that point.

### Duplicated icons

The two SVG icons are copied verbatim from `html/index.html:1670-1671` so both pages offer the same control. I verified the copies are byte-identical to the originals (581 and 1,662 bytes). This duplicates icon geometry in two files, and the copies can drift if the icons in `index.html` change; a comment in `api.html` says so. Two alternatives were considered and judged worse:

- Fetching the icons from `index.html` at runtime means downloading 62,062 bytes to obtain 2,243 bytes of markup, and adds a network dependency between two pages that are otherwise independent.
- Extracting the icons into a shared asset means adding it to `SRCS_HTML` in seven makefiles (`target/u2/microblaze/mb_update_to_rv`, `target/u2/riscv/updater`, `target/u2plus/nios/updater`, `target/u2plus_L/riscv/updater`, `target/u64/nios2/updater`, `target/u64ii/riscv/update`, `target/pc/linux/makefat`), and every one of those builds would then carry a third HTML object for 2 KB of icons.

### Device storage cost

`html/api.html` grows from 3,974 to 8,870 bytes, an increase of 4,896 bytes. For context, the same updater writes the generated OpenAPI document beside it in the flash disk: `doc/api/rest_api_openapi_u2.yaml` is 130,064 bytes and `doc/api/rest_api_openapi_u64.yaml` is 140,662 bytes. Swagger UI itself is not stored on the device at all; the viewer's browser fetches it from unpkg.

### CSP digest

The page admits its single inline script by a `sha256-` digest in its own `Content-Security-Policy` meta tag, so the digest had to be recomputed for the new script. `tools/openapi/test_explorer.py` enforces this: `test_the_policy_admits_the_page_own_inline_script_by_digest` computes the digest from the page's inline script and asserts it appears in `script-src`.

## Verification

No hardware was used. Both checks were run on this branch.

```
$ python3 -m pytest tools/openapi/test_explorer.py -q
................                                                         [100%]
16 passed in 0.05s
```

The recorded digest was also confirmed against the page independently, using `explorer.py`'s own helpers:

```
inline script count: 1
computed: sha256-jG/elDqAeYYU5kU5fxHvBLgsUPuUbQEjzMVi0CC3Rz0=
script-src: ["'sha256-jG/elDqAeYYU5kU5fxHvBLgsUPuUbQEjzMVi0CC3Rz0='", 'https://unpkg.com/swagger-ui-dist@5.32.14/']
MATCH: True
```

## Limitations

Dark styling for the explorer itself only appears when the viewer's browser can reach unpkg, because the theme lives in the stylesheet fetched from there. When it cannot, the page shows the offline notice instead, and that notice is themed by rules in `api.html` itself. This is why the notice carries its own dark colours rather than relying on Swagger's.

The setting is not persisted, so a viewer who switches theme with the buttons gets the browser's setting again on the next load. This matches `html/index.html`, which does not persist either.
