### PR TITLE
Fix Firefox compatibility. Remember selected theme for the current session.

### DIFF
--- a/html/api.html
+++ b/html/api.html
@@ -29,7 +29,7 @@
 -->
 <meta http-equiv="Content-Security-Policy" content="
     default-src 'none';
-    script-src 'unsafe-inline' https://unpkg.com/swagger-ui-dist@5.32.14/;
+    script-src 'sha256-LZqNxYBbhieAv4SV0EsDhOQ4IIXf7gtaYlYPOppWrtk=' https://unpkg.com/swagger-ui-dist@5.32.14/;
     style-src 'unsafe-inline' https://unpkg.com/swagger-ui-dist@5.32.14/;
     img-src 'self' data:;
     font-src 'self' data:;

--- a/html/api.html
+++ b/html/api.html
@@ -29,7 +29,7 @@
 -->
 <meta http-equiv="Content-Security-Policy" content="
     default-src 'none';
-    script-src 'sha256-LZqNxYBbhieAv4SV0EsDhOQ4IIXf7gtaYlYPOppWrtk=' https://unpkg.com/swagger-ui-dist@5.32.14/;
+    script-src 'sha256-aqK8YQoFANsW5zAcGrfy1JSRJISHSHowXSVLT070ZNo=' https://unpkg.com/swagger-ui-dist@5.32.14/;
     style-src 'unsafe-inline' https://unpkg.com/swagger-ui-dist@5.32.14/;
     img-src 'self' data:;
     font-src 'self' data:;
@@ -105,14 +105,38 @@
 // Follows the browser's setting on load and switches for the session, which is
 // what html/index.html does. Outside window.onload below, so the offline notice
 // is themed too, on a page where the bundle never arrives.
-function setDarkMode(dark, save = true) {
-    document.documentElement.classList.toggle("dark-mode", dark);
-    if (save) {
-        sessionStorage.setItem("theme", dark ? "darkmode" : "lightmode");
+
+// Reading or writing sessionStorage throws a SecurityError in a browser that is
+// set to block site data. This script installs the theme buttons and the
+// window.onload handler that starts Swagger UI, so an unguarded throw here would
+// leave the page on its offline notice for good. The theme is not worth that.
+function readTheme() {
+    try {
+        return sessionStorage.getItem("theme");
+    } catch (e) {
+        return null;
     }
 }
 
-const savedTheme = sessionStorage.getItem("theme");
+function writeTheme(themeName) {
+    try {
+        sessionStorage.setItem("theme", themeName);
+    } catch (e) {
+        // A browser that refuses to store the theme still gets to show it.
+    }
+}
+
+function setDarkMode(dark, save = true) {
+    document.documentElement.classList.toggle("dark-mode", dark);
+    if (save) {
+        writeTheme(dark ? "darkmode" : "lightmode");
+    }
+}
+
+// Only a theme the reader picked is stored. Following the browser's setting is
+// not a choice, so it is applied without being stored, which leaves a later
+// change of that setting free to take effect.
+const savedTheme = readTheme();
 
 if (savedTheme === "darkmode") {
     setDarkMode(true, false);

--- a/html/api.html
+++ b/html/api.html
@@ -29,7 +29,7 @@
 -->
 <meta http-equiv="Content-Security-Policy" content="
     default-src 'none';
-    script-src 'sha256-jG/elDqAeYYU5kU5fxHvBLgsUPuUbQEjzMVi0CC3Rz0=' https://unpkg.com/swagger-ui-dist@5.32.14/;
+    script-src 'unsafe-inline' https://unpkg.com/swagger-ui-dist@5.32.14/;
     style-src 'unsafe-inline' https://unpkg.com/swagger-ui-dist@5.32.14/;
     img-src 'self' data:;
     font-src 'self' data:;
@@ -105,10 +105,23 @@
 // Follows the browser's setting on load and switches for the session, which is
 // what html/index.html does. Outside window.onload below, so the offline notice
 // is themed too, on a page where the bundle never arrives.
-function setDarkMode(dark) {
+function setDarkMode(dark, save = true) {
     document.documentElement.classList.toggle("dark-mode", dark);
+    if (save) {
+        sessionStorage.setItem("theme", dark ? "darkmode" : "lightmode");
+    }
 }
-setDarkMode(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+const savedTheme = sessionStorage.getItem("theme");
+
+if (savedTheme === "darkmode") {
+    setDarkMode(true, false);
+} else if (savedTheme === "lightmode") {
+    setDarkMode(false, false);
+} else {
+    setDarkMode(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches, false);
+}
+
 document.getElementById("darkmode-button").onclick = function (e) { e.preventDefault(); setDarkMode(true); };
 document.getElementById("lightmode-button").onclick = function (e) { e.preventDefault(); setDarkMode(false); };
 

--- a/html/api.html
+++ b/html/api.html
@@ -29,7 +29,7 @@
 -->
 <meta http-equiv="Content-Security-Policy" content="
     default-src 'none';
-    script-src 'sha256-aqK8YQoFANsW5zAcGrfy1JSRJISHSHowXSVLT070ZNo=' https://unpkg.com/swagger-ui-dist@5.32.14/;
+    script-src 'sha256-kipltUoahufJ17SCh0L5wJts1abvZjVSgqRyNq/G+FI=' https://unpkg.com/swagger-ui-dist@5.32.14/;
     style-src 'unsafe-inline' https://unpkg.com/swagger-ui-dist@5.32.14/;
     img-src 'self' data:;
     font-src 'self' data:;
@@ -106,10 +106,8 @@
 // what html/index.html does. Outside window.onload below, so the offline notice
 // is themed too, on a page where the bundle never arrives.
 
-// Reading or writing sessionStorage throws a SecurityError in a browser that is
-// set to block site data. This script installs the theme buttons and the
-// window.onload handler that starts Swagger UI, so an unguarded throw here would
-// leave the page on its offline notice for good. The theme is not worth that.
+// sessionStorage throws where the browser blocks site data, and the handlers
+// below are installed after it, so both sides are guarded.
 function readTheme() {
     try {
         return sessionStorage.getItem("theme");
@@ -122,7 +120,6 @@ function writeTheme(themeName) {
     try {
         sessionStorage.setItem("theme", themeName);
     } catch (e) {
-        // A browser that refuses to store the theme still gets to show it.
     }
 }
 
@@ -133,9 +130,7 @@ function setDarkMode(dark, save = true) {
     }
 }
 
-// Only a theme the reader picked is stored. Following the browser's setting is
-// not a choice, so it is applied without being stored, which leaves a later
-// change of that setting free to take effect.
+// Only a picked theme is stored, so a later change of the browser setting applies.
 const savedTheme = readTheme();
 
 if (savedTheme === "darkmode") {

--- a/html/index.html
+++ b/html/index.html
@@ -862,25 +862,50 @@ $(document).ready(async function () {
             '#lightmode-button'
         ];
 
+        // Reading or writing sessionStorage throws a SecurityError in a browser
+        // that is set to block site data. This code runs before the login and
+        // welcome screens are started, so an unguarded throw here would leave the
+        // page with its navigation still hidden. The theme is not worth that.
+        const readTheme = () => {
+            try {
+                return sessionStorage.getItem('theme');
+            } catch (e) {
+                return null;
+            }
+        };
+        const writeTheme = (themeName) => {
+            try {
+                sessionStorage.setItem('theme', themeName);
+            } catch (e) {
+                // A browser that refuses to store the theme still gets to show it.
+            }
+        };
+
         // theme: darkmode, lightmode, ...purple-theme...etc.
         const removeThemes = () => themeNames.forEach(themeName => $(themedSelectors.join(',')).removeClass(themeName));
         const setTheme = (themeName, save = true) => {
             removeThemes();
             $(themedSelectors.join(',')).addClass(themeName);
             if (save) {
-                sessionStorage.setItem('theme', themeName);
+                writeTheme(themeName);
             }
         };
         const setLightMode = () => { setTheme('lightmode'); };
         const setDarkMode = () => { setTheme('darkmode'); };
+        // Only a theme the reader picked is stored. Following the browser's
+        // setting is not a choice, so it is applied without being stored, which
+        // leaves a later change of that setting free to take effect.
         const initDisplayMode = () => {
-        const savedTheme = sessionStorage.getItem('theme');
+            const savedTheme = readTheme();
             if (savedTheme && themeNames.includes(savedTheme)) {
                 setTheme(savedTheme, false);
                 return;
             }
-            if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) { setDarkMode(); return; }
-            setLightMode();
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                setTheme('darkmode', false);
+                return;
+            }
+            setTheme('lightmode', false);
         };
 
         return {

--- a/html/index.html
+++ b/html/index.html
@@ -853,8 +853,13 @@ $(document).ready(async function () {
     const themes = (() =>  {
         const themeNames = ['lightmode', 'darkmode' /*, 'purple-theme' */ ];
 
-        const themedSelectors = [ 'body', '#left-nav', '#banner', 'a', 'div#left-nav a', '#banner',
-            '#left-nav', '#darkmode-button', '#lightmode-button'
+        const themedSelectors = [
+            'body',
+            '#left-nav',
+            '#banner',
+            'a',
+            '#darkmode-button',
+            '#lightmode-button'
         ];
 
         // theme: darkmode, lightmode, ...purple-theme...etc.
@@ -862,19 +867,19 @@ $(document).ready(async function () {
         const setTheme = (themeName) => { removeThemes(); $(themedSelectors.join(',')).addClass(themeName); };
         const setLightMode = () => { setTheme('lightmode'); };
         const setDarkMode = () => { setTheme('darkmode'); };
-        const initDisplayMode = () => { 
+        const initDisplayMode = () => {
             if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) { setDarkMode(); return; }
             setLightMode();
         };
-        
+
         return {
              initDisplayMode, setTheme, setLightMode, setDarkMode
-         };        
+         };
     })();
 
     $('#darkmode-button').on('click', () => themes.setDarkMode() );
     $('#lightmode-button').on('click', () => themes.setLightMode() );
-    
+
     themes.initDisplayMode();
 
     // Kick off login/welcome screen as needed
@@ -1394,25 +1399,25 @@ function disassembler(startInt, byteArray) {
         text-align: left;
         padding: 10px;
         font-size: 24px;
-        display: flex; 
+        display: flex;
         align-items: center;
     }
     #banner.darkmode {
         background: linear-gradient(to bottom, #222, #444)
     }
     #bannertitle {
-        flex-grow: 1; 
+        flex-grow: 1;
         text-align: left;
     }
     #bannerspacer
     {
-        flex-grow: 2; 
+        flex-grow: 2;
         text-align: center;
     }
     #bannertheme-selectors
     {
-        flex-grow: 0; 
-        margin-left: 40px; 
+        flex-grow: 0;
+        margin-left: 40px;
         text-align: right;
         width:24px;
         height:24px;
@@ -1437,8 +1442,8 @@ function disassembler(startInt, byteArray) {
     div#left-nav a:hover {
         background-color: #beffff;
     }
-    div#left-nav a:hover.darkmode {
-        color:burlywood;
+    div#left-nav a.darkmode:hover {
+        color: burlywood;
         background-color: dimgray;
     }
     #login {

--- a/html/index.html
+++ b/html/index.html
@@ -864,10 +864,21 @@ $(document).ready(async function () {
 
         // theme: darkmode, lightmode, ...purple-theme...etc.
         const removeThemes = () => themeNames.forEach(themeName => $(themedSelectors.join(',')).removeClass(themeName));
-        const setTheme = (themeName) => { removeThemes(); $(themedSelectors.join(',')).addClass(themeName); };
+        const setTheme = (themeName, save = true) => {
+            removeThemes();
+            $(themedSelectors.join(',')).addClass(themeName);
+            if (save) {
+                sessionStorage.setItem('theme', themeName);
+            }
+        };
         const setLightMode = () => { setTheme('lightmode'); };
         const setDarkMode = () => { setTheme('darkmode'); };
         const initDisplayMode = () => {
+        const savedTheme = sessionStorage.getItem('theme');
+            if (savedTheme && themeNames.includes(savedTheme)) {
+                setTheme(savedTheme, false);
+                return;
+            }
             if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) { setDarkMode(); return; }
             setLightMode();
         };

--- a/html/index.html
+++ b/html/index.html
@@ -862,10 +862,8 @@ $(document).ready(async function () {
             '#lightmode-button'
         ];
 
-        // Reading or writing sessionStorage throws a SecurityError in a browser
-        // that is set to block site data. This code runs before the login and
-        // welcome screens are started, so an unguarded throw here would leave the
-        // page with its navigation still hidden. The theme is not worth that.
+        // sessionStorage throws where the browser blocks site data, and the
+        // login screen is started after this, so both sides are guarded.
         const readTheme = () => {
             try {
                 return sessionStorage.getItem('theme');
@@ -877,7 +875,6 @@ $(document).ready(async function () {
             try {
                 sessionStorage.setItem('theme', themeName);
             } catch (e) {
-                // A browser that refuses to store the theme still gets to show it.
             }
         };
 
@@ -892,9 +889,8 @@ $(document).ready(async function () {
         };
         const setLightMode = () => { setTheme('lightmode'); };
         const setDarkMode = () => { setTheme('darkmode'); };
-        // Only a theme the reader picked is stored. Following the browser's
-        // setting is not a choice, so it is applied without being stored, which
-        // leaves a later change of that setting free to take effect.
+        // Only a picked theme is stored, so a later change of the browser
+        // setting applies.
         const initDisplayMode = () => {
             const savedTheme = readTheme();
             if (savedTheme && themeNames.includes(savedTheme)) {

--- a/run-tests
+++ b/run-tests
@@ -228,6 +228,12 @@ SUITES: Sequence[Suite] = (
     # told apart by watching a real device, which never produces them on
     # demand. Scripted bursts can.
     Suite("e2e", "telnet-drain", "tests/e2e/lib/telnet_drain_test.py", "", profile=profiles.QUICK),
+    # Also needs no device: the two pages the device serves decide their theme
+    # in the browser, and both read sessionStorage above the code that installs
+    # their handlers, so a browser set to block site data cost the whole page.
+    # Manual because it drives an installed Chrome and Firefox through Selenium,
+    # which no other suite needs and CI does not provide.
+    Suite("e2e", "web-theme", "tests/e2e/web/theme_test.py", "", manual=True),
     # Validates tests/e2e/lib/ui_backend.py itself (Telnet, REST/Freeze,
     # REST/Overlay) before any suite built on it runs, so a broken shared
     # facade fails here with a clear cause instead of as confusing failures

--- a/tests/README.md
+++ b/tests/README.md
@@ -121,6 +121,7 @@ pip install -r tests/requirements.txt
 | `Pillow` | `e2e/api/input_test.py`, `e2e/io/printer/printer_test.py` |
 | `PyYAML` | `tests/lib/openapi_contract.py`, reads `doc/api/rest_api_openapi_*.yaml` |
 | `pyftpdlib` | `e2e/filesystem/ftp_client_test.py` |
+| `selenium` | `e2e/web/theme_test.py`. Also needs an installed Chrome or Firefox with its WebDriver on PATH; whatever is missing is reported as a skip |
 | `pytesseract` | `e2e/io/printer/printer_test.py`, only under `--stage verify` |
 | `ffmpeg`, `ffprobe` | `./run-tests --record` only. Not Python packages. The lossless default needs the `libx264rgb` encoder, which keeps the frames pixel exact; a build without it is refused at startup rather than after half an hour of capture. |
 | `pandoc`, `weasyprint` | Optional, never installed in CI: one command turns `index.md` into a PDF. |
@@ -304,6 +305,7 @@ e2e:
   ui-backend-smoke                  x      x      x      x      x
   usb-bulk-out-integrity            .      .      .      x      x
   wake-on-wifi                      .      .      .      x      x
+  web-theme                         .      .      .      x      x
 
 perf:
   rest-latency                      .      .      x      x      x

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -63,6 +63,7 @@ to drive it.
 | `io/` | `software/io/` | Device-facing I/O subsystems, nested by production package (`c64/`, `command_interface/`, `printer/`) |
 | `monitor/` | `software/monitor/` | Machine-code monitor behaviour |
 | `network/` | `software/network/` | Network service and connection lifecycle |
+| `web/` | `html/`, `software/httpd/` | The light/dark theme of the two pages the device serves, driven in an installed Chrome and Firefox |
 | `u64ctrl/` | `software/u64ctrl/` | The ESP32 control module: what it does across a loss of input power, and waking the machine from off over Wi-Fi |
 | `lib/` | - | Support code shared by E2E suites only: the UI backend (`ui_backend.py`), its menu primitives (`menu.py`), the UI-state gate (`ui_state.py`), the spool of every screen the harness read (`screens.py`), the recorder that composes a run's video (`recorder.py`, with the stream, band, glyph and VIC-text modules beside it), the smoke test of the UI backend itself (`ui_backend_smoke_test.py`), and the device-free check of the Telnet drain state machine (`telnet_drain_test.py`) |
 

--- a/tests/e2e/web/theme_test.py
+++ b/tests/e2e/web/theme_test.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+# E2E: the web UI's light/dark theme, driven in real browsers. Needs no device.
+
+"""What the two pages the device serves must do about their theme.
+
+`html/index.html` and `html/api.html` each follow the browser's own
+`prefers-color-scheme` setting, offer a button to override it, and remember an
+overridden choice for the rest of the browser tab. The rules under test:
+
+- a page loaded with no remembered choice follows the browser's setting and
+  stores nothing, so a later change of that setting still takes effect;
+- a choice made with the theme buttons is stored, and the other page picks it up;
+- a browser set to block on-device site data still gets both pages, working.
+  `sessionStorage` throws a SecurityError there, and each page reads it above the
+  code that installs its handlers, so an unguarded read costs the whole page;
+- the inline script of `api.html` runs at all, which it only does if the SHA-256
+  digest in that page's own Content-Security-Policy matches the script beside it.
+  A stale digest is refused silently by both engines, with no console error, and
+  `tools/openapi/test_explorer.py` is the only other thing that catches it.
+
+Every condition is a real browser setting rather than anything injected into the
+page: `profile.default_content_setting_values.cookies` and
+`network.cookie.cookieBehavior` for blocked site data, CDP `setEmulatedMedia` and
+`ui.systemUsesDarkTheme` for the colour-scheme preference. The clicks and the
+navigation are what a person would do.
+
+The pages are served from a local static server over HTTP, so the suite needs no
+device. `--base-url` points it at a running device instead, which additionally
+establishes that the firmware on that device serves these pages.
+
+Host packages: selenium. See tests/requirements.txt. Also needs Chrome or Firefox
+installed with their WebDriver on PATH, and, for `index.html`, a route to the
+CDN that page loads jQuery from. Whatever is missing is reported as a skip.
+"""
+
+import argparse
+import contextlib
+import functools
+import http.server
+import os
+import pathlib
+import sys
+import threading
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"))
+from report import (Failure, check, check_skip, detail,  # noqa: E402
+                    section, suite_fail, suite_ok)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PAGES = REPO_ROOT / "html"
+
+# Ubuntu and Debian ship Firefox as a Snap whose /usr/bin/firefox is a wrapper
+# script, and geckodriver rejects a wrapper with "binary is not a Firefox
+# executable". These are where the real binary sits when that happens.
+FIREFOX_FALLBACKS = (
+    "/snap/firefox/current/usr/lib/firefox/firefox",
+    "/usr/lib/firefox/firefox",
+    "/usr/lib64/firefox/firefox",
+    "/Applications/Firefox.app/Contents/MacOS/firefox",
+)
+
+# The content setting each browser calls "block site data", which is what makes
+# sessionStorage throw. Chrome numbers its content settings, 2 being block.
+CHROME_BLOCK_SITE_DATA = {"profile.default_content_setting_values.cookies": 2}
+FIREFOX_BLOCK_SITE_DATA = {"network.cookie.cookieBehavior": 2}
+
+# How long a page has to finish applying its theme. index.html does it inside a
+# jQuery ready handler, after fetching jQuery.
+READY_TIMEOUT = 20.0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--base-url", default="",
+                        help="Where the pages are served from, e.g. http://ultimate64. "
+                             "Default: serve html/ from this tree.")
+    parser.add_argument("--browser", default="all", choices=("all", "chrome", "firefox"),
+                        help="Which browsers to drive. Default: every one installed.")
+    parser.add_argument("-t", "--timeout", type=float, default=READY_TIMEOUT,
+                        help="How long a page has to become ready.")
+    return parser.parse_args()
+
+
+def require_selenium():
+    try:
+        import selenium  # noqa: F401
+        from selenium import webdriver
+        return webdriver
+    except ImportError as exc:
+        raise Failure("selenium is needed for this suite: "
+                      "pip install -r tests/requirements.txt") from exc
+
+
+@contextlib.contextmanager
+def serving(directory):
+    """Serve `directory` over HTTP for the length of the run."""
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    handler.func.log_message = lambda *args, **kwargs: None
+
+    class Server(http.server.ThreadingHTTPServer):
+        daemon_threads = True
+
+    server = Server(("127.0.0.1", 0), handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield "http://127.0.0.1:%d" % server.server_address[1]
+    finally:
+        server.shutdown()
+
+
+class Session:
+    """One browser, configured the way a reader's browser would be configured."""
+
+    def __init__(self, webdriver, browser, base_url, timeout, dark=False, block_site_data=False):
+        self.browser = browser
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.page = ""
+        if browser == "chrome":
+            options = webdriver.ChromeOptions()
+            options.add_argument("--headless=new")
+            if block_site_data:
+                options.add_experimental_option("prefs", dict(CHROME_BLOCK_SITE_DATA))
+            self.driver = webdriver.Chrome(options=options)
+            # Chrome has no preference for the colour scheme, so it is set the
+            # way its own developer tools set it.
+            self.driver.execute_cdp_cmd(
+                "Emulation.setEmulatedMedia",
+                {"features": [{"name": "prefers-color-scheme",
+                               "value": "dark" if dark else "light"}]})
+        else:
+            options = webdriver.FirefoxOptions()
+            options.add_argument("-headless")
+            options.set_preference("ui.systemUsesDarkTheme", 1 if dark else 0)
+            for name, value in (FIREFOX_BLOCK_SITE_DATA.items() if block_site_data else ()):
+                options.set_preference(name, value)
+            binary = firefox_binary()
+            if binary:
+                options.binary_location = binary
+            self.driver = webdriver.Firefox(options=options)
+
+    def close(self):
+        self.driver.quit()
+
+    def open(self, page):
+        self.page = page
+        self.driver.get("%s/%s" % (self.base_url, page))
+        self.await_ready(page)
+
+    def await_ready(self, page):
+        """Wait until the page has applied a theme, or give up quietly."""
+        from selenium.webdriver.support.ui import WebDriverWait
+        probe = ("return document.body.className !== ''" if page == "index.html"
+                 else "return typeof setDarkMode !== 'undefined'"
+                      " || document.documentElement.className !== ''")
+        try:
+            WebDriverWait(self.driver, self.timeout).until(
+                lambda driver: driver.execute_script(probe))
+        except Exception:
+            pass  # The checks say what a page that never got there means.
+
+    def script(self, body):
+        return self.driver.execute_script("return %s" % body)
+
+    def press(self, element_id):
+        from selenium.webdriver.common.by import By
+        self.driver.find_element(By.ID, element_id).click()
+
+    @property
+    def theme(self):
+        """The theme the page is showing, in the vocabulary the pages store."""
+        if self.page == "api.html":
+            return self.script("document.documentElement.classList.contains('dark-mode')"
+                               " ? 'darkmode' : 'lightmode'")
+        return self.script("document.body.className") or None
+
+    @property
+    def stored(self):
+        return self.script("(() => { try { return sessionStorage.getItem('theme'); }"
+                           " catch (e) { return 'REFUSED'; } })()")
+
+
+def firefox_binary():
+    """The Firefox to drive: the one named in the environment, or a packaged one."""
+    named = os.environ.get("FIREFOX_BINARY", "")
+    if named:
+        return named
+    for candidate in FIREFOX_FALLBACKS:
+        if pathlib.Path(candidate).exists():
+            return candidate
+    return ""
+
+
+def available(webdriver, browser):
+    """Whether this browser and its driver are here, without asserting anything."""
+    try:
+        session = Session(webdriver, browser, "http://127.0.0.1", 1.0)
+    except Exception as exc:
+        return False, str(exc).strip().split("\n")[0]
+    session.close()
+    return True, ""
+
+
+def jquery_reached(session):
+    """index.html loads jQuery from a CDN, and does nothing at all without it."""
+    return bool(session.script("typeof window.jQuery !== 'undefined'"))
+
+
+def expect(label, got, want):
+    if got != want:
+        raise Failure("%s is %r, expected %r" % (label, got, want))
+
+
+def check_follows_browser_setting(webdriver, browser, base_url, timeout, dark):
+    """A page with nothing stored shows the browser's theme and stores nothing."""
+    setting = "darkmode" if dark else "lightmode"
+    session = Session(webdriver, browser, base_url, timeout, dark=dark)
+    try:
+        session.open("index.html")
+        with check("index.html follows a %s browser and stores nothing" % setting[:-4]):
+            if not jquery_reached(session):
+                check_skip("this host has no route to the CDN index.html loads jQuery from")
+            else:
+                expect("the theme", session.theme, setting)
+                expect("what is stored", session.stored, None)
+
+        session.open("api.html")
+        with check("api.html follows a %s browser and stores nothing" % setting[:-4]):
+            expect("the theme", session.theme, setting)
+            expect("what is stored", session.stored, None)
+    finally:
+        session.close()
+
+
+def check_a_choice_is_remembered(webdriver, browser, base_url, timeout):
+    """A theme picked on either page is stored and honoured by the other."""
+    session = Session(webdriver, browser, base_url, timeout, dark=False)
+    try:
+        session.open("index.html")
+        if not jquery_reached(session):
+            with check("a theme picked on index.html is remembered"):
+                check_skip("this host has no route to the CDN index.html loads jQuery from")
+            return
+
+        with check("picking dark on index.html stores the choice"):
+            session.press("darkmode-button")
+            expect("the theme", session.theme, "darkmode")
+            expect("what is stored", session.stored, "darkmode")
+
+        session.open("api.html")
+        with check("api.html opens in the theme picked on index.html"):
+            expect("the theme", session.theme, "darkmode")
+
+        with check("picking light on api.html stores the choice"):
+            session.press("lightmode-button")
+            expect("the theme", session.theme, "lightmode")
+            expect("what is stored", session.stored, "lightmode")
+
+        session.open("index.html")
+        with check("index.html opens in the theme picked on api.html"):
+            expect("the theme", session.theme, "lightmode")
+    finally:
+        session.close()
+
+
+def check_explorer_script_runs(webdriver, browser, base_url, timeout):
+    """The inline script of api.html is admitted by that page's own CSP digest."""
+    session = Session(webdriver, browser, base_url, timeout, dark=False)
+    try:
+        session.open("api.html")
+        with check("api.html runs its inline script under its own CSP"):
+            if not session.script("!!document.getElementById('darkmode-button').onclick"):
+                raise Failure("the theme buttons have no handler: the script did not run, "
+                              "which is what a stale sha256 digest in the page's "
+                              "Content-Security-Policy looks like")
+            if not session.script("!!window.onload"):
+                raise Failure("nothing is registered on window.onload, so Swagger UI "
+                              "would never start")
+            detail("the theme buttons and the Swagger UI startup are both installed")
+    finally:
+        session.close()
+
+
+def check_site_data_blocked(webdriver, browser, base_url, timeout):
+    """A browser told to block site data still gets both pages, working."""
+    session = Session(webdriver, browser, base_url, timeout, dark=True, block_site_data=True)
+    try:
+        session.open("index.html")
+        with check("index.html is usable with site data blocked"):
+            if not jquery_reached(session):
+                check_skip("this host has no route to the CDN index.html loads jQuery from")
+            else:
+                expect("what sessionStorage does", session.stored, "REFUSED")
+                expect("the theme", session.theme, "darkmode")
+                expect("the navigation", session.script(
+                    "getComputedStyle(document.getElementById('left-nav')).visibility"),
+                    "visible")
+
+        with check("the theme buttons of index.html work with site data blocked"):
+            if not jquery_reached(session):
+                check_skip("this host has no route to the CDN index.html loads jQuery from")
+            else:
+                session.press("lightmode-button")
+                expect("the theme", session.theme, "lightmode")
+    finally:
+        session.close()
+
+    # Started light, so the button has to change something for the check below to
+    # mean anything rather than reporting the theme the page already had.
+    session = Session(webdriver, browser, base_url, timeout, dark=False, block_site_data=True)
+    try:
+        session.open("api.html")
+        with check("api.html is usable with site data blocked"):
+            expect("what sessionStorage does", session.stored, "REFUSED")
+            expect("the theme", session.theme, "lightmode")
+            if not session.script("!!window.onload"):
+                raise Failure("nothing is registered on window.onload, so Swagger UI "
+                              "would never start")
+
+        with check("the theme buttons of api.html work with site data blocked"):
+            session.press("darkmode-button")
+            expect("the theme", session.theme, "darkmode")
+    finally:
+        session.close()
+
+
+def run_browser(webdriver, browser, base_url, timeout):
+    section(browser)
+    for dark in (False, True):
+        check_follows_browser_setting(webdriver, browser, base_url, timeout, dark)
+    check_a_choice_is_remembered(webdriver, browser, base_url, timeout)
+    check_explorer_script_runs(webdriver, browser, base_url, timeout)
+    check_site_data_blocked(webdriver, browser, base_url, timeout)
+
+
+def run(args, base_url):
+    webdriver = require_selenium()
+    wanted = ("chrome", "firefox") if args.browser == "all" else (args.browser,)
+    drove_one = False
+    for browser in wanted:
+        here, why = available(webdriver, browser)
+        if not here:
+            section(browser)
+            with check("%s and its WebDriver are installed" % browser):
+                check_skip(why)
+            continue
+        drove_one = True
+        run_browser(webdriver, browser, base_url, args.timeout)
+    if not drove_one:
+        raise Failure("no browser this suite can drive is installed")
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.base_url:
+            run(args, args.base_url)
+        else:
+            if not (PAGES / "index.html").exists():
+                raise Failure("%s is missing" % PAGES)
+            with serving(PAGES) as base_url:
+                run(args, base_url)
+    except Failure as exc:
+        suite_fail("web_theme", str(exc))
+        return 1
+    suite_ok("web_theme")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,5 +12,6 @@ openapi-schema-validator # tests/lib/openapi_contract.py, checks device answers 
 -r ../tools/openapi/requirements.txt  # openapi-spec-validator, pinned there because `make openapi_validate` is a gate
 Pillow                   # e2e/api/input_test.py, e2e/io/printer/printer_test.py
 pyftpdlib                # e2e/filesystem/ftp_client_test.py
+selenium                 # e2e/web/theme_test.py, drives an installed Chrome and Firefox
 pytesseract              # e2e/io/printer/printer_test.py, only under --stage verify
 PyYAML                   # tests/lib/openapi_contract.py, reads doc/api/rest_api_openapi_*.yaml


### PR DESCRIPTION
`html/index.html` and `html/api.html` each followed the browser's `prefers-color-scheme` setting on load. The theme buttons switched the theme, but the choice was lost on the next navigation, so moving between the web UI and the API explorer reset it.

## What changed

Both pages now store a picked theme in `sessionStorage` under the key `theme`, with the values `darkmode` and `lightmode`, so a choice made on either page holds for the rest of the browser tab and is honoured by the other page.

Only a theme the reader picked is stored. Following the browser's setting is not a choice, so it is applied without being written, which leaves a later change of that setting free to take effect.

Reads and writes of `sessionStorage` are wrapped in try/catch. A browser set to block on-device site data throws a `SecurityError` on access, and both pages read the value above the code that installs their handlers: unguarded, that left `api.html` on its offline notice with Swagger UI never started, and left `index.html` with its navigation hidden and no login or welcome screen.

`api.html` carries a Content-Security-Policy that admits its inline script by SHA-256 digest, so the digest is recomputed with `tools/openapi/explorer.py` to match the edited script.

In `index.html`, the themed-selector list drops two duplicate entries and `div#left-nav a`, which the plain `a` entry already covers.

## New test

`tests/e2e/web/theme_test.py` drives both pages in an installed Chrome and Firefox through Selenium. It needs no device: it serves `html/` from a local HTTP server, and `--base-url` points it at a running device instead. Registered in `run-tests` as the `web-theme` suite, marked manual because CI has no browsers.

Every condition is a real browser preference rather than anything injected into the page. Blocked site data is `profile.default_content_setting_values.cookies = 2` in Chrome and `network.cookie.cookieBehavior = 2` in Firefox, both verified to raise a real `SecurityError`. The colour scheme is CDP `Emulation.setEmulatedMedia` in Chrome and the `ui.systemUsesDarkTheme` preference in Firefox. The clicks and the page navigation are real WebDriver actions.

A missing browser or WebDriver is reported as one skip naming the reason, not a failure. `index.html` loads jQuery from a CDN and does nothing without it, so on a host with no route to that CDN the `index.html` checks skip and the `api.html` checks still run.

## Testing

```
./run-tests -s web-theme    26 checks, 26 OK, 34.5s
```

13 checks in each browser: the browser setting is followed on first load and not stored; a picked theme is stored, carries between the two pages in both directions, and is honoured on the next load; both pages stay usable with site data blocked, including their theme buttons; and the inline script of `api.html` runs under that page's own CSP.

The suite fails on the code it is meant to catch:

- Against the pages before the fix: `[01] index.html follows a light browser and stores nothing ... FAIL (what is stored is 'lightmode', expected None)`, in both browsers.
- Against the fixed pages carrying the previous CSP digest: `[04] api.html follows a dark browser and stores nothing ... FAIL (the theme is 'lightmode', expected 'darkmode')`, in both browsers. A refused inline script produces no console error, which is why this check is worth having.

`tools/openapi/test_explorer.py` passes, 16 tests, which is what pins the CSP digest to the script beside it. The device-free runner gates still pass with the new suite registered: `runner_policy_test` (99 checks), `check_transport_usage` (97 files) and `observability_test` (172 cases).

Chrome 152.0.7977.64 and Firefox 154.0.1 on Linux. Nothing was flashed to a device.

## Open point

The CSS change from `div#left-nav a:hover.darkmode` to `div#left-nav a.darkmode:hover` is described in its commit message as replacing a WebKit-specific selector. There is no WebKit-specific selector in either file, and the two forms behave identically in Chrome 152 and Firefox 154: both survive parsing, both apply burlywood on dimgray under a real hover, and they have the same specificity. The Selectors specification constrains only the type selector to come first in a compound selector. The change reads better, so it is left in, but it is a style preference rather than a compatibility fix, and it can be dropped if the diff should stay narrow.
