### PR TITLE
Do not close a Telnet session on a send timeout

### DIFF
--- a/software/network/socket_stream.cc
+++ b/software/network/socket_stream.cc
@@ -86,13 +86,24 @@ int SocketStream :: purge() {
 	return ret;
 }
 
+// Consecutive send timeouts tolerated before the session is given up on. A timeout
+// costs SO_SNDTIMEO (5s, socket_gui.cc), so this bounds a peer that never drains at
+// about a minute, which is longer than the 35s the keepalive needs to spot a peer
+// that has really gone (socket_keepalive.h).
+#define TRANSMIT_TIMEOUT_RETRIES 12
+
 int SocketStream :: transmit(const char *buffer, int out_length)
 {
+	int retries = TRANSMIT_TIMEOUT_RETRIES;
 	while(out_length > 0) {
 		int n = send(actual_socket, buffer, out_length, 0);
 		if (n == out_length) {
 			return 0; // OK!
 		} else if (n < 0) {
+			// A full send buffer is a slow peer, not a gone one, so do not close on it.
+			if ((errno == EAGAIN || errno == EWOULDBLOCK) && (retries-- > 0)) {
+				continue;
+			}
 			puts("ERROR writing to socket");
 			close();
 			return -5;
@@ -102,6 +113,7 @@ int SocketStream :: transmit(const char *buffer, int out_length)
 		} else {
 			out_length -= n;
 			buffer += n;
+			retries = TRANSMIT_TIMEOUT_RETRIES; // the peer is draining after all
 		}
 	}
 	return 0;


### PR DESCRIPTION
Part 1 of GideonZ/1541ultimate#820. It does not close that issue: measurements
from this branch on an Ultimate II+L are below, and they show what actually ends
the session on that machine.

## Previous behaviour

`SocketStream::transmit()` in `software/network/socket_stream.cc` treated every
negative `send()` return as fatal:

```c
int n = send(actual_socket, buffer, out_length, 0);
if (n == out_length) {
    return 0;
} else if (n < 0) {
    puts("ERROR writing to socket");
    close();
    return -5;
}
```

`socket_gui_set_timeouts()` sets `SO_SNDTIMEO` to 5 seconds
(`software/network/socket_gui.cc`), so once the send buffer stayed full for 5
seconds, `send()` returned -1 with `EAGAIN`/`EWOULDBLOCK` and the session was
closed.

## The defect

A peer that has not drained the send buffer yet is a slow peer, not a gone peer.
Closing a socket that still has data queued makes lwIP send an RST, so the client
sees `ConnectionResetError: [Errno 104] Connection reset by peer`. `purge()` calls
`transmit()` as well, so all buffered UI output takes the same path.

The TCP keepalive installed by `net_enable_client_keepalive()` already exists to
detect a peer that has genuinely gone. Its detection window is 35 seconds
(`software/network/socket_keepalive.h`), so the send timeout does not need to
carry that job.

## The change

`transmit()` now distinguishes `EAGAIN`/`EWOULDBLOCK` from a real error, which is
the distinction the accept loop in `socket_gui.cc` already makes. On a send
timeout it retries instead of closing, bounded by `TRANSMIT_TIMEOUT_RETRIES`
consecutive timeouts. A partial write resets that budget, so the bound is on
consecutive timeouts that moved no bytes at all, not on the total time spent
sending one buffer. Each timeout costs `SO_SNDTIMEO`, so 12 of them bound a peer
that never drains at about a minute, which is longer than the keepalive needs to
spot a peer that has really gone. Every other `errno`, and a `send()` that returns
0, close the session exactly as before.

Twelve added lines in one function. Part 2 of the issue, bounding the repaint rate
so a full-screen view stops asking the link to carry more than it can, is not
attempted here.

## How it was verified

Bench: an Ultimate II+L on WiFi, in a C64 Ultimate host, addressed as `u2@c64u`.
Both the unfixed and the fixed image were built from this worktree with
`./build-tool -s u2pl`, so the only difference between them is this commit
(3076224 vs 3076296 bytes). Both packages carry the ECP5 bitstream from the CI
`factory_package_u2pl` artifact for the base commit.

Before the change, on firmware `c8b7551a`, all three attempts failed:

```
$ ./run-tests -s telnet-sustained-input --manual u2@c64u
[01] a held cursor key does not drop the Telnet session ... FAIL (the session died
     after 544 of 600 keys: ConnectionResetError: [Errno 104] Connection reset by
     peer. ...)
...
FAIL  1 of 1 suite runs failed.
```

After the change, the immediate reset is gone and the failure changes shape:

```
[01] a held cursor key does not drop the Telnet session ... FAIL (the session
     stopped answering after 600 keys: one more keystroke drew nothing within 5s,
     though the socket was still open, 29.4s SLOW)
```

`telnet-sustained-input` on an Ultimate 64, which is on wired Ethernet, passes:
600 keys, 792,477 bytes drawn back, 1,321 bytes a keystroke, still answering.
That machine is running an unmodified build of the base commit, so it is a check
that the suite behaves as its docstring says on a fast link, not a test of this
change. The change compiles for u2pl, u64 and u64ii.

## What still ends the session on the Ultimate II+L, and why part 1 cannot fix it

The remaining failure was traced with the firmware's own remote syslog and with
ICMP measured in parallel. A temporary build that printed `errno` in the give-up
branch produced:

```
ERROR writing to socket, errno=113 retries_left=7
```

`errno` 113 is `EHOSTUNREACH`, which lwIP returns as `ERR_RTE` from `tcp_output()`
when no route to the destination exists, meaning the WiFi interface is down.
`retries_left=7` says five send timeouts had already been ridden out, about 25
seconds, before that happened. The unfixed firmware would have closed on the first
of those five.

Measured on the same device, in the same session:

| Load | Result |
| --- | --- |
| Monitor repaint, 600 keys at 20/s | 792,477 bytes at 25.7 KB/s, no stall, answers in 0.1s |
| Monitor repaint, 600 keys at 25/s | 783,216 bytes at 31.8 KB/s, longest gap 2.0s, answers in 0.1s |
| Monitor repaint, 600 keys at 28/s | output stops 12.8s before the burst ends, silent for 34s |
| Monitor repaint, 600 keys at 30/s (what the suite drives) | output stops mid-burst, RST |
| File browser, 600 keys at 30/s | 128 bytes a keystroke, no stall, answers in 0.4s |
| FTP download of a 3 MB file | 416 KB/s, zero ICMP loss |

During the 30/s burst the device answered no ICMP at all for 24 seconds, starting
at the moment its Telnet output stopped, and the FTP control shows the link itself
is not slow. So above roughly 25 keystrokes a second the monitor's repaint, about
1,300 bytes a keystroke, exceeds what the Telnet path sustains, the backlog grows,
and the device's network interface then drops entirely for tens of seconds. That
is what closes the session now, and no retry in `transmit()` can help with it: the
socket layer is being told there is no route.

Two consequences worth stating plainly. `telnet-sustained-input` still fails on
`u2@c64u` after this change, so any gate on that suite has to stay. And the
interface dropping under sustained Telnet output looks like a separate defect from
the one this commit fixes; it is not addressed here.

## Alternatives considered

**Shortening `SO_SNDTIMEO`, or making the socket non-blocking and polling.** Both
change how long `send()` waits, not what a timeout is taken to mean. The session
would still be closed for a peer that is merely slow.

**Retrying without a bound.** A peer that is connected and acknowledging but never
reading keeps the connection alive indefinitely, so an unbounded retry would hold
the session task forever. The budget is what makes a peer that never drains still
get closed.

**Also retrying on `EHOSTUNREACH`, to ride out the interface outage above.** That
would be treating a link that has gone as a peer that is slow, and it needs its
own pacing, because `send()` returns `ERR_RTE` immediately rather than after
`SO_SNDTIMEO`, so a retry loop written for timeouts would spin. It belongs with
whatever fixes the interface dropping, not here.

**Deriving the budget from `NET_KEEPALIVE_*` and the `SO_SNDTIMEO` value.** Those
constants live in two other files and `SocketStream` sets neither of them, so
deriving the number would couple three files to save nothing. The constant carries
a comment naming both instead.
