### PR TITLE
Add a manual E2E reproducing #803 (FTP-to-USB corruption)

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -265,6 +265,11 @@ SUITES: Sequence[Suite] = (
     Suite("e2e", "cfg-whitespace", "tests/e2e/filemanager/cfg_whitespace_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
     Suite("e2e", "printer", "tests/e2e/io/printer/printer_test.py", "-H @HOST@ -p @PASS@"),
+    # Only reproduces on firmware carrying #803; clean on the 3.15 firmware
+    # this gate normally runs against, so it stays out of the default run.
+    Suite("e2e", "usb-bulk-out-integrity",
+          "tests/e2e/io/usb/bulk_out_integrity_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@", manual=True),
     # Drives the UCI control and SoftIEC targets over $DF1B-$DF1F; reproduces #740.
     # A #740 regression leaves the interface stuck in Command Busy for every target
     # until the firmware restarts, so run it after the suites that drive the menu

--- a/tests/e2e/io/usb/bulk_out_integrity_test.py
+++ b/tests/e2e/io/usb/bulk_out_integrity_test.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# E2E: USB storage writes preserve every byte received by the FTP server.
+
+"""Exercise the USB bulk-out tail transfer through the device FTP server.
+
+The file lives on the first physical USB volume the FTP root exposes.  The
+upload begins with 1024 bytes followed by two bytes, then continues in
+1024-byte writes.  The two-byte write keeps subsequent filesystem writes at an
+offset of two modulo 512, which forces the bulk-out tail geometry this check
+covers.
+
+Regression guard for GideonZ/1541ultimate#803 (FTP uploads to USB storage come
+back with a handful of wrong bytes at the correct size). GideonZ/1541ultimate#821
+carries a workaround for the same bulk-out bounce condition, targeted at
+(buffer alignment + length) mod 4 != 0; this reproduction takes a different
+path to the bug (a 512-byte-aligned two-sector `disk_write()` losing the top
+byte of its last word), so it is not known whether #821 addresses it.
+
+This is manual: it only reproduces on firmware where the defect is present
+(observed on a C64 Ultimate at firmware 1.2.0; not observed at 3.15 on a
+U2+L or a U64), so it does not belong in the default gate that runs against
+whatever firmware is currently flashed.
+
+Supported targets: devices with a writable physical USB volume.
+"""
+
+import argparse
+import hashlib
+import os
+import re
+import socket
+import struct
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "lib"))
+
+import ftp as ftp_lib
+from report import Failure, check, check_count, detail, format_exception, section, suite_fail, suite_ok
+
+SUITE = "bulk_out_integrity_test"
+PAYLOAD_BYTES = 8 * 1024
+CHUNK_BYTES = 1024
+INITIAL_TAIL_BYTES = 2
+SEND_DELAY_SECONDS = 0.020
+MISMATCH_LIMIT = 4
+
+
+def payload() -> bytes:
+    """Words identify their own expected offset without a separate fixture."""
+    return b"".join(struct.pack("<I", 0xA5000000 | index)
+                    for index in range(PAYLOAD_BYTES // 4))
+
+
+def fixture_name() -> str:
+    return f"usb_bulk_out_{os.getpid()}_{time.monotonic_ns():x}.bin"
+
+
+def first_usb_directory(client) -> str:
+    """Return the first physical USB volume the device exposes over FTP."""
+    entries = set()
+    for entry in ftp_lib.names(client, "/"):
+        name = entry.rsplit("/", 1)[-1]
+        if re.fullmatch(r"USB\d+", name):
+            entries.add(name)
+    for name in ("USB0", "USB1", "USB2"):
+        if name in entries:
+            return f"/{name}"
+    raise Failure(f"FTP root has no physical USB<n> volume: {sorted(entries)}")
+
+
+def send_payload(client, name: str, data: bytes) -> None:
+    """Send the known bulk-out trigger without letting ftplib coalesce writes."""
+    try:
+        connection = client.transfercmd(f"STOR {name}")
+        try:
+            connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            connection.sendall(data[:CHUNK_BYTES])
+            time.sleep(SEND_DELAY_SECONDS)
+            connection.sendall(data[CHUNK_BYTES:CHUNK_BYTES + INITIAL_TAIL_BYTES])
+            time.sleep(SEND_DELAY_SECONDS)
+            for offset in range(CHUNK_BYTES + INITIAL_TAIL_BYTES, len(data), CHUNK_BYTES):
+                connection.sendall(data[offset:offset + CHUNK_BYTES])
+                if offset + CHUNK_BYTES < len(data):
+                    time.sleep(SEND_DELAY_SECONDS)
+        finally:
+            connection.close()
+        client.voidresp()
+    except Exception as exc:  # noqa: BLE001 - a socket or FTP fault must not be a bare traceback
+        raise Failure(f"FTP STOR of {name} did not complete: {exc}") from exc
+
+
+def mismatches(expected: bytes, actual: bytes) -> list[str]:
+    """Describe word-level corruption at offsets meaningful to the USB transfer."""
+    found = []
+    words = (max(len(expected), len(actual)) + 3) // 4
+    for index in range(words):
+        offset = index * 4
+        wanted = expected[offset:offset + 4]
+        received = actual[offset:offset + 4]
+        if wanted == received:
+            continue
+        expected_value = (f"0x{struct.unpack('<I', wanted)[0]:08x}"
+                          if len(wanted) == 4 else wanted.hex())
+        actual_value = (f"0x{struct.unpack('<I', received)[0]:08x}"
+                        if len(received) == 4 else received.hex() or "<missing>")
+        found.append(
+            f"byte {offset}, word {index}: expected {expected_value}, got {actual_value}; "
+            f"mod 512={offset % 512}, mod 1024={offset % 1024}")
+        if len(found) == MISMATCH_LIMIT:
+            break
+    return found
+
+
+def scenario_bulk_out_integrity(host: str, password: str, timeout: float) -> None:
+    section("FTP round trip through physical USB storage")
+    name = fixture_name()
+    expected = payload()
+    client = ftp_lib.connect(host, password, timeout)
+    try:
+        with check("the paced bulk-out upload returns byte-exact data"):
+            volume = first_usb_directory(client)
+            client.cwd(volume)
+            detail(f"physical volume {volume}")
+            send_payload(client, name, expected)
+            actual = ftp_lib.retrieve(client, name)
+            if actual != expected:
+                detail(f"file {name}, expected {len(expected)} bytes, received {len(actual)} bytes")
+                detail(f"sha256 expected {hashlib.sha256(expected).hexdigest()}, "
+                       f"got {hashlib.sha256(actual).hexdigest()}")
+                for mismatch in mismatches(expected, actual):
+                    detail(mismatch)
+                raise Failure("FTP round trip changed USB storage data")
+    finally:
+        # This is the sole fixture the suite creates.  Keep cleanup independent
+        # of the comparison so a red run does not leave the USB volume dirty.
+        ftp_lib.delete_quietly(client, name)
+        ftp_lib.close(client)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Verify paced FTP writes round-trip exactly through physical USB storage.")
+    parser.add_argument("-H", "--host", default=os.environ.get("U64_HOST", "u64"))
+    parser.add_argument("-p", "--password", default=os.environ.get("U64_PASS", ""))
+    parser.add_argument("-t", "--timeout", type=float,
+                        default=float(os.environ.get("U64_TIMEOUT", "10.0")))
+    return parser.parse_args(argv)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        scenario_bulk_out_integrity(args.host, args.password, args.timeout)
+    except Failure as exc:
+        suite_fail(SUITE, str(exc))
+        return 1
+    except Exception as exc:  # noqa: BLE001 - a device/FTP fault must not be a bare traceback
+        suite_fail(SUITE, format_exception(exc))
+        return 1
+    suite_ok(SUITE, f"{check_count()} checks")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this adds

A new manual E2E suite, `usb-bulk-out-integrity` (`tests/e2e/io/usb/bulk_out_integrity_test.py`), that uploads a small known payload over FTP to the first physical USB volume the device exposes, paced so the file offset sits at 2 mod 512 for the writes that follow, then downloads it back and compares byte for byte.

This is a regression guard only. It does not attempt a fix; scope is limited to reproducing the defect on demand.

## Why paced at offset 2 mod 512

#821 describes a bulk-out bounce condition tied to `(buffer alignment + length) mod 4 != 0`. The pacing here (1024 bytes, then 2 bytes, then further 1024-byte writes, each its own TCP segment via `TCP_NODELAY` and a 20 ms gap) is meant to reach a related but not identical geometry: a 512-byte-aligned two-sector `disk_write()` where the corruption lands on the top byte of the last word of every other 512-byte sector. #821's alignment condition is not the same shape as what's reproduced here, so the docstring says explicitly that it is not known whether #821's workaround addresses this case. Anyone applying #821 can run this suite to check.

## Reproduction results

Ran the suite repeatedly against three real devices:

- **C64 Ultimate, firmware 1.2.0, fpga 122, core 1.4D** (stock flashed firmware): 20 of 20 consecutive runs FAIL, all with the same sha256 for the round-tripped file, so this is deterministic corruption for this payload and pacing, not intermittent noise. All 20 runs completed in under 2 seconds (typical ~0.5s, max ~1.0s), with an 8 KiB payload.
- **U2+L, firmware 3.15, fpga 123** (standalone, own IP): clean, 0 mismatches across repeated runs.
- **Ultimate 64 Elite, firmware 3.15, fpga 123, core 1.4F**: clean, 0 mismatches across repeated runs.

An earlier attempt on a U2+L running a `test-merge` development build also found zero mismatches (42 uploads, 226 MB, reported at #803's comment thread). Firmware version looks like the discriminator here, not product family: this only reproduces on the older 1.2.0 firmware, not on 3.15. Whether that means it's already fixed upstream of 1.2.0, or is specific to the C64 Ultimate's USB storage path and never regressed U2+L/U64, hasn't been determined — the suite is registered `manual=True` specifically because it goes red on some real firmware and would otherwise break the default gate that runs against whatever's currently flashed.

Corruption shape observed on the 1.2.0 device: exactly 4 words wrong in a 64 KiB payload (before payload was trimmed to 8 KiB for speed), at the last word of every other 512-byte sector. Only the top byte of each little-endian word is wrong (e.g. expected `0xa50005ff`, got `0x020005ff`); the low three bytes, which encode the payload's own offset index, are untouched.

## Registration

Registered manual in `run-tests`, next to `printer`, since it only reproduces on some firmware and shouldn't fail the default gate on devices where the defect is absent.

## Test plan

- [x] Ran 20 consecutive times against a C64 Ultimate on firmware 1.2.0: 20/20 FAIL, all under 2s, identical sha256 each time.
- [x] Ran repeatedly against a U2+L and an Ultimate 64 Elite, both on firmware 3.15: clean, no mismatches.
- [x] Verified fixture cleanup: no leftover files on any of the three devices' USB volumes after the runs.
- [x] Adversarial code review pass; two low-severity findings (a raw `client.nlst()` call instead of the shared `ftp_lib.names()` helper, and a socket-error path that bypassed the module's `Failure` wrapping convention) fixed.

https://claude.ai/code/session_01LFhvs4myrLvd8Go59jBu5L