### PR TITLE
Improve E2E tests for use against C64U

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -320,6 +320,13 @@ SUITES: Sequence[Suite] = (
           "-H @HOST@ -p @PASS@ --mode @MODE@"),
     Suite("e2e", "cfg-single-group", "tests/e2e/filemanager/cfg_single_group_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@", profile=profiles.QUICK),
+    # Needs no device: it reads the loader's debug log parser over recorded
+    # text. The device writes that log with an unlocked, character-at-a-time
+    # printf, so another task's line splices into the middle of a loader line;
+    # the splice is not reproducible on demand, which is why the case is a
+    # recorded one rather than a device run.
+    Suite("e2e", "cfg-loader-log", "tests/e2e/filemanager/cfg_loader_log_test.py",
+          "", profile=profiles.SMOKE),
     # Manual: loading a partial .cfg is supposed to leave the stores it does
     # not name alone, and that no longer holds. Measured on a C64 Ultimate
     # 1.2.0, a file naming one store listed nineteen in its loader

--- a/run-tests
+++ b/run-tests
@@ -439,6 +439,17 @@ SUITES: Sequence[Suite] = (
     # fix and green at about 10x after it.
     Suite("e2e", "fast-reset", "tests/e2e/io/c64/fast_reset_test.py",
           "-H @HOST@ -p @PASS@ -t @TIMEOUT@"),
+    # Guards GideonZ/commodore#1 (c66ef028): a Reset, a Reboot or a C=+R taken
+    # from the menu has to run after the UI has torn down, so the C64 comes
+    # back to a boot screen with none of the menu's characters on it. The
+    # other half of that change, the menu opening again afterwards, needs the
+    # hardware button's edge detector, which no route this harness has can
+    # reach; those three checks report SKIP with the measurement. It resets
+    # and reboots the machine several times, which is why it is not in the
+    # shallow profiles.
+    Suite("e2e", "deferred-machine-actions",
+          "tests/e2e/io/c64/deferred_actions_test.py",
+          "-H @HOST@ -p @PASS@ -t @TIMEOUT@ --mode @MODE@"),
     # Reproduces #733: with the FPGA decoder fix in the core, "mirroring off" is
     # the regression guard. Runs last, because a device whose core predates that
     # fix stalls the whole Nios on this scenario and needs a JTAG recovery.

--- a/tests/README.md
+++ b/tests/README.md
@@ -268,8 +268,10 @@ Profiles, shallowest first. A suite runs from its own profile up.
 
 e2e:
   assembly64                        .      x      x      x      x
+  av-stream                         .      .      x      x      x
   browser-filesystem-refresh        .      .      x      x      x
   browser-long-filename             .      x      x      x      x
+  cfg-loader-log                    x      x      x      x      x
   cfg-partial-effectuate            .      .      .      x      x
   cfg-single-group                  .      x      x      x      x
   cfg-unknown-items                 .      .      x      x      x
@@ -277,12 +279,15 @@ e2e:
   create-disk-image                 .      x      x      x      x
   doom-release                      .      .      .      x      x
   esp-depends                       x      x      x      x      x
+  fast-reset                        .      .      x      x      x
   freeze-menu                       .      .      x      x      x
   ftp-client                        .      x      x      x      x
   ftp-server                        x      x      x      x      x
+  ident-service-switch              .      .      x      x      x
   input                             .      x      x      x      x
   input-batching                    x      x      x      x      x
   key-injection                     .      .      x      x      x
+  lint                              x      x      x      x      x
   machine-code-monitor              .      .      .      x      x
   menu-screen                       x      x      x      x      x
   navigation-keys                   x      x      x      x      x
@@ -294,15 +299,19 @@ e2e:
   prg-load-path-trim                .      x      x      x      x
   printer                           .      x      x      x      x
   readmem-writemem                  x      x      x      x      x
+  registry                          x      x      x      x      x
   rest-api-coverage                 .      x      x      x      x
   reu-turbo                         .      .      x      x      x
   runner-policy                     .      x      x      x      x
+  stale-gates                       .      x      x      x      x
   telnet-drain                      .      x      x      x      x
   telnet-stale-session              .      .      .      x      x
+  telnet-sustained-input            .      .      .      x      x
   temp-auto-cleanup                 .      .      x      x      x
   transport-usage                   x      x      x      x      x
   uci-net-target                    .      .      .      x      x
   uci-targets                       .      .      x      x      x
+  ui-backend-parse                  x      x      x      x      x
   ui-backend-smoke                  x      x      x      x      x
   usb-bulk-out-integrity            .      .      .      x      x
   wake-on-wifi                      .      .      .      x      x
@@ -327,8 +336,8 @@ soak:
   usb-keyboard-repeat               .      .      .      x      x
 
                                ------ ------ ------ ------ ------
-  suites                            8     21     43     52     52
-  suite runs                        8     21     43    104    156
+  suites                           12     26     51     63     63
+  suite runs                       12     26     51    126    189
 
 Scenario and check counts, and durations, are not shown here:
 the registry does not know them. They depend on the machine and are

--- a/tests/README.md
+++ b/tests/README.md
@@ -277,6 +277,7 @@ e2e:
   cfg-unknown-items                 .      .      x      x      x
   cfg-whitespace                    .      .      x      x      x
   create-disk-image                 .      x      x      x      x
+  deferred-machine-actions          .      .      x      x      x
   doom-release                      .      .      .      x      x
   esp-depends                       x      x      x      x      x
   fast-reset                        .      .      x      x      x
@@ -336,8 +337,8 @@ soak:
   usb-keyboard-repeat               .      .      .      x      x
 
                                ------ ------ ------ ------ ------
-  suites                           12     26     51     63     63
-  suite runs                       12     26     51    126    189
+  suites                           12     26     52     64     64
+  suite runs                       12     26     52    128    192
 
 Scenario and check counts, and durations, are not shown here:
 the registry does not know them. They depend on the machine and are

--- a/tests/e2e/filemanager/cfg_loader_log_test.py
+++ b/tests/e2e/filemanager/cfg_loader_log_test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Gate check: the .cfg loader's debug log is read correctly when it interleaves.
+
+"""Verify parse_loader_log over a recorded debug log, intact and spliced.
+
+The device writes its debug log with printf, which emits one character at a
+time through outbyte() and takes no lock (software/system/small_printf.cc and
+software/application/ultimate/ultimate.cc). A task switch part way through a
+line therefore splices another task's output into the middle of it. The REST
+poller that every overlay-mode suite runs prints "Accept client 0 on socket 7."
+for each connection, so it is the task that lands in the loader's lines.
+
+That is not reproducible on demand, so it is checked here against the text
+measured on a C64 Ultimate 1.2RC rather than by driving a device. The intact
+log below was captured from an Ultimate 64 Elite on firmware 3.15, harness
+commit b3c76093.
+
+Needs no device.
+"""
+
+import sys
+from pathlib import Path
+
+# The one stanza that puts the shared library on sys.path; see tests/lib/bootstrap.py.
+sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
+                            if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
+import bootstrap  # noqa: E402,F401
+
+sys.path.insert(0, bootstrap.directory("e2e", "filemanager"))
+
+from report import (  # noqa: E402
+    Failure, add_colour_argument, apply_colour, check, suite_fail, suite_ok)
+from selftest import expect  # noqa: E402
+
+from cfg_single_group_test import parse_loader_log  # noqa: E402
+
+NAME = "cfg_loader_log_test"
+
+# Two records and the surrounding noise, as an Ultimate 64 Elite wrote them.
+INTACT = """\
+Accept client 0 on socket 7.  192.168.1.185:50898
+HTTP GET /v1/machine:menu_screen
+Effectuating settings of store 'Audio Mixer' after loading.
+Store 'SID Sockets Configuration' is clean after loading.
+Store 'Network Settings' is clean after loading.
+Object level 1 returned 1.
+"""
+
+# What a C64 Ultimate 1.2RC actually wrote. The network task's line was spliced
+# into the middle of the store name, and its newline cut the loader's line in
+# two: the first half keeps the prefix, the second half keeps the suffix.
+SPLICED = """\
+Effectuating settings of store 'Audio MAccept client 0 on socket 7.  192.168.1.185:49362
+ixer' after loading.
+Store 'Network Settings' is clean after loading.
+"""
+
+# The other measured shape, from attempt 1 of the same c64u run: the record is
+# appended to the line another task is part way through, so its prefix is not
+# at the start of any line and a parse anchored there sees no store at all.
+APPENDED = """\
+HTTP GET /v1/machine:menu_screenEffectuating settings of store 'Audio Mixer' after loading.
+Store 'Network Settings' is clean after loading.
+"""
+
+# The same splice landing in a "clean" record instead of an effectuated one.
+SPLICED_CLEAN = """\
+Effectuating settings of store 'Audio Mixer' after loading.
+Store 'Network SetAccept client 0 on socket 7.  192.168.1.185:49362
+tings' is clean after loading.
+"""
+
+
+def run_intact_checks() -> None:
+    with check("an uninterrupted log gives the stores it names"):
+        report = parse_loader_log(INTACT)
+        expect("effectuated", report.effectuated, ["Audio Mixer"])
+        expect("clean", report.clean,
+               ["SID Sockets Configuration", "Network Settings"])
+        expect("damaged", report.damaged, [])
+
+    with check("a log with no loader lines in it reports nothing"):
+        report = parse_loader_log(
+            "Accept client 0 on socket 7.  192.168.1.185:50898\n"
+            "HTTP GET /v1/machine:menu_screen\n")
+        expect("effectuated", report.effectuated, [])
+        expect("clean", report.clean, [])
+        expect("damaged", report.damaged, [])
+
+
+def run_spliced_checks() -> None:
+    with check("a spliced effectuated record yields no store name"):
+        report = parse_loader_log(SPLICED)
+        # The measured defect: "Audio MAccept client 0 on socket 7.
+        # 192.168.1.185:49362" was reported as a store the loader effectuated.
+        expect("effectuated", report.effectuated, [])
+        expect("clean", report.clean, ["Network Settings"])
+
+    with check("both halves of a spliced effectuated record are reported"):
+        report = parse_loader_log(SPLICED)
+        expect("damaged", report.damaged, [
+            "Effectuating settings of store 'Audio MAccept client 0 on socket 7."
+            "  192.168.1.185:49362",
+            "ixer' after loading.",
+        ])
+
+    with check("a record appended to another task's line is reported, not read"):
+        report = parse_loader_log(APPENDED)
+        expect("effectuated", report.effectuated, [])
+        expect("clean", report.clean, ["Network Settings"])
+        expect("damaged", report.damaged, [
+            "HTTP GET /v1/machine:menu_screenEffectuating settings of store "
+            "'Audio Mixer' after loading.",
+        ])
+
+    with check("a spliced clean record yields no store name and is reported"):
+        report = parse_loader_log(SPLICED_CLEAN)
+        expect("effectuated", report.effectuated, ["Audio Mixer"])
+        expect("clean", report.clean, [])
+        expect("damaged", report.damaged, [
+            "Store 'Network SetAccept client 0 on socket 7.  192.168.1.185:49362",
+            "tings' is clean after loading.",
+        ])
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    add_colour_argument(parser)
+    apply_colour(parser.parse_args().color)
+    try:
+        run_intact_checks()
+        run_spliced_checks()
+    except Failure as exc:
+        suite_fail(NAME, str(exc))
+        return 1
+    suite_ok(NAME)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/filemanager/cfg_partial_effectuate_test.py
+++ b/tests/e2e/filemanager/cfg_partial_effectuate_test.py
@@ -27,6 +27,17 @@ collect both into one list, which could not tell a loader that applied one store
 from one that applied all of them, so it failed on correct firmware too. See
 loader_report in cfg_single_group_test.py.
 
+The debug log interleaves. The device writes it with printf, one character at
+a time and without a lock, so another task printing while the loader prints
+splices its text into the middle of a loader line. Measured on a C64 Ultimate
+1.2RC, the REST poller's "Accept client 0 on socket 7." landed inside
+"Effectuating settings of store 'Audio Mixer' after loading." and this suite
+reported a store called "Audio MAccept client 0 on socket 7.  192.168.1.185:49362".
+`loader_report` now accepts a line only when the prefix and the suffix are both
+on it, and returns the part-lines separately as `damaged`. A run whose log holds
+such a line cannot say which stores were effectuated, so this check reports SKIP
+with those lines rather than a verdict.
+
 The half that holds everywhere is that such a file loads at all, and that stays
 in cfg_single_group_test.py and in the gate.
 
@@ -85,15 +96,35 @@ def main() -> int:
             upload_fixture(args.host, args.password, store, item,
                            alternate_value(api, store, item, original))
             load_fixture(browser)
-            effectuated, clean = loader_report(args.host, args.password)
-            detail(f"effectuated {len(effectuated)}, left clean {len(clean)}")
-            if effectuated != [store]:
-                extra = [name for name in effectuated if name != store]
+            report = loader_report(args.host, args.password)
+            detail(f"effectuated {len(report.effectuated)}, "
+                   f"left clean {len(report.clean)}, "
+                   f"unreadable {len(report.damaged)}")
+            extra = [name for name in report.effectuated if name != store]
+            if extra:
+                # An unexpected store that was read intact is the defect this
+                # suite exists to catch, so it is reported before anything is
+                # said about the log being damaged.
                 raise Failure(
                     f"the .cfg named only {store!r}, but the loader effectuated "
-                    f"{len(effectuated)} store(s): {effectuated!r}. "
+                    f"{len(report.effectuated)} store(s): {report.effectuated!r}. "
                     f"{len(extra)} store(s) the file never mentioned were applied: "
-                    f"{extra!r}. Stores left alone: {clean!r}")
+                    f"{extra!r}. Stores left alone: {report.clean!r}")
+            if report.damaged:
+                # Neither verdict can be reached: a spliced line may have been
+                # a store the file never named. Skipping says so and prints the
+                # lines, where failing would report the interleaving as a
+                # loader defect and passing would hide a store.
+                for line in report.damaged:
+                    detail(f"unreadable log line: {line!r}")
+                check_skip(
+                    f"{len(report.damaged)} loader log line(s) were spliced by "
+                    f"another task writing to the same debug log, so the set of "
+                    f"effectuated stores is not known")
+            elif report.effectuated != [store]:
+                raise Failure(
+                    f"the .cfg named {store!r}, but the loader effectuated "
+                    f"{report.effectuated!r}. Stores left alone: {report.clean!r}")
 
         suite_ok(SUITE)
         return 0

--- a/tests/e2e/filemanager/cfg_single_group_test.py
+++ b/tests/e2e/filemanager/cfg_single_group_test.py
@@ -22,6 +22,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 # The one stanza that puts the shared library on sys.path; see tests/lib/bootstrap.py.
 sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
@@ -65,28 +66,105 @@ def load_fixture(browser) -> None:
 
 
 EFFECTUATED_PREFIX = "Effectuating settings of store '"
+EFFECTUATED_SUFFIX = "' after loading."
 CLEAN_PREFIX = "Store '"
-CLEAN_SUFFIX = "is clean after loading."
+CLEAN_SUFFIX = "' is clean after loading."
 
 
-def loader_report(host: str, password: str) -> tuple[list[str], list[str]]:
-    """The stores the loader applied, and the stores it left alone.
+class LoaderReport(NamedTuple):
+    """What the debug log says about one .cfg load.
 
-    Two lists, because the loader prints a line per store either way and the
-    two mean opposite things. Collecting both into one cannot tell a loader
-    that applied one store from one that applied every store, which is the
-    distinction cfg_partial_effectuate_test exists to make.
+    `effectuated` and `clean` are separate lists, because the loader prints a
+    line per store either way and the two mean opposite things. Collecting
+    both into one cannot tell a loader that applied one store from one that
+    applied every store, which is the distinction
+    cfg_partial_effectuate_test exists to make.
+
+    `damaged` holds the log lines that carry part of a loader line but are not
+    a whole one, so a caller can say the log was unreadable instead of
+    reporting a store name that no store has.
     """
-    with ftp_lib.session(host, password, timeout=20) as ftp:
-        text = ftp_lib.retrieve(ftp, f"/Temp/{LOG_NAME}").decode("ascii", "replace")
+
+    effectuated: list[str]
+    clean: list[str]
+    damaged: list[str]
+
+
+def store_name(line: str, prefix: str, suffix: str) -> str | None:
+    """The store name in an intact loader line, or None when the line is not one.
+
+    Both ends are required. The device writes the debug log with printf, which
+    emits one character at a time through outbyte() with no lock (see
+    software/system/small_printf.cc and software/application/ultimate/
+    ultimate.cc), so a task switch part way through a line splices another
+    task's output into the middle of it. The spliced text ends at the
+    interrupting task's own newline, which cuts the loader line in two: the
+    first half keeps the prefix and loses the suffix, and the second half
+    keeps the suffix and has no prefix. Requiring the prefix and the suffix on
+    the same line rejects both halves.
+
+    A name containing a quote is rejected for the same reason: the loader
+    passes get_store_name() straight to printf, and no store this suite has
+    seen has a quote in its name, so a quote inside the name is a second
+    record spliced into the first rather than a store.
+    """
+    if not line.startswith(prefix) or not line.endswith(suffix):
+        return None
+    name = line[len(prefix):len(line) - len(suffix)]
+    if not name or "'" in name:
+        return None
+    return name
+
+
+def looks_like_loader_line(line: str) -> bool:
+    """Whether a line carries part of a loader record without being a whole one.
+
+    Containment rather than startswith/endswith, because a splice can land
+    anywhere. Measured on c64u: one run reported no effectuated store at all,
+    because the record had been appended to another task's line and so no
+    longer began with the prefix. Either half of a cut record is caught as
+    well: the first half still holds a prefix, the second half a suffix.
+
+    The two prefixes cannot be confused with each other. "Effectuating
+    settings of store '" spells "store" in lower case and "Store '" in upper
+    case, so a line holding one does not hold the other.
+    """
+    marks = (EFFECTUATED_PREFIX, CLEAN_PREFIX,
+             EFFECTUATED_SUFFIX, CLEAN_SUFFIX)
+    return any(mark in line for mark in marks)
+
+
+def parse_loader_log(text: str) -> LoaderReport:
+    """Read one saved debug log into the three lists.
+
+    A line that holds one of the two prefixes or one of the two suffixes but
+    is not a whole record is put in `damaged` rather than dropped. Dropping it
+    would let an interleaved log read as a load that touched fewer stores than
+    it did, which is the failure cfg_partial_effectuate_test is here to detect.
+
+    Separate from `loader_report` so that tests/e2e/filemanager/
+    cfg_loader_log_test.py can run it over a recorded log without a device.
+    """
     effectuated: list[str] = []
     clean: list[str] = []
+    damaged: list[str] = []
     for line in text.splitlines():
-        if line.startswith(EFFECTUATED_PREFIX):
-            effectuated.append(line.split("'", 2)[1])
-        elif line.startswith(CLEAN_PREFIX) and line.endswith(CLEAN_SUFFIX):
-            clean.append(line.split("'", 2)[1])
-    return effectuated, clean
+        applied = store_name(line, EFFECTUATED_PREFIX, EFFECTUATED_SUFFIX)
+        untouched = store_name(line, CLEAN_PREFIX, CLEAN_SUFFIX)
+        if applied is not None:
+            effectuated.append(applied)
+        elif untouched is not None:
+            clean.append(untouched)
+        elif looks_like_loader_line(line):
+            damaged.append(line)
+    return LoaderReport(effectuated, clean, damaged)
+
+
+def loader_report(host: str, password: str) -> LoaderReport:
+    """Fetch the debug log this run saved on the device, and read it."""
+    with ftp_lib.session(host, password, timeout=20) as ftp:
+        text = ftp_lib.retrieve(ftp, f"/Temp/{LOG_NAME}").decode("ascii", "replace")
+    return parse_loader_log(text)
 
 
 def cleanup(host: str, password: str) -> None:

--- a/tests/e2e/io/c64/assembly64_test.py
+++ b/tests/e2e/io/c64/assembly64_test.py
@@ -29,7 +29,6 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Sequence
 from pathlib import Path
 
 # The one stanza that puts the shared library on sys.path; see tests/lib/bootstrap.py.
@@ -49,6 +48,9 @@ from report import (
     suite_skip,
 )
 from menu import wait_until  # noqa: E402
+import machine  # noqa: E402
+import search_form  # noqa: E402
+from search_form import SearchForm  # noqa: E402
 from ui_backend import (
     Backend,
     MODE_TELNET,
@@ -61,22 +63,13 @@ from ui_backend import (
 MENU_BUTTON_PATH = "/v1/machine:menu_button"
 
 MENU_TOGGLE_TIMEOUT = 6.0
-# Both services draw the same form (AssemblySearchForm), so these are literals.
-NAME_FIELD = "Name:"
-SUBMIT_LABEL = "<<"
 EMPTY_QUERY_MESSAGE = "Queries cannot be empty"
 EMPTY_MARKER = "< No Items >"
 # The task menu is built from every registered category, so it takes noticeably
 # longer to draw than an ordinary redraw.
 TASK_MENU_TIMEOUT = 10.0
-# The form is fetched from the remote service, so it is far slower than a redraw.
-FORM_OPEN_TIMEOUT = 25.0
-# One retry, so a single slow fetch from a third-party server is not a failure.
-FORM_OPEN_ATTEMPTS = 2
 QUERY_TIMEOUT = 40.0
 RECOVER_TIMEOUT = 15.0
-# More than the form has selectable rows, so a walk always terminates.
-FIELD_WALK_LIMIT = 30
 # Unwinding is bounded by time, not by a press count: the UI task ignores keys
 # while a fetch is in flight, so a press can take as long as the service does.
 UNWIND_BUDGET = 60.0
@@ -93,8 +86,10 @@ TELNET_ENTRY_ROWS = range(1, 23)
 TELNET_STATUS_ROW = 23
 
 
-class Skip(RuntimeError):
-    pass
+# The form never appeared, which tests/e2e/lib/search_form.py raises and
+# main() reports as a suite skip: whether a third-party service answers is not
+# what a run of this firmware measures.
+Skip = search_form.Unreachable
 
 
 class Device:
@@ -111,6 +106,13 @@ class Device:
         self.host = host
         self.password = password
         self.timeout = timeout
+        # Everything this suite does inside the query form goes through here,
+        # so the suite reads no field label off the screen itself. The one
+        # step the form cannot do for itself is reaching it, because where the
+        # menu keeps the entry is the machine's business; see reach_form.
+        self.form: SearchForm = SearchForm(
+            backend, mode, self.entry_rows, self.form_title, self.reach_form,
+            telnet_mode=MODE_TELNET)
 
     @property
     def entry_rows(self) -> range:
@@ -121,9 +123,10 @@ class Device:
     # An Ultimate 64 and an Ultimate II+ search Assembly 64, reached from the
     # first entry of the task menu. A C64 Ultimate searches CommoServe,
     # reached from its launcher, and its task menu has no search entry at all.
-    # Both services draw the same query form, so every scenario below runs
-    # unchanged on all three once the name and the way in come from the
-    # machine. See tests/lib/machine.py.
+    # What the two services put on that form differs, which is why the fields
+    # are discovered rather than named; see tests/e2e/lib/search_form.py.
+    # These four are navigation, which is the machine's; see
+    # tests/lib/machine.py.
     @property
     def form_title(self) -> str:
         return self.backend.machine.search_form_title
@@ -169,12 +172,7 @@ class Device:
 
     def cursor_row(self) -> int | None:
         """Row the selection sits on, or None when the menu is closed."""
-        if self.mode == MODE_TELNET:
-            return telnet_field_row(self, self.entry_rows)
-        try:
-            return self.backend.selected_row(self.entry_rows)
-        except Failure:
-            return None
+        return self.form.cursor_row()
 
     def path_row(self) -> str:
         """The browser path from the status row, or "" when the menu is closed."""
@@ -215,7 +213,20 @@ class Device:
         return wait_until(lambda: self.menu_is_open() == want_open, timeout)
 
     def form_visible(self) -> bool:
-        return self.form_title in self.text()
+        return self.form.visible()
+
+    def reach_form(self) -> None:
+        """Navigate to the search entry and open it, from wherever the UI is.
+
+        SearchForm.open() calls this and then waits for the form's title, so
+        this is only the navigation: back out to the root browser, then open
+        the entry from wherever this machine keeps it.
+        """
+        unwind_to_root(self, "opening the query form")
+        if self.search_in_launcher:
+            open_search_entry_in_launcher(self)
+        else:
+            open_search_entry_in_task_menu(self)
 
     def screen_changed(self, before: Snapshot) -> bool:
         current = self.screen()
@@ -269,7 +280,7 @@ def task_menu_ready(device: Device) -> bool:
     and RETURN would then open whatever the browser cursor is on instead. The
     The entry's text can only come from the task menu itself, and it is always
     the menu's first, default-selected category on a freshly opened, not yet
-    navigated menu (exactly the state open_query_form calls this in), so its
+    navigated menu (exactly the state Device.reach_form calls this in), so its
     presence alone is a strong enough signal without needing to also identify
     which row the cursor sits on.
 
@@ -283,16 +294,7 @@ def task_menu_ready(device: Device) -> bool:
     column-0/1 marker check. Both are real, transport-specific limits of
     colour-based selection detection, not something to paper over here.
     """
-    return row_of(device, device.search_entry) is not None
-
-
-def describe_screen(device: Device) -> str:
-    """The non-blank rows, for a failure message that can be acted on."""
-    rows = device.rows()
-    if rows is None:
-        return "    (menu screen unavailable)"
-    lines = [f"    {n:02d}|{text}|" for n, text in enumerate(rows) if text.strip()]
-    return "\n".join(lines) or "    (screen is blank)"
+    return search_form.label_row(device.rows() or [], device.search_entry) is not None
 
 
 def open_search_entry_in_task_menu(device: Device) -> None:
@@ -337,50 +339,19 @@ def open_search_entry_in_launcher(device: Device) -> None:
     if not wait_until(lambda: launcher_entry_row(device) is not None,
                       TASK_MENU_TIMEOUT):
         raise Failure(f"the launcher did not offer {device.search_entry!r}; "
-                      f"screen was:\n{describe_screen(device)}")
+                      f"screen was:\n{device.form.describe_screen()}")
     found = launcher_entry_row(device)
     if found is None:
         raise Failure(f"{device.search_entry!r} left the launcher between two "
-                      f"reads; screen was:\n{describe_screen(device)}")
+                      f"reads; screen was:\n{device.form.describe_screen()}")
     row, cursor = found
     if row != cursor:
         device.send_key_repeat("DOWN" if row > cursor else "UP", abs(row - cursor))
     landed = launcher_entry_row(device)
     if landed is None or landed[1] != row:
         raise Failure(f"the launcher cursor is not on {device.search_entry!r} "
-                      f"at row {row}; screen was:\n{describe_screen(device)}")
+                      f"at row {row}; screen was:\n{device.form.describe_screen()}")
     device.send_key("ENTER")
-
-
-def open_query_form(device: Device) -> None:
-    """Open the machine's online-search query form, from wherever it lives.
-
-    Opening the form is a request to a third-party service, so it is retried
-    once. A single slow or dropped fetch is a property of that server, not
-    something this suite should report as a firmware defect.
-    """
-    for _ in range(FORM_OPEN_ATTEMPTS):
-        unwind_to_root(device, "opening the query form")
-        if device.search_in_launcher:
-            open_search_entry_in_launcher(device)
-        else:
-            open_search_entry_in_task_menu(device)
-        if wait_until(device.form_visible, FORM_OPEN_TIMEOUT):
-            return
-    raise Skip(
-        f"{device.form_title!r} did not appear within {FORM_OPEN_TIMEOUT:.0f}s on "
-        f"{FORM_OPEN_ATTEMPTS} attempts; the service is most likely unreachable "
-        f"from the device. Last screen:\n{describe_screen(device)}"
-    )
-
-
-def leave_form(device: Device) -> None:
-    """RUN/STOP unwinds one level per press until the form is gone."""
-    for _ in range(8):
-        if not device.menu_is_open() or not device.form_visible():
-            return
-        device.send_key("RUNSTOP")
-    raise Failure(f"{device.form_title!r} would not close")
 
 
 def unwind_to_root(device: Device, what: str) -> None:
@@ -485,57 +456,15 @@ def recover(device: Device, what: str) -> None:
         raise Failure(f"{what}: the browser came back empty")
 
 
-def row_of(device: Device, label: str) -> int | None:
-    # `in`, not `.startswith()`: on Telnet's one-row-shorter screen the task
-    # menu box renders a row higher than on REST, so a row can carry both the
-    # overlay's own label and, to its left, leftover text from whatever the
-    # root browser drew on that same row underneath -- the label is still on
-    # the row, just no longer at its start.
-    rows = device.rows()
-    if rows is None:
-        return None
-    for row, text in enumerate(rows):
-        if label in strip_frame(text):
-            return row
-    return None
-
-
-def _box_interior_bounds(text: str) -> tuple[int, int] | None:
-    """Column span strictly between a row's own left/right box border.
-
-    Finding the marker anywhere on the row is not enough: the box's own
-    title is drawn in the same colour as the marker (a header decoration,
-    not a selection), and so, further right, is a status column belonging
-    to whatever the root browser drew on that row before the box covered
-    most of it. Both sit outside the box's own field-label area, so scoping
-    the search to strictly between this row's two "|" border cells (the same
-    two columns select_row's caller already relies on to delimit the field
-    text itself) excludes both.
-    """
-    left = text.find("|")
-    right = text.rfind("|")
-    if left == -1 or right == -1 or left == right:
-        return None
-    return left + 1, right
-
-
-def no_cursor_reason(device: Device) -> str:
-    """Why cursor_row() answered None, which is two different faults."""
-    if device.mode == MODE_TELNET and device.backend.selected_sgr is None:
-        return ("the colour that marks a selection was never measured, so no "
-                "row can be read; see prime_selection_marker")
-    return "the menu closed while moving the cursor"
-
-
 def prime_selection_marker(device: Device) -> None:
     """Teach the Telnet backend which colour marks a selected row.
 
     TelnetBackend measures that colour the first time it is asked for a
-    selected row, and this suite never asks: for the form it reads
-    telnet_field_row instead, because the form's fields are indented past the
-    first two columns TelnetBackend scans. So the colour was never measured,
-    telnet_field_row found none, and every cursor_row() answered None as
-    though the menu had closed.
+    selected row, and this suite never asks: inside the form,
+    SearchForm.cursor_row reads the box interior instead, because the form's
+    fields are indented past the first two columns TelnetBackend scans. So the
+    colour was never measured, that reader found none, and every cursor_row()
+    answered None as though the menu had closed.
 
     The root browser is the screen the backend can measure, so it is measured
     here while that screen is still up and before a form covers it.
@@ -548,144 +477,12 @@ def prime_selection_marker(device: Device) -> None:
         pass
 
 
-def telnet_field_row(device: Device, entry_rows: Sequence[int]) -> int | None:
-    """Telnet equivalent of Backend.selected_row(), scoped to this form.
-
-    TelnetBackend.selected_row() only checks a row's first two columns for
-    the marker colour (see ui_backend.py), which assumes the selected
-    content starts at column 0 -- true for the root browser's own listing,
-    false for this form's box, which REST also draws differently positioned
-    but which happens to still leave REST's colour-plane detection intact.
-    Column 0 is unusable here (see row_of), so this scans within the row's
-    own box borders instead, and skips the title row (identified by its own
-    text, not by position) since its colour is cosmetic, not a selection.
-    """
-    rows = device.rows()
-    colours = device.backend.screen.colours
-    marker = device.backend.selected_sgr
-    if rows is None or marker is None:
-        return None
-    title_row = row_of(device, device.form_title)
-    for row in entry_rows:
-        if row == title_row:
-            continue
-        bounds = _box_interior_bounds(rows[row])
-        if bounds is None:
-            continue
-        left, right = bounds
-        # The colour is the machine's, measured by the backend from a listing
-        # rather than pinned here: an Ultimate 64 marks the cursor 0;32;1 and
-        # a C64 Ultimate 0;37;1.
-        if any(colours[row][col] == marker for col in range(left, right)):
-            return row
-    return None
-
-
-def select_row(device: Device, target: int, what: str) -> None:
-    """Put the selection on a known row.
-
-    The distance is read off the screen and covered in one batched run of
-    keys, the way Browser.select_entry moves a file listing, rather than one
-    request and one settle per row. Walking cost about a fifth of a second a
-    row, which is what made moving between form fields visibly slow.
-
-    The move is confirmed afterwards rather than assumed, because the cursor
-    lives only in the colour half of the screen and a form that wraps at its
-    ends would land somewhere else. Two batched attempts are made, so that a
-    run which only partly landed is corrected in one more request. If the
-    cursor is still not on the target row, the walk below takes over: it is
-    slower, but it reads the position back after every single step.
-    """
-    for _ in range(2):
-        current = device.cursor_row()
-        if current is None:
-            raise Failure(f"{what}: {no_cursor_reason(device)}")
-        if current == target:
-            return
-        device.send_key_repeat("DOWN" if current < target else "UP",
-                               abs(target - current))
-
-    # The jump did not land: fall back to one verified step at a time.
-    for _ in range(FIELD_WALK_LIMIT):
-        current = device.cursor_row()
-        if current is None:
-            raise Failure(f"{what}: {no_cursor_reason(device)}")
-        if current == target:
-            return
-        device.send_key("DOWN" if current < target else "UP")
-    raise Failure(f"{what}: the cursor never reached row {target}; "
-                  f"screen was:\n{device.text()}")
-
-
-def enter_field(device: Device, label: str) -> None:
-    """Put the cursor on a named field and open its editor."""
-    row = row_of(device, label)
-    if row is None:
-        raise Failure(f"the form has no {label!r} field")
-    select_row(device, row, f"selecting {label!r}")
-    device.send_key("ENTER")
-
-
-# An empty form field is drawn as a run of underscores, so what is read back
-# off the screen for one is not an empty string.
-FIELD_PLACEHOLDER_CHARS = "_ "
-
-
-def field_value(device: Device, label: str) -> str:
-    """What a form field currently shows, with its empty placeholder removed."""
-    row = row_of(device, label)
-    rows = device.rows() or []
-    if row is None or row >= len(rows):
-        return ""
-    text = strip_frame(rows[row]).split(label, 1)[-1]
-    return text.strip().strip(FIELD_PLACEHOLDER_CHARS).strip()
-
-
-def empty_field(device: Device, label: str, taps: int = 40,
-                attempts: int = 3) -> None:
-    """Leave a named form field empty, and confirm that it is.
-
-    KEY_CLEAR empties UIStringEdit's buffer whatever its length, so where the
-    transport can spell it this is one injected key instead of forty. On a
-    cartridge, where every key crosses the host's keyboard matrix, neither
-    spelling is reliable on its own: the field kept the previous check's text,
-    and the query that should have been refused as empty was sent as a real
-    search that took 46s to come back. So the field is read back and the other
-    spelling is tried, rather than a clear being assumed to have worked.
-    """
-    clear = getattr(device.backend, "clear_field_key", None)
-    for attempt in range(attempts):
-        enter_field(device, label)
-        if clear and attempt == 0:
-            device.send_key(clear)
-        else:
-            device.send_key_repeat("DEL", taps)
-        device.send_key("ENTER")
-        if not field_value(device, label):
-            return
-    raise Failure(
-        f"the {label!r} field still holds {field_value(device, label)!r} after "
-        f"{attempts} attempts to empty it"
-    )
-
-
-def submit_query(device: Device) -> None:
-    """RETURN on the Submit row at the bottom of the form runs the query."""
-    row = row_of(device, SUBMIT_LABEL)
-    if row is None:
-        raise Failure("the form has no Submit row")
-    select_row(device, row, "selecting Submit")
-    device.send_key("ENTER")
-
-
-# ---------------------------------------------------------------- happy path
-
 def scenario_open_and_leave(device: Device) -> None:
     section("the form opens from the menu and closes again")
     with check(f"open the {device.form_title}"):
-        open_query_form(device)
+        device.form.open()
     with check("the form leaves cleanly with RUN/STOP"):
-        leave_form(device)
+        device.form.leave()
         if device.form_visible():
             raise Failure("the form is still on screen")
     recover(device, "opening and leaving the form")
@@ -694,9 +491,11 @@ def scenario_open_and_leave(device: Device) -> None:
 def scenario_query_returns_results(device: Device) -> None:
     section(f"a real query is sent to {device.backend.machine.search_service}")
     with check("open the form and enter the first field"):
-        open_query_form(device)
+        device.form.open()
         before = device.screen()
-        enter_field(device, NAME_FIELD)
+        first = device.form.first_field()
+        detail(f"the query term goes in {first.label!r}, the form's first field")
+        device.form.edit(first)
         # Telnet's rendering shows no visible difference between the field
         # merely selected and its editor actually open (confirmed live: a
         # character typed right after ENTER lands correctly either way), so
@@ -707,17 +506,15 @@ def scenario_query_returns_results(device: Device) -> None:
             before is None or not wait_until(lambda: device.screen_changed(before), 8.0)
         ):
             raise Failure("the edit field did not open")
-    with check("the typed term lands in the Name field"):
-        device.type_text(SEARCH_TERM)
-        device.send_key("ENTER")
-        row = row_of(device, NAME_FIELD)
-        if row is None:
-            raise Failure("the form no longer shows a Name field")
-        shown = (device.rows() or [])[row]
+    with check("the typed term lands in the first field"):
+        device.form.type_text(SEARCH_TERM)
+        device.form.confirm()
+        shown = device.form.field(first.label).value
         if SEARCH_TERM not in shown.lower():
-            raise Failure(f"the Name field shows {shown.strip()!r}, not {SEARCH_TERM!r}")
+            raise Failure(f"the {first.label} field shows {shown!r}, "
+                          f"not {SEARCH_TERM!r}")
     with check("the service answers and the results match what was asked for"):
-        submit_query(device)
+        device.form.submit()
         if not wait_until(lambda: device.menu_is_open() and not device.form_visible(),
                           QUERY_TIMEOUT):
             raise Failure("the form never gave way to a result list")
@@ -735,49 +532,118 @@ def scenario_query_returns_results(device: Device) -> None:
     recover(device, "running a query")
 
 
+def field_term(index: int, field: search_form.Field) -> str:
+    """A distinct value to type into a discovered free-text field.
+
+    Built from the field's own name rather than from a table, so it stays
+    readable in a failure message whatever the service calls its fields, and
+    is unique per field so one field's value cannot pass for another's. Short
+    enough for the 26-character limit in AssemblySearchForm::change().
+    """
+    return f"{field.name.lower().replace(' ', '')[:8]}{index}"
+
+
 def scenario_dropdown_preserves_fields(device: Device) -> None:
     section("dropdown selections preserve the query form (#863)")
-    expected = {"Name:": "turrican", "Group:": "issue863",
-                "Handle:": "barry", "Event:": "hardware"}
+    form = device.form
+    texts: tuple[search_form.Field, ...] = ()
+    presets: tuple[search_form.Field, ...] = ()
 
-    def expect_fields() -> None:
-        for label, value in expected.items():
-            actual = field_value(device, label)
-            if actual != value:
-                raise Failure(f"{label} changed from {value!r} to {actual!r}")
+    with check("the form draws fields, and at least one of them is a dropdown"):
+        form.open()
+        drawn = form.fields()
+        detail(f"{len(drawn)} field(s) drawn: "
+               + ", ".join(field.label for field in drawn))
+        texts, presets = form.classify()
+        detail(f"{len(texts)} free text: "
+               + ", ".join(field.label for field in texts))
+        detail(f"{len(presets)} dropdown: "
+               + ", ".join(field.label for field in presets))
+        # Discovery that found nothing must fail rather than pass quietly: a
+        # scenario that silently covered no field would look the same as one
+        # that covered every field, which is exactly the state this scenario
+        # was in on a C64 Ultimate before the fields were discovered.
+        if not presets:
+            raise Failure(
+                f"none of the {len(drawn)} field(s) on the "
+                f"{device.form_title!r} took a value when it was cycled, so "
+                f"this machine's service offers no dropdown and the "
+                f"behaviour #863 is about cannot be exercised here")
+        if not texts:
+            raise Failure(
+                f"every field on the {device.form_title!r} is a dropdown, so "
+                f"there is no free-text field to prove is left alone")
 
-    with check("populate the text fields"):
-        open_query_form(device)
-        for label, value in expected.items():
-            enter_field(device, label)
-            device.type_text(value)
-            device.send_key("ENTER")
-        expect_fields()
+    with check("populate the free-text fields"):
+        expected: dict[str, str] = {}
+        for index, field in enumerate(texts):
+            form.edit(field)
+            form.type_text(field_term(index, field))
+            form.confirm()
+        expected = form.values()
+        for index, field in enumerate(texts):
+            term = field_term(index, field)
+            if expected.get(field.label) != term:
+                raise Failure(f"{field.label} holds "
+                              f"{expected.get(field.label)!r}, not {term!r}")
 
-    for label in ("Repo:", "Category:", "Subcat:"):
+    for field in presets:
+        label = field.label
+        # A field discovery found and that has since gone is a defect, not a
+        # reason to skip: SearchForm.field raises rather than returning None.
         with check(f"{label} +/- preserves existing fields"):
-            row = row_of(device, label)
-            if row is None:
-                raise Failure(f"the form has no {label!r} field")
-            select_row(device, row, f"selecting {label!r}")
-            device.type_text("+")
-            first = field_value(device, label)
-            if not first:
-                raise Failure(f"{label} has no preset after +")
-            device.type_text("+")
-            device.type_text("-")
-            expected[label] = first
-            expect_fields()
+            form.focus(field)
+            # Each step asserts the same thing: this field took a value, and
+            # no other field moved. Reading this field's own value back after
+            # every keystroke, rather than requiring the pair "+ +  -" to end
+            # where it started, keeps the check independent of how many
+            # presets the service listed for it. updown() clamps at both ends,
+            # so a two-entry list would not come back to where it started.
+            for keystroke in (form.cycle_next, form.cycle_next,
+                              form.cycle_previous):
+                keystroke()
+                value = form.field(label).value
+                if not value:
+                    raise Failure(f"{label} lost its value when it was cycled")
+                expected[label] = value
+                form.expect_unchanged(expected)
         with check(f"cancelling {label} preserves existing fields"):
-            enter_field(device, label)
-            device.send_key("RUNSTOP")
-            expect_fields()
-        with check(f"confirming {label} preserves its value and all other fields"):
-            enter_field(device, label)
-            device.send_key("DOWN")
-            device.send_key("UP")
-            device.send_key("ENTER")
-            expect_fields()
+            form.edit(field)
+            form.cancel()
+            form.expect_unchanged(expected)
+        confirm_label = f"confirming {label} preserves its value and all other fields"
+        if device.backend.machine.skip_without_fix(
+                machine.QUERY_FORM_SURVIVES_DROPDOWN_CONFIRM, confirm_label):
+            # The check is skipped rather than run and failed, so the rest of
+            # this scenario still runs on that machine: the defect empties
+            # every field, so a form left in that state would fail every
+            # later check for a reason that has nothing to do with what they
+            # assert.
+            continue
+        with check(confirm_label):
+            # The context menu opens on its own first item, not on the value
+            # the field is holding: AssemblySearchForm::change calls
+            # browser->context(0), and fetch_context_items lists the presets in
+            # the order the service gave them. So DOWN then UP is a no-op on
+            # the menu, and confirming applies the menu's first item. That
+            # preserves the field's value only when the field is already on the
+            # first preset, which is where the field is put first. The check
+            # that came before this one drove the field to an arbitrary preset,
+            # so without this step "confirming preserves its value" would be
+            # asserting the order the service listed its presets in.
+            form.focus(field)
+            form.cycle_to_first()
+            rewound = form.field(label).value
+            if not rewound:
+                raise Failure(f"{label} lost its value when it was rewound to "
+                              f"its first preset")
+            expected[label] = rewound
+            form.expect_unchanged(expected)
+            form.edit(field)
+            form.press("DOWN")
+            form.press("UP")
+            form.confirm()
+            form.expect_unchanged(expected)
     recover(device, "selecting query presets")
 
 
@@ -792,8 +658,8 @@ def scenario_menu_button_in_edit_field(device: Device) -> None:
             )
         return
     with check("open the form and enter the edit field"):
-        open_query_form(device)
-        enter_field(device, NAME_FIELD)
+        device.form.open()
+        device.form.edit(device.form.first_field())
     with check("the menu button closes the menu from inside the field"):
         press_menu_button(device)
         if not device.wait_menu(False, RECOVER_TIMEOUT):
@@ -818,10 +684,10 @@ def scenario_menu_button_in_edit_field(device: Device) -> None:
 def scenario_abort_edit(device: Device) -> None:
     section("an aborted edit must not wedge the form")
     with check("open the form, type into a field, then abort"):
-        open_query_form(device)
-        enter_field(device, NAME_FIELD)
-        device.type_text("zzz")
-        device.send_key("RUNSTOP")
+        device.form.open()
+        device.form.edit(device.form.first_field())
+        device.form.type_text("zzz")
+        device.form.cancel()
     with check("the form is still usable after the abort"):
         if not device.menu_is_open():
             raise Failure("the menu closed when the edit was aborted")
@@ -831,10 +697,10 @@ def scenario_abort_edit(device: Device) -> None:
 def scenario_overlong_and_empty(device: Device) -> None:
     section("over-long and empty input")
     with check("type more than the field accepts"):
-        open_query_form(device)
-        enter_field(device, NAME_FIELD)
-        device.type_text(OVERLONG_TEXT)
-        device.send_key("ENTER")
+        device.form.open()
+        device.form.edit(device.form.first_field())
+        device.form.type_text(OVERLONG_TEXT)
+        device.form.confirm()
     with check("an empty query is refused rather than sent"):
         if device.mode == MODE_TELNET:
             # The warning this produces is a third level of overlay nesting
@@ -851,8 +717,8 @@ def scenario_overlong_and_empty(device: Device) -> None:
             # Emptying the field is confirmed rather than assumed: a query
             # that still holds the previous check's text is a real search,
             # which takes tens of seconds to come back and reports no warning.
-            empty_field(device, NAME_FIELD)
-            submit_query(device)
+            device.form.clear(device.form.first_field())
+            device.form.submit()
             if not wait_until(lambda: EMPTY_QUERY_MESSAGE in device.text(), QUERY_TIMEOUT):
                 raise Failure(
                     f"submitting an empty query did not report "
@@ -877,11 +743,11 @@ def scenario_overlong_and_empty(device: Device) -> None:
 def scenario_key_mashing(device: Device) -> None:
     section("a user mashing keys while the form is busy")
     with check("submit a query and hammer keys while it runs"):
-        open_query_form(device)
-        enter_field(device, NAME_FIELD)
-        device.type_text(SEARCH_TERM)
-        device.send_key("ENTER")
-        submit_query(device)
+        device.form.open()
+        device.form.edit(device.form.first_field())
+        device.form.type_text(SEARCH_TERM)
+        device.form.confirm()
+        device.form.submit()
         # Deliberately not this machine's task-menu key. These presses are
         # noise a user makes while the form is busy, and the recovery
         # afterwards expects to be at most one nested object away from the
@@ -909,8 +775,8 @@ def scenario_reopen_repeatedly(device: Device) -> None:
     section("opening and abandoning the form repeatedly")
     with check("open and abandon the form three times"):
         for _ in range(3):
-            open_query_form(device)
-            leave_form(device)
+            device.form.open()
+            device.form.leave()
     with check("the menu button closes and reopens the form three times"):
         if device.mode == MODE_TELNET:
             check_skip(
@@ -918,14 +784,14 @@ def scenario_reopen_repeatedly(device: Device) -> None:
             )
         else:
             for _ in range(3):
-                open_query_form(device)
+                device.form.open()
                 press_menu_button(device)
                 if not device.wait_menu(False, RECOVER_TIMEOUT):
                     raise Failure("the menu would not close with the form open")
                 press_menu_button(device)
                 if not device.wait_menu(True, RECOVER_TIMEOUT):
                     raise Failure("the menu would not reopen after the form was left open")
-                leave_form(device)
+                device.form.leave()
     recover(device, "repeated open and abandon")
 
 
@@ -991,7 +857,7 @@ def main() -> int:
     finally:
         def leave_any_open_form() -> None:
             if device.menu_is_open():
-                leave_form(device)
+                device.form.leave()
 
         teardown_step("leave the query form", leave_any_open_form)
         backend.close()

--- a/tests/e2e/io/c64/deferred_actions_test.py
+++ b/tests/e2e/io/c64/deferred_actions_test.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+# E2E: a machine action taken from the menu runs after the UI has torn down.
+
+"""Reset and Reboot taken from the menu leave the machine at a clean prompt.
+
+Two behaviours belong to GideonZ/commodore#1 (commit c66ef028), and this
+suite covers one of them.
+
+Covered. A machine action taken from the menu is queued rather than run where
+the menu took it. `C64_Subsys::request_hide_then_action` records the action
+with `C64::defer_machine_action` and answers `MENU_HIDE`, so
+`UserInterface::run_once` calls `release_host` and `release_ownership` and
+only then `perform_deferred_machine_action`. The teardown therefore runs
+against a machine that is still frozen, and the screen the C64 comes back to
+holds the KERNAL's boot text and nothing of the menu's. Three routes reach
+that path and each is checked: "Reset C64" and "Reboot C64" from the task
+menu, and C= + R in the file browser, whose `KEY_CTRL_R` case in
+tree_browser.cc issues `MENU_C64_RESET` and returns
+`user_interface->menu_response_to_action`.
+
+Not covered, and the reason is a harness limit rather than a choice. The
+other behaviour is that the menu opens again after such an action:
+`C64::checkButton` holds its edge detector in the member `button_prev` and
+`C64::syncButtonState` resyncs it once `run_once` returns. Only two routes
+reach that detector, and this harness can drive neither. `PUT
+/v1/machine:menu_button` calls `setButtonPushed()` directly and never enters
+`checkButton`. The other is the hardware button, or the C64 keyboard
+combination that raises the same signal on a C64 Ultimate; that mapping is in
+the prebuilt bitstream (external/u64e2_*.bit) and in no C source here, and an
+injected combination does not reach it. Measured on c64u (C64 Ultimate,
+firmware 1.2RC) with the Overlay interface selected: a press of `commodore`,
+a tap of `restore` and a release of `commodore` left machine:menu_screen
+answering 404 for the whole 8s it was polled, with the same result when the
+three requests were spaced 0.5s apart and when `restore` was tapped alone,
+while `PUT /v1/machine:menu_button` in the same probe opened the menu every
+time. The same sequence does nothing on u64 either. So the three
+menu-reopening checks report SKIP with that measurement in the reason, and
+stay in the suite as the record that the behaviour needs a person.
+
+The REST routes are the third part and are machine-independent. With no menu
+open, `cmd->user_interface` is NULL, so `request_hide_then_action` takes its
+else branch: release the host, queue, and perform immediately. `PUT
+/v1/machine:reset` and `PUT /v1/machine:menu_button` must act on the machine
+straight away, and those checks run everywhere.
+
+Not covered either: starting a .crt from the menu, which the author's own
+reproduction lists. It reaches the same `request_hide_then_action` call
+(`C64_START_CART`), but it needs a cartridge image fixture on the device and
+leaves the machine running foreign code that no assertion here could then
+read a BASIC prompt from. It is left out rather than approximated.
+
+"A clean BASIC prompt" is asserted from screen RAM at $0400 rather than from
+the video stream: the KERNAL's banner and READY must be there, and no cell may
+hold a PETSCII graphic. Screen codes 0x00 to 0x3F are the letters, digits and
+punctuation a boot screen is made of; 0x40 to 0x7F are the graphics the menu
+draws its borders and its highlights with. Bit 7 is reverse video, so the test
+is on the low seven bits, which lets the cursor (a reverse space, 0xA0) pass
+and still catches a reversed menu character.
+
+Which of the two halves of that screen check can catch anything depends on
+the Interface Type the run selected, and `--mode` sets it. Under `freeze` the
+menu is drawn in C64 screen RAM, which is where a leftover would be; under
+`overlay` it is drawn on its own plane and the menu never writes screen RAM
+at all, so only the "the machine came back to BASIC" half is load bearing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+# The one stanza that puts the shared library on sys.path; see tests/lib/bootstrap.py.
+sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
+                            if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
+import bootstrap  # noqa: E402,F401
+
+import cli  # noqa: E402
+import pacing  # noqa: E402
+from api import SCREEN_RAM, UltimateApi  # noqa: E402
+from report import (Failure, check, check_skip, check_start, detail,  # noqa: E402
+                    format_exception, section, suite_fail, suite_ok,
+                    teardown_step)
+from ui_backend import MODE_FREEZE, add_mode_argument, make_browser  # noqa: E402
+
+SUITE = "deferred_actions_test"
+
+# The whole 40x25 text screen. A leftover from the menu can be anywhere on it,
+# so the check reads all of it rather than the first few lines the KERNAL
+# writes.
+SCREEN_COLUMNS = 40
+SCREEN_ROWS = 25
+SCREEN_BYTES = SCREEN_COLUMNS * SCREEN_ROWS
+SPACE_CODE = 0x20
+
+# The first screen code of the PETSCII graphics. Everything below it is a
+# letter, a digit or punctuation; everything from it up to 0x7F is a shape the
+# KERNAL's boot screen never prints and the menu draws with.
+FIRST_GRAPHIC_CODE = 0x40
+
+# Screen codes for the two strings the KERNAL's boot screen always carries.
+# Written out as codes rather than as text because screen codes are not ASCII:
+# 'A' is 0x01 on the screen and 0x41 in a Python string.
+BANNER = bytes([0x02, 0x01, 0x13, 0x09, 0x03])          # "BASIC"
+READY = bytes([0x12, 0x05, 0x01, 0x04, 0x19, 0x2E])     # "READY."
+
+# The two task-menu entries this suite invokes. The category they sit under is
+# the machine's (Machine.machine_task_category); the labels are not.
+RESET_ACTION = "Reset C64"
+REBOOT_ACTION = "Reboot C64"
+
+# A reset reaches READY in well under a second on the machines here; a reboot
+# restarts the cartridge first and is slower. Both are generous enough that a
+# failure means the prompt did not arrive, not that the budget was tight.
+RESET_TIMEOUT = 15.0
+REBOOT_TIMEOUT = 40.0
+# How long the menu is given to appear after the route that opens it. The
+# firmware polls the button in its main loop, so this is not instant.
+MENU_TIMEOUT = 8.0
+MENU_CLOSE_TIMEOUT = 8.0
+# How many menu buttons a step that only needs the menu up may send. See
+# open_menu, and the check that measures the single press.
+MENU_OPEN_PRESSES = 3
+
+# The browser row layout, the same as every other suite that drives the menu.
+ENTRY_ROWS = range(2, 24)
+STATUS_ROW = 24
+TELNET_ENTRY_ROWS = range(2, 23)
+TELNET_STATUS_ROW = 23
+
+
+# ------------------------------------------------------------------ screen --
+
+def read_screen(api: UltimateApi) -> bytes:
+    return api.machine.readmem(SCREEN_RAM, SCREEN_BYTES)
+
+
+def blank_screen(api: UltimateApi) -> None:
+    """Fill screen RAM with spaces, so what is read back is this boot's.
+
+    Without it the previous boot's READY is still on the screen and a wait for
+    the prompt returns at once, proving nothing. The menu's own characters
+    would still be there too, which is exactly what the leftover check is
+    looking for.
+    """
+    api.machine.writemem(SCREEN_RAM, bytes([SPACE_CODE]) * SCREEN_BYTES)
+
+
+def wait_for_prompt(api: UltimateApi, timeout: float) -> bytes:
+    """Poll screen RAM until READY appears, and answer the whole screen."""
+    deadline = time.monotonic() + timeout
+    while True:
+        screen = read_screen(api)
+        if READY in screen:
+            return screen
+        if time.monotonic() >= deadline:
+            raise Failure(
+                f"BASIC did not print its READY prompt within {timeout:.0f}s; "
+                f"the screen held:\n{describe(screen)}")
+        time.sleep(pacing.POLL_INTERVAL_SECONDS)
+
+
+def describe(screen: bytes) -> str:
+    """The screen as rows of screen codes, for a message someone has to read."""
+    rows = []
+    for row in range(SCREEN_ROWS):
+        codes = screen[row * SCREEN_COLUMNS:(row + 1) * SCREEN_COLUMNS]
+        text = "".join(_readable(code) for code in codes)
+        if text.strip():
+            rows.append(f"    {row:02d}|{text}|")
+    return "\n".join(rows) or "    (the screen is blank)"
+
+
+def _readable(code: int) -> str:
+    """One screen code as a character, with the graphics marked rather than named."""
+    plain = code & 0x7F
+    if 0x01 <= plain <= 0x1A:
+        return chr(ord("A") + plain - 1)
+    if 0x20 <= plain < FIRST_GRAPHIC_CODE:
+        return chr(plain)
+    if plain == 0x00:
+        return "@"
+    return "#"
+
+
+def graphic_cells(screen: bytes) -> list[tuple[int, int, int]]:
+    """(row, column, code) for every cell holding a PETSCII graphic."""
+    found = []
+    for index, code in enumerate(screen):
+        if (code & 0x7F) >= FIRST_GRAPHIC_CODE:
+            found.append((index // SCREEN_COLUMNS, index % SCREEN_COLUMNS, code))
+    return found
+
+
+def expect_clean_prompt(screen: bytes, what: str) -> None:
+    """The screen is the KERNAL's boot screen and nothing else."""
+    if BANNER not in screen:
+        raise Failure(f"{what}: the KERNAL's banner is not on the screen, so "
+                      f"the machine did not come back to BASIC. It held:\n"
+                      f"{describe(screen)}")
+    leftovers = graphic_cells(screen)
+    if leftovers:
+        where = ", ".join(f"row {row} column {column} code 0x{code:02X}"
+                          for row, column, code in leftovers[:8])
+        more = "" if len(leftovers) <= 8 else f", and {len(leftovers) - 8} more"
+        raise Failure(
+            f"{what}: {len(leftovers)} cell(s) hold a PETSCII graphic the "
+            f"KERNAL's boot screen never prints, so the menu's characters were "
+            f"left in screen RAM: {where}{more}. The screen held:\n"
+            f"{describe(screen)}")
+
+
+# ------------------------------------------------------------------- menu --
+
+def open_menu(api: UltimateApi, presses: int = MENU_OPEN_PRESSES) -> str:
+    """Open the on-device menu for a step that needs it open, and name the route.
+
+    Always the REST menu button: it is the only route this harness has. See
+    the module docstring for the measurement that rules out an injected
+    C= + RESTORE, and for what that costs in coverage.
+
+    More than one press is allowed here because a menu button issued straight
+    after a close is dropped on some firmware, which
+    scenario_rest_routes asserts directly and which c64u fails. This is the
+    setup for a different assertion, so it retries rather than carrying that
+    defect into every check that has to get the menu up first.
+    """
+    for attempt in range(presses):
+        api.machine.menu_button()
+        if wait_menu(api, True, MENU_TIMEOUT):
+            if attempt:
+                detail(f"the menu button had to be sent {attempt + 1} times")
+            return "PUT /v1/machine:menu_button"
+    return "PUT /v1/machine:menu_button"
+
+
+def wait_menu(api: UltimateApi, want_open: bool, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        if api.machine.menu_open() == want_open:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(pacing.POLL_INTERVAL_SECONDS)
+
+
+def close_menu(api: UltimateApi) -> None:
+    """Leave no menu open behind a check, whatever the check did."""
+    if api.machine.menu_open():
+        api.machine.menu_button()
+        wait_menu(api, False, MENU_CLOSE_TIMEOUT)
+
+
+# -------------------------------------------------------------- scenarios --
+
+def scenario_rest_routes(api: UltimateApi) -> None:
+    """The NULL-UI branch, which every machine takes and which must be unchanged."""
+    section("the REST routes still act immediately with no menu open")
+
+    with check("machine:reset with no menu open reaches a clean BASIC prompt"):
+        close_menu(api)
+        blank_screen(api)
+        api.machine.reset(force=True, wait=False)
+        screen = wait_for_prompt(api, RESET_TIMEOUT)
+        expect_clean_prompt(screen, "after PUT /v1/machine:reset")
+
+    with check("machine:menu_button with no menu open opens the menu"):
+        if api.machine.menu_open():
+            raise Failure("a menu was already open, so this proves nothing")
+        api.machine.menu_button()
+        if not wait_menu(api, True, MENU_TIMEOUT):
+            raise Failure(
+                f"the menu did not open within {MENU_TIMEOUT:.0f}s of "
+                f"PUT /v1/machine:menu_button")
+
+    with check("the same call closes it again"):
+        api.machine.menu_button()
+        if not wait_menu(api, False, MENU_CLOSE_TIMEOUT):
+            raise Failure(
+                f"the menu did not close within {MENU_CLOSE_TIMEOUT:.0f}s of "
+                f"a second PUT /v1/machine:menu_button")
+
+
+
+# How long the browser listing is given to stop changing, and how often it is
+# read while waiting. See settle_listing.
+LISTING_SETTLE_READS = 12
+LISTING_SETTLE_INTERVAL = 0.15
+
+
+def settle_listing(browser) -> None:
+    """Wait for the browser listing to stop changing before an overlay is opened.
+
+    Browser.overlay_items reads an overlay by diffing the screen against the
+    one captured before the key that opened it, so a row that changed for its
+    own reasons in between is taken for part of the overlay and the parse
+    comes back empty. A C64 Ultimate refreshes the drive status in its listing
+    without being asked, which is exactly such a row.
+
+    Measured on c64u (C64 Ultimate, firmware 1.2RC), overlay mode: opening the
+    task menu straight after go_to_root() parsed its categories in 3 of 5
+    attempts, and reading until two consecutive screens matched first parsed
+    them in 5 of 5. Browser.open_task_menu already presses the key twice
+    before giving up, and the second press closes a menu the first one opened,
+    so the retry cannot rescue this on its own.
+    """
+    last = browser.rows()
+    for _ in range(LISTING_SETTLE_READS):
+        time.sleep(LISTING_SETTLE_INTERVAL)
+        current = browser.rows()
+        if current == last:
+            return
+        last = current
+
+
+def scenario_menu_button_reopen(api: UltimateApi) -> None:
+    """One menu button, sent with nothing between it and the close before it.
+
+    Last in the suite deliberately. This measures a defect that a machine can
+    have on its own, and a failure here would otherwise stop the run before
+    the deferral checks, which are what the suite is mainly for.
+    """
+    section("a single menu button straight after a close")
+    with check("one menu button reopens the menu straight after a close"):
+        # The menu has to be up first, and getting it there is setup, so it
+        # may take more than one press.
+        open_menu(api)
+        if not api.machine.menu_open():
+            raise Failure("the menu would not open, so the reopen cannot be "
+                          "measured")
+        # From here the sequence is the one under test and nothing is added to
+        # it: close, wait only until the close is visible, then one press.
+        # Measured on c64u (C64 Ultimate, firmware 1.2RC), freeze mode: that
+        # press was dropped in 1 trial of 6 with no gap after the close, and
+        # opened the menu in 6 trials of 6 once a 0.25s gap was left.
+        api.machine.menu_button()
+        if not wait_menu(api, False, MENU_CLOSE_TIMEOUT):
+            raise Failure("the menu would not close, so the reopen cannot be "
+                          "measured")
+        api.machine.menu_button()
+        if not wait_menu(api, True, MENU_TIMEOUT):
+            raise Failure(
+                f"one PUT /v1/machine:menu_button sent straight after the "
+                f"close did not open the menu within {MENU_TIMEOUT:.0f}s, so "
+                f"the press was dropped")
+        close_menu(api)
+
+
+def take_menu_action(browser, category: str, item: str) -> None:
+    """Take a task-menu action whose whole effect is to close the menu.
+
+    Browser.invoke_task_action settles by re-reading the menu screen, and
+    machine:menu_screen answers 404 once the action has hidden the menu, so
+    the last keystroke raises "menu screen unavailable after ENTER". Here that
+    is the intended outcome, not a fault.
+
+    Swallowing it cannot hide a menu that was never driven. The caller blanks
+    screen RAM first and then waits for the BASIC prompt: had the category or
+    the item not been reached, nothing would have reset the machine and the
+    blanked screen would still be blank when the wait timed out.
+    """
+    settle_listing(browser)
+    try:
+        browser.invoke_task_action(category, item)
+    except Failure as exc:
+        if not str(exc).startswith("menu screen unavailable after"):
+            raise
+
+
+def run_menu_action(browser, api: UltimateApi, action: str,
+                    timeout: float) -> tuple[bytes, str]:
+    """Open the menu, take `action` from the task menu, and read the screen back."""
+    # C= + RESTORE toggles, so opening it while it is already open would close
+    # it instead. Nothing here should leave a menu behind, and this is the
+    # cheap guarantee that it did not.
+    close_menu(api)
+    route = open_menu(api)
+    if not api.machine.menu_open():
+        raise Failure(f"the menu did not open after {MENU_OPEN_PRESSES} x "
+                      f"{route}")
+    browser.go_to_root()
+    blank_screen(api)
+    take_menu_action(browser, browser.backend.machine.machine_task_category,
+                     action)
+    return wait_for_prompt(api, timeout), route
+
+
+def report_unreachable_reopen(label: str) -> None:
+    """Record that the menu-reopening behaviour needs a person, and why.
+
+    Reported as a skipped check rather than left out, so every run says the
+    behaviour was not measured and names what stops it. Passing it on the one
+    route the harness has would be worse than not running it: PUT
+    /v1/machine:menu_button never enters C64::checkButton, so it would answer
+    the same whatever the edge detector held.
+    """
+    check_start(label)
+    check_skip(
+        "the harness has no route to C64::checkButton's edge detector: PUT "
+        "/v1/machine:menu_button calls setButtonPushed() directly, and an "
+        "injected C= + RESTORE does not open the menu on a C64 Ultimate "
+        "(measured on c64u 1.2RC; see the module docstring), so this needs a "
+        "person at the machine")
+
+
+def scenario_menu_actions(browser, api: UltimateApi) -> None:
+    section("a machine action taken from the menu (GideonZ/commodore#1)")
+    for action, timeout in ((RESET_ACTION, RESET_TIMEOUT),
+                            (REBOOT_ACTION, REBOOT_TIMEOUT)):
+        # Not tagged with a firmware fix. Measured on u64 (Ultimate 64
+        # Elite, firmware 3.15, whose firmware carries none of c66ef028):
+        # both of these pass there, so a vintage gate would report SKIP for
+        # behaviour the machine satisfies and would leave the invariant
+        # unguarded on the machine that holds it.
+        with check(f"{action!r} from the menu reaches a clean BASIC prompt"):
+            screen, route = run_menu_action(browser, api, action, timeout)
+            detail(f"the menu was opened with {route}")
+            expect_clean_prompt(screen, f"after {action!r} from the menu")
+        report_unreachable_reopen(f"the menu opens again after {action!r}")
+
+
+def scenario_browser_reset_shortcut(browser, api: UltimateApi) -> None:
+    section("C= + R in the file browser takes the same deferred path")
+    with check("C= + R in the browser reaches a clean BASIC prompt"):
+        # tree_browser.cc's KEY_CTRL_R case issues MENU_C64_RESET and then
+        # returns user_interface->menu_response_to_action, which
+        # request_hide_then_action sets to MENU_HIDE, so the browser leaves
+        # before the reset runs.
+        close_menu(api)
+        route = open_menu(api)
+        if not api.machine.menu_open():
+            raise Failure(f"the menu did not open after {MENU_OPEN_PRESSES} x "
+                          f"{route}")
+        browser.go_to_root()
+        blank_screen(api)
+        # C= + R resets the machine, which closes the menu, so the settle read
+        # after the keystroke answers 404; see take_menu_action.
+        try:
+            browser.press("CBM_R")
+        except Failure as exc:
+            if not str(exc).startswith("menu screen unavailable after"):
+                raise
+        screen = wait_for_prompt(api, RESET_TIMEOUT)
+        expect_clean_prompt(screen, "after C= + R in the browser")
+    report_unreachable_reopen("the menu opens again after C= + R")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    cli.add_device_arguments(parser, timeout=10.0)
+    parser.add_argument("--telnet-port", type=int,
+                        default=int(os.environ.get("U64_TELNET_PORT", "23")))
+    add_mode_argument(parser)
+    args = parser.parse_args()
+
+    api = UltimateApi(args.host, args.password or None, args.timeout)
+    browser = make_browser(
+        args.mode, args.host, args.password or None, args.timeout,
+        entry_rows=ENTRY_ROWS, status_row=STATUS_ROW,
+        telnet_port=args.telnet_port,
+        telnet_entry_rows=TELNET_ENTRY_ROWS, telnet_status_row=TELNET_STATUS_ROW,
+    )
+    detail(f"{browser.backend.machine.described}, menu opened with PUT "
+           f"/v1/machine:menu_button")
+    if args.mode == MODE_FREEZE:
+        detail("the freeze interface draws the menu in C64 screen RAM, so a "
+               "leftover from it would be visible to the screen check")
+    else:
+        detail(f"the {args.mode} interface draws the menu on its own plane, "
+               f"so the screen check can only show that the machine came "
+               f"back to BASIC, not that no menu characters were left")
+    try:
+        scenario_rest_routes(api)
+        scenario_menu_actions(browser, api)
+        scenario_browser_reset_shortcut(browser, api)
+        scenario_menu_button_reopen(api)
+        suite_ok(SUITE)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        suite_fail(SUITE, format_exception(exc))
+        return 1
+    finally:
+        teardown_step("close any menu this suite left open",
+                      lambda: close_menu(api))
+        teardown_step("close the browser session", browser.close)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/lib/search_form.py
+++ b/tests/e2e/lib/search_form.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+# Driving the on-device online-search query form, over whichever backend.
+
+"""Driving the on-device online-search query form, over whichever backend.
+
+Opening the form, discovering the fields it draws, classifying them, editing
+them and submitting, written against `Backend` so the same steps work over
+REST and over Telnet. The same idea as `browser.py`, for the one screen that
+is not the file browser.
+
+What the form contains is not knowledge this module holds. The firmware draws
+four fixed text fields and then one field per preset the remote service
+answered with (`BrowsableAssemblyRoot::getSubItems` in
+software/userinterface/assembly_search.h appends one `BrowsableQueryField` per
+`{type, values}` entry), so the field set follows the service, not the machine
+and not the firmware. Measured with this module on 2026-09-07: Assembly 64
+draws thirteen fields, and CommoServe draws fewer and not the same ones. Code
+that named those labels would be asserting one service's current catalogue, so
+on a machine whose service answers with a different set it fails on a missing
+label instead of measuring the behaviour it is there for.
+
+So the fields are read off the screen, and whether one is a dropdown is
+settled by driving it rather than by a table: a preset field takes a value
+when it is cycled and a free-text field does not. Which service a machine
+searches, what the form is called and where the menu keeps it are properties
+of the machine and stay in tests/lib/machine.py.
+
+The two literals here are the firmware's own, not a service's. The submit row
+is written by `BrowsableQueryField::getDisplayString` as "<<  Submit  >>" for
+the field whose name is "$", and an empty field is drawn as a run of
+underscores by the same function. Both are the same on every machine and for
+every service.
+"""
+
+import re
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+# The one stanza that puts the shared library on sys.path; see tests/lib/bootstrap.py.
+sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
+                            if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
+import bootstrap  # noqa: E402,F401
+
+from backend import Backend, Snapshot, strip_frame  # noqa: E402
+from menu import wait_until  # noqa: E402
+from report import Failure  # noqa: E402
+
+# The submit row, as BrowsableQueryField::getDisplayString writes it for the
+# "$" field. Firmware text, identical on every machine and for every service.
+SUBMIT_MARKER = "<<"
+# An empty field is drawn as a run of underscores by the same function, so
+# what is read back for one is not an empty string.
+PLACEHOLDER_CHARS = "_ "
+
+# A field row is "Label:" written at the first column inside the form's box,
+# with the value ten columns further in. getDisplayString caps the name at
+# eight characters plus the colon and capitalises its first letter, so the
+# label is short and starts with a letter.
+#
+# Anchored on the box border rather than on the row start, and stopping at the
+# next border. On REST the form is an overlay drawn over the root listing, so
+# a row can carry the listing's text to the left of the box and its own status
+# column to the right; on a C64 Ultimate the listing underneath is itself
+# inside a framed window, so a row can hold two borders a side. Matching from
+# a "|" and reading up to the next one takes the box's own text in both cases.
+# The row start is accepted as well, for a Telnet session that renders the box
+# flush against the left edge.
+# Up to two spaces are allowed between the border and the label, because
+# where the box's content starts is the window's business and not every
+# machine's window draws it flush.
+FIELD_RE = re.compile(r"(?:^|\| {0,2})([A-Za-z][A-Za-z0-9 ]{0,8}):([^|]*)")
+
+# More than any form has selectable rows, so a walk always terminates.
+FIELD_WALK_LIMIT = 30
+# The form is fetched from the remote service, so it is far slower than a redraw.
+OPEN_TIMEOUT = 25.0
+# One retry, so a single slow fetch from a third-party server is not a failure.
+OPEN_ATTEMPTS = 2
+# More "-" presses than any preset list is long. updown() clamps at zero, so
+# the extra presses are no-ops and the field lands on the first entry.
+PRESET_REWIND = 40
+
+
+class Unreachable(RuntimeError):
+    """The form never appeared, so the service is most likely unreachable.
+
+    A suite reports this as a skip rather than a failure: whether a
+    third-party server answers is not what an E2E run of this firmware is
+    measuring.
+    """
+
+
+@dataclass(frozen=True)
+class Field:
+    """One query field, as the form drew it.
+
+    `label` carries the colon, because that is what the row shows and what
+    tells a field row from prose. `row` is where it was on the screen the
+    discovery read, and is re-read rather than remembered whenever the form
+    is driven: an overlay redraw can move the box.
+    """
+
+    label: str
+    row: int
+    value: str
+
+    @property
+    def name(self) -> str:
+        """The label without its colon, for a message."""
+        return self.label.rstrip(":")
+
+
+def label_row(rows: Sequence[str], label: str) -> int | None:
+    """The screen row `label` is drawn on, or None.
+
+    `in`, not `.startswith()`: on Telnet's one-row-shorter screen an overlay
+    box renders a row higher than on REST, so a row can carry both the box's
+    own label and, to its left, leftover text from whatever the root browser
+    drew on that same row underneath. The label is still on the row, just no
+    longer at its start.
+
+    Here rather than in backend.py because the form is its main reader; a
+    suite that has to find an entry on some other overlay uses it too rather
+    than writing a third copy.
+    """
+    for row, text in enumerate(rows):
+        if label in strip_frame(text):
+            return row
+    return None
+
+
+class SearchForm:
+    """The online-search query form, built on a Backend.
+
+    `reach` is supplied by the caller and is the only machine-specific step:
+    it navigates from wherever the UI is to having opened the form's menu
+    entry. Where that entry lives differs per machine
+    (`Machine.search_in_launcher`), and that is navigation, which is the
+    machine's business rather than the form's.
+    """
+
+    def __init__(self, backend: Backend, mode: str, entry_rows: Sequence[int],
+                 title: str, reach: Callable[[], None],
+                 telnet_mode: str = "telnet") -> None:
+        self.backend = backend
+        self.mode = mode
+        self.entry_rows = entry_rows
+        self.title = title
+        self.reach = reach
+        self.telnet_mode = telnet_mode
+        self._presets: tuple[Field, ...] | None = None
+        self._texts: tuple[Field, ...] | None = None
+
+    # ------------------------------------------------------------ screen --
+    def capture(self) -> Snapshot | None:
+        """The current screen, or None when the menu is closed."""
+        try:
+            return self.backend.capture()
+        except Failure as exc:
+            if str(exc).startswith("menu screen unavailable after"):
+                return None
+            raise
+
+    def rows(self) -> list[str] | None:
+        snapshot = self.capture()
+        return None if snapshot is None else snapshot.lines
+
+    def text(self) -> str:
+        snapshot = self.capture()
+        return "" if snapshot is None else snapshot.text()
+
+    def visible(self) -> bool:
+        return self.title in self.text()
+
+    def describe_screen(self) -> str:
+        """The non-blank rows, for a failure message that can be acted on."""
+        rows = self.rows()
+        if rows is None:
+            return "    (menu screen unavailable)"
+        lines = [f"    {n:02d}|{text}|" for n, text in enumerate(rows) if text.strip()]
+        return "\n".join(lines) or "    (screen is blank)"
+
+    # ------------------------------------------------------------- input --
+    def press(self, key: str) -> None:
+        # RUN/STOP legitimately closes the menu when it pops the last level off
+        # the object stack. Backend.send_key settles by re-capturing the screen,
+        # which raises "menu screen unavailable" in that case; the caller reads
+        # the screen back afterwards either way, so that outcome is not a
+        # failure here.
+        try:
+            self.backend.send_key(key)
+        except Failure as exc:
+            if not str(exc).startswith("menu screen unavailable after"):
+                raise
+
+    def press_many(self, key: str, count: int) -> None:
+        if count <= 0:
+            return
+        try:
+            self.backend.send_key_repeat(key, count)
+        except Failure as exc:
+            if not str(exc).startswith("menu screen unavailable after"):
+                raise
+
+    def type_text(self, text: str) -> None:
+        self.backend.send_text(text, f"type {text}")
+
+    # -------------------------------------------------------- opening it --
+    def open(self, attempts: int = OPEN_ATTEMPTS,
+             timeout: float = OPEN_TIMEOUT) -> None:
+        """Reach the form and wait for its title.
+
+        Opening it is a request to a third-party service, so it is retried
+        once. A single slow or dropped fetch is a property of that server, not
+        something a suite should report as a firmware defect.
+        """
+        for _ in range(attempts):
+            self.reach()
+            if wait_until(self.visible, timeout):
+                # A reopened form is a new AssemblySearchForm, with every
+                # preset at -1 and every text field empty, so what classify()
+                # learnt describes values this one does not hold.
+                self.forget_classification()
+                return
+        raise Unreachable(
+            f"{self.title!r} did not appear within {timeout:.0f}s on "
+            f"{attempts} attempts; the service is most likely unreachable "
+            f"from the device. Last screen:\n{self.describe_screen()}")
+
+    def leave(self, presses: int = 8) -> None:
+        """RUN/STOP unwinds one level per press until the form is gone."""
+        for _ in range(presses):
+            if self.capture() is None or not self.visible():
+                return
+            self.press("RUNSTOP")
+        raise Failure(f"{self.title!r} would not close")
+
+    # ---------------------------------------------------------- the rows --
+    def fields(self) -> list[Field]:
+        """Every field the form currently draws, in the order it draws them.
+
+        Read off the screen, so it is whatever this service answered with.
+        Only the rows strictly between the title and the submit row are
+        considered: below the box is the listing the form is drawn over, and
+        a status row there ("/  -F3=HELP-") is prose, not a field.
+        """
+        rows = self.rows()
+        if rows is None:
+            raise Failure("the menu closed while reading the form")
+        first = label_row(rows, self.title)
+        last = label_row(rows, SUBMIT_MARKER)
+        if first is None or last is None or last <= first:
+            raise Failure(
+                f"{self.title!r} is not on screen as a form: title row "
+                f"{first!r}, submit row {last!r}. Screen was:\n"
+                f"{self.describe_screen()}")
+        found: list[Field] = []
+        for row in range(first + 1, last):
+            field = self._field_of(row, rows[row])
+            if field is not None:
+                found.append(field)
+        if not found:
+            raise Failure(
+                f"{self.title!r} drew no query field between its title and its "
+                f"submit row. Screen was:\n{self.describe_screen()}")
+        return found
+
+    def _field_of(self, row: int, text: str) -> Field | None:
+        """The field on one row, or None when the row carries no field."""
+        match = FIELD_RE.search(text)
+        if match is None:
+            return None
+        return Field(label=f"{match.group(1)}:", row=row,
+                     value=_clean_value(match.group(2)))
+
+    def first_field(self) -> Field:
+        """The first field the form draws, which is where a query term goes.
+
+        Both services put a free-text field first, which `classify()` in
+        scenario_dropdown_preserves_fields reports for whichever machine the
+        run is aimed at; a service that put a dropdown first would show up
+        there as the first field appearing in the dropdown list.
+        """
+        return self.fields()[0]
+
+    def field(self, label: str) -> Field:
+        """The named field as it is drawn now, re-read rather than remembered."""
+        for field in self.fields():
+            if field.label == label:
+                return field
+        raise Failure(
+            f"the form has no {label!r} field, though discovery found it "
+            f"before. Screen was:\n{self.describe_screen()}")
+
+    def values(self) -> dict[str, str]:
+        """What every field shows now, by label."""
+        return {field.label: field.value for field in self.fields()}
+
+    def expect_unchanged(self, expected: dict[str, str]) -> None:
+        """Every field still shows what `expected` says, and none has gone."""
+        current = self.values()
+        for label, value in expected.items():
+            if label not in current:
+                raise Failure(f"the {label!r} field left the form")
+            if current[label] != value:
+                raise Failure(
+                    f"{label} changed from {value!r} to {current[label]!r}")
+
+    # ------------------------------------------------------ driving them --
+    def cursor_row(self) -> int | None:
+        """The row the selection sits on, or None when it cannot be read."""
+        if self.mode == self.telnet_mode:
+            return self._telnet_field_row()
+        try:
+            return self.backend.selected_row(self.entry_rows)
+        except Failure:
+            return None
+
+    def no_cursor_reason(self) -> str:
+        """Why cursor_row() answered None, which is two different faults."""
+        if self.mode == self.telnet_mode and self.backend.selected_sgr is None:
+            return ("the colour that marks a selection was never measured, so "
+                    "no row can be read; see prime_selection_marker")
+        return "the menu closed while moving the cursor"
+
+    def focus(self, field: Field, what: str | None = None) -> Field:
+        """Put the selection on a field, and answer where it actually is.
+
+        The row is re-read first, because an overlay redraw can move the box
+        between the discovery that produced `field` and this call.
+        """
+        what = what or f"selecting {field.label!r}"
+        target = self.field(field.label)
+        self._select_row(target.row, what)
+        return target
+
+    def edit(self, field: Field) -> Field:
+        """Focus a field and press RETURN, which opens its editor or dropdown."""
+        target = self.focus(field)
+        self.press("ENTER")
+        return target
+
+    def cycle_next(self) -> None:
+        """"+" moves a preset field to its next value and does nothing else.
+
+        AssemblySearch::handle_key sends "+" to increase() at the form level,
+        which BrowsableQueryField::updown ignores unless the field's target is
+        a list. It is not a character the string editor can receive, so it
+        cannot land in a free-text field as text.
+        """
+        self.type_text("+")
+
+    def cycle_previous(self) -> None:
+        self.type_text("-")
+
+    def cycle_to_first(self) -> None:
+        """Put a preset field on the first value its service listed.
+
+        BrowsableQueryField::updown clamps at zero, so pressing "-" more times
+        than the list is long lands on the first entry whatever the field was
+        holding and whatever the list contains. One request, because
+        send_text batches.
+        """
+        self.type_text("-" * PRESET_REWIND)
+
+    def cancel(self) -> None:
+        self.press("RUNSTOP")
+
+    def confirm(self) -> None:
+        self.press("ENTER")
+
+    def clear(self, field: Field, taps: int = 40, attempts: int = 3) -> None:
+        """Leave a field empty, and confirm that it is.
+
+        KEY_CLEAR empties UIStringEdit's buffer whatever its length, so where
+        the transport can spell it this is one injected key instead of forty.
+        On a cartridge, where every key crosses the host's keyboard matrix,
+        neither spelling is reliable on its own: the field kept the previous
+        check's text, and the query that should have been refused as empty was
+        sent as a real search that took 46s to come back. So the field is read
+        back and the other spelling is tried, rather than a clear being assumed
+        to have worked.
+        """
+        clear_key = getattr(self.backend, "clear_field_key", None)
+        for attempt in range(attempts):
+            self.edit(field)
+            if clear_key and attempt == 0:
+                self.press(clear_key)
+            else:
+                self.press_many("DEL", taps)
+            self.press("ENTER")
+            if not self.field(field.label).value:
+                return
+        raise Failure(
+            f"the {field.label!r} field still holds "
+            f"{self.field(field.label).value!r} after {attempts} attempts to "
+            f"empty it")
+
+    def submit(self) -> None:
+        """RETURN on the submit row at the bottom of the form runs the query."""
+        rows = self.rows()
+        if rows is None:
+            raise Failure("the menu closed before the query could be submitted")
+        row = label_row(rows, SUBMIT_MARKER)
+        if row is None:
+            raise Failure("the form has no submit row")
+        self._select_row(row, "selecting submit")
+        self.press("ENTER")
+
+    # ------------------------------------------------------ classifying --
+    def classify(self) -> tuple[tuple[Field, ...], tuple[Field, ...]]:
+        """(free-text fields, preset fields), settled by driving each one.
+
+        A preset field takes a value when it is cycled and a free-text field
+        does not, which is the only difference visible from outside: both are
+        drawn as a label and a run of underscores. The answer is computed once
+        and kept, because the probe writes into every preset field it finds
+        and because repeating it would cost a round of device calls per field
+        each time a caller asked.
+
+        The probe leaves each preset field holding its first value. A caller
+        that needs a known starting point takes `values()` afterwards rather
+        than before.
+        """
+        if self._texts is not None and self._presets is not None:
+            return self._texts, self._presets
+        texts: list[Field] = []
+        presets: list[Field] = []
+        for field in self.fields():
+            # `field.value` is what the same read that found the row saw, so
+            # no second read is needed for the "before" half. One read after
+            # the keystroke is what the classification costs per field.
+            self.focus(field, f"classifying {field.label!r}")
+            self.cycle_next()
+            after = self.field(field.label)
+            if after.value and after.value != field.value:
+                presets.append(after)
+            else:
+                texts.append(after)
+        self._texts, self._presets = tuple(texts), tuple(presets)
+        return self._texts, self._presets
+
+    def forget_classification(self) -> None:
+        """Drop what classify() learnt, for a caller that reopened the form."""
+        self._texts = self._presets = None
+
+    # ------------------------------------------------------------ cursor --
+    def _select_row(self, target: int, what: str) -> None:
+        """Put the selection on a known row.
+
+        The distance is read off the screen and covered in one batched run of
+        keys, the way Browser.select_entry moves a file listing, rather than
+        one request and one settle per row. Walking cost about a fifth of a
+        second a row, which is what made moving between form fields visibly
+        slow.
+
+        The move is confirmed afterwards rather than assumed, because the
+        cursor lives only in the colour half of the screen and a form that
+        wraps at its ends would land somewhere else. Two batched attempts are
+        made, so that a run which only partly landed is corrected in one more
+        request. If the cursor is still not on the target row, the walk below
+        takes over: it is slower, but it reads the position back after every
+        single step.
+        """
+        for _ in range(2):
+            current = self.cursor_row()
+            if current is None:
+                raise Failure(f"{what}: {self.no_cursor_reason()}")
+            if current == target:
+                return
+            self.press_many("DOWN" if current < target else "UP",
+                            abs(target - current))
+
+        for _ in range(FIELD_WALK_LIMIT):
+            current = self.cursor_row()
+            if current is None:
+                raise Failure(f"{what}: {self.no_cursor_reason()}")
+            if current == target:
+                return
+            self.press("DOWN" if current < target else "UP")
+        raise Failure(f"{what}: the cursor never reached row {target}; "
+                      f"screen was:\n{self.text()}")
+
+    def _telnet_field_row(self) -> int | None:
+        """Telnet equivalent of Backend.selected_row(), scoped to this form.
+
+        TelnetBackend.selected_row() only checks a row's first two columns for
+        the marker colour (see ui_backend.py), which assumes the selected
+        content starts at column 0 -- true for the root browser's own listing,
+        false for this form's box, which REST also draws differently
+        positioned but which happens to still leave REST's colour-plane
+        detection intact. Column 0 is unusable here (see label_row), so this
+        scans within the row's own box borders instead, and skips the title
+        row (identified by its own text, not by position) since its colour is
+        cosmetic, not a selection.
+        """
+        rows = self.rows()
+        colours = self.backend.screen.colours
+        marker = self.backend.selected_sgr
+        if rows is None or marker is None:
+            return None
+        title_row = label_row(rows, self.title)
+        for row in self.entry_rows:
+            if row == title_row or row >= len(rows):
+                continue
+            bounds = _box_interior_bounds(rows[row])
+            if bounds is None:
+                continue
+            left, right = bounds
+            # The colour is the machine's, measured by the backend from a
+            # listing rather than pinned here: an Ultimate 64 marks the cursor
+            # 0;32;1 and a C64 Ultimate 0;37;1.
+            if any(colours[row][col] == marker for col in range(left, right)):
+                return row
+        return None
+
+
+def _clean_value(text: str) -> str:
+    """What a field shows, with its empty placeholder removed."""
+    return text.strip().strip(PLACEHOLDER_CHARS).strip()
+
+
+def _box_interior_bounds(text: str) -> tuple[int, int] | None:
+    """Column span strictly between a row's own left/right box border.
+
+    Finding the marker anywhere on the row is not enough: the box's own title
+    is drawn in the same colour as the marker (a header decoration, not a
+    selection), and so, further right, is a status column belonging to
+    whatever the root browser drew on that row before the box covered most of
+    it. Both sit outside the box's own field-label area, so scoping the search
+    to strictly between this row's two "|" border cells (the same two columns
+    a field's own text is delimited by) excludes both.
+    """
+    left = text.find("|")
+    right = text.rfind("|")
+    if left == -1 or right == -1 or left == right:
+        return None
+    return left + 1, right

--- a/tests/lib/machine.py
+++ b/tests/lib/machine.py
@@ -344,6 +344,19 @@ class Machine:
                 else "Assembly 64 Query Form")
 
     @property
+    def machine_task_category(self) -> str:
+        """The task-menu category holding Reset, Reboot and the power actions.
+
+        C64_Subsys registers them under "C64 Machine"
+        (software/io/c64/c64_subsys.cc). A C64 Ultimate lists the same actions
+        under "Power & Reset": read off the device on 2026-09-07, where that
+        category offered Reset C64, Reboot C64, Reboot (Clr Mem), Power OFF,
+        Power Cycle, Save C64 Memory and Save REU Memory. Only the category
+        differs; the action labels are the same on both.
+        """
+        return "Power & Reset" if self.kind == C64U else "C64 Machine"
+
+    @property
     def rest_workers(self) -> int:
         """How many REST calls this machine can be asked for at once.
 

--- a/tests/lib/machine.py
+++ b/tests/lib/machine.py
@@ -191,6 +191,33 @@ MONITOR_D_KEY_RESERVED = _fix(
     "it, rather than entering the Debug mode this branch removed",
     (U2,))
 
+# What the "confirming ... preserves its value and all other fields" checks in
+# tests/e2e/io/c64/assembly64_test.py assert, and the behaviour
+# GideonZ/1541ultimate#865 gave the Assembly 64 query form. The C64 Ultimate
+# searches CommoServe, whose form is drawn by a different class in that
+# release line and still clears itself.
+#
+# Measured on a C64 Ultimate 1.2RC, overlay mode, 2026-09-07. With all nine
+# fields of the CommoServe File Search form holding values, opening the
+# "Category:" dropdown and confirming any item empties every field on the
+# form, free-text and preset alike:
+#
+#   before {'Name:': 'name0', 'Group:': 'group1', 'Handle:': 'handle2',
+#           'Event:': 'event3', 'Category:': 'Apps', 'Date:': '1980',
+#           'Type:': 'crt', 'Sort:': 'Name', 'Order:': 'Ascending'}
+#   after  every one of those nine ''
+#
+# Three key paths do it: RETURN on the item the menu opens on, DOWN then UP
+# then RETURN, and DOWN then RETURN. Leaving the menu with RUN/STOP keeps the
+# fields, and so does cycling the same field with "+" and "-", so only the
+# context-menu action is affected. An Ultimate 64 Elite on 3.15 keeps every
+# field on all three paths.
+QUERY_FORM_SURVIVES_DROPDOWN_CONFIRM = _fix(
+    "query-form-survives-dropdown-confirm",
+    "confirming a preset from the query form's dropdown keeps the values in "
+    "the other fields, rather than emptying the whole form",
+    (C64U,))
+
 # Every fix at once, for a sweep that asks whether the lagging line has caught
 # up rather than about one behaviour.
 ASSUME_ALL = "all"

--- a/tests/soak/io/c64/assembly_search_leak_test.py
+++ b/tests/soak/io/c64/assembly_search_leak_test.py
@@ -88,8 +88,8 @@ SETTLE_SECONDS = 6.0
 
 def open_and_leave(device) -> None:
     """One full open and close of the search browser."""
-    a64.open_query_form(device)
-    a64.leave_form(device)
+    device.form.open()
+    device.form.leave()
 
 
 def query_and_open_entry(device) -> bool:
@@ -100,11 +100,14 @@ def query_and_open_entry(device) -> bool:
     not the entries path. That is reported rather than failed: an empty corpus
     is the service's business, not the firmware's.
     """
-    a64.open_query_form(device)
-    a64.enter_field(device, a64.NAME_FIELD)
-    device.type_text(a64.SEARCH_TERM)
-    device.send_key("ENTER")
-    a64.submit_query(device)
+    device.form.open()
+    # The form's first field, read off the screen rather than named: which
+    # fields the form draws follows the service, so a literal label works on
+    # one machine and not the next. See tests/e2e/lib/search_form.py.
+    device.form.edit(device.form.first_field())
+    device.form.type_text(a64.SEARCH_TERM)
+    device.form.confirm()
+    device.form.submit()
 
     opened = False
     if wait_until(lambda: device.menu_is_open() and not device.form_visible(),


### PR DESCRIPTION
Three changes to the E2E harness, all under `tests/` and `run-tests`. No firmware is touched. Two are defect fixes found by running the suites on a C64 Ultimate; the third is a new suite guarding a change that is not in this branch yet.

Branched from `test-merge` at `b3c76093` ("Fix Fast Reset on the Ultimate 64 (#867)"). Ten files, +1569/-349, all under `tests/` and `run-tests`, and no binary entries in `git diff --numstat upstream/test-merge..HEAD`.

## 1. The online search suite named the search form's fields

Previous behaviour. `scenario_dropdown_preserves_fields` in `tests/e2e/io/c64/assembly64_test.py`, added by `4acc148c` (#865), iterated the literal tuple `("Repo:", "Category:", "Subcat:")` and raised a `Failure` when `row_of` could not find one of them. The rest of the suite named `"Name:"` and `"<<"` in the same way.

The defect. Those labels are not the firmware's. Four text fields are fixed, and after them `BrowsableAssemblyRoot::getSubItems` appends one `BrowsableQueryField` per `{type, values}` entry in the presets the remote service answered with (`software/userinterface/assembly_search.h`), so the field set follows the service. #865 landed after #849 ("Support all Ultimate devices in every E2E test") and was never run on a C64 Ultimate, which searches CommoServe rather than Assembly 64.

Evidence, harness commit `b3c76093`, overlay mode. On `u64` (Ultimate 64 Elite, firmware 3.15) the suite passed with 27 checks. On `c64u` (C64 Ultimate, firmware 1.2RC) it failed on all three attempts, and again in the freeze pass, with the first failing check `[07] Repo: +/- preserves existing fields` and the message `the form has no 'Repo:' field`. The check before it, "populate the text fields", passed, so the form was reachable and drivable and only the preset fields differed.

The change. `tests/e2e/lib/search_form.py` is a new page object for the query form, written against `Backend` in the same idiom as `browser.py`, so the same steps work over REST and Telnet. It opens the form, reads the fields off the rendered screen (label, row and current value, in the order the form draws them), classifies each field by driving it, and offers focus, type, cycle, cancel, confirm, clear and submit, plus a whole-form value snapshot and an "unchanged except for these" assertion.

Classification is behavioural rather than tabular: a preset field takes a value when it is cycled with `+`, a free-text field does not. `+` reaches `AssemblySearchForm::increase`, which `BrowsableQueryField::updown` ignores unless the field's target is a list, and it is not a character the string editor can receive, so probing a free-text field with it changes nothing.

The suite no longer holds any field label. `row_of`, `field_value`, `enter_field`, `select_row`, `open_query_form`, `leave_form`, `submit_query`, `empty_field`, `telnet_field_row`, `no_cursor_reason` and `_box_interior_bounds` moved into the new module. What the form is called and where the menu keeps it stay in `tests/lib/machine.py`: that is navigation, and it is a property of the machine. What the form contains is not, and is now discovered.

Discovery is guarded so it cannot degrade into covering nothing. The scenario reports the drawn fields, the free-text fields and the dropdown fields through `detail()`, so every run record names what was covered on that machine. It fails, rather than skipping, when no field takes a value when cycled, and it fails when every field is a dropdown. A field that discovery found and that cannot then be driven is still a hard failure: `SearchForm.field` raises rather than answering `None`.

The concrete effect on coverage: `assembly64` on `u64` runs 46 checks where it ran 27. Discovery finds 13 fields on the Assembly 64 form (Name, Group, Handle, Event, Repo, Category, Subcat, Rating, Type, Date, Latest, Sort, Order), classifies 4 as free text and 9 as dropdowns, and drives all 9 rather than the 3 that were named.

Two checks changed shape, and both changes are visible on `u64`.

The `+/-` check used to require the value to come back to where the sequence `+ + -` started. `updown()` clamps at both ends, so that only holds for a preset list of a particular length. The check now reads the field's own value back after each of the three keystrokes, requires it to be non-empty, and asserts that no other field moved. That is the #863 behaviour and it does not depend on how many presets a service listed.

The "confirming preserves its value" check passed only by accident. The context menu opens on its own first item (`AssemblySearchForm::change` calls `browser->context(0)`) rather than on the value the field holds, so DOWN, UP, RETURN applies the first preset. The old key sequence always left the field on that first preset, so the value happened not to change. Measured here, a field left on any other preset is reset to the first one by that sequence: `Repo: changed from 'Gamebase64' to 'CSDB'`. The check now rewinds the field to its first preset before opening the menu, which makes "confirming without moving preserves the value" an assertion about the firmware rather than about the order the service listed its presets in.

### A firmware defect the discovery reached

With every field of the CommoServe File Search form holding a value, confirming any item in a preset field's context menu empties the whole form on a C64 Ultimate 1.2RC. Measured in overlay mode on 2026-09-07:

```
before {'Name:': 'name0', 'Group:': 'group1', 'Handle:': 'handle2',
        'Event:': 'event3', 'Category:': 'Apps', 'Date:': '1980',
        'Type:': 'crt', 'Sort:': 'Name', 'Order:': 'Ascending'}
after  every one of those nine ''
```

Three key paths do it: RETURN on the item the menu opens on, DOWN then UP then RETURN, and DOWN then RETURN. Leaving the menu with RUN/STOP keeps the fields, and so does cycling the same field with `+` and `-`, so only the context-menu action is affected. An Ultimate 64 Elite on 3.15 keeps every field on all three paths, which is the behaviour #865 gave the Assembly 64 form; the CommoServe form is drawn by a different class in that release line.

That is a firmware gap rather than a harness one, so it is recorded in the `FIXES` table in `tests/lib/machine.py` as `query-form-survives-dropdown-confirm` with the C64 Ultimate listed as lacking it, and the "confirming ..." checks are tagged with it. They report SKIP naming the fix and the machine on a C64 Ultimate and run everywhere else. Skipping rather than failing there is what lets the rest of the suite run on that machine: the defect empties every field, so a form left in that state would fail every later check for a reason unrelated to what those checks assert.

## 2. The CFG loader log was parsed by its first quote

Previous behaviour. `loader_report` in `tests/e2e/filemanager/cfg_single_group_test.py` took a store name with `line.split("'", 2)[1]`, requiring only that the line started with the loader's prefix.

The defect. The device writes that debug log with `printf`, which emits one character at a time through `outbyte()` and takes no lock (`software/system/small_printf.cc`, `software/application/ultimate/ultimate.cc`). A task switch part way through a line splices another task's output into the middle of it. The REST poller that overlay mode runs prints `Accept client 0 on socket 7.` for every connection, so it is the task whose text lands in the loader's lines. A prefix-only parse then reports the spliced text as a store name, or misses the record entirely when the splice lands before the prefix.

Evidence, from one exhaustive run of `b3c76093` against `c64u` (C64 Ultimate, firmware 1.2RC), overlay mode. `cfg-partial-effectuate` failed twice and passed on the third attempt:

- attempt 1: `the loader effectuated 0 store(s): []` — the record had been appended to another task's line, so it no longer began with the prefix and was not counted at all;
- attempt 2: `1 store(s) the file never mentioned were applied: ['Audio MAccept client 0 on socket 7.  192.168.1.185:49362']` — the real store is `Audio Mixer`, and the splice ends at the interrupting task's own newline, so the rest of the record (`ixer' after loading.`) landed on the following line;
- attempt 3: OK, 1 effectuated and 21 left clean.

The same suite also failed once in the freeze pass of that run, with the attempt-1 shape. The suite was therefore flaky rather than broken, and its failure message printed spliced text where a reader expects a store name.

The change. A line is read as a loader record only when it starts with the prefix, ends with the matching suffix, and the name between them holds no quote. Lines that hold a prefix or a suffix anywhere without being a whole record are collected into a third list, `damaged`, rather than dropped: dropping them would let an interleaved log read as a load that touched fewer stores than it did, which is the failure `cfg_partial_effectuate_test` exists to detect. Containment rather than `startswith`/`endswith`, because attempt 1 above shows a splice can land before the prefix. The two prefixes cannot be confused: `Effectuating settings of store '` spells "store" in lower case and `Store '` in upper case.

`cfg_partial_effectuate_test` decides in that order. An unexpected store read from an intact line still fails the check, so a real loader defect stays visible whatever else the log holds. Only when the intact lines carry no unexpected store and the log also holds a damaged line is the result reported as SKIP, naming the count and printing each unreadable line: a spliced line may have carried a store the `.cfg` never named, so from that log neither a pass nor a fail can be justified.

Scope note. `loader_report` is defined in `cfg_single_group_test.py` but only `cfg_partial_effectuate_test.py` calls it. `cfg-single-group` loads the `.cfg` and asserts nothing about the log, so it was not failing on this; it shares the module, not the call.

## 3. New suite for the deferred machine actions in commodore#1

`GideonZ/commodore#1`, commit `c66ef028`, changes two things. `C64_Subsys::executeCommand` released the host and reset the machine while the menu was still drawn; it now queues the action (`C64::defer_machine_action`), answers `MENU_HIDE`, and `UserInterface::run_once` performs it after `release_host` and `release_ownership`. Separately, `C64::checkButton` kept its edge detector in a function-static `button_prev`, which a reset left holding the pre-reset level, so the next press produced no edge; `button_prev` is now a member that `C64::syncButtonState` resyncs after `run_once` returns.

`tests/e2e/io/c64/deferred_actions_test.py` is registered as `deferred-machine-actions` with no explicit profile, so the standard profile and everything above it select it. Ten checks in four scenarios.

The two REST checks run everywhere. With no menu open, `cmd->user_interface` is NULL and `request_hide_then_action` takes its else branch, so `PUT /v1/machine:reset` and `PUT /v1/machine:menu_button` must act on the machine straight away.

The three screen-cleanliness checks run everywhere as well, one per route into the deferred path: "Reset C64" and "Reboot C64" from the task menu, and C= + R in the file browser, whose `KEY_CTRL_R` case in `tree_browser.cc` issues `MENU_C64_RESET` and returns `user_interface->menu_response_to_action`. They are not tagged with a firmware fix: measured on `u64`, whose firmware carries none of `c66ef028`, all three pass, so a vintage gate would report SKIP for behaviour the machine satisfies and would leave the invariant unguarded on the machine that holds it.

The three menu-reopening checks report SKIP everywhere, because no route this harness has reaches `C64::checkButton`'s edge detector. `PUT /v1/machine:menu_button` calls `setButtonPushed()` directly and never enters it. The other route is the hardware button, or the C64 keyboard combination that raises the same signal on a C64 Ultimate, and injecting that combination does not reach it. Measured on `c64u` with the Overlay interface selected: a press of `commodore`, a tap of `restore` and a release of `commodore` left `machine:menu_screen` answering 404 for the whole 8s it was polled, with the same result when the three requests were spaced 0.5s apart and when `restore` was tapped alone, while `PUT /v1/machine:menu_button` in the same probe opened the menu every time. The same sequence does nothing on `u64`. The mapping is in the prebuilt C64 Ultimate bitstream (`external/u64e2_*.bit`) and in no C source here. The checks stay in the suite as skipped lines so every run says the behaviour was not measured and names what stops it.

The last check is separate, and it fails on `c64u`. It sends one menu button straight after a close with nothing between them. On `c64u` that press is dropped: 1 run in 4 of the whole suite fails on it, and a direct probe put it at 1 trial in 6 with no gap after the close and 0 in 6 once a 0.25s gap was left. It is last in the suite deliberately, so a failure there does not stop the run before the deferral checks, and the steps that only need the menu up retry the button rather than carrying this defect into every check. This is the same regression `readmem-writemem` fails 3 attempts of 3 on. It is left failing.

"A clean BASIC prompt" is asserted from screen RAM at `$0400`, over the whole 40x25 screen. The KERNAL's banner and READY must be present, and no cell may hold a screen code whose low seven bits are `0x40` or above; `0x00` to `0x3F` are the letters, digits and punctuation a boot screen is made of, and `0x40` to `0x7F` are the graphics the menu draws its borders with. Testing the low seven bits lets the cursor through (a reverse space, `0xA0`) and still catches a reversed menu character. The screen is blanked before each action.

That assertion is only load bearing under one interface, and the suite says which one it is running on. `--mode freeze` puts the menu in C64 screen RAM, where a leftover would be; `--mode overlay` draws it on its own plane, and the menu never writes screen RAM at all.

Two machine facts came out of running it. Which task-menu category holds the machine actions is the machine's, and is added as `Machine.machine_task_category`: `C64_Subsys` registers them under "C64 Machine", and a C64 Ultimate lists the same actions under "Power & Reset" (read off the device, where that category offered Reset C64, Reboot C64, Reboot (Clr Mem), Power OFF, Power Cycle, Save C64 Memory and Save REU Memory). Only the category differs. Separately, the suite settles the browser listing before it opens the task menu: `Browser.overlay_items` reads an overlay by diffing against the screen captured before the key, and a C64 Ultimate refreshes its drive status unprompted, so a row that changed for its own reasons is taken for part of the overlay. Measured on `c64u` in overlay mode, opening the task menu straight after `go_to_root()` parsed its categories in 3 attempts of 5, and reading until two consecutive screens matched first parsed them in 5 of 5.

Not covered: starting a `.crt` from the menu, which the author's reproduction lists. It reaches the same `request_hide_then_action` call (`C64_START_CART`), but it needs a cartridge image fixture on the device and leaves the machine running foreign code that no BASIC-prompt assertion could then read.

## Verification

Every run below was taken with the device held under a lock, one suite at a time, with retries limited to one attempt unless stated.

**u64** (Ultimate 64 Elite, firmware 3.15, `git_commit_hash b3c76093`), overlay mode, all five suites in one run: `assembly64` OK 46 checks 71.7s, `cfg-single-group` OK, `cfg-partial-effectuate` OK ("effectuated 1, left clean 18, unreadable 0"), `cfg-loader-log` OK 6 checks, `deferred-machine-actions` OK 10 checks 5.5s. Freeze mode: `assembly64` OK 46 checks 73.2s, `deferred-machine-actions` OK 10 checks 5.7s. Telnet mode: `assembly64` OK 44 checks 431s.

`assembly64` on u64 ran 27 checks in 42.3s before this change and runs 46 in 71.7s now, because discovery finds 13 fields and drives all 9 dropdowns rather than the 3 that were named.

**c64u** (C64 Ultimate, firmware 1.2RC), overlay mode: `assembly64` OK 34 checks 57.3s, where the same suite failed all three attempts before this change with `the form has no 'Repo:' field`. Discovery found 9 fields, 4 free text and 5 dropdowns, and the 5 "confirming ..." checks reported SKIP against the new `FIXES` entry. `cfg-single-group` OK, `cfg-loader-log` OK, `cfg-partial-effectuate` OK.

The damaged-log path was exercised on real hardware. Five consecutive `cfg-partial-effectuate` runs on `c64u` gave 2 clean logs and 3 interleaved ones, each of the latter reported as SKIP with the line quoted, for example:

```
effectuated 0, left clean 21, unreadable 1
unreadable log line: "ttings of store 'Audio Mixer' after loading."

effectuated 1, left clean 20, unreadable 1
unreadable log line: "Store 'SID Sockets Configuration' is clean afterAccept client 0 on socket 7.  192.168.1.185:36902"
```

Before this change the first of those reported `the loader effectuated 0 store(s)` as a failure and the second silently lost a store from the clean list.

`deferred-machine-actions` on `c64u`: overlay OK 10 checks in 3 runs of 3; freeze OK 10 checks in 3 runs of 4, and FAIL in 1 run of 4 on the last check, `one menu button reopens the menu straight after a close`, with `one PUT /v1/machine:menu_button sent straight after the close did not open the menu within 8s, so the press was dropped`. That check is left failing.

The device-free gates pass: `make lint_test` (ruff over `tests` and `run-tests`), `registry_test` (64 suites), `stale_gates_test`.

The `cfg-loader-log` suite is what proves the log-parser fix, because the interleaving is not reproducible on demand. Reverting `store_name` to the previous prefix-only parse makes its check 3 fail with `effectuated: got ['Audio MAccept client 0 on socket 7.  192.168.1.185:49362'], expected []`.

## Alternatives considered and rejected

Naming the C64 Ultimate's preset fields in `machine.py`, beside the other `search_*` properties. That would have fixed the failure and matched the existing pattern, but it puts one service's current catalogue into the harness, so the next service change or the next machine reintroduces the same failure. The fields are discovered instead, and `machine.py` keeps only navigation: `search_service`, `search_menu_entry`, `search_in_launcher`, `search_form_title`, `task_menu_key`.

Skipping the absent preset fields in the dropdown scenario. It would have turned a red suite green without covering anything on a C64 Ultimate, and a scenario that silently covered no field looks the same as one that covered every field.

Discarding the unreadable loader log lines. That is what makes the interleaving invisible, and an interleaved log would then read as a load that touched fewer stores than it did, which is the failure `cfg_partial_effectuate_test` exists to detect.

Rejoining the two halves of a spliced loader record by concatenating the following line. Nothing guarantees the two halves are adjacent, and more than two tasks can interleave, so the reconstruction would be a guess presented as a measurement.

Tagging the `deferred-machine-actions` screen-cleanliness checks with the firmware fix. They pass on `u64` under `--assume-fix`, so tagging them would report SKIP for behaviour the machine satisfies and would make `tools/stale_gates.py` read a forced pass as the fix having landed.

Failing rather than skipping the CommoServe dropdown-confirm checks. The defect empties every field on the form, so the failure would cascade into every later check in that scenario and stop the suite before the scenarios that follow it, which have never run on a C64 Ultimate. The `FIXES` entry reports it as a named SKIP on that machine and keeps it running everywhere else.

Letting the dropped menu button fail the deferral checks at their setup. It did, in 2 freeze runs of 3, and those runs then measured nothing about the deferral. The defect is asserted by its own check at the end of the suite instead, and the steps that only need the menu up retry the button.

Covering the `.crt` launch in the new suite. It needs a cartridge image fixture on the device and leaves the machine running foreign code, which no BASIC-prompt assertion could then read.
