### PR TITLE
Format INT_MIN without signed overflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,12 @@ jobs:
            PYTHONPATH=/tmp/openapi-packages python -m openapi_spec_validator \
              --validation-errors all \$(python tools/openapi/generate.py paths)"
 
+      - name: Test INT_MIN Formatting
+        run: |
+          docker run --rm \
+          -v /opt/build-tools:/mnt/build-tools:ro \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/api/tests CXX='g++ -fsanitize=undefined -fno-sanitize-recover=all'"
+
       - name: Determine FPGA & ESP32 dependencies
         run: |
           docker run --rm \
@@ -87,29 +93,6 @@ jobs:
           docker run --rm \
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/io/command_interface/tests"
-
-      - name: Verify printf-int-min red/green
-        run: |
-          docker run --rm -i \
-          -v /opt/build-tools:/mnt/build-tools:ro \
-          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -s <<'REGRESSION'
-          set -eu
-          cd /mnt/project
-          g++ --version
-          riscv32-unknown-elf-g++ --version
-          nios2-elf-g++ --version
-          trap 'git restore -- software/system/small_printf.cc' EXIT
-          git show 8596576fc358cdb0608a8f92c9db899a8c2950ea:software/system/small_printf.cc > software/system/small_printf.cc
-          if make -C software/api/tests CXX="g++ -fsanitize=undefined -fno-sanitize-recover=all" > /tmp/regression-red.log 2>&1; then
-            cat /tmp/regression-red.log
-            echo "ERROR: baseline unexpectedly passed"
-            exit 1
-          fi
-          cat /tmp/regression-red.log
-          grep -F 'runtime error: negation of -2147483648' /tmp/regression-red.log
-          git restore -- software/system/small_printf.cc
-          make -C software/api/tests CXX="g++ -fsanitize=undefined -fno-sanitize-recover=all"
-          REGRESSION
 
       - name: Cache U2 FPGA
         id: cache-u2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,29 @@ jobs:
           -v /opt/build-tools:/mnt/build-tools:ro \
           -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -c "cd /mnt/project && make -C software/io/command_interface/tests"
 
+      - name: Verify printf-int-min red/green
+        run: |
+          docker run --rm -i \
+          -v /opt/build-tools:/mnt/build-tools:ro \
+          -v $GITHUB_WORKSPACE:/mnt/project:rw my_docker_image /bin/bash -s <<'REGRESSION'
+          set -eu
+          cd /mnt/project
+          g++ --version
+          riscv32-unknown-elf-g++ --version
+          nios2-elf-g++ --version
+          trap 'git restore -- software/system/small_printf.cc' EXIT
+          git show 8596576fc358cdb0608a8f92c9db899a8c2950ea:software/system/small_printf.cc > software/system/small_printf.cc
+          if make -C software/api/tests CXX="g++ -fsanitize=undefined -fno-sanitize-recover=all" > /tmp/regression-red.log 2>&1; then
+            cat /tmp/regression-red.log
+            echo "ERROR: baseline unexpectedly passed"
+            exit 1
+          fi
+          cat /tmp/regression-red.log
+          grep -F 'runtime error: negation of -2147483648' /tmp/regression-red.log
+          git restore -- software/system/small_printf.cc
+          make -C software/api/tests CXX="g++ -fsanitize=undefined -fno-sanitize-recover=all"
+          REGRESSION
+
       - name: Cache U2 FPGA
         id: cache-u2
         uses: actions/cache@v6

--- a/software/api/tests/input_api_validation_test.cpp
+++ b/software/api/tests/input_api_validation_test.cpp
@@ -68,6 +68,18 @@ JSON *parse_json_text(const char *text, int &tokens)
 
 } // namespace
 
+TEST(JsonValueTest, RendersFullSignedIntegerRange)
+{
+    JSON_Integer minimum(INT32_MIN);
+    JSON_Integer maximum(INT32_MAX);
+    JSON_Integer negative(-1);
+    JSON_Integer zero(0);
+    EXPECT_EQ(std::string("-2147483648"), std::string(minimum.render()));
+    EXPECT_EQ(std::string("2147483647"), std::string(maximum.render()));
+    EXPECT_EQ(std::string("-1"), std::string(negative.render()));
+    EXPECT_EQ(std::string("0"), std::string(zero.render()));
+}
+
 TEST(InputApiValidationTest, ParsesValidBatchAndPreservesEventDetails)
 {
     InputParsedEvent events[INPUT_API_MAX_EVENTS];
@@ -258,16 +270,4 @@ TEST(InputApiValidationTest, RejectsMalformedJsonBeforeValidation)
 
     EXPECT_TRUE(tokens < 0);
     EXPECT_EQ((JSON *)0, root);
-}
-
-TEST(JsonValueTest, RendersFullSignedIntegerRange)
-{
-    JSON_Integer minimum(INT32_MIN);
-    JSON_Integer maximum(INT32_MAX);
-    JSON_Integer negative(-1);
-    JSON_Integer zero(0);
-    EXPECT_EQ(std::string("-2147483648"), std::string(minimum.render()));
-    EXPECT_EQ(std::string("2147483647"), std::string(maximum.render()));
-    EXPECT_EQ(std::string("-1"), std::string(negative.render()));
-    EXPECT_EQ(std::string("0"), std::string(zero.render()));
 }

--- a/software/api/tests/input_api_validation_test.cpp
+++ b/software/api/tests/input_api_validation_test.cpp
@@ -259,3 +259,15 @@ TEST(InputApiValidationTest, RejectsMalformedJsonBeforeValidation)
     EXPECT_TRUE(tokens < 0);
     EXPECT_EQ((JSON *)0, root);
 }
+
+TEST(JsonValueTest, RendersFullSignedIntegerRange)
+{
+    JSON_Integer minimum(INT32_MIN);
+    JSON_Integer maximum(INT32_MAX);
+    JSON_Integer negative(-1);
+    JSON_Integer zero(0);
+    EXPECT_EQ(std::string("-2147483648"), std::string(minimum.render()));
+    EXPECT_EQ(std::string("2147483647"), std::string(maximum.render()));
+    EXPECT_EQ(std::string("-1"), std::string(negative.render()));
+    EXPECT_EQ(std::string("0"), std::string(zero.render()));
+}

--- a/software/system/small_printf.cc
+++ b/software/system/small_printf.cc
@@ -21,7 +21,7 @@ _cvt(int val, char *buf, int radix, const char *digits, int leading_zeros, int w
 	if((signd) && (val < 0)) {
 		*buf++ = '-';
 		length++;
-		v = -val;
+		v = 0U - (unsigned int)val;
 	} else {
         v = val;
     }


### PR DESCRIPTION
Formatting `INT_MIN` negates a value that cannot be represented as a positive `int`. Compute its magnitude with unsigned arithmetic in `_cvt`. The regression checks JSON rendering of both signed extremes, -1 and zero.

This is a pre-existing defect, also present in 3.14. Tested independently against `test-merge` at `8596576f`, in the upstream pipeline’s `my_docker_image` (host G++ 13.3.0):

```sh
make -C software/api/tests CXX="g++ -fsanitize=undefined -fno-sanitize-recover=all"
```

Same tests, changing only the firmware fix:

```text
Before: UBSan: negation of -2147483648 cannot be represented in type 'int'; exit 2
After:  12 validation tests and 27 state tests passed; exit 0
```

[Red/green evidence](https://github.com/GideonZ/1541ultimate/actions/runs/33931063507/job/101209573877); [final CI build](https://github.com/GideonZ/1541ultimate/actions/runs/33932634064) passed all five firmware targets and the application-space gate. Hardware E2E was not run.
