### PR TITLE
Decode negative HTTP body integers consistently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,34 +82,17 @@ jobs:
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make fpga_depends && make esp_depends"
 
+      - name: Test HTTP Signed Integers
+        run: |
+          docker run --rm \
+          -v /opt/build-tools:/mnt/build-tools:ro \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -B -C target/pc/linux/test_http_target test-integer-widths"
+
       - name: Test UCI Palette Commands
         run: |
           docker run --rm \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/io/command_interface/tests"
-
-      - name: Verify http-signed-integers red/green
-        run: |
-          docker run --rm -i \
-          -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -s <<'REGRESSION'
-          set -eu
-          cd /mnt/project
-          g++ --version
-          riscv32-unknown-elf-g++ --version
-          nios2-elf-g++ --version
-          trap 'git restore -- software/io/command_interface/http_target.cc' EXIT
-          git show 8596576fc358cdb0608a8f92c9db899a8c2950ea:software/io/command_interface/http_target.cc > software/io/command_interface/http_target.cc
-          if make -B -C target/pc/linux/test_http_target test-integer-widths > /tmp/regression-red.log 2>&1; then
-            cat /tmp/regression-red.log
-            echo "ERROR: baseline unexpectedly passed"
-            exit 1
-          fi
-          cat /tmp/regression-red.log
-          grep -F 'Integer widths: 99 checks, 6 failures' /tmp/regression-red.log
-          git restore -- software/io/command_interface/http_target.cc
-          make -B -C target/pc/linux/test_http_target test-integer-widths
-          REGRESSION
 
       - name: Cache U2 FPGA
         id: cache-u2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,29 @@ jobs:
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/io/command_interface/tests"
 
+      - name: Verify http-signed-integers red/green
+        run: |
+          docker run --rm -i \
+          -v /opt/build-tools:/mnt/build-tools:ro \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -s <<'REGRESSION'
+          set -eu
+          cd /mnt/project
+          g++ --version
+          riscv32-unknown-elf-g++ --version
+          nios2-elf-g++ --version
+          trap 'git restore -- software/io/command_interface/http_target.cc' EXIT
+          git show 8596576fc358cdb0608a8f92c9db899a8c2950ea:software/io/command_interface/http_target.cc > software/io/command_interface/http_target.cc
+          if make -B -C target/pc/linux/test_http_target test-integer-widths > /tmp/regression-red.log 2>&1; then
+            cat /tmp/regression-red.log
+            echo "ERROR: baseline unexpectedly passed"
+            exit 1
+          fi
+          cat /tmp/regression-red.log
+          grep -F 'Integer widths: 99 checks, 6 failures' /tmp/regression-red.log
+          git restore -- software/io/command_interface/http_target.cc
+          make -B -C target/pc/linux/test_http_target test-integer-widths
+          REGRESSION
+
       - name: Cache U2 FPGA
         id: cache-u2
         uses: actions/cache@v6

--- a/software/io/command_interface/http_target.cc
+++ b/software/io/command_interface/http_target.cc
@@ -654,9 +654,9 @@ void HttpTarget::cmd_body_add_primitive(Message *command, Message **reply, Messa
                 // clunky way to sign extend
                 for(int i=len_int-1; i >= 0; i--) {
                     if(i == len_int-1) {
-                        value_int = (char)command->message[pos_val + i];
+                        value_int = (int8_t)command->message[pos_val + i];
                     } else {
-                        value_int <<= 8;
+                        value_int *= 256;
                         value_int |= command->message[pos_val + i];
                     }
                 }

--- a/software/io/command_interface/test_http_target.cc
+++ b/software/io/command_interface/test_http_target.cc
@@ -501,6 +501,28 @@ static void test_body_clear(HttpTarget *target)
     run_expect_empty(target, "body clear: invalid handle", &clear_bad, status_bad_req);
 }
 
+static void test_integer_widths(HttpTarget *target)
+{
+    char json[] = "{}";
+    uint8_t handle = 0xFF;
+    target->create_body_from_json(json, sizeof(json) - 1, &handle);
+    for (int width = 1; width <= 4; ++width) {
+        // Zero, maximum positive, minimum negative, and -1 at each wire width.
+        for (int boundary = 0; boundary < 4; ++boundary) {
+            uint8_t data[] = { 6, HTTP_CMD_BODY_ADD_INT, handle, 1, 'n', 0, 0, 0, 0 };
+            memset(data + 5, boundary == 1 || boundary == 3 ? 0xFF : 0, width);
+            data[4 + width] = boundary == 1 ? 0x7F : boundary == 2 ? 0x80 : boundary == 3 ? 0xFF : 0;
+            Message command = make_msg(data, 5 + width);
+            run_expect_empty(target, "add signed integer boundary", &command, status_ok);
+            uint8_t expected[] = { HTTP_DATA_INTEGER, 0, 0, 0, 0 };
+            memset(expected + 1, boundary >= 2 ? 0xFF : 0, 4);
+            memcpy(expected + 1, data + 5, width);
+            query_external(target, "integer sign extension", handle, "n", expected, sizeof(expected));
+        }
+    }
+    command_external_empty(target, "free integer body", HTTP_CMD_BODY_FREE, handle, "", status_ok);
+}
+
 static void run_network_smoke(HttpTarget *target)
 {
     Message *reply;
@@ -520,6 +542,11 @@ static void run_network_smoke(HttpTarget *target)
 int main(int argc, char **argv)
 {
     HttpTarget *target = (HttpTarget *)command_targets[6];
+    if (target && (argc > 1) && (strcmp(argv[1], "--integer-widths") == 0)) {
+        test_integer_widths(target);
+        printf("Integer widths: %d checks, %d failures\n", checks, failures);
+        return failures ? 1 : 0;
+    }
     if (!target) {
         printf("FAIL target 6 was not registered\n");
         return 1;
@@ -533,6 +560,7 @@ int main(int argc, char **argv)
     test_structured_body_add(target);
     test_external_json(target);
     test_free_all(target);
+    test_integer_widths(target);
     test_body_clear(target);
 
     if ((argc > 1) && (strcmp(argv[1], "--network") == 0)) {

--- a/target/pc/linux/test_http_target/Makefile
+++ b/target/pc/linux/test_http_target/Makefile
@@ -52,6 +52,13 @@ LFLAGS   = --gc-sections
 
 include ../../../common/rules.mk
 
+# Exercise sign extension even on hosts where plain char is signed by default.
+.PHONY: test-integer-widths
+test-integer-widths:
+	@$(MAKE) OUTPUT=output/integer-widths RESULT=result/integer-widths \
+	    CPP="$(CPP) -funsigned-char" all
+	@result/integer-widths/$(PRJ) --integer-widths
+
 $(RESULT)/$(PRJ): $(OBJS_C) $(OBJS_CC) $(OBJS_ASM) $(OBJS_6502) $(OBJS_BIN) $(OBJS_IEC) $(OBJS_NANO)
 	@echo Linking...
 	$(CPP) $(ALL_OBJS) $(LLIB) -o $(RESULT)/$(PRJ) $(LIBS)


### PR DESCRIPTION
Negative one-, two- and three-byte HTTP body integers decode as positive when plain `char` is unsigned. Use `int8_t` for the sign byte and multiplication instead of shifting a negative signed value.

Introduced after 3.14 with the HTTP target. Tests cover zero, maximum positive, minimum negative and -1 at all four wire widths. Tested independently against `test-merge` at `8596576f`, in the upstream pipeline’s `my_docker_image` (host G++ 13.3.0):

```sh
make -B -C target/pc/linux/test_http_target test-integer-widths
```

Same tests with unsigned `char`, changing only the firmware fix:

```text
Before: Integer widths: 99 checks, 6 failures; exit 2
After:  Integer widths: 99 checks, 0 failures; exit 0
```

[Red/green evidence](https://github.com/GideonZ/1541ultimate/actions/runs/33931063177/job/101209572784); [final CI build](https://github.com/GideonZ/1541ultimate/actions/runs/33932635667) passed all five firmware targets and the application-space gate. Hardware E2E was not run.
