### PR TITLE
Bounce a bulk_out transfer whose last word is only partly wanted (#803)

### DIFF
--- a/software/io/usb/usb_base.cc
+++ b/software/io/usb/usb_base.cc
@@ -758,15 +758,30 @@ int  UsbBase :: bulk_out(struct t_pipe *pipe, void *buf, int len, int timeout)
 	uint8_t sub = PROFILER_SUB; PROFILER_SUB = 13;
     volatile t_usb_descriptor *descr = USB2_DESCRIPTOR(0);
 
-/*
-    if (((uint32_t)buf) & 3) {
-    	printf("Bulk_out: Unaligned buffer %p (%d - len = %d)\n", buf, ((uint32_t)buf) & 3, len);
-    	dump_hex((void *)(((uint32_t)buf) & -4), 16);
-    	//while(1);
-    }
-*/
+	/* Issue #803. do_mem_read in the nano rounds a read up to whole words: it
+	   keeps the start address' byte offset and adds that, plus 3, to the
+	   length. A transfer whose last word is only partly wanted therefore makes
+	   the engine fetch a word the caller never asked for, and that word has
+	   been seen to reach the data written to a USB stick.
 
-    uint32_t addr = ((uint32_t)buf);
+	   Copy such a transfer to a buffer of our own. Two properties matter, and
+	   both were established on hardware:
+	     - the copy starts on a word boundary. Bouncing to an address that is
+	       just as misaligned as the original, with the same slack behind it,
+	       makes the corruption twice as bad instead of curing it.
+	     - the allocation has a spare word behind the rounded length, so the
+	       rounded read does not end exactly at the end of the block we own.
+	   get_mem() is malloc(), so the start is aligned for any fundamental type
+	   and no manual alignment is needed here. */
+	uint8_t *origbuf = (uint8_t *)buf;
+	uint8_t *newbuf = origbuf;
+
+	if (((((uint32_t)origbuf) & 3) + len) & 3) {
+		newbuf = new uint8_t[((len + 3) & ~3) + 4]; // get_mem panics, never returns 0
+		memcpy(newbuf, origbuf, len);
+	}
+
+    uint32_t addr = ((uint32_t)newbuf);
 	int total_trans = 0;
 
 	uint16_t result;
@@ -815,6 +830,10 @@ int  UsbBase :: bulk_out(struct t_pipe *pipe, void *buf, int len, int timeout)
 
     // printf("Bulk out done: %d\n", total_trans);
     xSemaphoreGive(mutex);
+
+	if (newbuf != origbuf) {
+		delete[] newbuf;
+	}
 
     PROFILER_SUB = sub;
 	return total_trans;


### PR DESCRIPTION
`bulk_out()` hands the USB engine the caller's pointer unchanged. `do_mem_read` in `software/io/usb/nano_minimal.nan` supports an unaligned source by keeping the start address' byte offset and rounding the read up to whole words:

```
    LOADI Descriptor,Offset_Command_MemLo
    OUTP  MEM_ADDR_LO
    AND   #3
    STORE Current_Word_Offset
    ...
    STORE CurrentLength
    ADD   Current_Word_Offset
    ADD   #3
    OUTP  MEM_TRANSFER_READ
```

So a transfer whose final word is only partly wanted makes the engine fetch a word the caller never asked for, and that word reaches the data: an FTP upload to a USB stick comes back with one 32-bit word per occurrence keeping its lower halfword and losing its upper one. The file has the right size, so nothing notices.

### Where it comes from

`FTPDataConnection::receivefile()` does `recv(sock, buffer, 1024, 0)` into `char buffer[1024]` and hands what it got to `f_write`. FatFs writes whole sectors straight out of the caller's buffer when the file pointer sits on a sector boundary, so the DMA source is `buffer + k` for whatever `k` has been consumed so far. A client sending 1350 bytes at a time makes `recv` return 1024 and then the remainder, and `k` walks all over the buffer.

Exactly one value of `k` breaks: 510, in a 512-byte transfer, whose word-rounded read ends exactly at `buffer + 1024`. `k = 506` is equally misaligned and also ends on a partial word, but its read stops four bytes short, and it is clean.

### Evidence

Instrumented firmware — a custom build on top of the Commodore 1.1.0 branch — recorded every `recv` size and every source address the block layer was handed. Over nine natural traces: 516 direct writes out of the receive buffer, 273 of them misaligned, three from `k = 510`. Exactly those three corrupted a word; the other 270 misaligned transfers were fine.

The offending offset can be predicted from the client's send pattern alone, so it can also be forced: send 1024 bytes, then 2, then 1024s. The file pointer lands on 2 mod 512 and stays there, which turns roughly one opportunity per upload into 63.

| firmware | client | runs | `k = 510` per run, from the device trace | corrupted words per run |
|---|---|---|---|---|
| unpatched | same LAN segment | 5 | 63 | 63 |
| unpatched | across a VPN | 5 | 63 | 63 |
| **this patch** | same LAN segment | 5 | 63 | **0** |
| **this patch** | across a VPN | 5 | 63 | **0** |

630 corrupted words in ten unpatched runs, none in ten patched runs, with the trigger present and counted in all twenty. Hardware: C64 Ultimate, board revision 0x17, FAT32 stick with 32 KiB clusters. A 4 MiB upload and read-back on the patched build matches sha256.

### Why the copy is word-aligned, and why it is over-allocated

A variant that bounces to an address just as misaligned as the original, with the same spare word behind it, changing only where the data sits, is **worse than no patch at all**: 126 corrupted words per run instead of 63, in ten runs out of ten, adding the first word of every transfer to the last. So the alignment is what does the work here, and the cure is not a timing artefact of the copy — that variant copies exactly as much.

The `+ 4` is not redundant after aligning. Without it the rounded read would end exactly at the end of the allocation, which is the condition that goes wrong in the first place.

The test is a property of the transfer rather than of the pointer, so it also covers `usb_ax88772.cc` and `usb_em1010.cc`, which pass `pkt_len + 4` and `pkt_len + 2` from an aligned start.

### What this does not do

- It does not fix the root cause, which is in the nano's read path. This is a driver-side workaround; if the handling of a partial final word is corrected there, this can go.
- `bulk_in()` bounces only when the start is misaligned, and allocates exactly `len` with no slack. If the write path rounds up the same way, an aligned start with a length that is not a multiple of four could write past the end of the caller's buffer. Not tested — only noticed while reading.
- The cost is one allocation and one `memcpy` per affected transfer. I have not measured throughput against an unpatched build on the same workload.
- An Ultimate II+L on 3.14d, with the same `char buffer[1024]` and the same `recv`, did not reproduce in 20 runs. There was no instrumentation on that machine, so that is an absence rather than a negative result.

Fixes #803.
