### PR TITLE
Fix Firefox home page theme selector

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -853,7 +853,7 @@ $(document).ready(async function () {
     const themes = (() =>  {
         const themeNames = ['lightmode', 'darkmode' /*, 'purple-theme' */ ];
 
-        const themedSelectors = [ 'body', '#left-nav', '#banner', 'a:-webkit-any-link', 'div#left-nav a', '#banner', 
+        const themedSelectors = [ 'body', '#left-nav', '#banner', 'a', 'div#left-nav a', '#banner',
             '#left-nav', '#darkmode-button', '#lightmode-button'
         ];
 
@@ -1622,7 +1622,7 @@ function disassembler(startInt, byteArray) {
     border: 2px solid var(--background);
 }
 
-a:-webkit-any-link.darkmode {
+a.darkmode {
     color: yellow;
 }
 div#left-nav a.darkmode {


### PR DESCRIPTION
Use standard anchor selectors for home-page theme setup and dark-link styling.

Validated on U64 with Firefox and Chrome: the home page loads, the API Explorer loads its U64 OpenAPI document, dark/light controls switch, and Swagger UI executes GET /v1/info with HTTP 200.

Thanks a lot to @radius75 for having made us aware of this issue, and for having researched the fix.