### PR TITLE
Fix Software IEC REL copies and record access

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -352,6 +352,8 @@ SUITES: Sequence[Suite] = (
     Suite("e2e", "usb-bulk-out-integrity",
           "tests/e2e/io/usb/bulk_out_integrity_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@", manual=True),
+    Suite("e2e", "rel-copy", "tests/e2e/io/iec/rel_copy_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     # Drives the UCI control and SoftIEC targets over $DF1B-$DF1F; reproduces #740.
     # A #740 regression leaves the interface stuck in Command Busy for every target
     # until the firmware restarts, so run it after the suites that drive the menu

--- a/software/filesystem/filesystem_d64.cc
+++ b/software/filesystem/filesystem_d64.cc
@@ -2442,8 +2442,11 @@ FRESULT FileInCBM::seek(uint32_t pos)
 
 
     if (start_cluster < 0) { // file doesn't yet exist
-        if (!pos) {
-            return FR_OK; // allow if seek to position 0
+        if (pos <= header.size) {
+            // The synthetic header exists before the first data sector is allocated.
+            header.pos = pos;
+            state = (pos < header.size) ? ST_HEADER : ST_LINEAR;
+            return FR_OK;
         }
     }
 

--- a/software/filesystem/side_sectors.h
+++ b/software/filesystem/side_sectors.h
@@ -378,6 +378,12 @@ public:
         int sect = pos / 254;
         offset_in_sector = 2 + (pos - (sect * 254));
 
+        // At a full-sector EOF, append from the end of the last allocated sector.
+        if (sect > 0 && sect == datablocks && offset_in_sector == 2 && pos == get_file_size()) {
+            sect--;
+            offset_in_sector = 256;
+        }
+
         int clust = sect / 720;
         if (clust >= clusters.get_elements()) {
             return FR_INVALID_PARAMETER;

--- a/software/io/iec/cbmdos_parser.cc
+++ b/software/io/iec/cbmdos_parser.cc
@@ -223,7 +223,7 @@ int parse_open(const char *buf, open_t& fn)
             if (i == 1) {
                 fn.filetype = e_rel;
                 if (modifiers[2]) {
-                    fn.record_size = modifiers[2][0];
+                    fn.record_size = (uint8_t)modifiers[2][0];
                 } // if not set, it will be zero
                 i++;
             } else {

--- a/software/io/iec/iec_channel.cc
+++ b/software/io/iec/iec_channel.cc
@@ -953,6 +953,25 @@ int IecChannel :: setup_file_access()
         return 0;
     }
 
+    // Existing REL files also open by name alone (for example the E.DATA editor).
+    // Resolve the type before choosing access flags and setting up record I/O.
+    if (name_to_open.filetype == e_any) {
+        FileInfo info(48);
+        FRESULT fres = fm->fstat(full_path, info);
+        if (fres == FR_NO_FILE) {
+            GETPARTITION(name_to_open.file.partition, partition, 0);
+            fres = resolve_existing_iec_path(fm, partition, name_to_open.file, e_any,
+                                             false, true, true, work, &info);
+            full_path = work.c_str();
+        }
+        if (fres != FR_OK) {
+            drive->set_error_fres(fres);
+            return 0;
+        }
+        char cbm_name[24];
+        IecPartition::CreateIecName(&info, cbm_name, name_to_open.filetype);
+    }
+
     uint8_t flags;
     switch(name_to_open.access) {
     case e_append:
@@ -1006,6 +1025,7 @@ int IecChannel :: setup_file_access()
             drive->set_error_fres(fres);
             if (fres == FR_OK) {
                 recordSize = name_to_open.record_size;
+                recordOffset = 2; // First record follows the REL header, also on a reused channel.
                 state = e_record;
             }
         } else { // file already exists

--- a/software/test/iecdrive/testdrive.cc
+++ b/software/test/iecdrive/testdrive.cc
@@ -1082,6 +1082,51 @@ static void run_iec_rel_sequence(IecDrive *dr, const char *testname)
     memset(gap, 0, sizeof(gap));
     gap[0] = 0xFF;
 
+    // Issue #655: COPY-ALL writes records without a P command and reuses the channel.
+    // Check the native header and exact contents before reopening can alter the file.
+    const char *copy_names[] = { "4:COPYFIRST", "4:COPYSECOND", "4:COPYBOUNDARY" };
+    const char *copy_files[] = { "COPYFIRST.rel", "COPYSECOND.rel", "COPYBOUNDARY.rel" };
+    const uint8_t copy_sizes[] = { 164, 31, 254 };
+    FileManager *fm = FileManager::getFileManager();
+    for (int file = 0; file < 3; file++) {
+        const int size = copy_sizes[file];
+        uint8_t records[2][254];
+        memset(records[0], 'A' + file, sizeof(records[0]));
+        memset(records[1], 'a' + file, sizeof(records[1]));
+        expect_rel_open("Suite4-CopyCreate", dr, chan, copy_names[file], size);
+        expect_rel_write("Suite4-CopyFirstRecord", dr, chan, records[0], size);
+        expect_rel_write("Suite4-CopySecondRecord", dr, chan, records[1], size - 3);
+        close_file(dr, chan);
+        expect_status_ok("Suite4-CopyClose", copy_names[file]);
+        memset(records[1] + size - 3, 0, 3);
+
+        File *verify = NULL;
+        REQUIRE(fm->fopen(dr->get_partition_dir(4), copy_files[file], FA_READ, &verify) == FR_OK);
+        const uint32_t expected_size = 2 + 2 * size;
+        printf("%s: %s: size %u, expected %u\n", testname, copy_names[file],
+               verify->get_size(), expected_size);
+        REQUIRE(verify->get_size() == expected_size);
+        uint8_t actual[510];
+        uint32_t got = 0;
+        REQUIRE(verify->read(actual, sizeof(actual), &got) == FR_OK);
+        fm->fclose(verify);
+        REQUIRE(got == expected_size);
+        REQUIRE(actual[0] == size && actual[1] == 0);
+        REQUIRE(memcmp(actual + 2, records[0], size) == 0);
+        REQUIRE(memcmp(actual + 2 + size, records[1], size) == 0);
+
+        // The supplied editor opens by name alone, then positions the REL record.
+        open_file(dr, chan, copy_names[file]);
+        get_status(dr);
+        expect_status_ok("Suite4-CopyReopenUntyped", copy_names[file]);
+        expect_rel_position_status("Suite4-CopyPositionUntyped", dr, chan, 1, 1, "00, OK,00,00\r");
+        expect_rel_write("Suite4-CopyUpdateUntyped", dr, chan, records[0], size);
+        expect_rel_position_status("Suite4-CopyRepositionUntyped", dr, chan, 1, 1, "00, OK,00,00\r");
+        expect_rel_read("Suite4-CopyReadFirst", dr, chan, records[0], size);
+        expect_rel_read("Suite4-CopyReadSecond", dr, chan, records[1], size - 3);
+        close_file(dr, chan);
+    }
+
     expect_rel_open("Suite4-CreateRel", dr, chan, "4:RELTEST", record_size);
     expect_rel_position_status("Suite4-PositionRecord1", dr, chan, 1, 1, "50,RECORD NOT PRESENT,00,00\r");
     expect_rel_write("Suite4-WriteRecord1", dr, chan, record1, record_size);

--- a/target/pc/linux/iecdrive/Makefile
+++ b/target/pc/linux/iecdrive/Makefile
@@ -66,7 +66,8 @@ SRCS_IEC =
 SRCS_NANO = 
 
 PATH_INC =  $(addprefix -I, $(VPATH))
-OPTIONS  = -g -ffunction-sections -O0 -DRUNS_ON_PC -DSAFEMODE -Wno-format -Wno-format-extra-args
+# Match Nios char signedness even when the host is ARM.
+OPTIONS  = -g -ffunction-sections -O0 -DRUNS_ON_PC -DSAFEMODE -Wno-format -Wno-format-extra-args -fsigned-char
 COPTIONS = $(OPTIONS) -std=c99
 CPPOPT   = $(OPTIONS) -fno-exceptions -fno-rtti -fno-threadsafe-statics -fpermissive
 LIBS     =  -lgcc -lcurses

--- a/tests/e2e/io/iec/README.md
+++ b/tests/e2e/io/iec/README.md
@@ -1,0 +1,44 @@
+# REL copying (#655)
+
+Run against an idle Ultimate 64 with a standard C64 KERNAL and no image in drive A:
+
+```sh
+./run-tests 192.168.1.148 -s rel-copy --no-retry -o runs/rel-copy
+```
+
+The suite assembles `rel_agent.asm` with the repository's 64tass. The C64 runs
+KERNAL OPEN, CHKOUT/CHROUT, CHKIN/CHRIN and CLOSE over the actual IEC bus; REST
+only supplies the agent's commands and retrieves its results. FTP independently
+checks the stored REL header, file size and every data byte.
+Each transaction gets two uninterrupted seconds before its result is checked:
+REST memory reads stop the C64 and can otherwise disturb IEC timing. A transaction
+that is still busy then fails the test. Allow roughly ten minutes for the suite.
+
+Generated fixtures cover FAT, D64 and D81 destinations, record lengths 1, 31,
+164 and 254, consecutive files on the same channel without a positioning command,
+full records, zero-padding of short records, and reopening without specifying
+the file type or record length, followed by a record-position command, as the
+supplied E.DATA editor does. D64/D81 files are also read through emulated
+1541/1581 drive A.
+
+The suite temporarily uses devices 10 and 11, rejects conflicting devices, restores
+drive configuration and the Software IEC working directory, and deletes only its
+unique fixture directory. It returns failure for incomplete cleanup. It currently
+requires one Software IEC partition, numbered 1. Other Ultimate models have not
+been hardware-validated with this suite.
+
+Raw expected/actual REL files and before/after device state are retained in
+`rel-copy-evidence/`. For a direct diagnostic run, choose another evidence directory:
+
+```sh
+python3 tests/e2e/io/iec/rel_copy_test.py -H 192.168.1.148 --evidence-dir /tmp/rel-copy
+```
+
+The host regression is part of `target/pc/linux/iecdrive/result/testdrive`. Its
+Makefile explicitly uses signed `char`, matching the Nios CPU, including when built
+on an ARM host. This catches the high-bit record-length parsing failure that would
+otherwise disappear on hosts whose plain `char` is unsigned.
+
+The reporter's disk and copy utilities are not bundled; the deterministic suite
+requires no external disk image. A separate reproduction using the issue attachment
+can verify COPY-ALL and the supplied `edata edit 3.0` editor on the same firmware.

--- a/tests/e2e/io/iec/rel_agent.asm
+++ b/tests/e2e/io/iec/rel_agent.asm
@@ -1,0 +1,93 @@
+; KERNAL IEC transactions on real C64 hardware. Host mailbox at $c000:
+; GO (1=open, 2=write, 3=read to EOI, 4=close), READY, device, channel,
+; byte count, KERNAL status, carry/error. Input/output bytes at $c100.
+; OPEN uses channel as both logical file number and secondary address.
+* = $0801
+    .word basic_end, 10
+    .byte $9e
+    .text "2061"
+    .byte 0
+basic_end
+    .word 0
+    lda #0
+    sta $c000
+    lda #$a5
+    sta $c001
+wait
+    lda $c000
+    beq wait
+    lda #0
+    sta $c005
+    sta $c006
+    sta $90
+    lda $c000
+    cmp #1
+    beq do_open
+    cmp #2
+    beq do_write
+    cmp #3
+    beq do_read
+    lda $c003
+    jsr $ffc3
+    jmp done
+do_open
+    lda $c004
+    ldx #<$c100
+    ldy #>$c100
+    jsr $ffbd
+    lda $c003
+    ldx $c002
+    ldy $c003
+    jsr $ffba
+    jsr $ffc0
+    bcc done
+error
+    sta $c006
+    jmp done
+do_write
+    ldx $c003
+    jsr $ffc9
+    bcs error
+    lda #0
+    sta index
+write_loop
+    ldx index
+    cpx $c004
+    beq done
+    lda $c100,x
+    jsr $ffd2
+    inc index
+    jmp write_loop
+do_read
+    ldx $c003
+    jsr $ffc6
+    bcs error
+    lda #0
+    sta index
+read_loop
+    jsr $ffcf
+    ldx index
+    sta $c100,x
+    inc index
+    jsr $ffb7
+    bne read_done
+    lda index
+    cmp #254
+    bne read_loop
+    lda #$ff
+    sta $c006
+read_done
+    sta $c005
+    lda index
+    sta $c004
+done
+    jsr $ffcc
+    lda $c005
+    bne finish
+    jsr $ffb7
+    sta $c005
+finish
+    lda #0
+    sta $c000
+    jmp wait
+index .byte 0

--- a/tests/e2e/io/iec/rel_copy_test.py
+++ b/tests/e2e/io/iec/rel_copy_test.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Hardware regression for #655 via the C64 KERNAL's real IEC bus.
+
+Requires a C64 with standard KERNAL, REST/FTP, Software IEC, and an empty drive A.
+Tests FAT, D64 and D81 destinations; record lengths 1, 31, 164 and 254; channel
+reuse; short-record padding; reopen/read; and emulated-drive interoperability.
+Uses only generated fixtures. Saves byte evidence with --evidence-dir.
+"""
+import argparse
+import json
+import sys
+import time
+import traceback
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
+                          if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
+import bootstrap  # noqa: E402,F401
+import cli  # noqa: E402
+import ftp  # noqa: E402
+from api import UltimateApi  # noqa: E402
+from assembler import assemble  # noqa: E402
+from config_snapshot import Snapshot  # noqa: E402
+from report import Failure, check, detail, section, suite_fail, suite_ok, teardown_step  # noqa: E402
+
+SUITE = "rel_copy_test"
+
+
+class Agent:
+    def __init__(self, api):
+        self.api = api
+
+    def start(self):
+        self.api.machine.close_menu_from_anywhere()
+        self.api.machine.writemem(0xc000, bytes(7))
+        self.api.runners.upload("run_prg", assemble(Path(__file__).with_name("rel_agent.asm")))
+        self.wait(0xc001, 0xa5)
+
+    def wait(self, address, value):
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if self.api.machine.readmem(address, 1) == bytes([value]):
+                return
+            time.sleep(.05)
+        raise Failure(f"IEC agent timed out at ${address:04x}")
+
+    def call(self, op, channel=5, data=b"", device=11):
+        if len(data) > 254:
+            raise ValueError("IEC transaction exceeds mailbox capacity")
+        if data:
+            self.api.machine.writemem(0xc100, data)
+        self.api.machine.writemem(0xc002, bytes([device, channel, len(data), 0, 0]))
+        self.api.machine.writemem(0xc000, bytes([op]))
+        # REST memory reads halt the C64; let the IEC transaction finish first.
+        time.sleep(2)
+        if self.api.machine.readmem(0xc000, 1) != b"\0":
+            raise Failure("IEC transaction exceeded the two-second observation window")
+        count, status, error = self.api.machine.readmem(0xc004, 3)
+        if error or status & ~64:
+            raise Failure(f"KERNAL op={op} device={device} channel={channel}: ST={status}, error={error}")
+        if op == 3:
+            if status != 64:
+                raise Failure(f"IEC read ended without EOI: ST={status}")
+            return self.api.machine.readmem(0xc100, count)
+        return b""
+
+    def status(self, allowed=(0,)):
+        response = self.call(3, 15).decode("ascii").strip()
+        if int(response.split(",", 1)[0]) not in allowed:
+            raise Failure(f"DOS status: {response}")
+        return response
+
+    def command(self, command, allowed=(0,)):
+        self.call(2, 15, command if isinstance(command, bytes) else command.encode("ascii"))
+        self.status(allowed)
+
+
+def require_equal(actual, expected, context):
+    if actual != expected:
+        first = next((i for i, (a, b) in enumerate(zip(actual, expected)) if a != b), None)
+        raise Failure(f"{context}: got {len(actual)} bytes, expected {len(expected)}; first mismatch {first}")
+
+
+def run(args):
+    api = UltimateApi(args.host, args.password, args.timeout)
+    agent = Agent(api)
+    evidence = Path(args.evidence_dir)
+    evidence.mkdir(parents=True, exist_ok=True)
+    info = api.rest.json("/v1/info")
+    original_drives = api.rest.json("/v1/drives")
+    drives = {name: value for entry in original_drives["drives"] for name, value in entry.items()}
+    if drives["a"]["image_file"]:
+        raise Failure("Drive A must be empty; refusing to displace a mounted image")
+    if any(d.get("enabled") and d.get("bus_id") in (10, 11)
+           for name, d in drives.items() if name not in ("a", "IEC Drive")):
+        raise Failure("Device 10 or 11 is already in use")
+    saved = Snapshot(args.host, {name: api.configs.category(name) for name in
+                                ("Drive A Settings", "SoftIEC Drive Settings")})
+    old_parts = drives["IEC Drive"]["partitions"]
+    if len(old_parts) != 1 or old_parts[0]["id"] != 1:
+        raise Failure("This test currently requires one Software IEC partition, numbered 1")
+    original_path = old_parts[0]["path"]
+    (evidence / "before.json").write_text(json.dumps({"info": info, "drives": original_drives,
+                                                     "configs": saved.settings}, indent=2))
+    detail(json.dumps(info))
+    folder = "rel" + uuid.uuid4().hex[:8]
+    root = None
+    created = []
+    failed = False
+    mounted = False
+    started = False
+    try:
+        api.configs.set("SoftIEC Drive Settings", "Soft Drive Bus ID", 11)
+        api.configs.set("SoftIEC Drive Settings", "IEC Drive", "Enabled")
+        agent.start()
+        started = True
+        agent.call(1, 15)
+        agent.status((0, 73))
+        agent.command("CD//")
+        current = api.rest.json("/v1/drives")
+        root = next(e["IEC Drive"]["partitions"][0]["path"] for e in current["drives"] if "IEC Drive" in e)
+        if not original_path.startswith(root):
+            raise Failure("Cannot restore Software IEC path relative to its partition root")
+        path = root.rstrip("/") + "/" + folder
+        with ftp.session(args.host, args.password) as client:
+            client.mkd(path)
+        created.append((path, True))
+        for kind in ("fat", "d64", "d81"):
+            section(kind)
+            target = path
+            relative = folder
+            if kind != "fat":
+                target = f"{path}/case.{kind}"
+                getattr(api.files, "create_" + kind)(target)
+                created.append((target, False))
+                relative += f"/case.{kind}"
+            agent.command("CD//" + relative.upper())
+            fixtures = []
+            for index, size in enumerate((164, 31, 1, 254, 31)):
+                name = f"COPY{index}"
+                first = bytes(33 + i % 80 for i in range(size))
+                second = bytes([97 + index]) * max(1, size - 3)
+                expected = bytes([size, 0]) + first + second.ljust(size, b"\0")
+                remote = target + "/" + name + ".rel"
+                if kind == "fat":
+                    created.append((remote, False))
+                with check(f"{kind}: sequential writes, {size}-byte records, reused channel ({name})"):
+                    agent.call(1, data=name.encode() + b",L," + bytes([size]))
+                    agent.status()
+                    for record in (first, second):
+                        agent.call(2, data=record)
+                        agent.status()
+                    agent.call(4)
+                    agent.status()
+                with ftp.session(args.host, args.password) as client:
+                    actual = ftp.retrieve(client, remote)
+                (evidence / f"{kind}-{name}.actual.rel").write_bytes(actual)
+                (evidence / f"{kind}-{name}.expected.rel").write_bytes(expected)
+                try:
+                    with check(f"{kind}: header, exact size, contents and padding ({name})"):
+                        require_equal(actual, expected, name)
+                except Failure:
+                    failed = True
+                else:
+                    fixtures.append((name, size, first, second))
+            # All files are created before any reopen, matching a copy utility.
+            for name, _size, first, second in fixtures:
+                with check(f"{kind}: reopen by name, position and read over Software IEC ({name})"):
+                    agent.call(1, data=name.encode())
+                    agent.status()
+                    agent.command(b"P\x05\x01\x00\x01")
+                    require_equal(agent.call(3), first, name + " record 1")
+                    require_equal(agent.call(3), second, name + " record 2")
+                    agent.call(4)
+                    agent.status()
+            agent.command("CD//")
+            if kind != "fat" and len(fixtures) == 5:
+                api.configs.set("Drive A Settings", "Drive Bus ID", 10)
+                api.drives.set_mode("a", "1541" if kind == "d64" else "1581")
+                api.drives.on("a")
+                api.drives.mount("a", target, type=kind, mode="readonly")
+                mounted = True
+                time.sleep(2)
+                for name, _size, first, second in fixtures:
+                    with check(f"{kind}: read copied records through emulated drive 10 ({name})"):
+                        agent.call(1, data=name.encode() + b",L", device=10)
+                        require_equal(agent.call(3, device=10), first, name + " record 1")
+                        require_equal(agent.call(3, device=10), second, name + " record 2")
+                        agent.call(4, device=10)
+                api.drives.remove("a")
+                mounted = False
+        return not failed
+    finally:
+        def restore_iec():
+            if started:
+                agent.call(4)
+                if root is not None:
+                    agent.command("CD//" + original_path[len(root):].upper())
+                agent.call(4, 15)
+        def restore_config():
+            if mounted:
+                api.drives.remove("a")
+            _, refused = saved.restore(api)
+            if refused:
+                raise Failure(f"Settings restoration refused: {refused}")
+            after = api.rest.json("/v1/drives")
+            (evidence / "after.json").write_text(json.dumps(after, indent=2))
+            path_after = next(e["IEC Drive"]["partitions"][0]["path"] for e in after["drives"] if "IEC Drive" in e)
+            if path_after.casefold() != original_path.casefold():
+                raise Failure(f"Software IEC path not restored: {path_after}")
+        def remove_fixtures():
+            with ftp.session(args.host, args.password) as client:
+                for name, directory in reversed(created):
+                    parent, _, leaf = name.rpartition("/")
+                    if leaf in ftp.names(client, parent):
+                        (client.rmd if directory else client.delete)(name)
+        cleanup_ok = True
+        for label, action in (("restore IEC working directory", restore_iec),
+                              ("restore drive settings", restore_config),
+                              ("remove only this run's fixtures", remove_fixtures),
+                              ("return C64 to BASIC", lambda: api.machine.reset(force=True))):
+            cleanup_ok = teardown_step(label, action) and cleanup_ok
+        if not cleanup_ok:
+            raise Failure("Hardware test cleanup incomplete")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    cli.add_device_arguments(parser)
+    parser.add_argument("--evidence-dir", default="rel-copy-evidence")
+    args = parser.parse_args()
+    try:
+        if not run(args):
+            raise Failure("Copied REL files differ from expected bytes")
+    except Exception as exc:
+        traceback.print_exc()
+        suite_fail(SUITE, str(exc))
+        return 1
+    suite_ok(SUITE)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
COPY-ALL can corrupt REL files when it reuses a Software IEC channel: the first file's data overwrites its two-byte record-length header, and later files inherit the previous file's offset. The supplied E.DATA editor also cannot position records when it opens an existing REL file by name without `,L`.

Refs #655.

This fixes the reproduced Software IEC path from the issue's attached disk:

- Start each new REL file's records immediately after its header.
- Allow seeks in the synthetic header before a CBM data sector is allocated, and appends at a full REL data-sector boundary.
- Parse record lengths as unsigned bytes, avoiding sign extension for lengths such as 164 and 254 on Nios.
- Detect the type of an existing file before choosing access flags and initializing record access, including directory-assisted name resolution.

The host regression exercises consecutive copies, exact headers and payloads, short-record padding, and opening, positioning and updating REL files without an explicit type. Its build uses signed `char` even on ARM hosts so the Nios parsing failure remains reproducible.

Validation:

| Check | Result |
| --- | --- |
| Host IEC suite, including D64/D81/FAT REL regression and existing name-resolution cases | Pass; failing tests were added before each fix |
| Broader filesystem suite on D64/D71/D81/DNP/FAT | Pass after the filesystem changes |
| Registered hardware suite on Ultimate 64 Elite | 55 checks passed in 628 seconds, one attempt |
| Generated FAT/D64/D81 files, record lengths 1/31/164/254 | All 15 files byte-identical; untyped reopen and record positioning pass |
| D64/D81 readback through emulated 1541/1581 drives | All ten files pass |
| Original attachment, unmodified COPY-ALL | All three outputs byte-identical with correct headers: 6,070 / 20,010 / 2,017 bytes |
| Original attachment, unmodified E.DATA editor | Lists all 58 records and returns to its option prompt |

The hardware run used FPGA 124/core 1.4F and the installed `f3935d44` diagnostic baseline plus these production changes. All four changed production files matched this branch byte-for-byte. Drive settings were restored and generated fixtures removed. Testing used wired Ethernet with Wi-Fi temporarily disconnected; Wi-Fi was reconnected afterward.

Run the hardware regression on an idle Ultimate 64 with a standard KERNAL and an empty drive A:

```sh
./run-tests 192.168.1.148 -s rel-copy --no-retry -o runs/rel-copy
```

`tests/e2e/io/iec/README.md` documents prerequisites, evidence files and the timing needed to avoid pausing the C64 during IEC transfers. The test uses generated fixtures and does not require downloading the reporter's disk.

FCOPY+, physical 1541/FD-4000 destinations, stock 3.14d and other Ultimate models were not tested. This PR does not establish that the broader emulated-drive-to-emulated-drive or physical-drive report in #655 is resolved.
