### PR TITLE
Build 64tass on macOS, and rebuild it when the one in the tree cannot run here (#837)

### DIFF
--- a/tests/e2e/lib/assembler.py
+++ b/tests/e2e/lib/assembler.py
@@ -33,16 +33,33 @@ ASSEMBLER = os.path.join(REPO_ROOT, "tools", "64tass", "64tass")
 ASSEMBLER_SOURCE_DIR = os.path.dirname(ASSEMBLER)
 ASSEMBLE_TIMEOUT_SECONDS = 120.0
 BUILD_TIMEOUT_SECONDS = 600.0
+VERSION_TIMEOUT_SECONDS = 30.0
+
+
+def assembler_runs() -> bool:
+    """Whether the binary at ASSEMBLER is one this machine can actually run.
+
+    Its presence is not enough. A firmware build under docker on a bind-mounted
+    tree leaves a Linux binary at that path, which the host then cannot execute,
+    and the failure surfaces from assemble() as `Exec format error` rather than
+    as anything about the build.
+    """
+    try:
+        return subprocess.run(
+            [ASSEMBLER, "--version"], capture_output=True,
+            timeout=VERSION_TIMEOUT_SECONDS).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
 
 
 def ensure_assembler() -> None:
-    """Build `tools/64tass/64tass` from the source beside it when it is absent.
+    """Build `tools/64tass/64tass` when it is absent, or cannot run here.
 
     The same make that a firmware build runs, so the binary is the one the
     repository would have produced anyway, and a fresh checkout does not fail
     every assembling suite for want of a build step nobody was told about.
     """
-    if os.path.exists(ASSEMBLER):
+    if assembler_runs():
         return
     # A run naming several targets starts one process per target, and on a
     # fresh checkout two of them can reach an assembling suite together. The
@@ -50,17 +67,28 @@ def ensure_assembler() -> None:
     # over the same object files; it then finds the binary and returns.
     with open(os.path.join(ASSEMBLER_SOURCE_DIR, ".build-lock"), "w") as lock:
         fcntl.flock(lock, fcntl.LOCK_EX)
-        if os.path.exists(ASSEMBLER):
+        if assembler_runs():
             return
+        # Anything already here was built for another platform, so it can be
+        # neither run nor linked against. `make` alone would keep the objects
+        # and relink them, failing with "unknown file type", so clear both
+        # first. On a fresh checkout there is nothing to clear and this costs
+        # one no-op make.
+        subprocess.run(["make", "-C", ASSEMBLER_SOURCE_DIR, "clean"],
+                       capture_output=True, timeout=BUILD_TIMEOUT_SECONDS)
+        try:
+            os.remove(ASSEMBLER)
+        except OSError:
+            pass
         try:
             result = subprocess.run(
                 ["make", "-C", ASSEMBLER_SOURCE_DIR],
                 capture_output=True, text=True, timeout=BUILD_TIMEOUT_SECONDS)
         except (OSError, subprocess.SubprocessError) as exc:
             raise Failure(f"could not build {ASSEMBLER}: {exc}") from exc
-        if result.returncode or not os.path.exists(ASSEMBLER):
-            raise Failure(f"{ASSEMBLER} is missing and `make -C tools/64tass` did "
-                          f"not produce it: "
+        if result.returncode or not assembler_runs():
+            raise Failure(f"{ASSEMBLER} is missing, or not runnable here, and "
+                          f"`make -C tools/64tass` did not produce one: "
                           f"{(result.stderr or result.stdout).strip()[:400]}")
 
 

--- a/tools/64tass/Makefile
+++ b/tools/64tass/Makefile
@@ -9,6 +9,16 @@ LDLIBS = -lm
 LANG = C
 REVISION := "1515?"
 CFLAGS = -O2 -DREVISION="\"$(REVISION)\""
+# wchar.h declares wcwidth() only when _XOPEN_SOURCE is undefined, while the
+# macOS SDK declares it unconditionally, so the two conflict and the build
+# stops at 64tass.o. Defining it also selects the platform's wcwidth over the
+# one below, which is what that guard is for. 700 clears the `>= 500` test in
+# isnprintf.c, under which a fallback replaces snprintf and drops its size
+# bound; 500 itself does not build, the SDK exposing snprintf only above the
+# level it selects.
+ifeq ($(shell uname -s), Darwin)
+CFLAGS += -D_XOPEN_SOURCE=700
+endif
 LDFLAGS =
 CFLAGS += $(LDFLAGS)
 TARGET = 64tass


### PR DESCRIPTION
Fixes #837.

Two commits: one makes 64tass build on macOS, one stops a binary built for
another platform being accepted and then failing later.

## 1. The build fails on macOS

Since the binary stopped being committed, 64tass is built from source on demand
— by `make -C tools` for a firmware build, and by the E2E suites for their 6502
stimulus. Both fail on macOS, as does building it directly:

```
./wchar.h:46:12: error: conflicting types for 'wcwidth'
   46 | extern int wcwidth(uchar_t);
MacOSX.sdk/usr/include/_wchar.h:183:5: note: previous declaration is here
  183 | int     wcwidth(wchar_t);
```

`wchar.h:45` declares `wcwidth` only `#ifndef _XOPEN_SOURCE`, and the macOS SDK
declares it unconditionally. Defining the macro is 64tass's own porting knob
rather than a workaround around one: `wchar.c:452-617` guards the bundled
implementation and its width tables the same way, so an XSI-conformant platform
links its libc's instead.

**Why in `tools/64tass/Makefile` rather than in the callers.** I first put it in
`tools/Makefile` and in the E2E helper, and that was wrong: it left
`make -C tools/64tass` still failing, which is both a reasonable thing to run
and what the helper's own error message tells you to try. Appending it in the
vendored Makefile fixes every caller from one place, and is a smaller change
than patching each of them. It is appended, so the existing `-O2` and
`-DREVISION` survive, and guarded on `uname`, so no other platform changes.

**One thing to weigh, since it is yours to decide rather than mine.** This is
the first local source change to vendored 64tass in the repository's history:
every previous touch has been a wholesale version drop (`34172882`, 163 files)
or the binary artifact. So the next "New version of 64tass" would drop these
three lines silently, and macOS would break again with nothing to say why. If
you would rather keep the vendored tree pristine, the same flag works from
`tools/Makefile` and the E2E helper instead — that survives a re-vendor, at the
cost of leaving a direct `make -C tools/64tass` broken. I have put it here
because it is the complete fix, but you do those updates and are better placed
to judge which trade you want.

**Why 700.** `isnprintf.c:62` reads `_XOPEN_SOURCE >= 500` as "the platform has
`snprintf`"; below that, a fallback replaces it and drops the size bound at its
one call site — on macOS masked only by the SDK having already defined
`snprintf`. `500` itself does not build, the SDK exposing `snprintf` only above
the level it selects. `600` and `700` give a byte-identical binary here; `700`
is the current POSIX level.

## 2. A binary from another platform is accepted, then fails

`ensure_assembler()` tested only whether the binary *existed*. A firmware build
under docker on a bind-mounted tree leaves a Linux binary and Linux objects
behind, so a later run on the host accepted them and failed in `assemble()` with
`Exec format error` — which says nothing about where the binary came from. The
reverse happens too: a host-built binary is not runnable inside the container.

It now tests whether the binary actually runs, and clears both it and the
objects before building, since `make` would otherwise keep the objects and
relink them into `unknown file type in 'str.o'`. On a fresh checkout there is
nothing to clear and this costs one no-op `make`.

Not macOS-specific — it is symmetric — but it is what makes the first fix hold
in a tree that has seen both platforms, which any macOS contributor who also
builds firmware will have.

## Against your four conditions

**Minimal.** Two files, and the first fix is three lines in one of them.

**Does not break Linux.** Guarded on `uname -s`, so no other platform's build
changes at all. Verified rather than assumed, from a fresh clone of this branch:

| | macOS 15, arm64 | `ghcr.io/gideonz/riscv:latest` |
| --- | --- | --- |
| `make -C tools/64tass` | builds | builds |
| `make -C tools` | builds | builds |
| the E2E helper, from clean | builds | builds |
| after the *other* platform built in the same tree | rebuilds, runs | rebuilds, runs |

All produce `64tass Turbo Assembler Macro V1.53.1515?`, so the revision string
survives everywhere. Before these changes the macOS column fails at `64tass.o`,
and the last row fails with `Exec format error` on both.

**Backwards compatible.** Nothing any non-Darwin platform executes has changed.

**No tests**, as you asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
