### PR TITLE
Say which of the two addresses actually wakes the device

### DIFF
--- a/doc/api/rest_api_openapi_u2.yaml
+++ b/doc/api/rest_api_openapi_u2.yaml
@@ -1814,7 +1814,7 @@ paths:
 
         `git_commit_hash` is the abbreviated hash of the commit the firmware was built from, the same one the System Information screen shows. It tells two builds that carry the same version number apart.
 
-        `ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless interface. Each is left out when the device has no such interface, or when that interface has not started and its address is therefore not known yet. They are what a caller sends a Wake-on-LAN magic packet to, which carries a MAC and not an IP address.
+        `ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless interface. Each is left out when the device has no such interface, or when that interface has not started and its address is therefore not known yet, and only the first interface of each kind is reported. A caller that wants to wake the device sends its magic packet to `wifi_mac`, which carries a MAC and not an IP address; the wired interface does not wake the device.
 
         The same information is also available without HTTP, from the Ultimate Ident Service on UDP port 64, which answers a broadcast and so can be used to find a device whose address is not known.
       operationId: getInfo

--- a/doc/api/rest_api_openapi_u64.yaml
+++ b/doc/api/rest_api_openapi_u64.yaml
@@ -1817,7 +1817,7 @@ paths:
 
         `git_commit_hash` is the abbreviated hash of the commit the firmware was built from, the same one the System Information screen shows. It tells two builds that carry the same version number apart.
 
-        `ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless interface. Each is left out when the device has no such interface, or when that interface has not started and its address is therefore not known yet. They are what a caller sends a Wake-on-LAN magic packet to, which carries a MAC and not an IP address.
+        `ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless interface. Each is left out when the device has no such interface, or when that interface has not started and its address is therefore not known yet, and only the first interface of each kind is reported. A caller that wants to wake the device sends its magic packet to `wifi_mac`, which carries a MAC and not an IP address; the wired interface does not wake the device.
 
         The same information is also available without HTTP, from the Ultimate Ident Service on UDP port 64, which answers a broadcast and so can be used to find a device whose address is not known.
       operationId: getInfo

--- a/software/api/routes.cc
+++ b/software/api/routes.cc
@@ -180,9 +180,10 @@ API_DOC(GET, info, none,
                 "\n"
                 "`ethernet_mac` and `wifi_mac` are the addresses of the wired and the wireless "
                 "interface. Each is left out when the device has no such interface, or when that "
-                "interface has not started and its address is therefore not known yet. They are "
-                "what a caller sends a Wake-on-LAN magic packet to, which carries a MAC and not "
-                "an IP address.\n"
+                "interface has not started and its address is therefore not known yet, and only "
+                "the first interface of each kind is reported. A caller that wants to wake the "
+                "device sends its magic packet to `wifi_mac`, which carries a MAC and not an IP "
+                "address; the wired interface does not wake the device.\n"
                 "\n"
                 "The same information is also available without HTTP, from the Ultimate Ident "
                 "Service on UDP port 64, which answers a broadcast and so can be used to find a "
@@ -220,8 +221,10 @@ API_CALL(GET, info, none, NULL, ARRAY( { }))
     }
 
     // The hardware addresses, one per kind of interface. A caller that wants to
-    // wake the device needs them: a magic packet carries a MAC, not an IP. Only
-    // the first interface of a kind is reported, and one that has not learned
+    // wake the device needs wifi_mac: a magic packet carries a MAC, not an IP,
+    // and waking is Wi-Fi only. The matcher is wol_magic.c on the ESP32, reached
+    // from the Wi-Fi path alone, and there is no counterpart on the wired side.
+    // Only the first interface of a kind is reported, and one that has not learned
     // its address yet, because it never started, is left out entirely.
     static const char *const mac_keys[2] = { "ethernet_mac", "wifi_mac" };
     bool reported[2] = { false, false };


### PR DESCRIPTION
The description of `GET /v1/info` added in #827 says that `ethernet_mac` and `wifi_mac` are "what a caller sends a Wake-on-LAN magic packet to". That holds for one of the two.

The only magic packet matcher in the tree is `software/u64ctrl/main/wol_magic.c`, and it is reached from exactly one place, `wifi_modem.c:164` on the ESP32. The setting is `CFG_WAKE_ON_WIFI`, "Wake On Wi-Fi", added in #815. There is nothing equivalent on the RMII side — no config item, no matcher, no caller. So a magic packet sent to `ethernet_mac` wakes nothing, and someone reading the current wording and building against it gets a feature that does not exist.

My fault, and I would rather fix it than leave it: I wrote that sentence.

While the paragraph is open it also gains something the code has always done but never said — only the first interface of each kind is reported, `routes.cc` skips any later one with `if (reported[kind]) continue;`.

Both OpenAPI documents are **regenerated** from the changed string rather than hand-edited, so `make openapi_check` still passes.

## Verified

- `make openapi_check` — 2 documents match the sources.
- `make openapi_test` — 191 tests, OK.
- `make u64ii_no_esp` in `ghcr.io/gideonz/riscv`, from a tree with every `output/` and `result/` under `target/` removed first: exit 0, zero errors, `routes.cc` compiles for both the application and the updater, `update.ue2` and `update.cfw` produced.

The companion change is GideonZ/1541u-documentation#33, which documents these fields for the first time and now says the same thing. Merging one without the other leaves the two sources disagreeing, which is what prompted this.
