### PR TITLE
Fix heap leak in JSON discovery replies

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -478,6 +478,8 @@ SUITES: Sequence[Suite] = (
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     Suite("soak", "listener-soak", "tests/soak/network/listener_soak_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
+    Suite("soak", "ident-leak", "tests/soak/network/ident_leak_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     # Physical Pico 2 W fixture; selected explicitly with -s after setup.
     Suite("soak", "usb-keyboard-repeat", "tests/soak/io/usb/usb_keyboard_repeat_soak_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --profile @SOAKPROFILE@", manual=True),

--- a/software/network/socket_dma.cc
+++ b/software/network/socket_dma.cc
@@ -601,7 +601,6 @@ void SocketDMA::identThread(void *a)
 
             if (strncmp(client_message, "json", 4) == 0) {
                 client_message[36] = 0;
-                JSON_Bool password_protected(*password ? 1 : 0);
                 JSON *obj = JSON::Obj()
                     ->add("product", product)
                     ->add("firmware_version", APPL_VERSION_ASCII)
@@ -616,7 +615,7 @@ void SocketDMA::identThread(void *a)
                 // Current Assembly64 ignores responses with booleans so we only send this if passwords
                 // are active, in which case Assembly won't work anyway.
                 if (*password) {
-                    ((JSON_Object *)obj)->add("password_protected", &password_protected);
+                    ((JSON_Object *)obj)->add("password_protected", true);
                 }
 
                 // Add unique id if configured
@@ -632,6 +631,7 @@ void SocketDMA::identThread(void *a)
                 const char *msg = obj->render();
                 n = sendto(sockfd, msg, strlen(msg), 0, (struct sockaddr *)&cli_addr,
                         client_struct_length);
+                delete obj;
 
             } else {
                 // Respond to client:

--- a/tests/soak/network/ident_leak_test.py
+++ b/tests/soak/network/ident_leak_test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Require repeated JSON discovery replies to return their heap."""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
+                            if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
+import bootstrap  # noqa: E402,F401
+import cli  # noqa: E402
+import leak  # noqa: E402
+from api import UltimateApi  # noqa: E402
+from report import Failure, format_exception, suite_fail, suite_ok  # noqa: E402
+
+sys.path.insert(0, bootstrap.directory("e2e", "network"))
+from ident_service_switch_test import identify  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    cli.add_device_arguments(parser, timeout=5.0, colour=False)
+    args = parser.parse_args()
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    if not leak.heap_is_served(api.machine.heap, "ident_leak_test"):
+        return 0
+
+    def once() -> None:
+        if not identify(args.host):
+            raise Failure("ident did not return a matching JSON reply (no retry)")
+
+    leak.slope(once, api.machine.heap_free, warmup=3, iterations=20,
+               tolerance_bytes_per_op=128, unit="reply", units="replies",
+               settle_seconds=2,
+               title="JSON discovery returns the heap it borrows")
+    suite_ok("ident_leak_test")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        suite_fail("ident_leak_test", format_exception(exc))
+        raise SystemExit(1)


### PR DESCRIPTION
Release each UDP JSON discovery reply after sending it, and give the reply ownership of its password boolean. This fixes an existing leak of about 1.26 KB per discovery request; its role in #856 is not yet established.

Linux hardware regression, same test before and after: 20 replies retained 25,208 bytes before; zero afterward. Password-protected replies and caller-tracking checks also pass. Local checks with pipeline tooling passed on Linux: lint, registry checks and the U64 firmware build. Hardware used f3935d44 with FPGA124 plus allocation tracking and this fix.
