### PR TITLE
Stop the API document repeating the product list it just gave

### DIFF
--- a/doc/api/openapi-generation.md
+++ b/doc/api/openapi-generation.md
@@ -18,8 +18,8 @@ time, so one document cannot describe both families:
 
 | document | products | paths | operations | size |
 | --- | --- | --- | --- | --- |
-| `rest_api_openapi_u2.yaml` | Ultimate II, II+, II+L | 44 | 55 | 130,064 B |
-| `rest_api_openapi_u64.yaml` | Ultimate 64, 64 Elite, 64 Elite II | 47 | 59 | 140,662 B |
+| `rest_api_openapi_u2.yaml` | Ultimate II, II+, II+L | 44 | 55 | 129,837 B |
+| `rest_api_openapi_u64.yaml` | Ultimate 64, 64 Elite, 64 Elite II | 47 | 59 | 140,423 B |
 
 The Ultimate 64 document is larger because `route_streams.cc` is compiled only by
 its makefiles, and because `machine:debugreg` sits behind `#if U64`.

--- a/doc/api/rest_api_openapi_u2.yaml
+++ b/doc/api/rest_api_openapi_u2.yaml
@@ -7,9 +7,7 @@ info:
   version: '0.1'
   summary: REST interface of the Ultimate firmware on the Ultimate II, Ultimate II+ and Ultimate II+L.
   description: |2
-    Available since release 3.11. This document covers the Ultimate II, Ultimate II+ and Ultimate II+L; there is a
-    separate one for the other family, because which calls a product serves is
-    decided when the firmware is compiled rather than at run time.
+    Available since release 3.11.
 
     This document is generated from the firmware sources. Every call in it is
     registered in `software/api/route_*.cc` in the build it came from, and no call

--- a/doc/api/rest_api_openapi_u64.yaml
+++ b/doc/api/rest_api_openapi_u64.yaml
@@ -7,9 +7,7 @@ info:
   version: '0.1'
   summary: REST interface of the Ultimate firmware on the Ultimate 64, Ultimate 64 Elite and Ultimate 64 Elite II.
   description: |2
-    Available since release 3.11. This document covers the Ultimate 64, Ultimate 64 Elite and Ultimate 64 Elite II; there is a
-    separate one for the other family, because which calls a product serves is
-    decided when the firmware is compiled rather than at run time.
+    Available since release 3.11.
 
     This document is generated from the firmware sources. Every call in it is
     registered in `software/api/route_*.cc` in the build it came from, and no call

--- a/tools/openapi/schemas.py
+++ b/tools/openapi/schemas.py
@@ -36,9 +36,7 @@ PROFILES = {
 API_VERSION = "0.1"
 
 DESCRIPTION = """\
-Available since release 3.11. This document covers {products}; there is a
-separate one for the other family, because which calls a product serves is
-decided when the firmware is compiled rather than at run time.
+Available since release 3.11.
 
 This document is generated from the firmware sources. Every call in it is
 registered in `software/api/route_*.cc` in the build it came from, and no call


### PR DESCRIPTION
## What the document said

`info.summary` already names the products a document covers:

> REST interface of the Ultimate firmware on the Ultimate II, Ultimate II+ and Ultimate II+L.

The first sentence of `info.description` then named them a second time, and explained why there are two documents:

> Available since release 3.11. This document covers the Ultimate II, Ultimate II+ and Ultimate II+L; there is a separate one for the other family, because which calls a product serves is decided when the firmware is compiled rather than at run time.

Swagger UI renders `summary` and `description` one after the other, so a reader of `/api.html` sees the product list twice in consecutive lines.

## What changed

The trailing sentence is removed from the `DESCRIPTION` template in `tools/openapi/schemas.py`. The description now opens with `Available since release 3.11.` and goes straight on to how the document is generated.

`summary` is untouched, so the product list is still stated once, in the line that exists to state it. The explanation of why there are two documents is not lost: `doc/api/openapi-generation.md` already carries it, which is where a reader looking for build-time detail would go.

## Regenerated output

Both checked-in documents were regenerated with `make openapi`:

| File | Before | After | Change |
| --- | ---: | ---: | ---: |
| `doc/api/rest_api_openapi_u2.yaml` | 130,064 | 129,837 | -227 |
| `doc/api/rest_api_openapi_u64.yaml` | 140,662 | 140,423 | -239 |

`doc/api/openapi-generation.md` pins those byte counts in a table, so they are updated to match; leaving them would make that document stale.

## Verification

- `make openapi_check` reports `openapi: 2 documents match the sources`, so the committed YAML is what the generator produces.
- `python3 -m pytest tools/openapi/ -q` passes 191 tests.
- `python3 tests/lib/openapi_contract_test.py` passes 16 checks, reporting `u2 55 operations, u64 59 operations`.

No test asserted the removed sentence, so no assertion needed changing. A search for the removed phrases across the tree found them only in `schemas.py`, the two generated documents, and the separate explanatory sentence in `doc/api/openapi-generation.md`.

## Known leftover

`tools/openapi/document.py:415` still calls `DESCRIPTION.format(products=...)`, but the template no longer contains a `{products}` placeholder, so that call is now a no-op. It is harmless and left alone here to keep this change to the text; `summary` at line 414 still uses `profile["products"]`, so the product list is not orphaned.