### PR TITLE
E2E: standard profile green on u64 and c64u after the 64tass removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,6 +292,8 @@ software/io/command_interface/tests/paletteCommandTest
 *.d
 tools/dump_bus_trace
 tools/64tass/*.o
+tools/64tass/64tass
+tools/64tass/.build-lock
 /chars/
 .vscode
 .idea

--- a/run-tests
+++ b/run-tests
@@ -1291,6 +1291,29 @@ def die(message: str) -> None:
     raise SystemExit(EXIT_USAGE)
 
 
+def expand_recover_command(command: str, host: str, password: str,
+                           timeout: float) -> str:
+    """Fill in the target's own details, so one command serves every target.
+
+    A run naming several targets runs one of these processes per target, and
+    each is given the same `--recover-command` string. A recovery tool has to
+    be told which device to work on, and there is nothing else to tell it
+    with: the tool is started by the shell, not as a suite, so it sees none of
+    the E2E_* variables a suite is given.
+
+    The tokens are the ones a suite's arguments already use, so a recovery
+    command reads like the rest of the registry:
+
+        --recover-command 'tooling/recover_ultimate.py @HOST@'
+
+    @PASS@ is quoted, because unlike a suite's argument list this string is
+    handed to a shell.
+    """
+    command = command.replace("@HOST@", host)
+    command = command.replace("@PASS@", shlex.quote(password))
+    return command.replace("@TIMEOUT@", f"{timeout:g}")
+
+
 class Device:
     """The few device calls the harness itself makes, outside any suite."""
 
@@ -1304,7 +1327,8 @@ class Device:
         self.api = UltimateApi(host, password, timeout)
         self.probe = UltimateApi(host, password,
                                  DEVICE_RECOVERY_PROBE_TIMEOUT_SECONDS)
-        self.recover_command = recover_command
+        self.recover_command = expand_recover_command(recover_command, host,
+                                                      password, timeout)
         self.recover_max_per_suite = recover_max_per_suite if recover_command else 0
         self.recover_max_total = recover_max_total if recover_command else 0
         self.recover_timeout = recover_timeout
@@ -2463,7 +2487,10 @@ def build_parser() -> argparse.ArgumentParser:
                          help="Run this shell command to bring an unhealthy "
                               "device back, for example 'build u64'. There is "
                               "no default: the mechanism is site-specific, so "
-                              "without it nothing is recovered. Its exit "
+                              "without it nothing is recovered. @HOST@, @PASS@ "
+                              "and @TIMEOUT@ are filled in with the target "
+                              "this recovery is for, which is how one command "
+                              "serves a run naming several targets. Its exit "
                               "status is advisory; the health check decides "
                               "whether the device came back."),
     health.add_argument("--recover-max-per-suite", type=int,
@@ -3325,8 +3352,11 @@ def main(argv: List[str]) -> int:
                   + (f", up to {options.attempts} attempts per suite"
                      if options.attempts > 1 else ", one attempt per suite"))
     if options.recover_command:
-        report.detail(f"recovery:   {options.recover_command} "
-                      f"(up to {options.recover_max_per_suite} per suite, "
+        report.detail("recovery:   "
+                      + expand_recover_command(options.recover_command,
+                                               options.host, options.password,
+                                               float(options.timeout))
+                      + f" (up to {options.recover_max_per_suite} per suite, "
                       f"{options.recover_max_total} in the run)")
     if options.output_dir:
         report.detail(f"jsonl:      {options.output_dir}/")

--- a/tests/e2e/lib/assembler.py
+++ b/tests/e2e/lib/assembler.py
@@ -5,17 +5,21 @@ Several suites run small C64 programs as their stimulus. They build them here
 rather than committing the assembled binary, so the source beside the test is
 the thing that runs and the two cannot drift apart.
 
-`tools/64tass/64tass` is committed and is also built by `make -C tools`, which
-every firmware build runs, so a checkout that can build firmware can run these
-suites. There is no fallback to another assembler on purpose: a different 64tass
-would be a different fixture, and a suite that quietly assembled with one would
-be reporting on something other than what the repository contains.
+The assembler's source is in `tools/64tass`, and `make -C tools`, which every
+firmware build runs, builds it. The binary itself is not committed, so a
+checkout that has not built firmware has no `tools/64tass/64tass`; `assemble`
+builds it from that source the first time it is needed, which takes about ten
+seconds once. There is no fallback to another assembler on purpose: a different
+64tass would be a different fixture, and a suite that quietly assembled with a
+`64tass` from the PATH would be reporting on something other than what the
+repository contains.
 
 tests/e2e/io/printer takes the other approach and commits its .prg with a
 Makefile to regenerate it, so that suite needs no assembler at all. Both are
 reasonable; this is for the ones that would rather not commit a binary.
 """
 
+import fcntl
 import os
 import subprocess
 import tempfile
@@ -26,7 +30,38 @@ from report import Failure
 REPO_ROOT = os.path.abspath(os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
 ASSEMBLER = os.path.join(REPO_ROOT, "tools", "64tass", "64tass")
+ASSEMBLER_SOURCE_DIR = os.path.dirname(ASSEMBLER)
 ASSEMBLE_TIMEOUT_SECONDS = 120.0
+BUILD_TIMEOUT_SECONDS = 600.0
+
+
+def ensure_assembler() -> None:
+    """Build `tools/64tass/64tass` from the source beside it when it is absent.
+
+    The same make that a firmware build runs, so the binary is the one the
+    repository would have produced anyway, and a fresh checkout does not fail
+    every assembling suite for want of a build step nobody was told about.
+    """
+    if os.path.exists(ASSEMBLER):
+        return
+    # A run naming several targets starts one process per target, and on a
+    # fresh checkout two of them can reach an assembling suite together. The
+    # lock makes the second wait for the first's make rather than run its own
+    # over the same object files; it then finds the binary and returns.
+    with open(os.path.join(ASSEMBLER_SOURCE_DIR, ".build-lock"), "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        if os.path.exists(ASSEMBLER):
+            return
+        try:
+            result = subprocess.run(
+                ["make", "-C", ASSEMBLER_SOURCE_DIR],
+                capture_output=True, text=True, timeout=BUILD_TIMEOUT_SECONDS)
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise Failure(f"could not build {ASSEMBLER}: {exc}") from exc
+        if result.returncode or not os.path.exists(ASSEMBLER):
+            raise Failure(f"{ASSEMBLER} is missing and `make -C tools/64tass` did "
+                          f"not produce it: "
+                          f"{(result.stderr or result.stdout).strip()[:400]}")
 
 
 def assemble(source: Union[str, "os.PathLike[str]"],
@@ -40,8 +75,7 @@ def assemble(source: Union[str, "os.PathLike[str]"],
     source = os.path.abspath(os.fspath(source))
     if not os.path.exists(source):
         raise Failure(f"no such 6502 source: {source}")
-    if not os.path.exists(ASSEMBLER):
-        raise Failure(f"{ASSEMBLER} is missing; run `make -C tools` to build it")
+    ensure_assembler()
     name = os.path.basename(source)
     with tempfile.TemporaryDirectory(prefix="c64-asm-") as directory:
         output = os.path.join(directory, "fixture.prg")

--- a/tests/e2e/network/ident_service_switch_test.py
+++ b/tests/e2e/network/ident_service_switch_test.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
 
+import machine as machine_lib
+import targets
 from api import UltimateApi
 from report import Failure, check, check_count, format_exception, suite_fail, suite_ok
 
@@ -72,17 +74,34 @@ def main() -> int:
         suite_fail("ident_service_switch_test", "device did not report the original setting")
         return 1
 
+    info = api.info()
+    machine = machine_lib.identify(
+        targets.device_of(args.host),
+        lambda: (str(info.product), str(info.firmware_version)))
+
     failure = ""
     try:
         with check("ident answers when enabled"):
             api.configs.set(STORE, ITEM, "Enabled")
             wait_enabled(args.host)
-        with check("ident stops answering when disabled"):
-            api.configs.set(STORE, ITEM, "Disabled")
-            wait_disabled(args.host)
-        with check("ident answers again when re-enabled"):
-            api.configs.set(STORE, ITEM, "Enabled")
-            wait_enabled(args.host)
+        # Both of these need the listener to act on the switch while it runs.
+        # Firmware without that reads the switch once, when the listener
+        # starts, so the first would fail and the second would then prove
+        # nothing. Skipped together, with the fix named on each line: a list
+        # rather than a generator, so both lines are printed.
+        live_checks = [
+            "ident stops answering when disabled",
+            "ident answers again when re-enabled",
+        ]
+        if not any([machine.skip_without_fix(
+                machine_lib.SERVICE_SWITCHES_APPLY_LIVE, label)
+                    for label in live_checks]):
+            with check(live_checks[0]):
+                api.configs.set(STORE, ITEM, "Disabled")
+                wait_disabled(args.host)
+            with check(live_checks[1]):
+                api.configs.set(STORE, ITEM, "Enabled")
+                wait_enabled(args.host)
     except Failure as exc:
         failure = str(exc)
     except Exception as exc:  # noqa: BLE001

--- a/tests/lib/machine.py
+++ b/tests/lib/machine.py
@@ -404,6 +404,21 @@ MONITOR_D_KEY_RESERVED = _fix(
     "it, rather than entering the Debug mode this branch removed",
     (U2,))
 
+# What tests/e2e/network/ident_service_switch_test.py asserts. Firmware without
+# the fix reads each network service switch once, when that listener's task
+# starts, so turning the Ultimate Ident Service off leaves the listener
+# answering until the device restarts; with it, the listener closes its socket
+# when the setting changes and opens one again when it is turned back on.
+# Measured on a C64 Ultimate 1.2.0, which kept answering for the 3 seconds the
+# check waits after the switch was set to Disabled, three attempts out of
+# three.
+SERVICE_SWITCHES_APPLY_LIVE = _fix(
+    "service-switches-apply-live",
+    "a network service switch takes effect while the device runs, so the "
+    "ident listener stops answering when it is disabled and answers again "
+    "when it is re-enabled",
+    (C64U,))
+
 # Every fix at once, for a sweep that asks whether the lagging line has caught
 # up rather than about one behaviour.
 ASSUME_ALL = "all"

--- a/tests/lib/report.py
+++ b/tests/lib/report.py
@@ -186,6 +186,10 @@ _depth = 0
 _last_label = ""
 # Detail lines produced while a check line is still open.
 _pending: List[str] = []
+# Whether those lines are being printed as they come rather than held back.
+# Set when a heading is printed under a check line that never got its verdict;
+# see _release_details.
+_details_live = False
 _check_started = 0.0
 # Whether a check or step line is open and still owes a verdict. A body that
 # reports its own verdict, `check_skip` inside a `with check(...)` being the
@@ -335,7 +339,7 @@ def last_label() -> str:
 
 def check_start(label: str) -> None:
     """Open a check line as `[NN] label ... `, leaving the verdict for later."""
-    global _count, _depth, _last_label, _check_started, _line_open
+    global _count, _depth, _last_label, _check_started, _line_open, _details_live
     _depth += 1
     if _depth > 1:
         return
@@ -343,6 +347,7 @@ def check_start(label: str) -> None:
     _last_label = label
     _check_started = time.monotonic()
     _line_open = True
+    _details_live = False
     print(f"[{_count:02d}] {label} ... ", end="", flush=True)
 
 
@@ -363,10 +368,11 @@ def step_start(label: str) -> None:
 
 
 def _close(verdict: str, extra: str = "", *, elapsed: Optional[float] = None) -> None:
-    global _depth, _line_open
+    global _depth, _line_open, _details_live
     _depth = max(0, _depth - 1)
     if _depth:
         return
+    _details_live = False
     if not _line_open:
         # Already answered by the block itself. Closing again would print a
         # second verdict for one check and record a second, contradictory one:
@@ -445,7 +451,7 @@ def detail(text: str) -> None:
     verdict onto the next line, which is the one-line rule broken from the other
     side: not a nested check, but a caller narrating mid-check.
     """
-    if _depth:
+    if _depth and not _details_live:
         _pending.extend(str(text).splitlines() or [""])
         return
     _emit_detail(str(text).splitlines() or [""])
@@ -476,9 +482,44 @@ def progress_done() -> None:
         sys.stdout.flush()
 
 
+def _release_details() -> None:
+    """Stop holding detail lines back once a check line has been left behind.
+
+    `detail` holds its lines until the open check has printed its verdict, so
+    that a caller narrating mid-check cannot push the verdict onto the next
+    line. That is right while the check is still running, and wrong once it is
+    not: an exception raised between `check_start` and the verdict call unwinds
+    past the verdict, the line stays open for the rest of the process, and
+    every later `detail` is buffered and never printed.
+
+    That is where a suite prints its failure diagnostics. Measured on
+    ftp_client_test against a C64 Ultimate: the check that raised printed no
+    verdict, and the whole of `print_failure_diagnostics` -- the exception, the
+    last REST input, the last FTP command, the decoded menu screen, the server
+    log tail -- went into the buffer and was never seen, leaving "FAIL
+    (failed)" as the only evidence the run kept.
+
+    A heading is the signal that the check is behind us, so the pending lines
+    are emitted here and later ones go straight out. No verdict is invented for
+    the check: a heading printed while a check is open is also what an
+    in-process suite driving the runner produces, and that check does go on to
+    report its own verdict. See runner_policy_test, which runs `run_targets`
+    inside a `check` block.
+    """
+    global _details_live
+    if not _line_open:
+        return
+    _details_live = True
+    print(flush=True)              # end the check line the verdict never closed
+    if _pending:
+        _emit_detail(_pending)
+        _pending.clear()
+
+
 def _close_scenario() -> None:
     """Print the open scenario's own verdict, so a group can be read at a glance."""
     global _scenario
+    _release_details()
     if _scenario is None:
         return
     scenario, _scenario = _scenario, None
@@ -738,9 +779,10 @@ def format_exception(exc: BaseException) -> str:
 
 def reset(count_from: Optional[int] = None) -> None:
     """Start numbering again. Only for a harness that runs suites in-process."""
-    global _count, _depth, _last_label, _scenario, _suite_started
+    global _count, _depth, _last_label, _scenario, _suite_started, _details_live
     _count = 0 if count_from is None else count_from
     _depth = 0
+    _details_live = False
     _last_label = ""
     _scenario = None
     _suite_started = time.monotonic()


### PR DESCRIPTION
Four fixes that came out of running the `smoke`, `quick` and `standard` E2E profiles against an Ultimate 64 Elite (3.15) and a C64 Ultimate (1.2.0) at the same time. After them, all three profiles pass on both machines on the same tree. Each fix is its own commit.

## `reu-turbo` failed: `tools/64tass/64tass` is no longer in the repository

d33b7802 removed the assembled 64tass binary. `tests/e2e/lib/assembler.py` required that exact file and reported `64tass is missing; run make -C tools to build it`, so every suite that assembles a 6502 fixture failed on a checkout that had not built firmware. The 64tass source is still committed.

`assemble` now builds the binary from that source the first time it is needed, with the same `make -C tools/64tass` a firmware build runs. A clean build takes about ten seconds. The build is guarded by a file lock, because a run naming several targets starts one process per target and two of them can reach an assembling suite together on a fresh checkout. The binary and the lock file are added to `.gitignore`, since the binary is otherwise left as an untracked file after every run.

Verified by deleting the binary and running `reu-turbo` on the u64: the suite rebuilt it and passed. There is still no fallback to a `64tass` on the PATH, for the reason the module already gives: a different assembler would be a different fixture.

## `ident-service-switch` failed on the C64 Ultimate

The suite, added with #788, asserts that the ident listener stops answering when the Ultimate Ident Service setting is switched off and answers again when it is switched on. Firmware without #788 reads the switch once, when the listener task starts, so the C64 Ultimate 1.2.0 kept answering for the whole 3 second wait, on all three attempts.

The gap is now an entry in the fix table in `tests/lib/machine.py`, `service-switches-apply-live`, lacking on the C64 Ultimate. The two checks that need the fix are skipped there with the fix named on each line; the first check, that ident answers when enabled, still runs. `run-tests --assume-fix service-switches-apply-live` runs the skipped checks anyway, which is how a backport is confirmed before the entry is removed. On the u64 all three checks still run and pass.

## Failure diagnostics were lost after a check raised

`report.detail` holds its lines while a check line is open and prints them after the verdict, so a caller narrating mid-check cannot push the verdict onto the next line. An exception raised between `check_start` and the verdict unwinds past the verdict call, the check stays open for the rest of the process, and every later `detail` is buffered and never printed.

That is where a suite prints its failure diagnostics. When `ftp_client_test` failed on the C64 Ultimate, the log showed the heading `--- failure diagnostics` and nothing under it: no exception, no last REST input, no last FTP command, no menu screen, no server log tail.

A heading printed while a check is still open now ends the check line, prints the held lines, and switches `detail` to printing as it comes until the next `check_start`. No verdict is invented for the abandoned check. That matters for `runner_policy_test`, which drives `run_targets` in-process inside a `with check(...)` block: the nested runner prints headings while the outer check is legitimately open, and that check goes on to report its own verdict. An earlier version of this change closed the abandoned check with a FAIL, which made that suite write two invented FAIL records into its own JSONL and broke observability case 109 on both machines.

Verified: `runner_policy_test` reports 99 checks and writes 101 JSONL records with no FAIL record. Before this change it wrote 93 records, because two of its checks were producing neither a verdict nor a record. The `observability` suite passes on both machines, 172 cases.

## `--recover-command` could not name a per-target recovery

`--recover-command` is one shell string for the whole run, and a run naming several targets hands the same string to every target's child process. The recovery command is started by a shell, not as a suite, so it does not see `E2E_TARGET` either. There was no way to tell the recovery tool which device to recover.

`run-tests` now expands `@HOST@`, `@PASS@` and `@TIMEOUT@` in the recovery command, the same tokens a suite's argument template uses. `@PASS@` is shell-quoted, because unlike a suite's argument list this string goes through a shell. The run header prints the expanded command. Verified on a `u64 c64u` run: each target's header shows the command with its own host.

## Test runs

All on the same tree, u64 and c64u run concurrently:

- `smoke`: 8 of 8 suites on each machine
- `quick`: 21 of 21 on each machine
- `standard`: 32 of 32 on each machine

The `standard` run on the C64 Ultimate needed one recovery. Its menu stopped opening after the `ftp-client` suite submitted the New Host form, which is the known menu wedge on 1.2.0 and not caused by this tree. A bench-local recovery command power-cycled the device through the Telnet UI and the suite passed on its second attempt. That recovery tool is not part of this PR.
