### PR TITLE
Report the interface MAC addresses from GET /v1/info

### DIFF
--- a/doc/api/openapi-generation.md
+++ b/doc/api/openapi-generation.md
@@ -18,8 +18,8 @@ time, so one document cannot describe both families:
 
 | document | products | paths | operations | size |
 | --- | --- | --- | --- | --- |
-| `rest_api_openapi_u2.yaml` | Ultimate II, II+, II+L | 44 | 55 | 130,826 B |
-| `rest_api_openapi_u64.yaml` | Ultimate 64, 64 Elite, 64 Elite II | 47 | 59 | 141,412 B |
+| `rest_api_openapi_u2.yaml` | Ultimate II, II+, II+L | 44 | 55 | 131,333 B |
+| `rest_api_openapi_u64.yaml` | Ultimate 64, 64 Elite, 64 Elite II | 47 | 59 | 141,919 B |
 
 The Ultimate 64 document is larger because `route_streams.cc` is compiled only by
 its makefiles, and because `machine:debugreg` sits behind `#if U64`.

--- a/doc/api/openapi-generation.md
+++ b/doc/api/openapi-generation.md
@@ -18,8 +18,8 @@ time, so one document cannot describe both families:
 
 | document | products | paths | operations | size |
 | --- | --- | --- | --- | --- |
-| `rest_api_openapi_u2.yaml` | Ultimate II, II+, II+L | 44 | 55 | 129,837 B |
-| `rest_api_openapi_u64.yaml` | Ultimate 64, 64 Elite, 64 Elite II | 47 | 59 | 140,423 B |
+| `rest_api_openapi_u2.yaml` | Ultimate II, II+, II+L | 44 | 55 | 130,826 B |
+| `rest_api_openapi_u64.yaml` | Ultimate 64, 64 Elite, 64 Elite II | 47 | 59 | 141,412 B |
 
 The Ultimate 64 document is larger because `route_streams.cc` is compiled only by
 its makefiles, and because `machine:debugreg` sits behind `#if U64`.

--- a/doc/api/rest_api_openapi_u2.yaml
+++ b/doc/api/rest_api_openapi_u2.yaml
@@ -1812,6 +1812,8 @@ paths:
       description: |2-
         Identifies the device: product name, firmware version, FPGA build number, host name, unique id and hardware addresses. `core_version` is the version of the C64 core and is present on Ultimate 64 hardware only. `unique_id` is left out when the device has none configured.
 
+        `git_commit_hash` is the abbreviated hash of the commit the firmware was built from, the same one the System Information screen shows. It tells two builds that carry the same version number apart.
+
         `ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless interface. Each is left out when the device has no such interface, or when that interface has not started and its address is therefore not known yet. They are what a caller sends a Wake-on-LAN magic packet to, which carries a MAC and not an IP address.
 
         The same information is also available without HTTP, from the Ultimate Ident Service on UDP port 64, which answers a broadcast and so can be used to find a device whose address is not known.
@@ -1828,6 +1830,7 @@ paths:
                   value:
                     product: Ultimate 64 Elite (V1.49) 3.14d
                     firmware_version: '3.14d'
+                    git_commit_hash: '5ee21b65'
                     fpga_version: '122'
                     core_version: '1.49'
                     hostname: Ultimate-64-Elite-C89085
@@ -1839,6 +1842,7 @@ paths:
                   value:
                     product: '1541 Ultimate II+ 3.14d'
                     firmware_version: '3.14d'
+                    git_commit_hash: '5ee21b65'
                     fpga_version: '11f'
                     hostname: Ultimate-II-Plus
                     ethernet_mac: '02:15:41:AA:BB:CC'
@@ -3441,6 +3445,9 @@ components:
               description: Full product name, including the core version on Ultimate 64 hardware.
             firmware_version:
               type: string
+            git_commit_hash:
+              type: string
+              description: Abbreviated hash of the commit the firmware was built from. It tells two builds that carry the same version number apart.
             fpga_version:
               type: string
               description: FPGA build number in hexadecimal.

--- a/doc/api/rest_api_openapi_u2.yaml
+++ b/doc/api/rest_api_openapi_u2.yaml
@@ -1810,7 +1810,9 @@ paths:
         - About
       summary: Product and version information
       description: |2-
-        Identifies the device: product name, firmware version, FPGA build number, host name and unique id. `core_version` is the version of the C64 core and is present on Ultimate 64 hardware only. `unique_id` is left out when the device has none configured.
+        Identifies the device: product name, firmware version, FPGA build number, host name, unique id and hardware addresses. `core_version` is the version of the C64 core and is present on Ultimate 64 hardware only. `unique_id` is left out when the device has none configured.
+
+        `ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless interface. Each is left out when the device has no such interface, or when that interface has not started and its address is therefore not known yet. They are what a caller sends a Wake-on-LAN magic packet to, which carries a MAC and not an IP address.
 
         The same information is also available without HTTP, from the Ultimate Ident Service on UDP port 64, which answers a broadcast and so can be used to find a device whose address is not known.
       operationId: getInfo
@@ -1830,6 +1832,8 @@ paths:
                     core_version: '1.49'
                     hostname: Ultimate-64-Elite-C89085
                     unique_id: D09B96
+                    ethernet_mac: '02:15:41:C8:90:85'
+                    wifi_mac: '24:0A:C4:1A:2B:3C'
                     errors: []
                 Ultimate II+:
                   value:
@@ -1837,6 +1841,7 @@ paths:
                     firmware_version: '3.14d'
                     fpga_version: '11f'
                     hostname: Ultimate-II-Plus
+                    ethernet_mac: '02:15:41:AA:BB:CC'
                     errors: []
         '403':
           $ref: '#/components/responses/Forbidden'
@@ -3447,6 +3452,12 @@ components:
             unique_id:
               type: string
               description: Omitted when the device has no unique id configured.
+            ethernet_mac:
+              type: string
+              description: MAC address of the wired interface, upper case, colon separated. Omitted while the interface has not started and its address is not known.
+            wifi_mac:
+              type: string
+              description: MAC address of the Wi-Fi interface, upper case, colon separated. Omitted on hardware without a Wi-Fi module, and while the module has not started and its address is not known.
     InputBatch:
       type: object
       description: A batch of input events, applied in order. The whole batch is validated before any of it is applied, so a rejected batch changes nothing.

--- a/doc/api/rest_api_openapi_u64.yaml
+++ b/doc/api/rest_api_openapi_u64.yaml
@@ -1813,7 +1813,9 @@ paths:
         - About
       summary: Product and version information
       description: |2-
-        Identifies the device: product name, firmware version, FPGA build number, host name and unique id. `core_version` is the version of the C64 core and is present on Ultimate 64 hardware only. `unique_id` is left out when the device has none configured.
+        Identifies the device: product name, firmware version, FPGA build number, host name, unique id and hardware addresses. `core_version` is the version of the C64 core and is present on Ultimate 64 hardware only. `unique_id` is left out when the device has none configured.
+
+        `ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless interface. Each is left out when the device has no such interface, or when that interface has not started and its address is therefore not known yet. They are what a caller sends a Wake-on-LAN magic packet to, which carries a MAC and not an IP address.
 
         The same information is also available without HTTP, from the Ultimate Ident Service on UDP port 64, which answers a broadcast and so can be used to find a device whose address is not known.
       operationId: getInfo
@@ -1833,6 +1835,8 @@ paths:
                     core_version: '1.49'
                     hostname: Ultimate-64-Elite-C89085
                     unique_id: D09B96
+                    ethernet_mac: '02:15:41:C8:90:85'
+                    wifi_mac: '24:0A:C4:1A:2B:3C'
                     errors: []
                 Ultimate II+:
                   value:
@@ -1840,6 +1844,7 @@ paths:
                     firmware_version: '3.14d'
                     fpga_version: '11f'
                     hostname: Ultimate-II-Plus
+                    ethernet_mac: '02:15:41:AA:BB:CC'
                     errors: []
         '403':
           $ref: '#/components/responses/Forbidden'
@@ -3722,6 +3727,12 @@ components:
             unique_id:
               type: string
               description: Omitted when the device has no unique id configured.
+            ethernet_mac:
+              type: string
+              description: MAC address of the wired interface, upper case, colon separated. Omitted while the interface has not started and its address is not known.
+            wifi_mac:
+              type: string
+              description: MAC address of the Wi-Fi interface, upper case, colon separated. Omitted on hardware without a Wi-Fi module, and while the module has not started and its address is not known.
     InputBatch:
       type: object
       description: A batch of input events, applied in order. The whole batch is validated before any of it is applied, so a rejected batch changes nothing.

--- a/doc/api/rest_api_openapi_u64.yaml
+++ b/doc/api/rest_api_openapi_u64.yaml
@@ -1815,6 +1815,8 @@ paths:
       description: |2-
         Identifies the device: product name, firmware version, FPGA build number, host name, unique id and hardware addresses. `core_version` is the version of the C64 core and is present on Ultimate 64 hardware only. `unique_id` is left out when the device has none configured.
 
+        `git_commit_hash` is the abbreviated hash of the commit the firmware was built from, the same one the System Information screen shows. It tells two builds that carry the same version number apart.
+
         `ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless interface. Each is left out when the device has no such interface, or when that interface has not started and its address is therefore not known yet. They are what a caller sends a Wake-on-LAN magic packet to, which carries a MAC and not an IP address.
 
         The same information is also available without HTTP, from the Ultimate Ident Service on UDP port 64, which answers a broadcast and so can be used to find a device whose address is not known.
@@ -1831,6 +1833,7 @@ paths:
                   value:
                     product: Ultimate 64 Elite (V1.49) 3.14d
                     firmware_version: '3.14d'
+                    git_commit_hash: '5ee21b65'
                     fpga_version: '122'
                     core_version: '1.49'
                     hostname: Ultimate-64-Elite-C89085
@@ -1842,6 +1845,7 @@ paths:
                   value:
                     product: '1541 Ultimate II+ 3.14d'
                     firmware_version: '3.14d'
+                    git_commit_hash: '5ee21b65'
                     fpga_version: '11f'
                     hostname: Ultimate-II-Plus
                     ethernet_mac: '02:15:41:AA:BB:CC'
@@ -3716,6 +3720,9 @@ components:
               description: Full product name, including the core version on Ultimate 64 hardware.
             firmware_version:
               type: string
+            git_commit_hash:
+              type: string
+              description: Abbreviated hash of the commit the firmware was built from. It tells two builds that carry the same version number apart.
             fpga_version:
               type: string
               description: FPGA build number in hexadecimal.

--- a/software/api/routes.cc
+++ b/software/api/routes.cc
@@ -4,6 +4,7 @@
 #include "stream_uart.h"
 #include "dump_hex.h"
 #include "network_config.h"
+#include "network_interface.h"
 #include "product.h"
 #include "versions.h"
 #include "u64.h"
@@ -168,17 +169,23 @@ API_DOC(GET, info, none,
     TAG("About")
     SUMMARY("Product and version information")
     DESCRIPTION("Identifies the device: product name, firmware version, FPGA build number, host "
-                "name and unique id. `core_version` is the version of the C64 core and is present "
-                "on Ultimate 64 hardware only. `unique_id` is left out when the device has none "
-                "configured.\n"
+                "name, unique id and hardware addresses. `core_version` is the version of the C64 "
+                "core and is present on Ultimate 64 hardware only. `unique_id` is left out when "
+                "the device has none configured.\n"
+                "\n"
+                "`ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless "
+                "interface. Each is left out when the device has no such interface, or when that "
+                "interface has not started and its address is therefore not known yet. They are "
+                "what a caller sends a Wake-on-LAN magic packet to, which carries a MAC and not "
+                "an IP address.\n"
                 "\n"
                 "The same information is also available without HTTP, from the Ultimate Ident "
                 "Service on UDP port 64, which answers a broadcast and so can be used to find a "
                 "device whose address is not known.")
     PATH("/v1/info", "getInfo", "")
     RESPONSE("200", "application/json", "InfoResponse", "What the device is and what it is running.", "")
-    RESPONSE_EXAMPLE("200", "Ultimate 64 Elite", "{\n  \"product\" : \"Ultimate 64 Elite (V1.49) 3.14d\",\n  \"firmware_version\" : \"3.14d\",\n  \"fpga_version\" : \"122\",\n  \"core_version\" : \"1.49\",\n  \"hostname\" : \"Ultimate-64-Elite-C89085\",\n  \"unique_id\" : \"D09B96\",\n  \"errors\" : []\n}", "")
-    RESPONSE_EXAMPLE("200", "Ultimate II+", "{\n  \"product\" : \"1541 Ultimate II+ 3.14d\",\n  \"firmware_version\" : \"3.14d\",\n  \"fpga_version\" : \"11f\",\n  \"hostname\" : \"Ultimate-II-Plus\",\n  \"errors\" : []\n}", "")
+    RESPONSE_EXAMPLE("200", "Ultimate 64 Elite", "{\n  \"product\" : \"Ultimate 64 Elite (V1.49) 3.14d\",\n  \"firmware_version\" : \"3.14d\",\n  \"fpga_version\" : \"122\",\n  \"core_version\" : \"1.49\",\n  \"hostname\" : \"Ultimate-64-Elite-C89085\",\n  \"unique_id\" : \"D09B96\",\n  \"ethernet_mac\" : \"02:15:41:C8:90:85\",\n  \"wifi_mac\" : \"24:0A:C4:1A:2B:3C\",\n  \"errors\" : []\n}", "")
+    RESPONSE_EXAMPLE("200", "Ultimate II+", "{\n  \"product\" : \"1541 Ultimate II+ 3.14d\",\n  \"firmware_version\" : \"3.14d\",\n  \"fpga_version\" : \"11f\",\n  \"hostname\" : \"Ultimate-II-Plus\",\n  \"ethernet_mac\" : \"02:15:41:AA:BB:CC\",\n  \"errors\" : []\n}", "")
 )
 API_CALL(GET, info, none, NULL, ARRAY( { }))
 {
@@ -204,6 +211,33 @@ API_CALL(GET, info, none, NULL, ARRAY( { }))
             unique_id = getProductUniqueId();
         }
         resp->json->add("unique_id", unique_id);
+    }
+
+    // The hardware addresses, one per kind of interface. A caller that wants to
+    // wake the device needs them: a magic packet carries a MAC, not an IP. Only
+    // the first interface of a kind is reported, and one that has not learned
+    // its address yet, because it never started, is left out entirely.
+    static const char *const mac_keys[2] = { "ethernet_mac", "wifi_mac" };
+    bool reported[2] = { false, false };
+    int interfaces = NetworkInterface::getNumberOfInterfaces();
+    for (int i = 0; i < interfaces; i++) {
+        NetworkInterface *intf = NetworkInterface::getInterface(i);
+        if (!intf) {
+            continue;
+        }
+        const int kind = intf->is_wireless() ? 1 : 0;
+        if (reported[kind]) {
+            continue;
+        }
+        uint8_t mac[6];
+        intf->getMacAddr(mac);
+        if (!(mac[0] | mac[1] | mac[2] | mac[3] | mac[4] | mac[5])) {
+            continue;
+        }
+        char mac_str[18];
+        sprintf(mac_str, "%b:%b:%b:%b:%b:%b", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+        resp->json->add(mac_keys[kind], mac_str);
+        reported[kind] = true;
     }
 
     resp->json_response(HTTP_OK);

--- a/software/api/routes.cc
+++ b/software/api/routes.cc
@@ -7,6 +7,7 @@
 #include "network_interface.h"
 #include "product.h"
 #include "versions.h"
+#include "gitinfo.h"
 #include "u64.h"
 #include <string.h>
 #include <strings.h>
@@ -173,6 +174,10 @@ API_DOC(GET, info, none,
                 "core and is present on Ultimate 64 hardware only. `unique_id` is left out when "
                 "the device has none configured.\n"
                 "\n"
+                "`git_commit_hash` is the abbreviated hash of the commit the firmware was built "
+                "from, the same one the System Information screen shows. It tells two builds that "
+                "carry the same version number apart.\n"
+                "\n"
                 "`ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless "
                 "interface. Each is left out when the device has no such interface, or when that "
                 "interface has not started and its address is therefore not known yet. They are "
@@ -184,8 +189,8 @@ API_DOC(GET, info, none,
                 "device whose address is not known.")
     PATH("/v1/info", "getInfo", "")
     RESPONSE("200", "application/json", "InfoResponse", "What the device is and what it is running.", "")
-    RESPONSE_EXAMPLE("200", "Ultimate 64 Elite", "{\n  \"product\" : \"Ultimate 64 Elite (V1.49) 3.14d\",\n  \"firmware_version\" : \"3.14d\",\n  \"fpga_version\" : \"122\",\n  \"core_version\" : \"1.49\",\n  \"hostname\" : \"Ultimate-64-Elite-C89085\",\n  \"unique_id\" : \"D09B96\",\n  \"ethernet_mac\" : \"02:15:41:C8:90:85\",\n  \"wifi_mac\" : \"24:0A:C4:1A:2B:3C\",\n  \"errors\" : []\n}", "")
-    RESPONSE_EXAMPLE("200", "Ultimate II+", "{\n  \"product\" : \"1541 Ultimate II+ 3.14d\",\n  \"firmware_version\" : \"3.14d\",\n  \"fpga_version\" : \"11f\",\n  \"hostname\" : \"Ultimate-II-Plus\",\n  \"ethernet_mac\" : \"02:15:41:AA:BB:CC\",\n  \"errors\" : []\n}", "")
+    RESPONSE_EXAMPLE("200", "Ultimate 64 Elite", "{\n  \"product\" : \"Ultimate 64 Elite (V1.49) 3.14d\",\n  \"firmware_version\" : \"3.14d\",\n  \"git_commit_hash\" : \"5ee21b65\",\n  \"fpga_version\" : \"122\",\n  \"core_version\" : \"1.49\",\n  \"hostname\" : \"Ultimate-64-Elite-C89085\",\n  \"unique_id\" : \"D09B96\",\n  \"ethernet_mac\" : \"02:15:41:C8:90:85\",\n  \"wifi_mac\" : \"24:0A:C4:1A:2B:3C\",\n  \"errors\" : []\n}", "")
+    RESPONSE_EXAMPLE("200", "Ultimate II+", "{\n  \"product\" : \"1541 Ultimate II+ 3.14d\",\n  \"firmware_version\" : \"3.14d\",\n  \"git_commit_hash\" : \"5ee21b65\",\n  \"fpga_version\" : \"11f\",\n  \"hostname\" : \"Ultimate-II-Plus\",\n  \"ethernet_mac\" : \"02:15:41:AA:BB:CC\",\n  \"errors\" : []\n}", "")
 )
 API_CALL(GET, info, none, NULL, ARRAY( { }))
 {
@@ -199,6 +204,7 @@ API_CALL(GET, info, none, NULL, ARRAY( { }))
 
     resp->json->add("product", getProductString())
         ->add("firmware_version", APPL_VERSION_ASCII)
+        ->add("git_commit_hash", APP_VERSION_HASH)
         ->add("fpga_version", fpga_version)
 #ifdef U64
         ->add("core_version", core_version)

--- a/software/io/network/network_esp32.h
+++ b/software/io/network/network_esp32.h
@@ -35,6 +35,7 @@ public:
     virtual ~NetworkLWIP_WiFi();
 
     const char *identify() { return "WiFi"; }
+    bool is_wireless() { return true; }
     void attach_config();
 
     // User Interface

--- a/software/io/network/network_interface.h
+++ b/software/io/network/network_interface.h
@@ -113,6 +113,9 @@ public:
 
     virtual void attach_config();
     virtual const char *identify() { return "Wired Network"; }
+    // Whether this interface is a radio. Only a radio stays up while the
+    // machine is off, which is what makes it the one that can be woken.
+    virtual bool is_wireless() { return false; }
 
 	bool start();
     void stop();

--- a/tests/e2e/api/rest_api_coverage_test.py
+++ b/tests/e2e/api/rest_api_coverage_test.py
@@ -272,6 +272,20 @@ def build_cases() -> List[Case]:
             raise Failure(f"product or firmware missing: {info}")
     case(("GET", "/v1/info"), "names product and firmware", "happy", _info)
 
+    def _info_macs(ctx: Ctx) -> None:
+        info = ctx.api.info()
+        found = {k: v for k, v in info.extra.items()
+                 if k in ("ethernet_mac", "wifi_mac")}
+        for key, value in found.items():
+            if not re.fullmatch(r"([0-9A-F]{2}:){5}[0-9A-F]{2}", str(value)):
+                raise Failure(f"{key} is not a MAC address: {value!r}")
+        # The request that just answered arrived over one of the interfaces, so
+        # at least one of them has to know its own address.
+        if not found:
+            raise Failure(f"no interface address reported: {info}")
+    case(("GET", "/v1/info"), "reports the interface MAC addresses", "happy",
+         _info_macs)
+
     def _help(ctx: Ctx) -> None:
         if not ctx.api.help("version"):
             raise Failure("the help page was empty")

--- a/tests/e2e/api/rest_api_coverage_test.py
+++ b/tests/e2e/api/rest_api_coverage_test.py
@@ -286,6 +286,19 @@ def build_cases() -> List[Case]:
     case(("GET", "/v1/info"), "reports the interface MAC addresses", "happy",
          _info_macs)
 
+    def _info_git(ctx: Ctx) -> None:
+        info = ctx.api.info()
+        commit = info.extra.get("git_commit_hash")
+        if commit is None:
+            raise Failure(f"no git_commit_hash reported: {info}")
+        # An abbreviated hash, as `git rev-parse --short HEAD` prints it. An
+        # empty one means the firmware was built outside a git checkout, which
+        # leaves the field unable to answer what is running.
+        if not re.fullmatch(r"[0-9a-f]{7,40}", str(commit)):
+            raise Failure(f"git_commit_hash is not a commit hash: {commit!r}")
+    case(("GET", "/v1/info"), "names the commit it was built from", "happy",
+         _info_git)
+
     def _help(ctx: Ctx) -> None:
         if not ctx.api.help("version"):
             raise Failure("the help page was empty")

--- a/tools/openapi/schemas.py
+++ b/tools/openapi/schemas.py
@@ -181,6 +181,13 @@ SCHEMAS = {
                         "description": "Full product name, including the core version on Ultimate 64 hardware.",
                     },
                     "firmware_version": {"type": "string"},
+                    "git_commit_hash": {
+                        "type": "string",
+                        "description": (
+                            "Abbreviated hash of the commit the firmware was built from. It "
+                            "tells two builds that carry the same version number apart."
+                        ),
+                    },
                     "fpga_version": {
                         "type": "string",
                         "description": "FPGA build number in hexadecimal.",

--- a/tools/openapi/schemas.py
+++ b/tools/openapi/schemas.py
@@ -194,6 +194,22 @@ SCHEMAS = {
                         "type": "string",
                         "description": "Omitted when the device has no unique id configured.",
                     },
+                    "ethernet_mac": {
+                        "type": "string",
+                        "description": (
+                            "MAC address of the wired interface, upper case, colon separated. "
+                            "Omitted while the interface has not started and its address is "
+                            "not known."
+                        ),
+                    },
+                    "wifi_mac": {
+                        "type": "string",
+                        "description": (
+                            "MAC address of the Wi-Fi interface, upper case, colon separated. "
+                            "Omitted on hardware without a Wi-Fi module, and while the module "
+                            "has not started and its address is not known."
+                        ),
+                    },
                 },
             },
         ]


### PR DESCRIPTION
### What

`GET /v1/info` gains three optional fields:

```json
{
  "product" : "Ultimate 64 Elite (V1.49) 3.14d",
  "firmware_version" : "3.14d",
  "git_commit_hash" : "5ee21b65",
  ...
  "ethernet_mac" : "02:15:41:C8:90:85",
  "wifi_mac" : "24:0A:C4:1A:2B:3C",
  "errors" : []
}
```

### Why the MAC addresses

Wake-on-Wi-Fi matches a magic packet, and a magic packet carries a MAC address, not an IP one. `wol_is_magic_packet()` compares against the station netif's `hwaddr`, which is the Wi-Fi STA address the firmware also gets back from `CMD_WIFI_GETMAC` — so `wifi_mac` is exactly the address a remote client has to send to.

Until now that address was on the configuration screen and nowhere else, so an app that wants a "switch it on" button had to have the user type it in or dig it out of an ARP table, both of which are wrong the first time the device is on a network the app has never seen it on. `ethernet_mac` is there for the wired side of the same question.

### Why the commit hash

A version number does not say which build is running. Between two firmwares that both call themselves 3.15 there is nothing in the API to tell them apart, so a bug report against "3.15" cannot be tied to a tree.

The firmware already knows: the `gitinfo` rule in `target/common/rules.mk` writes `APP_VERSION_HASH` from `git rev-parse --short HEAD`, and the System Information screen has been showing it all along. `/v1/info` reports the same string, so a caller on the network can read it without someone walking up to the machine.

### How

The addresses come from the interface registry, not from a product test:

* `NetworkInterface::is_wireless()` is new, `false` in the base class and `true` in `NetworkLWIP_WiFi`. It is the only thing that decides which of the two keys an interface fills.
* The first interface of each kind wins; the rest are skipped, so a USB Ethernet adapter does not displace the on-board one.
* An interface whose address is still all zeroes, because it never started, is left out entirely rather than reported as `00:00:00:00:00:00`. A build without a Wi-Fi module therefore has no `wifi_mac` at all, and no `#ifdef` is needed to arrange that.

Formatting matches what the configuration screen shows: upper case, colon separated.

### Documentation

`API_DOC` and `InfoResponse` in `tools/openapi/schemas.py` describe all three fields and when each is absent; `make openapi` regenerated both documents, and `make openapi_check` and `make openapi_test` pass. The size row in `doc/api/openapi-generation.md` is updated with the new byte counts. A PR against `1541ultimate-documentation` can follow once this one has a shape everybody is happy with.

### Tests

`tests/e2e/api/rest_api_coverage_test.py` gets two cases on `GET /v1/info`:

* the shape of whichever MAC addresses are reported, and that at least one is: the request it just answered arrived over some interface, so that interface knows its own address.
* `git_commit_hash` is present and looks like an abbreviated hash. An empty one means the firmware was built outside a git checkout, and a field that cannot answer what is running is worse than no field at all.

### Build

Built this time, unlike the first round: `make u64ii_no_esp` on this branch is green in `ghcr.io/gideonz/riscv`, `routes.cc` compiles and links without a new warning, and `app_space_test` and `openapi_check` pass as part of it. The generated `gitinfo.h` of that build reads `APP_VERSION_HASH "270e48587"`, which is what the new field returns.

The E2E cases have not run against hardware yet — that needs the branch flashed, and the updater asks its questions at the local keyboard.
