### PR TITLE
Do not spin on a failed allocation; report a menu that did not act

### DIFF
--- a/doc/api/rest_api_openapi_u2.yaml
+++ b/doc/api/rest_api_openapi_u2.yaml
@@ -1996,6 +1996,8 @@ paths:
       description: |2-
         Acts as if the menu button on the device had been pressed, which opens the Ultimate menu or closes it again. There is no way to ask whether the menu is open; `GET /v1/machine:menu_screen` answers 404 while it is not.
 
+        A press raises a flag that the menu loop reads. The call waits up to half a second for the loop to take it and answers 503 if the flag is still up, which is what a menu loop that has stopped running looks like from outside. The press stays pending after such an answer, so the menu still acts on it if the loop resumes. A 200 means the loop took the press, not that the menu has finished drawing.
+
         While the menu is open it takes the keyboard, so keys injected through `POST /v1/machine:input` reach the menu rather than the running program.
       operationId: pushMenuButton
       responses:
@@ -2029,6 +2031,10 @@ paths:
                   value:
                     errors:
                       - SubSystem does not exist
+                The menu did not act on the button press:
+                  value:
+                    errors:
+                      - The menu did not act on the button press
   '/v1/machine:menu_screen':
     get:
       tags:

--- a/doc/api/rest_api_openapi_u64.yaml
+++ b/doc/api/rest_api_openapi_u64.yaml
@@ -2134,6 +2134,8 @@ paths:
       description: |2-
         Acts as if the menu button on the device had been pressed, which opens the Ultimate menu or closes it again. There is no way to ask whether the menu is open; `GET /v1/machine:menu_screen` answers 404 while it is not.
 
+        A press raises a flag that the menu loop reads. The call waits up to half a second for the loop to take it and answers 503 if the flag is still up, which is what a menu loop that has stopped running looks like from outside. The press stays pending after such an answer, so the menu still acts on it if the loop resumes. A 200 means the loop took the press, not that the menu has finished drawing.
+
         While the menu is open it takes the keyboard, so keys injected through `POST /v1/machine:input` reach the menu rather than the running program.
       operationId: pushMenuButton
       responses:
@@ -2167,6 +2169,10 @@ paths:
                   value:
                     errors:
                       - SubSystem does not exist
+                The menu did not act on the button press:
+                  value:
+                    errors:
+                      - The menu did not act on the button press
   '/v1/machine:menu_screen':
     get:
       tags:

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -5,6 +5,8 @@
 #include "c64.h"
 #include "c64_subsys.h"
 #include "userinterface.h"
+#include "FreeRTOS.h"
+#include "task.h"
 #if U64
 #include "keyboard_usb.h"
 #include "joystick_output.h"
@@ -14,6 +16,11 @@ extern "C" bool push_active_menu_button(void) __attribute__((weak));
 
 #define MENU_C64_PAUSE      0x640B
 #define MENU_C64_RESUME     0x640C
+
+// How long machine:menu_button waits for the menu loop to take the press it
+// just queued. The loop runs every three ticks, so this is more than thirty
+// passes of headroom, and it is short enough to leave an HTTP worker free.
+#define MENU_BUTTON_PICKUP_TICKS    (500 / portTICK_PERIOD_MS)
 
 static uint8_t chartohex(const char a)
 {
@@ -33,12 +40,20 @@ API_DOC(PUT, machine, menu_button,
                 "Ultimate menu or closes it again. There is no way to ask whether the menu is "
                 "open; `GET /v1/machine:menu_screen` answers 404 while it is not.\n"
                 "\n"
+                "A press raises a flag that the menu loop reads. The call waits up to half a "
+                "second for the loop to take it and answers 503 if the flag is still up, which "
+                "is what a menu loop that has stopped running looks like from outside. The press "
+                "stays pending after such an answer, so the menu still acts on it if the loop "
+                "resumes. A 200 means the loop took the press, not that the menu has finished "
+                "drawing.\n"
+                "\n"
                 "While the menu is open it takes the keyboard, so keys injected through "
                 "`POST /v1/machine:input` reach the menu rather than the running program.")
     PATH("/v1/machine:menu_button", "pushMenuButton", "")
     RESPONSE("200", "application/json", "ErrorResponse", "The button press was delivered.", "")
     RESPONSE_ERROR("423", "Could not obtain lock of subsystem", "")
     RESPONSE_ERROR("503", "SubSystem does not exist", "")
+    RESPONSE_ERROR("503", "The menu did not act on the button press", "")
 )
 API_CALL(PUT, machine, menu_button, NULL, ARRAY( {  }))
 {
@@ -51,8 +66,29 @@ API_CALL(PUT, machine, menu_button, NULL, ARRAY( {  }))
 #endif
     SubsysCommand *cmd = new SubsysCommand(NULL, SUBSYSID_C64, C64_PUSH_BUTTON, 0);
     SubsysResultCode_t retval = cmd->execute();
-    resp->error(SubsysCommand::error_string(retval.status));
-    resp->json_response(SubsysCommand::http_response_map(retval.status));
+    if (retval.status != SSRET_OK) {
+        resp->error(SubsysCommand::error_string(retval.status));
+        resp->json_response(SubsysCommand::http_response_map(retval.status));
+        return;
+    }
+
+    // The command only raises a flag; the menu loop is what acts on it, and it
+    // clears the flag on every pass. Answering here without looking reported
+    // success for a menu that never opened, and no client could tell the two
+    // apart. A flag that is still up after the wait means the loop is not
+    // running, so the press has not been acted on and will not be until it is.
+    C64 *machine = C64::getMachine();
+    bool pending = machine && machine->buttonPushPending();
+    for (TickType_t waited = 0; pending && (waited < MENU_BUTTON_PICKUP_TICKS); waited++) {
+        vTaskDelay(1);
+        pending = machine->buttonPushPending();
+    }
+    if (pending) {
+        resp->error("The menu did not act on the button press");
+        resp->json_response(HTTP_SERVICE_UNAVAILABLE);
+        return;
+    }
+    resp->json_response(HTTP_OK);
 }
 
 API_DOC(PUT, machine, reset,

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -1481,6 +1481,13 @@ void C64::setButtonPushed(void)
     buttonPushSeen = true;
 }
 
+// The menu loop clears this on every pass, so a press that is still pending
+// means the loop has not run since it was made.
+bool C64::buttonPushPending(void)
+{
+    return buttonPushSeen;
+}
+
 void C64::checkButton(void)
 {
     static uint8_t button_prev;

--- a/software/io/c64/c64.h
+++ b/software/io/c64/c64.h
@@ -367,6 +367,7 @@ public:
     }
     bool buttonPush(void);
     void setButtonPushed(void);
+    bool buttonPushPending(void);
 
     bool exists(void);
     bool is_accessible(void);

--- a/software/system/memory_wrap.cc
+++ b/software/system/memory_wrap.cc
@@ -1,4 +1,5 @@
 #include "FreeRTOS.h"
+#include "task.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -7,6 +8,9 @@
  * size with the target alignment and must not be inspected here. */
 static const size_t malloc_header_size =
     (sizeof(size_t) + portBYTE_ALIGNMENT - 1) & ~portBYTE_ALIGNMENT_MASK;
+
+/* How long a failed operator new waits before asking for the memory again. */
+#define OUT_OF_MEMORY_RETRY_TICKS   (100 / portTICK_PERIOD_MS)
 
 static void *malloc_allocate(size_t size)
 {
@@ -35,8 +39,18 @@ void * get_mem(size_t size)
 
 	if (!ret) {
         printf("** PANIC **: Error allocating %p..\n", __builtin_return_address(0));
-        while(1)
-            ;
+        /* Callers of operator new cannot take a NULL, so this has to keep
+         * trying. It must not spin while it does: a busy loop here never
+         * yields, so it hangs this task and starves every task below its
+         * priority, which turns one failed allocation into a dead device. */
+        while (!ret) {
+            if (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
+                vTaskDelay(OUT_OF_MEMORY_RETRY_TICKS);
+            }
+            ret = pvPortMalloc(size ? size : 1);
+        }
+        printf("Allocation for %p succeeded after waiting for memory.\n",
+               __builtin_return_address(0));
     }
     return ret;
 }


### PR DESCRIPTION
Fixes #856

## Previous behaviour

`get_mem()` in `software/system/memory_wrap.cc` is the global `operator new`. When
`pvPortMalloc` returned NULL it printed a PANIC line and then entered `while(1);`. The
loop never yielded, so the task that hit it stopped making progress permanently and held
the CPU at its own priority.

`PUT /v1/machine:menu_button` sent `C64_PUSH_BUTTON` to the C64 subsystem, which sets
`C64::buttonPushSeen`, and then answered 200 without looking at what happened to the flag.

## The defect

The only consumer of `buttonPushSeen` is the `while(c64)` loop in `ultimate_main`
(`software/application/ultimate/ultimate.cc:166`). A failed allocation anywhere under that
loop stops it for good, and after that no menu button press from REST, from the physical
button or from the keyboard can be acted on.

This was found on an Ultimate 64 Elite that had been running an E2E soak. The menu would
not open, `machine:menu_button` answered `200 {"errors":[]}`, `machine:menu_screen`
answered 404 indefinitely, and REST, FTP, Telnet, DMA, ICMP and the C64 itself were all
healthy. Reading the device over Nios JTAG gdb found the UI task in the spin:

```
#0  get_mem () at software/system/memory_wrap.cc:37
#1  BinImage::BinImage () at software/drive/disk_image.cc:1044
#2  ImageCreator::S_createD64 () at software/drive/disk_image.cc:1491
#3  SubsysCommand::execute () at software/infra/subsys.cc:12
#4  ContextMenu::executeSelected (p="/Temp/zbfr605620837/") at software/userinterface/context_menu.cc:146
#5  TreeBrowser::poll () at software/userinterface/tree_browser.cc:193
#6  UserInterface::pollFocussed () at software/userinterface/userinterface.cc:442
#7  UserInterface::run_once () at software/userinterface/userinterface.cc:331
#8  ultimate_main () at software/application/ultimate/ultimate.cc:199
```

The UI task runs at priority 0, so its spin only cost CPU. Later the same device ran out
of heap entirely and the `UDP Ident Task` hit the same loop at priority 1, which starved
every priority 0 task including the idle task, and the device stopped answering REST and
ICMP as well.

## Implemented change

`get_mem()` still cannot return NULL, because its callers do not check. It now waits for
memory instead of spinning: it logs the same PANIC line once, then retries `pvPortMalloc`
every 100 ms, calling `vTaskDelay` between attempts. A second line is logged if the
allocation later succeeds, so the syslog distinguishes a transient shortage from a
permanent one. The delay is skipped when the scheduler is not running, which is the only
context where `vTaskDelay` is not valid; that case keeps the old spin, and it was already
fatal before this change.

`machine:menu_button` now confirms the press was taken. `C64::buttonPushPending()` reads
`buttonPushSeen` without clearing it, and the route polls it for up to 500 ms after the
subsystem command returns. The menu loop clears the flag on every pass, so a flag that is
still up means the loop has not run. The route then answers
`503 {"errors":["The menu did not act on the button press"]}` instead of 200. The press
stays pending, so the menu still acts on it if the loop starts running again.

The generated OpenAPI documents were rebuilt with `python3 tools/openapi/generate.py
generate`; the change is the new wording of the 503 response and the added paragraph in
the route description.

## Verification

Firmware built from this branch and deployed to an Ultimate 64 Elite over JTAG with
`tooling/build_and_deploy_u64.sh`.

The forcing procedure is the same on both sides: open the menu over REST, navigate to
`/USB2/`, take memory out of the heap with `pvPortMalloc` calls from Nios JTAG gdb until
`GET /v1/machine:heap` reports about 700 KB free, resume the target, then drive the task
menu to `Create` / `G64 Image` and give a name. That asks for a 197 KB `BinImage` buffer,
which fits, and then a 636 KB `GcrImage` buffer, which does not.

**Red, on this branch's parent commit (8596576f) with no change applied.** The firmware
logged `** PANIC **: Error allocating 0002C49C..` to syslog, which is
`GcrImage::GcrImage`. After `PUT /v1/machine:reset` closed the frozen menu:

```
PUT machine:reset : {"errors":[]}HTTP200
menu_screen after reset x4: 404 404 404 404
PUT menu_button : {"errors":[]}HTTP200
menu_screen x12 after press: 404 404 404 404 404 404 404 404 404 404 404 404
```

with the device otherwise healthy:

```
ICMP           : 0% packet loss
REST version   : HTTP 200 in 0.009266s
REST heap      : {"free":474448,"min_ever_free":454792,"total":8388608,"errors":[]}
FTP LIST       : OK, 3 entries via PASV data connection
Telnet banner  : OK, 200 bytes
menu_button    : {"errors":[]}HTTP200
menu_screen x6 : 404 404 404 404 404 404
```

gdb showed the UI task in `get_mem`, and the enumeration put it in the ready list, that is
runnable and spinning.

**Green, with the change.** Same procedure, same syslog PANIC line:

```
ICMP           : 0% packet loss
REST version   : HTTP 200 in 0.009585s
REST heap      : {"free":476892,"min_ever_free":472088,"total":8388608,"errors":[]}
FTP LIST       : OK, 3 entries via PASV data connection
Telnet banner  : OK, 200 bytes
menu_button    : {"errors":["The menu did not act on the button press"]}HTTP503
menu_screen x6 : 200 200 200 200 200 200
```

and the task enumeration over gdb shows the difference the change makes:

```
READY   prio 0  IDLE
DELAYED U-II Main            top=0x150c00
... every other task in its normal delayed state ...

#0  vTaskDelay (xTicksToDelay@entry=20) at tasks.c:1371
#1  get_mem (size@entry=635932) at software/system/memory_wrap.cc:48
#2  operator new[] (size@entry=635932) at software/system/memory_wrap.cc:71
#3  GcrImage::GcrImage () at software/drive/disk_image.cc:116
```

The UI task is blocked in the retry rather than runnable and spinning, only the idle task
is ready, and nothing is starved.

Normal operation, on the same firmware: `PUT /v1/machine:menu_button` answers 200,
`GET /v1/machine:menu_screen` then answers 200, and a second press closes the menu again.

Regression: `./run-tests --profile standard u64` reports `OK  all 37 suite runs passed`
in 923 s, exit 0. That run drives `machine:menu_button` through
`tests/e2e/lib/rest_backend.py` hundreds of times, so it is also the check that the new
confirmation does not answer 503 under normal use.

Device-free checks: `python3 tests/lib/lint_test.py` OK, `python3 tests/lib/registry_test.py`
OK (61 suites), `python3 tools/openapi/generate.py check` reports both documents match the
sources, and the five OpenAPI unit test files pass.

Cross target compile: `BUILD_TOOL_ALLOW_PARTIAL=1 ./build-tool -s u64 u64ii u2 u2plus`
links `ultimate.elf` for all four, so the three changed files compile under both the Nios
and the RISC-V toolchains. The `u2` and `u2plus` builds then stop in the updater packaging
step on a missing FPGA bitstream, which is a build artifact this environment does not
have and is unrelated to this change.

Size on the target that has the least room: the U2 application grows by 272 bytes,
from 720.7 KiB to 721.0 KiB against the 792.0 KiB limit, and the build's own size check
reports PASS in both cases.

## What is and is not verified on hardware

The out of memory behaviour is verified on an Ultimate 64 Elite only. It was not forced on
the Ultimate II+L, and the reason is that nothing available can drive that device's heap
low enough.

The u64 procedure used Nios JTAG gdb to call `pvPortMalloc` on the running target. The
U2+L is an ECP5 with a RISC-V soft core and no CPU debug module, so its JTAG reaches the
FPGA and the flash but not the processor, and there is no equivalent injection.

Driving the heap down over the network does not work either. The U2+L has the same 8 MB
heap and about 5.3 MB free at rest, so an allocation failure needs roughly 4.6 MB to be
taken out of it. Its `/Temp` RAM disk is not heap backed: 1 MB written over FTP moved
`GET /v1/machine:heap` by nothing. Nine candidate operations were each run in a loop with
a heap sample before and after, and the largest per operation cost was 38 bytes:

```
GET /v1/info             n=100  delta=       0 bytes  per-op=     0.0
GET /v1/drives           n=100  delta=    1616 bytes  per-op=    16.2
GET /v1/configs          n=100  delta=       0 bytes  per-op=     0.0
GET menu_screen(404)     n=100  delta=       0 bytes  per-op=     0.0
GET readmem 256          n=100  delta=       0 bytes  per-op=     0.0
GET /v1/files listing    n= 60  delta=    2000 bytes  per-op=    33.3
FTP LIST                 n= 40  delta=       0 bytes  per-op=     0.0
FTP STOR+DELE            n= 40  delta=       0 bytes  per-op=     0.0
telnet connect/close     n= 40  delta=    1504 bytes  per-op=    37.6
```

At 38 bytes per operation, 4.6 MB needs about 120,000 operations, which is hours of load
and not a controlled experiment. Faking it by shrinking `configTOTAL_HEAP_SIZE` for the
test build was rejected, because that would test a firmware that differs from the one
being proposed.

So for the Ultimate II+L and the C64 Ultimate this change rests on the code being shared,
on all four product applications compiling and linking, and on the U2 size check passing.
The `machine:menu_button` change matters more on the U2 than on the U64, because the U2
has no `#if U64` fast path, so every press goes through the new wait. The pickup latency
the wait measures is set by the menu loop's `vTaskDelay(3)` and the 200 Hz tick, both of
which are identical on every target, and the measured u64 figures leave an eleven times
margin.

## Alternatives rejected

Returning NULL from `operator new` on failure was rejected. Callers throughout the
firmware use the result without checking it, so this would turn a hang into a NULL
dereference.

Bounding the retry and then aborting or rebooting was rejected. There is nothing safe to
do at the point of failure that a caller can observe, and a device that recovers when
memory comes back is better than one that restarts.

Making `machine:menu_button` wait for `machine:menu_screen` to answer 200 was rejected. The
button toggles, so the expected screen state depends on what the menu was doing, and the
menu takes a few hundred milliseconds to draw after the press is taken. The pending flag is
the exact question the route needs answered: did the loop run.

An E2E test was considered and not added. The only way to make `machine:menu_button`
answer 503 is to stop the menu loop, and there is no way to do that over the API that a
suite could use safely. A test that presses the button and checks it still answers 200
passes on the unfixed firmware as well, so it would not be able to fail. The risk the
change does carry, a false 503 under normal use, is already covered: every overlay mode
E2E suite presses this button through `tests/e2e/lib/rest_backend.py`, which raises on any
non-200 answer.

## Limitations

The `#if U64` fast path in `machine:menu_button`, which calls `push_active_menu_button()`
when the overlay is already showing, still answers 200 without confirming anything. It is
only reached when the menu is open, and in that state `machine:menu_screen` already tells a
client what it needs to know.

The route reports a failure after 500 ms. A press made while the menu is busy with a long
operation, such as a large file copy, is reported as 503 even though the press is still
pending and will be acted on when the operation finishes.

What exhausted the heap on the device that produced this is not addressed here.
