### PR TITLE
Fix oversized D81 track initialization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,11 @@ jobs:
              --target /tmp/lint-packages -r tests/requirements-lint.txt && \
            PYTHONPATH=/tmp/lint-packages python3 tests/lib/lint_test.py"
 
+      - name: Check D81 track bounds
+        run: |
+          docker run --rm \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make d81_tracks_test"
+
       # Also the gate that catches an endpoint whose documentation was not
       # updated with it. Runs before the firmware builds because it costs seconds.
       - name: Check OpenAPI Specification

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OPENAPI = python3 tools/openapi/generate.py
 #   make openapi_validate PYTHON=/path/to/venv/bin/python
 PYTHON ?= python3
 
-.PHONY: all app_space app_space_test observability_test lint_test host_tests openapi openapi_check openapi_test openapi_validate
+.PHONY: all app_space app_space_test d81_tracks_test observability_test lint_test host_tests openapi openapi_check openapi_test openapi_validate
 
 all: esp32 u2_rv u2plus u2pl u64 u64ii
 	@$(APP_SPACE) report
@@ -19,6 +19,14 @@ app_space:
 
 app_space_test:
 	@python3 tools/test_app_space.py
+
+d81_tracks_test:
+	@tmpdir=$$(mktemp -d); trap 'rm -rf "$$tmpdir"' EXIT; \
+	$(CXX) -std=c++11 -fsanitize=address,undefined \
+	$(if $(filter Linux,$(shell uname -s)),-static-libasan -static-libubsan) \
+	-fno-omit-frame-pointer \
+	-Isoftware/drive software/drive/mfmdisk.cc software/test/drive/mfmdisk_tracks_test.cc -o "$$tmpdir/test"; \
+	"$$tmpdir/test"
 
 # The observability harness: the report generator, the console capture, the
 # device double and everything else that watches a gate run. Needs no device

--- a/run-tests
+++ b/run-tests
@@ -291,6 +291,10 @@ SUITES: Sequence[Suite] = (
     # fail for a reason that is not its own.
     Suite("e2e", "create-disk-image", "tests/e2e/api/create_disk_image_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@", profile=profiles.QUICK),
+    # Reads physical track 81 through a real emulated 1581, then mounts an
+    # oversized D81 and proves the bounded layout leaves the device usable.
+    Suite("e2e", "d81-track-bounds", "tests/e2e/drive/d81_track_bounds_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --test all", profile=profiles.QUICK),
     # Calls every endpoint the firmware registers, and fails when one is
     # neither probed nor excluded with a reason. The lockup that prompted it
     # shipped because no suite called that route at all, so the gate matters

--- a/software/drive/mfmdisk.cc
+++ b/software/drive/mfmdisk.cc
@@ -95,6 +95,13 @@ uint32_t MfmDisk :: init(MfmFormat_t type, int tracks)
     uint32_t size = 0;
     uint32_t offset = 0;
 
+    // D81 track counts come from file size; keep them within the fixed arrays.
+    if (tracks < 0) {
+        tracks = 0;
+    } else if (tracks > WD_MAX_TRACKS_PER_SIDE) {
+        tracks = WD_MAX_TRACKS_PER_SIDE;
+    }
+
     printf("MfmDiskInit: Sizeof side0 = %d\n", sizeof(side0));
     memset(side0, 0, sizeof(side0));
     memset(side1, 0, sizeof(side1));

--- a/software/test/drive/mfmdisk_tracks_test.cc
+++ b/software/test/drive/mfmdisk_tracks_test.cc
@@ -1,0 +1,41 @@
+#include "mfmdisk.h"
+
+#include <assert.h>
+
+static void expect_formatted_tracks(int tracks)
+{
+    MfmDisk disk;
+    disk.init(fmt_D81, tracks);
+
+    for (int track = 0; track < WD_MAX_TRACKS_PER_SIDE; ++track) {
+        const int expected = track < tracks ? 10 : 0;
+        assert(disk.GetTrack(track, 0)->numSectors == expected);
+        assert(disk.GetTrack(track, 1)->numSectors == expected);
+    }
+}
+
+static void expect_track_81_layout()
+{
+    MfmDisk disk;
+    disk.init(fmt_D81, 81);
+
+    MfmSector sector = { 80, 1, 10, 2, 0 };
+    uint32_t position = 0;
+    uint32_t size = 0;
+    assert(disk.GetSector(80, 1, sector, position, size) == 9);
+    assert(position == 829440 - 512);
+    assert(size == 512);
+}
+
+int main()
+{
+    expect_formatted_tracks(-1);
+    expect_formatted_tracks(80);
+    expect_formatted_tracks(81);
+    expect_track_81_layout();
+    expect_formatted_tracks(WD_MAX_TRACKS_PER_SIDE);
+
+    // An oversized image must not write past MfmDisk's fixed track arrays.
+    expect_formatted_tracks(WD_MAX_TRACKS_PER_SIDE + 1);
+    return 0;
+}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -58,6 +58,7 @@ to drive it.
 | Folder | Production owner | Coverage |
 |---|---|---|
 | `api/` | `software/api/` | REST contracts for input, menu screen, memory, disk-image creation and PRG runners, plus `rest-api-coverage`, which calls every registered operation |
+| `drive/` | `software/drive/` | Emulated drive geometry and media access through the C64-facing drive protocol |
 | `filemanager/` | `software/filemanager/`, `software/userinterface/` | Browser actions, change notification, and managed `/Temp` lifecycle |
 | `filesystem/` | `software/filesystem/` | Filesystem implementations, including the remote FTP filesystem |
 | `io/` | `software/io/` | Device-facing I/O subsystems, nested by production package (`c64/`, `command_interface/`, `printer/`) |

--- a/tests/e2e/drive/d81_track_bounds_test.py
+++ b/tests/e2e/drive/d81_track_bounds_test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""E2E: read D81 track 81 and survive an oversized D81 on real hardware."""
+
+import argparse
+import posixpath
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+# The one stanza that puts the shared library on sys.path; see tests/lib/bootstrap.py.
+sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
+                            if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
+import bootstrap  # noqa: E402,F401
+import cli  # noqa: E402
+
+import ftp as ftp_lib  # noqa: E402
+from api import DriveInfo, UltimateApi  # noqa: E402
+from assembler import assemble  # noqa: E402
+from report import (  # noqa: E402
+    Failure,
+    check,
+    detail,
+    format_exception,
+    section,
+    suite_fail,
+    suite_ok,
+)
+
+SUITE = "d81_track_bounds_test"
+SOURCE = SCRIPT_DIR / "d81_track_reader.asm"
+
+BYTES_PER_TRACK = 10240
+BYTES_PER_SIDE = 5120
+BYTES_PER_SECTOR = 512
+TRACK_81 = 80
+SECTOR_5 = 4
+MAX_TRACKS = 84
+OVERSIZED_TRACKS = MAX_TRACKS + 1
+SENTINEL = bytes((value ^ 0xa5) for value in range(256)) * 2
+
+RESULT_STATUS = 0xc000
+RESULT_BYTES = 4
+RESULT_DATA = 0xc100
+STATUS_DONE = 1
+READY_MARK = 0xa5
+POLL_SECONDS = 0.05
+PROGRAM_TIMEOUT_SECONDS = 10.0
+LIVENESS_TIMEOUT_SECONDS = 10.0
+
+CASES = {
+    "missing-track-81": (80, False),
+    "track-81": (81, True),
+    "oversized": (OVERSIZED_TRACKS, True),
+}
+
+
+def fixture(tracks: int, with_track_81: bool) -> bytes:
+    image = bytearray(tracks * BYTES_PER_TRACK)
+    if with_track_81:
+        for side in range(2):
+            offset = (TRACK_81 * BYTES_PER_TRACK + side * BYTES_PER_SIDE
+                      + SECTOR_5 * BYTES_PER_SECTOR)
+            image[offset:offset + BYTES_PER_SECTOR] = SENTINEL
+    return bytes(image)
+
+
+def mounted_path(drive: DriveInfo) -> str:
+    if drive.image_file.startswith("/"):
+        return drive.image_file
+    return posixpath.join(drive.image_path, drive.image_file) if drive.image_file else ""
+
+
+class SuiteRunner:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.api = UltimateApi(args.host, args.password or None, args.timeout)
+        self.slot = ""
+        self.original: DriveInfo | None = None
+        self.paths: dict[str, str] = {}
+
+    def prepare(self) -> bytes:
+        drives = self.api.drives.list()
+        self.slot = "b" if "b" in drives else "a"
+        if self.slot not in drives:
+            raise Failure("the device exposes neither drive a nor drive b")
+        self.original = drives[self.slot]
+        if self.original.bus_id is None:
+            raise Failure(f"drive {self.slot} has no IEC bus ID")
+
+        self.api.drives.set_mode(self.slot, "1581")
+        self.api.drives.on(self.slot)
+        with ftp_lib.session(self.args.host, self.args.password or None) as client:
+            for name, (tracks, expected) in CASES.items():
+                path = f"/Temp/d81-e2e-{name}.d81"
+                ftp_lib.store(client, path, fixture(tracks, expected))
+                self.paths[name] = path
+        return assemble(SOURCE, {"DEVICE": self.original.bus_id})
+
+    def await_program(self) -> bytes:
+        deadline = time.monotonic() + PROGRAM_TIMEOUT_SECONDS
+        while True:
+            result = self.api.machine.readmem(RESULT_STATUS, RESULT_BYTES)
+            if result[1] == READY_MARK and result[0] != 0:
+                return result
+            if time.monotonic() >= deadline:
+                raise Failure(f"track reader did not finish: result={result.hex(' ')}")
+            time.sleep(POLL_SECONDS)
+
+    def run_case(self, name: str, prg: bytes) -> None:
+        tracks, expected = CASES[name]
+        path = self.paths[name]
+        section(name)
+
+        with check(f"mount {tracks}-track D81 on drive {self.slot}"):
+            self.api.drives.mount(self.slot, path, type="d81", mode="readonly")
+            mounted = self.api.drives.get(self.slot)
+            if posixpath.basename(path) not in mounted.image_file:
+                raise Failure(f"drive reports {mounted.image_file!r}, expected {path!r}")
+
+        with check("device remains reachable after mount"):
+            reason = self.api.unreachable_reason(LIVENESS_TIMEOUT_SECONDS)
+            if reason:
+                raise Failure(reason)
+
+        with check("physical track 81 has the expected result"):
+            self.api.machine.writemem(RESULT_STATUS, bytes(RESULT_BYTES), idempotent=True)
+            self.api.machine.writemem(RESULT_DATA, bytes(BYTES_PER_SECTOR), idempotent=True)
+            status, _, body = self.api.runners.upload("run_prg", prg)
+            if status != 200:
+                raise Failure(f"run_prg returned HTTP {status}: {body[:160]!r}")
+            result = self.await_program()
+            data = self.api.machine.readmem(RESULT_DATA, BYTES_PER_SECTOR)
+            detail(f"tracks={tracks}, job=${result[2]:02x}, io=${result[3]:02x}")
+            if result[0] != STATUS_DONE:
+                raise Failure(f"reader failed: result={result.hex(' ')}")
+            if expected and data != SENTINEL:
+                raise Failure("track 81 sector 5 did not return its sentinel")
+            if not expected and data == SENTINEL:
+                raise Failure("an 80-track image unexpectedly exposed track 81")
+
+    def cleanup(self) -> None:
+        try:
+            if self.slot:
+                self.api.drives.remove(self.slot)
+        except Exception:
+            pass
+        try:
+            with ftp_lib.session(self.args.host, self.args.password or None) as client:
+                for path in self.paths.values():
+                    ftp_lib.delete_quietly(client, path)
+        except Exception:
+            pass
+        if self.original is not None:
+            try:
+                self.api.drives.set_mode(self.slot, self.original.type)
+                image = mounted_path(self.original)
+                if image:
+                    self.api.drives.mount(self.slot, image)
+                (self.api.drives.on if self.original.enabled else self.api.drives.off)(self.slot)
+            except Exception as exc:
+                detail(f"could not restore drive {self.slot}: {exc}")
+        try:
+            self.api.machine.reset(force=True)
+        except Exception:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    cli.add_device_arguments(parser, timeout=15.0, colour=False)
+    parser.add_argument("--test", choices=("all", *CASES), default="all")
+    args = parser.parse_args()
+
+    runner = SuiteRunner(args)
+    try:
+        with check("prepare 1581 and generated D81 fixtures"):
+            prg = runner.prepare()
+        selected = CASES if args.test == "all" else (args.test,)
+        for name in selected:
+            runner.run_case(name, prg)
+    except Exception as exc:
+        suite_fail(SUITE, format_exception(exc))
+        return 1
+    finally:
+        runner.cleanup()
+    suite_ok(SUITE)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/drive/d81_track_reader.asm
+++ b/tests/e2e/drive/d81_track_reader.asm
@@ -1,0 +1,228 @@
+; Read physical track 81, sector 5 through the 1581 job interface. The host
+; supplies DEVICE and checks the copied sector at RESULT_DATA.
+
+SETLFS = $ffba
+SETNAM = $ffbd
+OPEN   = $ffc0
+CLOSE  = $ffc3
+CHKIN  = $ffc6
+CHKOUT = $ffc9
+CLRCHN = $ffcc
+CHRIN  = $ffcf
+CHROUT = $ffd2
+READST = $ffb7
+
+RESULT_STATUS = $c000
+RESULT_READY  = $c001
+RESULT_JOB    = $c002
+RESULT_IO     = $c003
+RESULT_DATA   = $c100
+
+STATUS_RUNNING = $00
+STATUS_DONE    = $01
+STATUS_IO_ERROR = $02
+READY_MARK = $a5
+
+src = $fb
+dst = $fd
+index = $02
+
+* = $0801
+    .word basic_end, 2026
+    .null $9e, format("%d", start)
+basic_end:
+    .word 0
+
+start:
+    lda #STATUS_RUNNING
+    sta RESULT_STATUS
+    lda #READY_MARK
+    sta RESULT_READY
+    lda #0
+    sta RESULT_JOB
+    sta RESULT_IO
+
+    lda #15
+    ldx #DEVICE
+    ldy #15
+    jsr SETLFS
+    lda #0
+    ldx #0
+    ldy #0
+    jsr SETNAM
+    jsr OPEN
+    bcs io_error
+
+    jsr write_drive_code
+    jsr execute_drive_code
+    jsr read_job_result
+
+    lda #<$0300
+    sta src
+    lda #>$0300
+    sta src+1
+    lda #<RESULT_DATA
+    sta dst
+    lda #>RESULT_DATA
+    sta dst+1
+    jsr read_128
+    jsr read_128
+    jsr read_128
+    jsr read_128
+
+    lda #STATUS_DONE
+finish:
+    sta RESULT_STATUS
+    lda #15
+    jsr CLOSE
+    jsr CLRCHN
+    rts
+
+io_error:
+    jsr READST
+    sta RESULT_IO
+    lda #STATUS_IO_ERROR
+    bne finish
+
+write_drive_code:
+    ldx #15
+    jsr CHKOUT
+    bcc +
+    jmp io_error
++
+    lda #'M'
+    jsr CHROUT
+    lda #'-'
+    jsr CHROUT
+    lda #'W'
+    jsr CHROUT
+    lda #<drive_code
+    jsr CHROUT
+    lda #>drive_code
+    jsr CHROUT
+    lda #drive_code_end-drive_code
+    jsr CHROUT
+    ldy #0
+-   lda drive_code,y
+    jsr CHROUT
+    iny
+    cpy #drive_code_end-drive_code
+    bne -
+    jsr CLRCHN
+    rts
+
+execute_drive_code:
+    ldx #15
+    jsr CHKOUT
+    bcc +
+    jmp io_error
++
+    lda #'M'
+    jsr CHROUT
+    lda #'-'
+    jsr CHROUT
+    lda #'E'
+    jsr CHROUT
+    lda #<drive_code
+    jsr CHROUT
+    lda #>drive_code
+    jsr CHROUT
+    jsr CLRCHN
+    rts
+
+read_job_result:
+    ldx #15
+    jsr CHKOUT
+    bcc +
+    jmp io_error
++
+    lda #'M'
+    jsr CHROUT
+    lda #'-'
+    jsr CHROUT
+    lda #'R'
+    jsr CHROUT
+    lda #<$01ce
+    jsr CHROUT
+    lda #>$01ce
+    jsr CHROUT
+    lda #1
+    jsr CHROUT
+    jsr CLRCHN
+    ldx #15
+    jsr CHKIN
+    bcc +
+    jmp io_error
++
+    jsr CHRIN
+    sta RESULT_JOB
+    jsr CLRCHN
+    rts
+
+read_128:
+    ldx #15
+    jsr CHKOUT
+    bcc +
+    jmp io_error
++
+    lda #'M'
+    jsr CHROUT
+    lda #'-'
+    jsr CHROUT
+    lda #'R'
+    jsr CHROUT
+    lda src
+    jsr CHROUT
+    lda src+1
+    jsr CHROUT
+    lda #128
+    jsr CHROUT
+    jsr CLRCHN
+
+    ldx #15
+    jsr CHKIN
+    bcc +
+    jmp io_error
++
+    lda #0
+    sta index
+-   jsr CHRIN
+    pha
+    ldy index
+    pla
+    sta (dst),y
+    inc index
+    bpl -
+    jsr CLRCHN
+
+    clc
+    lda src
+    adc #128
+    sta src
+    bcc +
+    inc src+1
++   clc
+    lda dst
+    adc #128
+    sta dst
+    bcc +
+    inc dst+1
++   rts
+
+; Wheels MakeSysDisk uses this 1581 ROM job to read physical track 80
+; (the 81st track), sector 5 into the drive's $0300-$04ff buffer.
+drive_code:
+    php
+    sei
+    lda #$50
+    sta $0b
+    lda #$05
+    sta $0c
+    lda #$00
+    sta $01ce
+    lda #$a4
+    ldx #$00
+    jsr $ff54
+    plp
+    rts
+drive_code_end:


### PR DESCRIPTION
## Summary

- clamp MFM track initialization to the fixed 84-track arrays
- add an ASan/UBSan regression test for 80, 81, 84, and oversized layouts
- add a hardware E2E suite using generated 80-, 81-, and 85-track D81 images

## Root cause

D81 track counts come from image size. An image containing more than 84 tracks made `MfmDisk::init()` index past its fixed `side0` and `side1` arrays, corrupting adjacent memory.

The bound is enforced once in `MfmDisk::init()`, covering every caller.

## Verification

- without the guard, the host regression test reports index 84 out of bounds and an ASan stack-buffer-overflow
- with the guard, `make d81_tracks_test` passes under macOS Clang and Linux GCC
- Ultimate 64 firmware builds and packages with Quartus 18.1
- Ultimate 64 Elite hardware: all 10 generated-D81 checks pass, including the 85-track regression and exact 512-byte track-81 reads
- full hardware gate executed: D81, UCI, filesystem, drive, Assembly64, key-injection, REU, freeze-menu, and device health checks pass without recovery

The E2E fixtures are generated during the test; no Wheels image is distributed.

Closes #846
