### PR TITLE
Preserve JSON parent links when replacing values

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,12 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Test JSON Replacement
+        run: |
+          docker run --rm \
+          -v /opt/build-tools:/mnt/build-tools:ro \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/api/tests"
+
       - name: Generate Version String
         run: echo "GIT_VERSION=$(git describe --tags --always)" >>$GITHUB_ENV
 
@@ -87,29 +93,6 @@ jobs:
           docker run --rm \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/io/command_interface/tests"
-
-      - name: Verify json-replacement-parent red/green
-        run: |
-          docker run --rm -i \
-          -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -s <<'REGRESSION'
-          set -eu
-          cd /mnt/project
-          g++ --version
-          riscv32-unknown-elf-g++ --version
-          nios2-elf-g++ --version
-          trap 'git restore -- software/api/json.h' EXIT
-          git show 8596576fc358cdb0608a8f92c9db899a8c2950ea:software/api/json.h > software/api/json.h
-          if make -C software/api/tests > /tmp/regression-red.log 2>&1; then
-            cat /tmp/regression-red.log
-            echo "ERROR: baseline unexpectedly passed"
-            exit 1
-          fi
-          cat /tmp/regression-red.log
-          grep -F '1 test(s) failed' /tmp/regression-red.log
-          git restore -- software/api/json.h
-          make -C software/api/tests
-          REGRESSION
 
       - name: Cache U2 FPGA
         id: cache-u2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,29 @@ jobs:
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/io/command_interface/tests"
 
+      - name: Verify json-replacement-parent red/green
+        run: |
+          docker run --rm -i \
+          -v /opt/build-tools:/mnt/build-tools:ro \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -s <<'REGRESSION'
+          set -eu
+          cd /mnt/project
+          g++ --version
+          riscv32-unknown-elf-g++ --version
+          nios2-elf-g++ --version
+          trap 'git restore -- software/api/json.h' EXIT
+          git show 8596576fc358cdb0608a8f92c9db899a8c2950ea:software/api/json.h > software/api/json.h
+          if make -C software/api/tests > /tmp/regression-red.log 2>&1; then
+            cat /tmp/regression-red.log
+            echo "ERROR: baseline unexpectedly passed"
+            exit 1
+          fi
+          cat /tmp/regression-red.log
+          grep -F '1 test(s) failed' /tmp/regression-red.log
+          git restore -- software/api/json.h
+          make -C software/api/tests
+          REGRESSION
+
       - name: Cache U2 FPGA
         id: cache-u2
         uses: actions/cache@v6

--- a/software/api/json.h
+++ b/software/api/json.h
@@ -154,6 +154,7 @@ public:
             if (strcasecmp(keys[i], key) == 0) { // key exists!
                 delete values[i];
                 values.replace_idx(i, new JSON_Integer(val));
+                values[i]->parent = this;
                 return this;
             }
         }
@@ -165,6 +166,7 @@ public:
             if (strcasecmp(keys[i], key) == 0) { // key exists!
                 delete values[i];
                 values.replace_idx(i, new JSON_Bool(b));
+                values[i]->parent = this;
                 return this;
             }
         }
@@ -176,6 +178,7 @@ public:
             if (strcasecmp(keys[i], key) == 0) { // key exists!
                 delete values[i];
                 values.replace_idx(i, new JSON_String(str));
+                values[i]->parent = this;
                 return this;
             }
         }

--- a/software/api/tests/input_api_validation_test.cpp
+++ b/software/api/tests/input_api_validation_test.cpp
@@ -259,3 +259,21 @@ TEST(InputApiValidationTest, RejectsMalformedJsonBeforeValidation)
     EXPECT_TRUE(tokens < 0);
     EXPECT_EQ((JSON *)0, root);
 }
+
+TEST(JsonValueTest, ReplacedPrimitivesRetainTheirParent)
+{
+    JSON_Object object;
+    object.add("value", 0);
+
+    object.set("value", 123);
+    EXPECT_EQ(eInteger, object.get("value")->type());
+    EXPECT_EQ(static_cast<JSON *>(&object), object.get("value")->parent);
+
+    object.set("value", true);
+    EXPECT_EQ(eBool, object.get("value")->type());
+    EXPECT_EQ(static_cast<JSON *>(&object), object.get("value")->parent);
+
+    object.set("value", "replacement");
+    EXPECT_EQ(eString, object.get("value")->type());
+    EXPECT_EQ(static_cast<JSON *>(&object), object.get("value")->parent);
+}


### PR DESCRIPTION
Replacing an existing JSON integer, boolean or string loses its parent link, breaking subsequent HTTP body UP and REMOVE commands. Set the parent on replacement values in the three `JSON_Object::set` overloads.

Introduced after 3.14 with the HTTP target. Tested independently against `test-merge` at `8596576f`, in the upstream pipeline’s `my_docker_image` (host G++ 13.3.0):

```sh
make -C software/api/tests
```

Same tests, changing only the firmware fix:

```text
Before: 3 parent-link assertions fail; 1 test failed; exit 2
After:  12 validation tests and 27 state tests passed; exit 0
```

[Red/green evidence](https://github.com/GideonZ/1541ultimate/actions/runs/33931063372/job/101209573238); [final CI build](https://github.com/GideonZ/1541ultimate/actions/runs/33932631857) passed all five firmware targets and the application-space gate. Hardware E2E was not run.
