### PR TITLE
Fix HTTP body editing after deleting the selected node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,29 +88,11 @@ jobs:
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/io/command_interface/tests"
 
-      - name: Verify http-body-removal red/green
+      - name: Test HTTP Body Removal
         run: |
-          docker run --rm -i \
+          docker run --rm \
           -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -s <<'REGRESSION'
-          set -eu
-          cd /mnt/project
-          g++ --version
-          printf 'LD_PRELOAD=%s\n' "${LD_PRELOAD-}"
-          riscv32-unknown-elf-g++ --version
-          nios2-elf-g++ --version
-          trap 'git restore -- software/io/command_interface/http_target.h' EXIT
-          git show 8596576fc358cdb0608a8f92c9db899a8c2950ea:software/io/command_interface/http_target.h > software/io/command_interface/http_target.h
-          if make -B -C target/pc/linux/test_http_target test-body-removal > /tmp/regression-red.log 2>&1; then
-            cat /tmp/regression-red.log
-            echo "ERROR: baseline unexpectedly passed"
-            exit 1
-          fi
-          cat /tmp/regression-red.log
-          grep -F 'AddressSanitizer: heap-use-after-free' /tmp/regression-red.log
-          git restore -- software/io/command_interface/http_target.h
-          make -B -C target/pc/linux/test_http_target test-body-removal
-          REGRESSION
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -B -C target/pc/linux/test_http_target test-body-removal"
 
       - name: Cache U2 FPGA
         id: cache-u2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,29 @@ jobs:
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/io/command_interface/tests"
 
+      - name: Verify http-body-removal red/green
+        run: |
+          docker run --rm -i \
+          -v /opt/build-tools:/mnt/build-tools:ro \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -s <<'REGRESSION'
+          set -eu
+          cd /mnt/project
+          g++ --version
+          riscv32-unknown-elf-g++ --version
+          nios2-elf-g++ --version
+          trap 'git restore -- software/io/command_interface/http_target.h' EXIT
+          git show 8596576fc358cdb0608a8f92c9db899a8c2950ea:software/io/command_interface/http_target.h > software/io/command_interface/http_target.h
+          if make -B -C target/pc/linux/test_http_target test-body-removal > /tmp/regression-red.log 2>&1; then
+            cat /tmp/regression-red.log
+            echo "ERROR: baseline unexpectedly passed"
+            exit 1
+          fi
+          cat /tmp/regression-red.log
+          grep -F 'AddressSanitizer: heap-use-after-free' /tmp/regression-red.log
+          git restore -- software/io/command_interface/http_target.h
+          make -B -C target/pc/linux/test_http_target test-body-removal
+          REGRESSION
+
       - name: Cache U2 FPGA
         id: cache-u2
         uses: actions/cache@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,7 @@ jobs:
           set -eu
           cd /mnt/project
           g++ --version
+          printf 'LD_PRELOAD=%s\n' "${LD_PRELOAD-}"
           riscv32-unknown-elf-g++ --version
           nios2-elf-g++ --version
           trap 'git restore -- software/io/command_interface/http_target.h' EXIT

--- a/software/io/command_interface/http_target.h
+++ b/software/io/command_interface/http_target.h
@@ -465,6 +465,13 @@ public:
     void remove(JSON *j)
     {
         if (j && j->parent) {
+            // Keep the editing position alive when removing it or an ancestor.
+            for (JSON *cursor = current; cursor; cursor = cursor->parent) {
+                if (cursor == j) {
+                    current = j->parent;
+                    break;
+                }
+            }
             if (j->parent->type() == eObject) {
                 JSON_Object *p = (JSON_Object  *)j->parent;
                 p->remove(j);

--- a/software/io/command_interface/test_http_target.cc
+++ b/software/io/command_interface/test_http_target.cc
@@ -424,6 +424,30 @@ static void test_external_json(HttpTarget *target)
     command_external_empty(target, "external delete object", HTTP_CMD_BODY_REMOVE, handle, "%1", status_ok);
 }
 
+static void test_body_removal(HttpTarget *target)
+{
+    static const uint8_t gideon[] = { HTTP_DATA_STRING, 6, 'G', 'i', 'd', 'e', 'o', 'n' };
+    const char *removed[] = { "branch/child", "branch", "sibling", "items[0]" };
+    const char *selected[] = { "branch/child", "branch/child", "branch/child", "items[0]" };
+    const char *destination[] = { "branch/name", "name", "branch/child/name", "items[0]/name" };
+    for (unsigned i = 0; i < sizeof(removed) / sizeof(removed[0]); ++i) {
+        char json[] = "{\"branch\":{\"child\":{}},\"sibling\":{},\"items\":[{}]}";
+        uint8_t handle = 0xFF;
+        target->create_body_from_json(json, sizeof(json) - 1, &handle);
+        command_external_empty(target, "select editing position", HTTP_CMD_BODY_MOVE, handle, selected[i], status_ok);
+        command_external_empty(target, "delete selected node, ancestor or sibling", HTTP_CMD_BODY_REMOVE, handle, removed[i], status_ok);
+        if (i == 3) {
+            // Deleting an array element should leave its containing array selected.
+            uint8_t data[] = { 6, HTTP_CMD_BODY_ADD_OBJECT, handle, 0 };
+            Message command = make_msg(data, sizeof(data));
+            run_expect_empty(target, "append after deleting array selection", &command, status_ok);
+        }
+        add_external_name(target, handle);
+        query_external(target, "edit after deletion reaches surviving parent", handle, destination[i], gideon, sizeof(gideon));
+        command_external_empty(target, "free navigation body", HTTP_CMD_BODY_FREE, handle, "", status_ok);
+    }
+}
+
 static void test_free_all(HttpTarget *target)
 {
     // After test_external_json: headers[0] and bodies[0..2] are all allocated.
@@ -525,6 +549,12 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    if ((argc > 1) && (strcmp(argv[1], "--body-removal") == 0)) {
+        test_body_removal(target);
+        printf("Body removal: %d checks, %d failures\n", checks, failures);
+        return failures ? 1 : 0;
+    }
+
     test_headers(target);
     test_legacy_body_object(target);
     test_legacy_body_array(target);
@@ -534,6 +564,7 @@ int main(int argc, char **argv)
     test_external_json(target);
     test_free_all(target);
     test_body_clear(target);
+    test_body_removal(target);
 
     if ((argc > 1) && (strcmp(argv[1], "--network") == 0)) {
         run_network_smoke(target);

--- a/target/pc/linux/test_http_target/Makefile
+++ b/target/pc/linux/test_http_target/Makefile
@@ -62,4 +62,5 @@ test-body-removal:
 	@$(MAKE) OUTPUT=output/body-removal RESULT=result/body-removal \
 	    CC="$(CC) -fsanitize=address,undefined -fno-sanitize-recover=all" \
 	    CPP="$(CPP) -fsanitize=address,undefined -fno-sanitize-recover=all" all
+	# ASan must precede any libraries preloaded by the build environment.
 	@LD_PRELOAD="$$($(CPP) -print-file-name=libasan.so)$${LD_PRELOAD:+:$$LD_PRELOAD}" result/body-removal/$(PRJ) --body-removal

--- a/target/pc/linux/test_http_target/Makefile
+++ b/target/pc/linux/test_http_target/Makefile
@@ -62,4 +62,4 @@ test-body-removal:
 	@$(MAKE) OUTPUT=output/body-removal RESULT=result/body-removal \
 	    CC="$(CC) -fsanitize=address,undefined -fno-sanitize-recover=all" \
 	    CPP="$(CPP) -fsanitize=address,undefined -fno-sanitize-recover=all" all
-	@result/body-removal/$(PRJ) --body-removal
+	@LD_PRELOAD="$$($(CPP) -print-file-name=libasan.so)$${LD_PRELOAD:+:$$LD_PRELOAD}" result/body-removal/$(PRJ) --body-removal

--- a/target/pc/linux/test_http_target/Makefile
+++ b/target/pc/linux/test_http_target/Makefile
@@ -56,3 +56,10 @@ $(RESULT)/$(PRJ): $(OBJS_C) $(OBJS_CC) $(OBJS_ASM) $(OBJS_6502) $(OBJS_BIN) $(OB
 	@echo Linking...
 	$(CPP) $(ALL_OBJS) $(LLIB) -o $(RESULT)/$(PRJ) $(LIBS)
 
+# Run the removal regression independently of the external JSON fixture.
+.PHONY: test-body-removal
+test-body-removal:
+	@$(MAKE) OUTPUT=output/body-removal RESULT=result/body-removal \
+	    CC="$(CC) -fsanitize=address,undefined -fno-sanitize-recover=all" \
+	    CPP="$(CPP) -fsanitize=address,undefined -fno-sanitize-recover=all" all
+	@result/body-removal/$(PRJ) --body-removal


### PR DESCRIPTION
Deleting the selected HTTP body object, or its ancestor, leaves the next edit using freed storage. Keep the editing position at the surviving parent in `HttpBodySlot::remove`. Tests cover deleting the selection, an ancestor, an unrelated sibling and an array element.

Introduced after 3.14 with the HTTP target. Tested independently against `test-merge` at `8596576f`, in the upstream pipeline’s `my_docker_image` (host G++ 13.3.0):

```sh
make -B -C target/pc/linux/test_http_target test-body-removal
```

Same tests, changing only the firmware fix:

```text
Before: AddressSanitizer: heap-use-after-free; exit 2
After:  Body removal: 63 checks, 0 failures; exit 0
```

[Red/green evidence](https://github.com/GideonZ/1541ultimate/actions/runs/33932324740/job/101213300364); [final CI build](https://github.com/GideonZ/1541ultimate/actions/runs/33932682504) passed all five firmware targets and the application-space gate. The test target loads ASan before the CI image’s preloaded libraries. Hardware E2E was not run.
