### PR TITLE
Preserve Assembly64 query fields after dropdown selection

### DIFF
--- a/software/userinterface/assembly_search.h
+++ b/software/userinterface/assembly_search.h
@@ -24,6 +24,7 @@ class AssemblySearchForm: public TreeBrowserState
 public:
     AssemblySearchForm(Browsable *node, TreeBrowser *tb, int level);
     ~AssemblySearchForm();
+    bool reload_on_action(void) { return false; }
 
     void into(void) { printf("Search Form Into\n"); }
     void level_up(void) { printf("Search Form Up\n"); };

--- a/software/userinterface/form.h
+++ b/software/userinterface/form.h
@@ -58,6 +58,7 @@ class FormUIState: public TreeBrowserState
 public:
     FormUIState(Browsable *node, TreeBrowser *tb, int level);
     ~FormUIState();
+    bool reload_on_action(void) { return false; }
 
     void into(void) { printf("Search Form Into\n"); }
     void level_up(void) { printf("Search Form Up\n"); };

--- a/software/userinterface/tree_browser.cc
+++ b/software/userinterface/tree_browser.cc
@@ -204,7 +204,7 @@ int TreeBrowser :: poll(int sub_returned)
             // so the notification for what the action just did may have been
             // dropped; re-read the directory instead of trusting the cache.
             state->refresh = true;
-            state->needs_reload = true;
+            state->needs_reload |= state->reload_on_action();
         }
         return ret;
     }

--- a/software/userinterface/tree_browser_state.h
+++ b/software/userinterface/tree_browser_state.h
@@ -38,6 +38,8 @@ public:
     virtual void draw_item(Browsable *t, int line, bool selected);
 
     //    virtual void reselect();
+    // Forms retain live field values; directory states can rebuild their entries.
+    virtual bool reload_on_action(void) { return true; }
     virtual void reload(void);
     virtual void up(int);
     virtual void down(int);

--- a/tests/e2e/io/c64/assembly64_test.py
+++ b/tests/e2e/io/c64/assembly64_test.py
@@ -735,6 +735,52 @@ def scenario_query_returns_results(device: Device) -> None:
     recover(device, "running a query")
 
 
+def scenario_dropdown_preserves_fields(device: Device) -> None:
+    section("dropdown selections preserve the query form (#863)")
+    expected = {"Name:": "turrican", "Group:": "issue863",
+                "Handle:": "barry", "Event:": "hardware"}
+
+    def expect_fields() -> None:
+        for label, value in expected.items():
+            actual = field_value(device, label)
+            if actual != value:
+                raise Failure(f"{label} changed from {value!r} to {actual!r}")
+
+    with check("populate the text fields"):
+        open_query_form(device)
+        for label, value in expected.items():
+            enter_field(device, label)
+            device.type_text(value)
+            device.send_key("ENTER")
+        expect_fields()
+
+    for label in ("Repo:", "Category:", "Subcat:"):
+        with check(f"{label} +/- preserves existing fields"):
+            row = row_of(device, label)
+            if row is None:
+                raise Failure(f"the form has no {label!r} field")
+            select_row(device, row, f"selecting {label!r}")
+            device.type_text("+")
+            first = field_value(device, label)
+            if not first:
+                raise Failure(f"{label} has no preset after +")
+            device.type_text("+")
+            device.type_text("-")
+            expected[label] = first
+            expect_fields()
+        with check(f"cancelling {label} preserves existing fields"):
+            enter_field(device, label)
+            device.send_key("RUNSTOP")
+            expect_fields()
+        with check(f"confirming {label} preserves its value and all other fields"):
+            enter_field(device, label)
+            device.send_key("DOWN")
+            device.send_key("UP")
+            device.send_key("ENTER")
+            expect_fields()
+    recover(device, "selecting query presets")
+
+
 # ------------------------------------------------------------ misbehaviour
 
 def scenario_menu_button_in_edit_field(device: Device) -> None:
@@ -886,6 +932,7 @@ def scenario_reopen_repeatedly(device: Device) -> None:
 SCENARIOS = {
     "open-and-leave": scenario_open_and_leave,
     "query": scenario_query_returns_results,
+    "dropdown-preserves-fields": scenario_dropdown_preserves_fields,
     "menu-button-in-field": scenario_menu_button_in_edit_field,
     "abort-edit": scenario_abort_edit,
     "overlong-and-empty": scenario_overlong_and_empty,


### PR DESCRIPTION
Selecting a dropdown in the Assembly64 query form erased the selected value and every previously entered field. Form states now opt out of the automatic reload after context actions; directory and result browsers retain their existing reload behavior, and explicit CLEAR still resets the form. The shared FormUI editor receives the same protection.

Fixes #863.

The production change adds five lines and changes one. The regression scenario is part of the existing Assembly64 hardware suite and checks populated text fields, +/- changes, cancellation, and confirmation for Repo, Category and Subcat, including retention of earlier selections.

Validation on Ultimate 64 Elite, FPGA 124/core 1.4F:
- **TDD red:** before the fix, population, +/- and cancellation passed; confirming Repo failed with `Name: changed from 'turrican' to ''`.
- **TDD green:** all 10 regression checks pass on the flashed fix.
- Full Assembly64 overlay suite: **27 checks pass**, including a real search returning 20 matching results, aborted edits, empty-query handling and repeated reopening.
- Full browser filesystem refresh suite: **38 checks pass**, with 140 successful observer comparisons across Menu, Telnet, FTP and REST, including event-queue pressure, deletion, copying and moving.
- Separate hardware check confirms explicit CLEAR still empties populated text and preset fields. Menu closed and temporary test files absent afterward.
- Full Nios II application/updater builds, Python syntax, CRLF-aware diff checks, and GitHub build CI pass.

The hardware application was built from base `abd0888c` plus the exact production changes in `94a3d455`; it reports the base hash. Application SHA256: `6ab20214e558d756da53018140908c47aa4c614c2b43f232674fd9f350928318`. The updater's FPGA payload matches the board's existing FPGA 124 image. The reporter's Elite-II model was not separately tested.
