### PR TITLE
Fix Fast Reset on the Ultimate 64

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -425,6 +425,13 @@ SUITES: Sequence[Suite] = (
     # back the wrong bytes. Measured red on core 1.4E and green on 1.4F.
     Suite("e2e", "reu-turbo", "tests/e2e/io/c64/reu_turbo_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
+    # Fast Reset patches the KERNAL's RAM test out of the image the machine
+    # boots, so the observable is how long a reset takes to reach READY. The
+    # setting is applied when the system ROMs load, so the suite reboots
+    # between the two states. Measured red at 1.0x on an Ultimate 64 before the
+    # fix and green at about 10x after it.
+    Suite("e2e", "fast-reset", "tests/e2e/io/c64/fast_reset_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
     # Reproduces #733: with the FPGA decoder fix in the core, "mirroring off" is
     # the regression guard. Runs last, because a device whose core predates that
     # fix stalls the whole Nios on this scenario and needs a JTAG recovery.

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -1083,15 +1083,14 @@ void C64::init_system_roms(void)
     extern uint8_t _default_kernal_65_start[];
     extern uint8_t _default_chars_bin_start[];
 
-    // The ROM image aperture at U64_KERNAL_BASE is write only: a read of it returns
-    // zeros, so the memcmp below never matched there and Fast Reset was never
-    // applied. Build the image in RAM instead and write it to the aperture once.
-    // Cleared first because load_file reports FR_OK for a file shorter than the
-    // buffer and leaves the remaining bytes untouched.
+    // U64_KERNAL_BASE is write only, so the Fast Reset patch below cannot compare
+    // against it. Stage the image in RAM and write it to the aperture once.
+    // A KERNAL shorter than 8192 bytes has no reset vector at $FFFC, so it is
+    // rejected in favour of the default.
     unsigned char *kernal = new unsigned char[8192];
-    memset(kernal, 0, 8192);
-    FRESULT fres = FileManager :: getFileManager()->load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_KERNFILE), (uint8_t *)kernal, 8192, NULL);
-    if (fres != FR_OK) {
+    uint32_t kernal_bytes = 0;
+    FRESULT fres = FileManager :: getFileManager()->load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_KERNFILE), (uint8_t *)kernal, 8192, &kernal_bytes);
+    if (fres != FR_OK || kernal_bytes != 8192) {
         printf("Failed to load KERNAL ROM; loading default.\n");
         memcpy((void *)kernal, (void *)_default_kernal_65_start, 8192);
     } else if (cfg->get_value(CFG_C64_FASTRESET)) {

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -1083,26 +1083,20 @@ void C64::init_system_roms(void)
     extern uint8_t _default_kernal_65_start[];
     extern uint8_t _default_chars_bin_start[];
 
-    // The FPGA ROM image aperture at U64_KERNAL_BASE is write only. A read of it
-    // on an Ultimate 64 Elite I returns zero for all 8192 bytes, both through a
-    // block memcpy and byte by byte through a volatile pointer, and a read back
-    // straight after a write returns zeros as well. So the KERNAL image is staged
-    // in a buffer in main memory, where the Fast Reset patch can compare it
-    // against the unpatched original, and only then written to the aperture.
-    // Cleared first because load_file answers FR_OK for a file shorter than the
-    // buffer and leaves the rest of it untouched. Writing to the aperture used
-    // to leave the bytes past the end of such a file as they were; staging in a
-    // fresh allocation would put uninitialised memory there instead.
-    uint8_t *kernal = new uint8_t[8192];
+    // The ROM image aperture at U64_KERNAL_BASE is write only: a read of it returns
+    // zeros, so the memcmp below never matched there and Fast Reset was never
+    // applied. Build the image in RAM instead and write it to the aperture once.
+    // Cleared first because load_file reports FR_OK for a file shorter than the
+    // buffer and leaves the remaining bytes untouched.
+    unsigned char *kernal = new unsigned char[8192];
     memset(kernal, 0, 8192);
-    FRESULT fres = FileManager :: getFileManager()->load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_KERNFILE), kernal, 8192, NULL);
+    FRESULT fres = FileManager :: getFileManager()->load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_KERNFILE), (uint8_t *)kernal, 8192, NULL);
     if (fres != FR_OK) {
         printf("Failed to load KERNAL ROM; loading default.\n");
-        memcpy(kernal, (void *)_default_kernal_65_start, 8192);
-    }
-    if (cfg->get_value(CFG_C64_FASTRESET)) {
+        memcpy((void *)kernal, (void *)_default_kernal_65_start, 8192);
+    } else if (cfg->get_value(CFG_C64_FASTRESET)) {
         if (!memcmp((void *) (kernal+0x1d6c), (void *) fastresetOrg, sizeof(fastresetOrg))) {
-            memcpy((void *) (kernal+0x1d6c), (void *) fastresetPatch, sizeof(fastresetPatch));
+            memcpy((void *) (kernal+0x1d6c), (void *) fastresetPatch, 22);
         }
     }
     memcpy((void *)U64_KERNAL_BASE, kernal, 8192);

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -1083,16 +1083,30 @@ void C64::init_system_roms(void)
     extern uint8_t _default_kernal_65_start[];
     extern uint8_t _default_chars_bin_start[];
 
-    FRESULT fres = FileManager :: getFileManager()->load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_KERNFILE), (uint8_t *)U64_KERNAL_BASE, 8192, NULL);
+    // The FPGA ROM image aperture at U64_KERNAL_BASE is write only. A read of it
+    // on an Ultimate 64 Elite I returns zero for all 8192 bytes, both through a
+    // block memcpy and byte by byte through a volatile pointer, and a read back
+    // straight after a write returns zeros as well. So the KERNAL image is staged
+    // in a buffer in main memory, where the Fast Reset patch can compare it
+    // against the unpatched original, and only then written to the aperture.
+    // Cleared first because load_file answers FR_OK for a file shorter than the
+    // buffer and leaves the rest of it untouched. Writing to the aperture used
+    // to leave the bytes past the end of such a file as they were; staging in a
+    // fresh allocation would put uninitialised memory there instead.
+    uint8_t *kernal = new uint8_t[8192];
+    memset(kernal, 0, 8192);
+    FRESULT fres = FileManager :: getFileManager()->load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_KERNFILE), kernal, 8192, NULL);
     if (fres != FR_OK) {
         printf("Failed to load KERNAL ROM; loading default.\n");
-        memcpy((void *)U64_KERNAL_BASE, (void *)_default_kernal_65_start, 8192);
-    } else if (cfg->get_value(CFG_C64_FASTRESET)) {
-        unsigned char *kernal = (unsigned char *)U64_KERNAL_BASE;
+        memcpy(kernal, (void *)_default_kernal_65_start, 8192);
+    }
+    if (cfg->get_value(CFG_C64_FASTRESET)) {
         if (!memcmp((void *) (kernal+0x1d6c), (void *) fastresetOrg, sizeof(fastresetOrg))) {
-            memcpy((void *) (kernal+0x1d6c), (void *) fastresetPatch, 22);
+            memcpy((void *) (kernal+0x1d6c), (void *) fastresetPatch, sizeof(fastresetPatch));
         }
     }
+    memcpy((void *)U64_KERNAL_BASE, kernal, 8192);
+    delete[] kernal;
 
     FileManager :: getFileManager()->load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_BASIFILE), (uint8_t *)U64_BASIC_BASE, 8192, NULL);
     fres = FileManager :: getFileManager()->load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_CHARFILE), (uint8_t *)U64_CHARROM_BASE, 4096, NULL);

--- a/tests/e2e/io/c64/fast_reset_test.py
+++ b/tests/e2e/io/c64/fast_reset_test.py
@@ -1,51 +1,29 @@
 #!/usr/bin/env python3
 """E2E: Fast Reset has to make the machine reach the BASIC prompt sooner.
 
-Most of the time a C64 spends between a reset and the READY prompt is the
-KERNAL's RAM test at $FD6C. The firmware's "Fast Reset" setting replaces that
-test with 22 bytes that skip it and jump to $FD8C, patched into the KERNAL
-image the machine boots from. The setting is applied when the system ROMs are
-loaded, which happens when the cartridge starts, so it takes effect on the next
-reboot rather than on the next reset. This suite reboots between the two
-states for that reason.
+Most of the time between a reset and the READY prompt is the KERNAL's RAM test
+at $FD6C. Fast Reset patches 22 bytes over it that jump to $FD8C. The patch is
+applied when the system ROMs load, which is on cartridge start, so this suite
+reboots between the two states rather than only resetting.
 
-The observable is the only one a user has: how long the machine takes to print
-READY after a reset. The suite measures that with the setting enabled and with
-it disabled, and requires the enabled state to be the faster of the two.
+The measurement is reset to READY, screen blanked first so a READY from the
+previous boot cannot match. Measured on an Ultimate 64 Elite I, median of five:
+enabled 0.18s against disabled 2.40s where the patch lands, and 2.40s against
+2.42s where it does not. MIN_SPEEDUP of 2.0 sits between those two populations
+with room for a slow link on either side; above MAX_ENABLED_SECONDS the poll
+cost swamps the difference and the suite skips instead of failing.
 
-Measured reset-to-READY, median of five samples, the screen blanked before each
-reset so a READY left by the previous boot cannot match:
+Two checks the verdict depends on:
 
-    Ultimate 64 Elite I, this branch with software/io/c64/c64.cc reverted to
-    test-merge 4acc148c
-        Enabled 2.40s   Disabled 2.42s
-    Ultimate 64 Elite I, this branch as it stands
-        Enabled 0.18s   Disabled 2.40s
+- The disabled measurement is the control. A machine that reaches READY
+  quickly with Fast Reset off is not running the RAM test the setting removes,
+  so the comparison says nothing. That is reported as a control failure.
+- A machine whose KERNAL the firmware does not supply cannot be patched. An
+  Ultimate 64 always loads the KERNAL from a file; an Ultimate II takes it from
+  the computer unless an "Alternate Kernal" is configured. The suite skips when
+  that item is empty.
 
-So a machine that applies the patch is about thirteen times faster and a
-machine that does not is not faster at all. MIN_SPEEDUP is 2.0, which sits
-between those two populations with a wide margin on both sides, and the margin
-is what absorbs a slow network: one 400-byte screen read costs 12 to 18ms on
-this bench, and even a poll costing 0.5s would leave the enabled measurement at
-roughly 0.7s against a 1.20s threshold. Above that the measurement can no longer resolve the
-difference, so the suite says so and skips rather than failing.
-
-Two things the pass would otherwise not mean anything against:
-
-- The disabled measurement is the control. If the machine reaches READY
-  quickly with Fast Reset disabled, then it is not running the RAM test the
-  setting removes, and no comparison against it says anything about the
-  setting. That is reported as a failure of the control, and named as such,
-  rather than as the Fast Reset defect.
-- A machine whose KERNAL the firmware does not supply cannot be patched at
-  all, so Fast Reset genuinely does nothing there. On an Ultimate 64 the
-  firmware always loads the KERNAL from a file, and the store carries a
-  "Kernal ROM" item. On an Ultimate II the KERNAL comes from the computer
-  unless an alternate one is configured, and the store carries an "Alternate
-  Kernal" item instead. The suite skips when that item is empty.
-
-The machine is left with the Fast Reset setting it was found with, and rebooted
-so that setting is the one in force.
+The setting and a reboot into it are restored on the way out.
 """
 
 from __future__ import annotations
@@ -86,33 +64,27 @@ ALTERNATE_KERNAL_ITEM = "Alternate Kernal"
 SCREEN_BYTES = 400
 BLANK = bytes([0x20]) * SCREEN_BYTES
 
-# Three samples per state, reported as a median, because the quantity separating
-# a pass from a failure is about 2.2s and the spread within a state was 0.02s
-# over five samples on this bench. The median discards a single sample delayed
-# by the network.
+# A median of three. Within-state spread was 0.02s against the 2.2s that
+# separates a pass from a failure, so this only has to discard a slow sample.
 SAMPLES = 3
 
 # See the measurements in the module docstring.
 MIN_SPEEDUP = 2.0
 
-# Below this, the machine did not run the RAM test with the setting disabled, so
-# the comparison has nothing to measure against. The disabled state measured
-# 2.40s to 2.42s on an Ultimate 64, and 1.20s is half of that.
+# Half the 2.40s the disabled state measures. Below this the machine is not
+# running the RAM test, so there is nothing to compare against.
 MIN_CONTROL_SECONDS = 1.20
 
-# One screen read is the resolution of the measurement. 12 to 18ms on this bench
-# over wired Ethernet. Above this the enabled state cannot be told from the
-# threshold any more, so the suite skips instead of reporting a failure it
-# cannot stand behind.
+# One screen read is the resolution, 12 to 18ms here. Past this the poll cost
+# swamps the difference, so the suite skips rather than guess.
 MAX_POLL_SECONDS = 0.5
 
 RESET_TIMEOUT_SECONDS = 20.0
 REBOOT_TIMEOUT_SECONDS = 30.0
 
-# READY appearing after a reboot says the KERNAL has printed it, not that the
-# firmware has finished restarting the cartridge. A reset issued in that window
-# measured 10.74s once, against 2.32s and 2.34s for the two samples after it, so
-# the first sample of every state waits this long after the prompt appears.
+# READY after a reboot means the KERNAL printed it, not that the firmware has
+# finished restarting the cartridge. A reset inside that window measured 10.74s
+# against 2.32s just after, so the first sample of each state waits.
 SETTLE_SECONDS = 2.0
 
 

--- a/tests/e2e/io/c64/fast_reset_test.py
+++ b/tests/e2e/io/c64/fast_reset_test.py
@@ -7,11 +7,11 @@ applied when the system ROMs load, which is on cartridge start, so this suite
 reboots between the two states rather than only resetting.
 
 The measurement is reset to READY, screen blanked first so a READY from the
-previous boot cannot match. Measured on an Ultimate 64 Elite I, median of five:
-enabled 0.18s against disabled 2.40s where the patch lands, and 2.40s against
-2.42s where it does not. MIN_SPEEDUP of 2.0 sits between those two populations
-with room for a slow link on either side; above MAX_ENABLED_SECONDS the poll
-cost swamps the difference and the suite skips instead of failing.
+previous boot cannot match, once per state. On an Ultimate 64 Elite I that is
+0.18s enabled against 2.40s disabled where the patch lands, and 2.40s against
+2.42s where it does not, so a single reset each separates them by 10x and no
+averaging is needed. Above MAX_POLL_SECONDS the poll cost swamps the
+difference and the suite skips instead of failing.
 
 Two checks the verdict depends on:
 
@@ -29,7 +29,6 @@ The setting and a reboot into it are restored on the way out.
 from __future__ import annotations
 
 import argparse
-import statistics
 import sys
 import time
 from pathlib import Path
@@ -64,11 +63,9 @@ ALTERNATE_KERNAL_ITEM = "Alternate Kernal"
 SCREEN_BYTES = 400
 BLANK = bytes([0x20]) * SCREEN_BYTES
 
-# A median of three. Within-state spread was 0.02s against the 2.2s that
-# separates a pass from a failure, so this only has to discard a slow sample.
-SAMPLES = 3
-
-# See the measurements in the module docstring.
+# One reset each is enough: the two states are about 10x apart and a machine
+# that cannot patch is 1.0x, so no threshold between them is delicate. 2.0 keeps
+# the margin wide on a slower link.
 MIN_SPEEDUP = 2.0
 
 # Half the 2.40s the disabled state measures. Below this the machine is not
@@ -150,13 +147,11 @@ def apply_and_reboot(api: UltimateApi, value: str) -> None:
 
 
 def measure(api: UltimateApi, value: str) -> float:
-    """Median reset-to-READY seconds with Fast Reset set to `value`."""
+    """Reset-to-READY seconds with Fast Reset set to `value`."""
     apply_and_reboot(api, value)
-    samples = [seconds_to_ready(api) for _ in range(SAMPLES)]
-    median = statistics.median(samples)
-    detail(f"{FAST_RESET}={value}: reset to READY "
-           f"{', '.join(f'{s:.2f}s' for s in samples)}, median {median:.2f}s")
-    return median
+    seconds = seconds_to_ready(api)
+    detail(f"{FAST_RESET}={value}: reset to READY {seconds:.2f}s")
+    return seconds
 
 
 def run(args) -> str | None:

--- a/tests/e2e/io/c64/fast_reset_test.py
+++ b/tests/e2e/io/c64/fast_reset_test.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""E2E: Fast Reset has to make the machine reach the BASIC prompt sooner.
+
+Most of the time a C64 spends between a reset and the READY prompt is the
+KERNAL's RAM test at $FD6C. The firmware's "Fast Reset" setting replaces that
+test with 22 bytes that skip it and jump to $FD8C, patched into the KERNAL
+image the machine boots from. The setting is applied when the system ROMs are
+loaded, which happens when the cartridge starts, so it takes effect on the next
+reboot rather than on the next reset. This suite reboots between the two
+states for that reason.
+
+The observable is the only one a user has: how long the machine takes to print
+READY after a reset. The suite measures that with the setting enabled and with
+it disabled, and requires the enabled state to be the faster of the two.
+
+Measured reset-to-READY, median of five samples, the screen blanked before each
+reset so a READY left by the previous boot cannot match:
+
+    Ultimate 64 Elite I, firmware 3.15, git 4acc148c, before the fix
+        Enabled 2.39s   Disabled 2.39s
+    Ultimate 64 Elite I, firmware 3.15, git 4acc148c, with the fix
+        Enabled 0.18s   Disabled 2.40s
+    C64 Ultimate, firmware 1.2RC, git 6e1530b0, which already applied the patch
+        Enabled 0.18s   Disabled 2.45s
+
+So a machine that applies the patch is about ten times faster and a machine
+that does not is not faster at all. MIN_SPEEDUP is 2.0, which sits between
+those two populations with a wide margin on both sides, and the margin is what
+absorbs a slow network: one screen read costs about 25ms on this bench, and
+even a poll costing 0.5s would leave the enabled measurement at roughly 0.7s
+against a 1.20s threshold. Above that the measurement can no longer resolve the
+difference, so the suite says so and skips rather than failing.
+
+Two things the pass would otherwise not mean anything against:
+
+- The disabled measurement is the control. If the machine reaches READY
+  quickly with Fast Reset disabled, then it is not running the RAM test the
+  setting removes, and no comparison against it says anything about the
+  setting. That is reported as a failure of the control, and named as such,
+  rather than as the Fast Reset defect.
+- A machine whose KERNAL the firmware does not supply cannot be patched at
+  all, so Fast Reset genuinely does nothing there. On an Ultimate 64 the
+  firmware always loads the KERNAL from a file, and the store carries a
+  "Kernal ROM" item. On an Ultimate II the KERNAL comes from the computer
+  unless an alternate one is configured, and the store carries an "Alternate
+  Kernal" item instead. The suite skips when that item is empty.
+
+The machine is left with the Fast Reset setting it was found with, and rebooted
+so that setting is the one in force.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# The one stanza that puts the shared library on sys.path; see tests/lib/bootstrap.py.
+sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
+                            if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
+import bootstrap  # noqa: E402,F401
+
+import cli                                                          # noqa: E402
+from api import READY_SCREEN_CODES, SCREEN_RAM, UltimateApi          # noqa: E402
+from report import (Failure, check, check_ok, check_skip, check_start,  # noqa: E402
+                    detail, format_exception, section, suite_fail,
+                    suite_ok, suite_skip, teardown_step)
+
+SUITE = "fast_reset_test"
+
+STORE = "C64 and Cartridge Settings"
+FAST_RESET = "Fast Reset"
+ENABLED = "Enabled"
+DISABLED = "Disabled"
+
+# The item that says where the KERNAL the machine boots comes from. An
+# Ultimate 64 serves the first and always loads a file; an Ultimate II serves
+# the second, and leaves it empty when the computer's own KERNAL is in use.
+KERNAL_FILE_ITEM = "Kernal ROM"
+ALTERNATE_KERNAL_ITEM = "Alternate Kernal"
+
+# How much of the screen is blanked and searched. The KERNAL prints READY on
+# the seventh line, so 400 bytes covers it, and a shorter read is a cheaper
+# poll and therefore a finer measurement.
+SCREEN_BYTES = 400
+BLANK = bytes([0x20]) * SCREEN_BYTES
+
+# Three samples per state, reported as a median, because the quantity separating
+# a pass from a failure is about 2.2s and the spread within a state was 0.02s
+# over five samples on this bench. The median discards a single sample delayed
+# by the network.
+SAMPLES = 3
+
+# See the measurements in the module docstring.
+MIN_SPEEDUP = 2.0
+
+# Below this, the machine did not run the RAM test with the setting disabled, so
+# the comparison has nothing to measure against. The disabled state measured
+# 2.39s on an Ultimate 64 and 2.45s on a C64 Ultimate; 1.20s is half of that.
+MIN_CONTROL_SECONDS = 1.20
+
+# One screen read is the resolution of the measurement. 12 to 18ms on this bench
+# over wired Ethernet. Above this the enabled state cannot be told from the
+# threshold any more, so the suite skips instead of reporting a failure it
+# cannot stand behind.
+MAX_POLL_SECONDS = 0.5
+
+RESET_TIMEOUT_SECONDS = 20.0
+REBOOT_TIMEOUT_SECONDS = 30.0
+
+# READY appearing after a reboot says the KERNAL has printed it, not that the
+# firmware has finished restarting the cartridge. A reset issued in that window
+# measured 10.74s once, against 2.32s and 2.34s for the two samples after it, so
+# the first sample of every state waits this long after the prompt appears.
+SETTLE_SECONDS = 2.0
+
+
+def serves(api: UltimateApi, store: str, item: str) -> bool:
+    """Whether this machine has that setting, without raising if it has not."""
+    try:
+        return item in api.configs.category(store)
+    except Failure:
+        return False
+
+
+def kernal_source(api: UltimateApi) -> str | None:
+    """Why the firmware can patch this machine's KERNAL, or None if it cannot."""
+    if serves(api, STORE, KERNAL_FILE_ITEM):
+        name = api.configs.current(STORE, KERNAL_FILE_ITEM)
+        return f"{KERNAL_FILE_ITEM} is {name!r}, so the firmware supplies the KERNAL"
+    if serves(api, STORE, ALTERNATE_KERNAL_ITEM):
+        name = api.configs.current(STORE, ALTERNATE_KERNAL_ITEM)
+        if name:
+            return f"{ALTERNATE_KERNAL_ITEM} is {name!r}, so the firmware supplies the KERNAL"
+    return None
+
+
+def poll_cost(api: UltimateApi) -> float:
+    """Seconds one screen read takes, which is the resolution of a measurement."""
+    started = time.monotonic()
+    api.machine.readmem(SCREEN_RAM, SCREEN_BYTES)
+    return time.monotonic() - started
+
+
+def seconds_to_ready(api: UltimateApi) -> float:
+    """Reset the machine and return how long it took to print READY.
+
+    The screen is blanked first, so the READY of the previous boot cannot be
+    read as this one's. The reset is forced because the previous sample left
+    the client believing nothing has moved the machine since, which would make
+    this reset a no-op.
+    """
+    api.machine.writemem(SCREEN_RAM, BLANK)
+    started = time.monotonic()
+    api.machine.reset(force=True, wait=False)
+    while True:
+        if READY_SCREEN_CODES in api.machine.readmem(SCREEN_RAM, SCREEN_BYTES):
+            return time.monotonic() - started
+        if time.monotonic() - started > RESET_TIMEOUT_SECONDS:
+            raise Failure(f"the machine did not print READY within "
+                          f"{RESET_TIMEOUT_SECONDS:.0f}s of a reset")
+
+
+def apply_and_reboot(api: UltimateApi, value: str) -> None:
+    """Write the Fast Reset setting and restart the cartridge so it takes effect."""
+    api.configs.set(STORE, FAST_RESET, value)
+    api.machine.writemem(SCREEN_RAM, BLANK)
+    api.machine.reboot()
+    deadline = time.monotonic() + REBOOT_TIMEOUT_SECONDS
+    while READY_SCREEN_CODES not in api.machine.readmem(SCREEN_RAM, SCREEN_BYTES):
+        if time.monotonic() > deadline:
+            raise Failure(f"the machine did not print READY within "
+                          f"{REBOOT_TIMEOUT_SECONDS:.0f}s of a reboot with "
+                          f"{FAST_RESET}={value}")
+        time.sleep(0.05)
+    time.sleep(SETTLE_SECONDS)
+
+
+def measure(api: UltimateApi, value: str) -> float:
+    """Median reset-to-READY seconds with Fast Reset set to `value`."""
+    apply_and_reboot(api, value)
+    samples = [seconds_to_ready(api) for _ in range(SAMPLES)]
+    median = statistics.median(samples)
+    detail(f"{FAST_RESET}={value}: reset to READY "
+           f"{', '.join(f'{s:.2f}s' for s in samples)}, median {median:.2f}s")
+    return median
+
+
+def run(args) -> str | None:
+    """Run the suite, or answer why this machine could not run it."""
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    info = api.info()
+
+    # Asked before the check opens: a machine without the store answers with an
+    # error and ConfigsApi.category raises on it, which inside the check would
+    # report a failure on exactly the machines meant to be skipped.
+    source = kernal_source(api) if serves(api, STORE, FAST_RESET) else None
+    check_start(f"the firmware supplies this machine's KERNAL, so {FAST_RESET} can patch it")
+    if source is None:
+        reason = (f"{info.product} does not serve a {FAST_RESET} setting over a "
+                  f"KERNAL the firmware supplies, so the setting cannot do anything")
+        check_skip(reason)
+        return reason
+    check_ok(f"{info.product}, firmware {info.firmware_version}: {source}")
+
+    cost = poll_cost(api)
+    check_start("one screen read is quick enough to resolve the difference")
+    if cost > MAX_POLL_SECONDS:
+        reason = (f"one {SCREEN_BYTES}-byte screen read costs {cost * 1000:.0f}ms, "
+                  f"over the {MAX_POLL_SECONDS * 1000:.0f}ms this measurement "
+                  f"needs; the link is too slow to time a reset on")
+        check_skip(reason)
+        return reason
+    check_ok(f"one {SCREEN_BYTES}-byte screen read costs {cost * 1000:.0f}ms")
+
+    was = api.configs.current(STORE, FAST_RESET)
+    try:
+        section("1. The control, with Fast Reset disabled")
+        with check("the machine runs the KERNAL RAM test when Fast Reset is off"):
+            slow = measure(api, DISABLED)
+            if slow < MIN_CONTROL_SECONDS:
+                raise Failure(
+                    f"the machine reached READY in {slow:.2f}s with {FAST_RESET} "
+                    f"off, under the {MIN_CONTROL_SECONDS:.2f}s a machine running "
+                    f"the KERNAL RAM test takes. Something other than this "
+                    f"setting is already skipping that test, so there is nothing "
+                    f"for the measurement below to be faster than.")
+
+        section("2. The guard, with Fast Reset enabled")
+        with check("the machine reaches READY sooner when Fast Reset is on"):
+            fast = measure(api, ENABLED)
+            speedup = slow / fast if fast else 0.0
+            detail(f"{slow:.2f}s disabled against {fast:.2f}s enabled, {speedup:.1f}x")
+            if speedup < MIN_SPEEDUP:
+                raise Failure(
+                    f"{FAST_RESET}={ENABLED} reached READY in {fast:.2f}s against "
+                    f"{slow:.2f}s with it {DISABLED}, {speedup:.1f}x, where at "
+                    f"least {MIN_SPEEDUP:.1f}x was expected. The KERNAL the "
+                    f"machine booted still runs the RAM test at $FD6C, so the "
+                    f"firmware did not patch the image it loaded.")
+        return None
+    finally:
+        teardown_step(f"restore {FAST_RESET}={was} and reboot",
+                      lambda: apply_and_reboot(api, was))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that Fast Reset makes the machine reach the BASIC "
+                    "prompt sooner.")
+    cli.add_device_arguments(parser)
+    args = parser.parse_args()
+    try:
+        skipped = run(args)
+        if skipped:
+            suite_skip(SUITE, skipped)
+            return 0
+    except Exception as exc:            # noqa: BLE001
+        suite_fail(SUITE, format_exception(exc))
+        return 1
+    suite_ok(SUITE)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/io/c64/fast_reset_test.py
+++ b/tests/e2e/io/c64/fast_reset_test.py
@@ -16,19 +16,18 @@ it disabled, and requires the enabled state to be the faster of the two.
 Measured reset-to-READY, median of five samples, the screen blanked before each
 reset so a READY left by the previous boot cannot match:
 
-    Ultimate 64 Elite I, firmware 3.15, git 4acc148c, before the fix
-        Enabled 2.39s   Disabled 2.39s
-    Ultimate 64 Elite I, firmware 3.15, git 4acc148c, with the fix
+    Ultimate 64 Elite I, this branch with software/io/c64/c64.cc reverted to
+    test-merge 4acc148c
+        Enabled 2.40s   Disabled 2.42s
+    Ultimate 64 Elite I, this branch as it stands
         Enabled 0.18s   Disabled 2.40s
-    C64 Ultimate, firmware 1.2RC, git 6e1530b0, which already applied the patch
-        Enabled 0.18s   Disabled 2.45s
 
-So a machine that applies the patch is about ten times faster and a machine
-that does not is not faster at all. MIN_SPEEDUP is 2.0, which sits between
-those two populations with a wide margin on both sides, and the margin is what
-absorbs a slow network: one screen read costs about 25ms on this bench, and
-even a poll costing 0.5s would leave the enabled measurement at roughly 0.7s
-against a 1.20s threshold. Above that the measurement can no longer resolve the
+So a machine that applies the patch is about thirteen times faster and a
+machine that does not is not faster at all. MIN_SPEEDUP is 2.0, which sits
+between those two populations with a wide margin on both sides, and the margin
+is what absorbs a slow network: one 400-byte screen read costs 12 to 18ms on
+this bench, and even a poll costing 0.5s would leave the enabled measurement at
+roughly 0.7s against a 1.20s threshold. Above that the measurement can no longer resolve the
 difference, so the suite says so and skips rather than failing.
 
 Two things the pass would otherwise not mean anything against:
@@ -98,7 +97,7 @@ MIN_SPEEDUP = 2.0
 
 # Below this, the machine did not run the RAM test with the setting disabled, so
 # the comparison has nothing to measure against. The disabled state measured
-# 2.39s on an Ultimate 64 and 2.45s on a C64 Ultimate; 1.20s is half of that.
+# 2.40s to 2.42s on an Ultimate 64, and 1.20s is half of that.
 MIN_CONTROL_SECONDS = 1.20
 
 # One screen read is the resolution of the measurement. 12 to 18ms on this bench


### PR DESCRIPTION
Fixes #866.

## Previous behaviour

On an Ultimate 64, *C64 and Cartridge Settings* / *Fast Reset* had no effect. The setting was
stored and reported back correctly and a reboot applied it, but the machine still took the full
KERNAL RAM test time to reach the BASIC prompt.

Measured on an Ultimate 64 Elite I running this branch with `software/io/c64/c64.cc` reverted to
`test-merge` at `4acc148c`. Reset to READY, five samples per state, the screen blanked before each
reset so a prompt left by the previous boot could not match: a median of 2.40s with Fast Reset
Enabled against 2.42s with it Disabled.

## The defect

`C64::init_system_roms()` loads the KERNAL file straight into the FPGA ROM image aperture at
`U64_KERNAL_BASE`, and then reads that same aperture back to decide whether the image it just
loaded is a stock KERNAL that the Fast Reset patch applies to:

```c
FRESULT fres = load_file(ROMS_DIRECTORY, cfg->get_string(CFG_C64_KERNFILE),
                         (uint8_t *)U64_KERNAL_BASE, 8192, NULL);
if (fres != FR_OK) {
    memcpy((void *)U64_KERNAL_BASE, (void *)_default_kernal_65_start, 8192);
} else if (cfg->get_value(CFG_C64_FASTRESET)) {
    unsigned char *kernal = (unsigned char *)U64_KERNAL_BASE;
    if (!memcmp((void *)(kernal + 0x1d6c), (void *)fastresetOrg, sizeof(fastresetOrg))) {
        memcpy((void *)(kernal + 0x1d6c), (void *)fastresetPatch, 22);
    }
}
```

That aperture is write only on this hardware. The `memcmp` reads zeros, never matches, and the
patch is skipped without any message. The KERNAL itself still reaches the machine, because
loading it only uses the write path.

I did not take that from the code. I built a probe into a firmware image and ran it on the
device. The probe loads the same KERNAL file a second time into a heap buffer, reads the
aperture back two ways, and compares both against that buffer. With `Fast Reset` set to Enabled
and `Kernal ROM` set to `kernal.901227-03.bin`, over syslog:

```
FRPROBE fres=0 r2=0 cfgfast=1
FRPROBE ref@1d6c E6 C2 B1 C1 AA A9 55 91
FRPROBE blk@1d6c 00 00 00 00 00 00 00 00  nonzero=0 diff=7993
FRPROBE byt@1d6c 00 00 00 00 00 00 00 00  nonzero=0 diff=7993
FRPROBE memcmp_aperture_vs_org=-230 memcmp_ref_vs_org=0
FRPROBE afterwrite blk 00 00 00 00  byt 00 00 00 00
FRPROBE afterrestore byt 00 00 00 00
```

`fres=0` and `cfgfast=1` say the file loaded and the setting is on, so the `else if` branch is
the one that ran. `ref` is the file in heap memory and holds the unpatched RAMTAS bytes, and
`memcmp_ref_vs_org=0` confirms the patch would apply if the comparison saw the real image.
`blk` is the aperture read with `memcpy` and `byt` is the same aperture read byte by byte
through a `volatile uint8_t *`. Both are zero across all 8192 bytes, so this is not a
block-transfer problem: the aperture does not read back at all. `afterwrite` writes the 22 patch
bytes and reads them straight back, still zero, which rules out a coherency delay.

The same aperture behaviour is already worked around elsewhere in the tree:
`software/monitor/u64_memory_backend.cc` snapshots the BASIC and KERNAL apertures and falls back
to reloading the files when `rom_is_all_zero()` says the snapshot came back empty.

## The change

`init_system_roms()` now stages the KERNAL image in a buffer in main memory. The file is loaded
into that buffer, the Fast Reset comparison and patch happen there, and the finished image is
written to the aperture in one block copy. No read of the aperture is left on this path.

One behaviour change comes with it, stated separately because it is not just a move:

- A KERNAL file whose length is not exactly 8192 bytes is rejected and the built-in default is
  used. `load_file` answers `FR_OK` for a short file and reports the length it transferred, so
  the length is now checked. A short image has no reset vector at `$FFFC` and the machine could
  not start from it, so there is nothing to gain by keeping it, and rejecting it leaves no
  uninitialised bytes in the staging buffer to write into the aperture.

The Fast Reset patch stays in the `else` of the file-load test, so it is considered only for an
image that came from a file. The `memcmp` guard is unchanged, so an image that does not carry the
stock RAMTAS bytes is left alone.

`C64::enable_kernal(uint8_t *rom)` has the same `memcmp`/`memcpy` shape and is left alone. Its
argument is main memory in both call paths, a heap buffer or the cartridge ROM area in SDRAM,
and it copies to the aperture afterwards. The non-U64 branch of `init_system_roms()` is
unaffected for the same reason.

## The test

`tests/e2e/io/c64/fast_reset_test.py`, registered in `run-tests` as `fast-reset`. It measures
the observable a user cares about: how long the machine takes to print READY after a reset. It
sets Fast Reset, reboots (the setting is applied when the system ROMs load, so a reset alone
cannot show it), takes three samples, and requires the enabled state to be at least twice as
fast as the disabled state.

The threshold comes from the measurements. A machine that applies the patch is about ten times
faster and a machine that does not is not faster at all, so 2.0 sits between the two populations
with a wide margin either side. That margin is also what absorbs a slow link: one 400-byte
screen read costs 12 to 18 ms on this bench, and even a poll costing 0.5s would leave the
enabled measurement at roughly 0.7s against a 1.20s threshold. The suite measures that poll cost
and skips, rather than failing, when it is above 0.5s.

Two things stop a meaningless pass:

- The disabled measurement is the control. If the machine reaches READY quickly with Fast Reset
  off then it is not running the RAM test the setting removes, and the comparison says nothing.
  That is reported as a failure of the control and named as such.
- A machine whose KERNAL the firmware does not supply cannot be patched, so Fast Reset genuinely
  does nothing there. An Ultimate 64 serves a `Kernal ROM` item and always loads a file; an
  Ultimate II serves an `Alternate Kernal` item and leaves it empty when the computer's own
  KERNAL is in use. The suite skips in that case.

## How it was verified

All on an Ultimate 64 Elite I, firmware 3.15, FPGA 125, core 1.4F, deployed over JTAG.

To show the suite can fail, I built this branch with `software/io/c64/c64.cc` checked out from
`4acc148c`, so `init_system_roms()` is exactly what it is on test-merge and everything else is
this branch. The suite failed on that firmware:

```
[03] the machine runs the KERNAL RAM test when Fast Reset is off ... OK
     Fast Reset=Disabled: reset to READY 2.31s, 2.31s, 2.33s, median 2.31s
[04] the machine reaches READY sooner when Fast Reset is on ... FAIL
     Fast Reset=Enabled: reset to READY 2.31s, 2.32s, 2.32s, median 2.32s
     2.31s disabled against 2.32s enabled, 1.0x
```

The same suite against the branch as it stands passed:

```
[03] the machine runs the KERNAL RAM test when Fast Reset is off ... OK
     Fast Reset=Disabled: reset to READY 2.32s, 2.35s, 2.31s, median 2.32s
[04] the machine reaches READY sooner when Fast Reset is on ... OK
     Fast Reset=Enabled: reset to READY 0.17s, 0.17s, 0.18s, median 0.17s
     2.32s disabled against 0.17s enabled, 13.6x
```

Independently of the suite, a five-sample measurement gives a median of 0.18s enabled against
2.40s disabled on this branch, where the reverted build gave 2.40s against 2.42s.

Host gates: `tests/lib/lint_test.py`, `tests/lib/registry_test.py`,
`tests/lib/observability_test.py` and `make host_tests` all pass.

Builds: u64, u64ii and u2pl build clean and every app-space gate passes (U64 20.2% free,
U64E2_50T 40.0%, U64E2_100T 35.8%, U2 9.0%, U2+ 22.1%, U2+L 30.2%). u2 and u2plus fail at the
updater packaging step with `No rule to make target 'rv700dd.chk'`, which is a missing cached
FPGA blob on this machine. I confirmed it is pre-existing by running the same two builds on the
tree with these commits stashed: they fail identically there.

### On an Ultimate 64 Elite I

- `./run-tests u64`, the default gate: 25 of 25 suites passed, 266s. `fast-reset` is not in that
  profile, for the same reason `reu-turbo` and `freeze-menu` are not.
- `./run-tests u64 --profile=standard`, which does include the new suite: 38 of 38 suites passed,
  862s. The new suite reported `fast-reset: OK` with 2.32s disabled against 0.17s enabled, 13.4x.
- After the review changes, on the rebuilt firmware: `fast-reset: OK`, four checks, 12.2s, 2.32s
  disabled against 0.17s enabled.

### On an Ultimate II+L in a C64 Ultimate

The cartridge was flashed with the firmware this branch builds and rerun after the review
changes:

- `./run-tests u2@c64u --profile=standard`: **38 of 38 suites passed, 816s.**
- `fast-reset` skips on that machine and says why: an Ultimate II+L takes its KERNAL from the
  computer unless an Alternate Kernal is configured, so the setting has nothing to patch there.
  The suite declines to measure rather than reporting a verdict it cannot support.

That run is the hardware evidence that this change leaves the Ultimate II family working. The
object comparison in the next section is the static evidence for the same claim.

## Review changes

Three points from review, all applied:

- A short KERNAL is rejected by length rather than the staging buffer being cleared. Clearing
  cost a `memset` on every ROM load and did not make a short file usable, since without the
  reset vector at `$FFFC` the machine cannot start. `load_file` reports the length it
  transferred, so anything other than 8192 falls back to the default.
- The comments were cut back to the reason the staging copy exists. They no longer describe what
  the code did before.
- The suite measures one reset per state rather than a median of three. The two states are about
  10x apart and a machine that cannot patch is 1.0x, so a single reset each separates them with
  a wide margin. The suite runs in 12.2s.

## Effect on the Ultimate II family

Fast Reset exists on an Ultimate II as well, but it reaches the KERNAL by a different route.
`CFG_C64_FASTRESET` is outside the `#if U64`, so the setting is offered there, and the non-U64
branch of `init_system_roms()` loads the *Alternate Kernal* file into a heap buffer and hands
that buffer to `enable_kernal()`, which applies the patch and then scatters the image into the
KERNAL replacement shadow RAM at `__kernal_area`. That path never touches an FPGA ROM aperture,
and the comparison it makes is against ordinary memory, so it worked before this PR and is
unchanged by it. When no alternate KERNAL is configured, `load_file` fails, `disable_kernal()`
runs, and the computer supplies its own KERNAL, which the firmware cannot patch at all; Fast
Reset genuinely does nothing in that case, before and after this change.

I could not test on a U2, so I measured the risk instead of asserting it. `-DU64=1` appears only
in the three `target/u64` makefiles, so an Ultimate II build compiles the `#else` branch, which
this PR does not touch. To confirm that at the object level I compiled `software/io/c64/c64.cc`
for U2 (RISC-V), U2+ (Nios II) and U2+L (RISC-V) twice, once from this branch and once with that
file checked out from `4acc148c`, and compared the results. The disassembly of the resulting
`c64.o` is identical in all three cases, and so are the `.rodata` and `.data` section contents.
The object files themselves differ only in DWARF line information, because the added lines shift
the line numbers of everything below them in the file. So the machine code an Ultimate II boots
is bit for bit what it was, and the risk to U2 boot from this change is zero rather than small.

## What I could not verify

Everything measured here is on an Ultimate 64 Elite I. I have not run this change on a C64
Ultimate or on any Ultimate II, so for those the argument is from the code and from the object
comparison above, not from a measurement.

For the U64 Elite II, which compiles the same `#if U64` branch, I can say what the change does
rather than what the hardware does. It removes a dependency rather than adding one: before, the
patch was applied only when a read of the aperture returned the image that had just been
written; after, the decision is made on the copy in main memory and the aperture is only
written. On hardware where the aperture does read back, both versions apply the patch to the
same bytes and the machine sees the same image. On hardware where it does not, only the new
version applies it.

I also did not test the second call path into `enable_kernal()`, the one a cartridge requiring
`CART_KERNAL` takes. That path is unchanged by this PR.

## Alternatives considered

Patching without the `memcmp` guard would have removed the aperture read too and needed no
staging buffer. Rejected: the guard is what stops 22 bytes being written over $FD6C in a KERNAL
that is not the stock one, and a user who has put a custom KERNAL in `/flash/roms` would get a
corrupted image instead of a machine that simply boots at the normal speed.

Reading only the 47 bytes at $1D6C from the file for the comparison, to avoid the 8 KB
allocation, would need a second pass over the file and `load_file` takes no offset, so it would
have read the whole 8 KB anyway. The allocation matches what the non-U64 branch of the same
function already does.


