### PR TITLE
Add runtime VIC palette stream metadata

### DIFF
--- a/doc/api/rest_api_openapi_u64.yaml
+++ b/doc/api/rest_api_openapi_u64.yaml
@@ -3342,6 +3342,13 @@ paths:
           schema:
             type: string
           example: '192.168.1.10:11000'
+        - name: palette
+          in: query
+          required: false
+          description: For video, request runtime VIC palette packets (0 or 1).
+          schema:
+            type: integer
+          example: 0
       responses:
         '200':
           description: The stream is running.
@@ -3349,6 +3356,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                Palette must be 0 or 1:
+                  value:
+                    errors:
+                      - Palette must be 0 or 1
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':

--- a/doc/api/rest_api_openapi_u64.yaml
+++ b/doc/api/rest_api_openapi_u64.yaml
@@ -3363,10 +3363,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                Palette must be 0 or 1:
+                Palette must be 0 or 1 and is only valid for the video stream:
                   value:
                     errors:
-                      - Palette must be 0 or 1
+                      - Palette must be 0 or 1 and is only valid for the video stream
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':

--- a/software/api/route_streams.cc
+++ b/software/api/route_streams.cc
@@ -31,11 +31,13 @@ API_DOC(PUT, streams, start,
     PATH_PARAM("stream", "string", "Which stream to act on.", "video")
     PATH_PARAM_ENUM("stream", "video,audio,debug")
     PARAM("ip", "string", "Where to send the stream. An address, optionally followed by a port.", "", "192.168.1.10:11000")
+    PARAM("palette", "integer", "For video, request runtime VIC palette packets (0 or 1).", "", "0")
     RESPONSE("200", "application/json", "ErrorResponse", "The stream is running.", "")
+    RESPONSE_ERROR("400", "Palette must be 0 or 1", "")
     RESPONSE_ERROR("404", "Unrecognized stream name 'screen'", "")
     RESPONSE_ERROR("500", "No Operational Network Interface", "")
 )
-API_CALL(PUT, streams, start, NULL, ARRAY ( { { "ip", P_REQUIRED } }))
+API_CALL(PUT, streams, start, NULL, ARRAY ( { { "ip", P_REQUIRED }, { "palette", P_OPTIONAL } }))
 {
     const char *streamName = args.get_path(0);
     SubsysCommand *sys_command;
@@ -58,7 +60,16 @@ API_CALL(PUT, streams, start, NULL, ARRAY ( { { "ip", P_REQUIRED } }))
         sys_command->execute();
     }
 
-    sys_command = new SubsysCommand(NULL, -1, (int)dataStreamer, streamIndex, args["ip"], "");
+    const char *paletteArg = args.get_or("palette", NULL);
+    const bool paletteRequested = paletteArg && strcmp(paletteArg, "1") == 0;
+    if ((paletteArg && strcmp(paletteArg, "0") != 0 && !paletteRequested) ||
+        (streamIndex != 0 && paletteRequested)) {
+        resp->error("Palette must be 0 or 1 and is only valid for the video stream");
+        resp->json_response(HTTP_BAD_REQUEST);
+        return;
+    }
+    const char *palette = paletteRequested ? "1" : "";
+    sys_command = new SubsysCommand(NULL, -1, (int)dataStreamer, streamIndex, args["ip"], palette);
     sys_command->direct_call = DataStreamer :: S_startStream;
     SubsysResultCode_t retval = sys_command->execute();
     resp->error(SubsysCommand::error_string(retval.status));

--- a/software/api/route_streams.cc
+++ b/software/api/route_streams.cc
@@ -33,7 +33,7 @@ API_DOC(PUT, streams, start,
     PARAM("ip", "string", "Where to send the stream. An address, optionally followed by a port.", "", "192.168.1.10:11000")
     PARAM("palette", "integer", "For video, request runtime VIC palette packets (0 or 1).", "", "0")
     RESPONSE("200", "application/json", "ErrorResponse", "The stream is running.", "")
-    RESPONSE_ERROR("400", "Palette must be 0 or 1", "")
+    RESPONSE_ERROR("400", "Palette must be 0 or 1 and is only valid for the video stream", "")
     RESPONSE_ERROR("404", "Unrecognized stream name 'screen'", "")
     RESPONSE_ERROR("500", "No Operational Network Interface", "")
 )
@@ -62,8 +62,7 @@ API_CALL(PUT, streams, start, NULL, ARRAY ( { { "ip", P_REQUIRED }, { "palette",
 
     const char *paletteArg = args.get_or("palette", NULL);
     const bool paletteRequested = paletteArg && strcmp(paletteArg, "1") == 0;
-    if ((paletteArg && strcmp(paletteArg, "0") != 0 && !paletteRequested) ||
-        (streamIndex != 0 && paletteRequested)) {
+    if (paletteArg && (streamIndex != 0 || (strcmp(paletteArg, "0") != 0 && !paletteRequested))) {
         resp->error("Palette must be 0 or 1 and is only valid for the video stream");
         resp->json_response(HTTP_BAD_REQUEST);
         return;

--- a/software/io/command_interface/control_target.cc
+++ b/software/io/command_interface/control_target.cc
@@ -13,6 +13,7 @@
 #if U64
 #include "u64_config.h"
 #include "u64.h"
+#include "data_streamer.h"
 #else
 #include "audio_select.h"
 #endif
@@ -273,6 +274,7 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
                 *status = &c_status_invalid_params;
             } else {
                 U64Config::set_palette_rgb(rgb);
+                if (dataStreamer) dataStreamer->sendVicPalette();
                 *status = &c_status_ok;
             }
             break;
@@ -285,6 +287,7 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
                 *status = &c_status_invalid_params;
             } else {
                 U64Config::set_palette_color(index, rgb);
+                if (dataStreamer) dataStreamer->sendVicPalette();
                 *status = &c_status_ok;
             }
             break;
@@ -295,6 +298,7 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
                 *status = &c_status_invalid_params;
             } else {
                 U64Config::reset_palette();
+                if (dataStreamer) dataStreamer->sendVicPalette();
                 *status = &c_status_ok;
             }
             break;

--- a/software/io/command_interface/control_target.cc
+++ b/software/io/command_interface/control_target.cc
@@ -13,7 +13,6 @@
 #if U64
 #include "u64_config.h"
 #include "u64.h"
-#include "data_streamer.h"
 #else
 #include "audio_select.h"
 #endif
@@ -274,7 +273,6 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
                 *status = &c_status_invalid_params;
             } else {
                 U64Config::set_palette_rgb(rgb);
-                if (dataStreamer) dataStreamer->sendVicPalette();
                 *status = &c_status_ok;
             }
             break;
@@ -287,7 +285,6 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
                 *status = &c_status_invalid_params;
             } else {
                 U64Config::set_palette_color(index, rgb);
-                if (dataStreamer) dataStreamer->sendVicPalette();
                 *status = &c_status_ok;
             }
             break;
@@ -298,7 +295,6 @@ void ControlTarget :: parse_command(Message *command, Message **reply, Message *
                 *status = &c_status_invalid_params;
             } else {
                 U64Config::reset_palette();
-                if (dataStreamer) dataStreamer->sendVicPalette();
                 *status = &c_status_ok;
             }
             break;

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -356,7 +356,10 @@ bool DataStreamer :: sendVicPalette()
         return false;
     }
 
-    if ((palette_socket < 0) || (palette_socket_ip != source_ip)) {
+    // LwIP may route unicast over another active interface, so let it choose
+    // that packet's source. Multicast keeps the VIC source for client filtering.
+    const uint32_t socket_ip = (dest_ip & 0x000000F8) == 0x000000E8 ? source_ip : 0;
+    if ((palette_socket < 0) || (palette_socket_ip != socket_ip)) {
         if (palette_socket >= 0) {
             lwip_close(palette_socket);
         }
@@ -365,18 +368,18 @@ bool DataStreamer :: sendVicPalette()
         if (palette_socket < 0) {
             return false;
         }
-
-        struct sockaddr_in local;
-        memset(&local, 0, sizeof(local));
-        local.sin_family = AF_INET;
-        local.sin_addr.s_addr = source_ip;
-        local.sin_port = 0;
-        if (bind(palette_socket, (const struct sockaddr *)&local, sizeof(local)) < 0) {
-            lwip_close(palette_socket);
-            palette_socket = -1;
-            return false;
+        if (socket_ip) {
+            struct sockaddr_in local;
+            memset(&local, 0, sizeof(local));
+            local.sin_family = AF_INET;
+            local.sin_addr.s_addr = socket_ip;
+            if (bind(palette_socket, (const struct sockaddr *)&local, sizeof(local)) < 0) {
+                lwip_close(palette_socket);
+                palette_socket = -1;
+                return false;
+            }
         }
-        palette_socket_ip = source_ip;
+        palette_socket_ip = socket_ip;
     }
 
     uint8_t packet[60] = { 0 };

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -39,7 +39,11 @@ struct t_cfg_definition stream_cfg[] = {
 DataStreamer :: DataStreamer()
 {
     my_ip = 0;
-    palette_stream_enabled = false;
+    palette_stream_requested = false;
+    palette_generation = 0;
+    palette_task_handle = NULL;
+    palette_socket = -1;
+    palette_socket_ip = 0;
     memset(streams, 0, 4*sizeof(stream_config_t));
 
     cfg = ConfigManager :: getConfigManager()->register_store(0x44617461, "Data Streams", stream_cfg, NULL);
@@ -49,12 +53,19 @@ DataStreamer :: DataStreamer()
     for (int i=0; i < 4; i++) {
         timers[i] = xTimerCreate("StreamTimer", 100, pdFALSE, (void *)i, DataStreamer :: S_timer);
     }
+    if (xTaskCreate(DataStreamer :: S_palette_task, "VIC Palette", configMINIMAL_STACK_SIZE,
+                    this, PRIO_NETSERVICE, &palette_task_handle) != pdPASS) {
+        palette_task_handle = NULL;
+        puts("Could not create VIC palette stream task");
+    }
 }
 
 // This should never be called
 DataStreamer :: ~DataStreamer()
 {
-
+    if (palette_socket >= 0) {
+        lwip_close(palette_socket);
+    }
 }
 
 DataStreamer *dataStreamer;
@@ -86,6 +97,11 @@ void DataStreamer :: S_timer(TimerHandle_t a)
         stream->enable = 0;
         dataStreamer->calculate_udp_headers(streamID);
     }
+}
+
+void DataStreamer :: S_palette_task(void *context)
+{
+    ((DataStreamer *)context)->paletteTask();
 }
 
 SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
@@ -221,11 +237,19 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
     }
     stream->enable = 1;
 
+    if (streamID == 0) {
+        const bool requested = strcmp(cmd->filename.c_str(), "1") == 0;
+        taskENTER_CRITICAL();
+        palette_stream_requested = requested;
+        taskEXIT_CRITICAL();
+
+        if (requested && palette_task_handle) {
+            xTaskNotifyGive(palette_task_handle);
+        }
+    }
+
     // start stream!
     calculate_udp_headers(streamID);
-    if ((streamID == 0) && palette_stream_enabled) {
-        sendVicPalette();
-    }
 
     if (cmd->bufferSize) {
         int stopAfter = cmd->bufferSize;
@@ -251,6 +275,11 @@ SubsysResultCode_e DataStreamer :: stopStream(SubsysCommand *cmd)
     }
     stream_config_t *stream = &streams[streamID];
     stream->enable = 0;
+    if (streamID == 0) {
+        taskENTER_CRITICAL();
+        palette_stream_requested = false;
+        taskEXIT_CRITICAL();
+    }
     calculate_udp_headers(streamID);
     return SSRET_OK;
 }
@@ -288,7 +317,7 @@ void DataStreamer :: update_task_items(bool writablePath)
 void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *data, int length)
 {
     int sockfd;
-    static struct sockaddr_in server;
+    struct sockaddr_in server;
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
@@ -302,7 +331,6 @@ void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *
     server.sin_addr.s_addr = ip;
     server.sin_port = htons(port);
 
-    printf("Send UDP data...\n");
     if (sendto(sockfd, data, length, 0, (const struct sockaddr*)&server, sizeof(server)) < 0) {
         printf("Error in sendto()\n");
     }
@@ -310,15 +338,50 @@ void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *
     lwip_close(sockfd);
 }
 
-void DataStreamer :: sendVicPalette()
+bool DataStreamer :: sendVicPalette()
 {
-    palette_stream_enabled = true;
-    stream_config_t *stream = &streams[0];
-    if (!stream->enable) {
-        return;
+    uint32_t source_ip;
+    uint32_t dest_ip;
+    uint16_t dest_port;
+    uint16_t generation;
+    taskENTER_CRITICAL();
+    const bool requested = palette_stream_requested && streams[0].enable;
+    source_ip = my_ip;
+    dest_ip = streams[0].dest_ip;
+    dest_port = streams[0].dest_port;
+    generation = palette_generation;
+    taskEXIT_CRITICAL();
+
+    if (!requested || !source_ip || !dest_ip || !dest_port) {
+        return false;
+    }
+
+    if ((palette_socket < 0) || (palette_socket_ip != source_ip)) {
+        if (palette_socket >= 0) {
+            lwip_close(palette_socket);
+        }
+        palette_socket = socket(AF_INET, SOCK_DGRAM, 0);
+        palette_socket_ip = 0;
+        if (palette_socket < 0) {
+            return false;
+        }
+
+        struct sockaddr_in local;
+        memset(&local, 0, sizeof(local));
+        local.sin_family = AF_INET;
+        local.sin_addr.s_addr = source_ip;
+        local.sin_port = htons(53248);
+        if (bind(palette_socket, (const struct sockaddr *)&local, sizeof(local)) < 0) {
+            lwip_close(palette_socket);
+            palette_socket = -1;
+            return false;
+        }
+        palette_socket_ip = source_ip;
     }
 
     uint8_t packet[60] = { 0 };
+    packet[0] = (uint8_t)generation;
+    packet[1] = (uint8_t)(generation >> 8);
     packet[4] = 239;
     packet[6] = 0x80;
     packet[7] = 0x01;
@@ -328,7 +391,51 @@ void DataStreamer :: sendVicPalette()
     uint8_t rgb[16][3];
     U64Config::get_palette_rgb(rgb);
     memcpy(packet + 12, rgb, 48);
-    send_udp_packet(stream->dest_ip, stream->dest_port, packet, sizeof(packet));
+
+    struct sockaddr_in destination;
+    memset(&destination, 0, sizeof(destination));
+    destination.sin_family = AF_INET;
+    destination.sin_addr.s_addr = dest_ip;
+    destination.sin_port = htons(dest_port);
+    if (sendto(palette_socket, packet, sizeof(packet), 0,
+               (const struct sockaddr *)&destination, sizeof(destination)) < 0) {
+        lwip_close(palette_socket);
+        palette_socket = -1;
+        palette_socket_ip = 0;
+        return false;
+    }
+    return true;
+}
+
+void DataStreamer :: vicPaletteChanged()
+{
+    taskENTER_CRITICAL();
+    palette_generation++;
+    taskEXIT_CRITICAL();
+    if (palette_task_handle) {
+        xTaskNotifyGive(palette_task_handle);
+    }
+}
+
+void DataStreamer :: paletteTask()
+{
+    const TickType_t repeat_ticks = 1000 / portTICK_PERIOD_MS;
+    const TickType_t minimum_ticks = 20 / portTICK_PERIOD_MS;
+    TickType_t last_send = 0;
+
+    while (true) {
+        const uint32_t notified = ulTaskNotifyTake(pdTRUE, repeat_ticks);
+        if (notified && last_send) {
+            const TickType_t now = xTaskGetTickCount();
+            const TickType_t elapsed = now - last_send;
+            if (elapsed < minimum_ticks) {
+                vTaskDelay(minimum_ticks - elapsed);
+            }
+        }
+        if (sendVicPalette()) {
+            last_send = xTaskGetTickCount();
+        }
+    }
 }
 
 

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -39,7 +39,7 @@ struct t_cfg_definition stream_cfg[] = {
 DataStreamer :: DataStreamer()
 {
     my_ip = 0;
-    palette_sequence = 0;
+    palette_stream_enabled = false;
     memset(streams, 0, 4*sizeof(stream_config_t));
 
     cfg = ConfigManager :: getConfigManager()->register_store(0x44617461, "Data Streams", stream_cfg, NULL);
@@ -223,10 +223,8 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
 
     // start stream!
     calculate_udp_headers(streamID);
-    if (streamID == 0) {
-        uint8_t rgb[16][3];
-        U64Config::get_palette_rgb(rgb);
-        sendVicPalette(rgb);
+    if ((streamID == 0) && palette_stream_enabled) {
+        sendVicPalette();
     }
 
     if (cmd->bufferSize) {
@@ -312,22 +310,23 @@ void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *
     lwip_close(sockfd);
 }
 
-void DataStreamer :: sendVicPalette(const uint8_t rgb[16][3])
+void DataStreamer :: sendVicPalette()
 {
+    palette_stream_enabled = true;
     stream_config_t *stream = &streams[0];
     if (!stream->enable) {
         return;
     }
 
     uint8_t packet[60] = { 0 };
-    uint16_t sequence = palette_sequence++;
-    packet[0] = (uint8_t)sequence;
-    packet[1] = (uint8_t)(sequence >> 8);
-    packet[4] = 0xFF;
-    packet[5] = 0x7F; // Reserved line number: this packet carries the VIC palette.
-    packet[6] = 16;
+    packet[4] = 239;
+    packet[6] = 0x80;
+    packet[7] = 0x01;
     packet[8] = 1;
-    packet[9] = 24;
+    packet[9] = 4;
+    packet[10] = 1;
+    uint8_t rgb[16][3];
+    U64Config::get_palette_rgb(rgb);
     memcpy(packet + 12, rgb, 48);
     send_udp_packet(stream->dest_ip, stream->dest_port, packet, sizeof(packet));
 }

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -354,9 +354,9 @@ bool DataStreamer :: sendVicPalette()
         return false;
     }
 
-    // LwIP may route unicast over another active interface, so let it choose
-    // that packet's source. Multicast keeps the VIC source for client filtering.
-    const uint32_t socket_ip = (dest_ip & 0x000000F8) == 0x000000E8 ? source_ip : 0;
+    // Match the FPGA VIC stream source so receivers can apply the same peer
+    // filter to video and palette packets.
+    const uint32_t socket_ip = source_ip;
     if ((palette_socket < 0) || (palette_socket_ip != socket_ip)) {
         if (palette_socket >= 0) {
             lwip_close(palette_socket);
@@ -366,16 +366,14 @@ bool DataStreamer :: sendVicPalette()
         if (palette_socket < 0) {
             return false;
         }
-        if (socket_ip) {
-            struct sockaddr_in local;
-            memset(&local, 0, sizeof(local));
-            local.sin_family = AF_INET;
-            local.sin_addr.s_addr = socket_ip;
-            if (bind(palette_socket, (const struct sockaddr *)&local, sizeof(local)) < 0) {
-                lwip_close(palette_socket);
-                palette_socket = -1;
-                return false;
-            }
+        struct sockaddr_in local;
+        memset(&local, 0, sizeof(local));
+        local.sin_family = AF_INET;
+        local.sin_addr.s_addr = socket_ip;
+        if (bind(palette_socket, (const struct sockaddr *)&local, sizeof(local)) < 0) {
+            lwip_close(palette_socket);
+            palette_socket = -1;
+            return false;
         }
         palette_socket_ip = socket_ip;
     }
@@ -390,7 +388,7 @@ bool DataStreamer :: sendVicPalette()
     packet[7] = 0x01;
     packet[8] = 1;    // one palette
     packet[9] = 4;    // four bits per VIC color index
-    packet[10] = 1;   // RGB palette encoding
+    packet[10] = 1;   // palette packet type indicator
     memcpy(packet + 12, rgb, sizeof(rgb));
 
     struct sockaddr_in destination;

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -354,9 +354,9 @@ bool DataStreamer :: sendVicPalette()
         return false;
     }
 
-    // Match the FPGA VIC stream source so receivers can apply the same peer
-    // filter to video and palette packets.
-    const uint32_t socket_ip = source_ip;
+    // LwIP may route unicast over another active interface, so let it choose
+    // that packet's source. Multicast keeps the VIC source for client filtering.
+    const uint32_t socket_ip = (dest_ip & 0x000000F8) == 0x000000E8 ? source_ip : 0;
     if ((palette_socket < 0) || (palette_socket_ip != socket_ip)) {
         if (palette_socket >= 0) {
             lwip_close(palette_socket);
@@ -366,14 +366,16 @@ bool DataStreamer :: sendVicPalette()
         if (palette_socket < 0) {
             return false;
         }
-        struct sockaddr_in local;
-        memset(&local, 0, sizeof(local));
-        local.sin_family = AF_INET;
-        local.sin_addr.s_addr = socket_ip;
-        if (bind(palette_socket, (const struct sockaddr *)&local, sizeof(local)) < 0) {
-            lwip_close(palette_socket);
-            palette_socket = -1;
-            return false;
+        if (socket_ip) {
+            struct sockaddr_in local;
+            memset(&local, 0, sizeof(local));
+            local.sin_family = AF_INET;
+            local.sin_addr.s_addr = socket_ip;
+            if (bind(palette_socket, (const struct sockaddr *)&local, sizeof(local)) < 0) {
+                lwip_close(palette_socket);
+                palette_socket = -1;
+                return false;
+            }
         }
         palette_socket_ip = socket_ip;
     }

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -370,7 +370,7 @@ bool DataStreamer :: sendVicPalette()
         memset(&local, 0, sizeof(local));
         local.sin_family = AF_INET;
         local.sin_addr.s_addr = source_ip;
-        local.sin_port = htons(53248);
+        local.sin_port = 0;
         if (bind(palette_socket, (const struct sockaddr *)&local, sizeof(local)) < 0) {
             lwip_close(palette_socket);
             palette_socket = -1;

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -8,6 +8,7 @@
 #include "network_interface.h"
 #include "socket.h"
 #include "netdb.h"
+#include "u64_config.h"
 #include "userinterface.h"
 #include "profiler.h"
 #include "init_function.h"
@@ -38,6 +39,7 @@ struct t_cfg_definition stream_cfg[] = {
 DataStreamer :: DataStreamer()
 {
     my_ip = 0;
+    palette_sequence = 0;
     memset(streams, 0, 4*sizeof(stream_config_t));
 
     cfg = ConfigManager :: getConfigManager()->register_store(0x44617461, "Data Streams", stream_cfg, NULL);
@@ -201,7 +203,8 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
     } else {
         bool ok = false;
         for(int i=0;i<10;i++) {
-            send_udp_packet(query_ip, stream->dest_port);
+            const uint8_t probe[2] = { 0, 0 };
+            send_udp_packet(query_ip, stream->dest_port, probe, sizeof(probe));
             vTaskDelay(20);
             if (intf->peekArpTable(query_ip, stream->dest_mac)) {
                 ok = true;
@@ -220,6 +223,11 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
 
     // start stream!
     calculate_udp_headers(streamID);
+    if (streamID == 0) {
+        uint8_t rgb[16][3];
+        U64Config::get_palette_rgb(rgb);
+        sendVicPalette(rgb);
+    }
 
     if (cmd->bufferSize) {
         int stopAfter = cmd->bufferSize;
@@ -279,7 +287,7 @@ void DataStreamer :: update_task_items(bool writablePath)
     myActions.stopDbg->setHidden(streams[2].enable == 0);
 }
 
-void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port)
+void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *data, int length)
 {
     int sockfd;
     static struct sockaddr_in server;
@@ -296,13 +304,32 @@ void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port)
     server.sin_addr.s_addr = ip;
     server.sin_port = htons(port);
 
-    uint8_t buffer[2] = { 0, 0 };
     printf("Send UDP data...\n");
-    if (sendto(sockfd, buffer, 2, 0, (const struct sockaddr*)&server, sizeof(server)) < 0) {
+    if (sendto(sockfd, data, length, 0, (const struct sockaddr*)&server, sizeof(server)) < 0) {
         printf("Error in sendto()\n");
     }
     // close the socket again
     lwip_close(sockfd);
+}
+
+void DataStreamer :: sendVicPalette(const uint8_t rgb[16][3])
+{
+    stream_config_t *stream = &streams[0];
+    if (!stream->enable) {
+        return;
+    }
+
+    uint8_t packet[60] = { 0 };
+    uint16_t sequence = palette_sequence++;
+    packet[0] = (uint8_t)sequence;
+    packet[1] = (uint8_t)(sequence >> 8);
+    packet[4] = 0xFF;
+    packet[5] = 0x7F; // Reserved line number: this packet carries the VIC palette.
+    packet[6] = 16;
+    packet[8] = 1;
+    packet[9] = 24;
+    memcpy(packet + 12, rgb, 48);
+    send_udp_packet(stream->dest_ip, stream->dest_port, packet, sizeof(packet));
 }
 
 

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -40,7 +40,6 @@ DataStreamer :: DataStreamer()
 {
     my_ip = 0;
     palette_stream_requested = false;
-    palette_generation = 0;
     palette_task_handle = NULL;
     palette_socket = -1;
     palette_socket_ip = 0;
@@ -219,8 +218,7 @@ SubsysResultCode_e DataStreamer :: startStream(SubsysCommand *cmd)
     } else {
         bool ok = false;
         for(int i=0;i<10;i++) {
-            const uint8_t probe[2] = { 0, 0 };
-            send_udp_packet(query_ip, stream->dest_port, probe, sizeof(probe));
+            send_udp_packet(query_ip, stream->dest_port);
             vTaskDelay(20);
             if (intf->peekArpTable(query_ip, stream->dest_mac)) {
                 ok = true;
@@ -279,6 +277,9 @@ SubsysResultCode_e DataStreamer :: stopStream(SubsysCommand *cmd)
         taskENTER_CRITICAL();
         palette_stream_requested = false;
         taskEXIT_CRITICAL();
+        if (palette_task_handle) {
+            xTaskNotifyGive(palette_task_handle);
+        }
     }
     calculate_udp_headers(streamID);
     return SSRET_OK;
@@ -314,7 +315,7 @@ void DataStreamer :: update_task_items(bool writablePath)
     myActions.stopDbg->setHidden(streams[2].enable == 0);
 }
 
-void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *data, int length)
+void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port)
 {
     int sockfd;
     struct sockaddr_in server;
@@ -331,7 +332,9 @@ void DataStreamer :: send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *
     server.sin_addr.s_addr = ip;
     server.sin_port = htons(port);
 
-    if (sendto(sockfd, data, length, 0, (const struct sockaddr*)&server, sizeof(server)) < 0) {
+    uint8_t buffer[2] = { 0, 0 };
+    printf("Send UDP data...\n");
+    if (sendto(sockfd, buffer, 2, 0, (const struct sockaddr*)&server, sizeof(server)) < 0) {
         printf("Error in sendto()\n");
     }
     // close the socket again
@@ -343,16 +346,19 @@ bool DataStreamer :: sendVicPalette()
     uint32_t source_ip;
     uint32_t dest_ip;
     uint16_t dest_port;
-    uint16_t generation;
     taskENTER_CRITICAL();
     const bool requested = palette_stream_requested && streams[0].enable;
     source_ip = my_ip;
     dest_ip = streams[0].dest_ip;
     dest_port = streams[0].dest_port;
-    generation = palette_generation;
     taskEXIT_CRITICAL();
 
     if (!requested || !source_ip || !dest_ip || !dest_port) {
+        if (palette_socket >= 0) {
+            lwip_close(palette_socket);
+            palette_socket = -1;
+            palette_socket_ip = 0;
+        }
         return false;
     }
 
@@ -383,17 +389,17 @@ bool DataStreamer :: sendVicPalette()
     }
 
     uint8_t packet[60] = { 0 };
+    uint8_t rgb[16][3];
+    const uint16_t generation = U64Config::get_palette_rgb(rgb);
     packet[0] = (uint8_t)generation;
     packet[1] = (uint8_t)(generation >> 8);
-    packet[4] = 239;
-    packet[6] = 0x80;
+    packet[4] = 239;  // reserved line number
+    packet[6] = 0x80; // 384 pixels per line, little endian
     packet[7] = 0x01;
-    packet[8] = 1;
-    packet[9] = 4;
-    packet[10] = 1;
-    uint8_t rgb[16][3];
-    U64Config::get_palette_rgb(rgb);
-    memcpy(packet + 12, rgb, 48);
+    packet[8] = 1;    // one palette
+    packet[9] = 4;    // four bits per VIC color index
+    packet[10] = 1;   // RGB palette encoding
+    memcpy(packet + 12, rgb, sizeof(rgb));
 
     struct sockaddr_in destination;
     memset(&destination, 0, sizeof(destination));
@@ -412,9 +418,6 @@ bool DataStreamer :: sendVicPalette()
 
 void DataStreamer :: vicPaletteChanged()
 {
-    taskENTER_CRITICAL();
-    palette_generation++;
-    taskEXIT_CRITICAL();
     if (palette_task_handle) {
         xTaskNotifyGive(palette_task_handle);
     }
@@ -422,12 +425,17 @@ void DataStreamer :: vicPaletteChanged()
 
 void DataStreamer :: paletteTask()
 {
-    const TickType_t repeat_ticks = 1000 / portTICK_PERIOD_MS;
-    const TickType_t minimum_ticks = 20 / portTICK_PERIOD_MS;
+    const TickType_t repeat_ticks = pdMS_TO_TICKS(1000);
+    // Twenty milliseconds is longer than one PAL or NTSC frame, so even a
+    // burst of palette writes adds at most one metadata packet per video frame.
+    const TickType_t minimum_ticks = pdMS_TO_TICKS(20);
     TickType_t last_send = 0;
 
     while (true) {
-        const uint32_t notified = ulTaskNotifyTake(pdTRUE, repeat_ticks);
+        taskENTER_CRITICAL();
+        const bool requested = palette_stream_requested && streams[0].enable;
+        taskEXIT_CRITICAL();
+        const uint32_t notified = ulTaskNotifyTake(pdTRUE, requested ? repeat_ticks : portMAX_DELAY);
         if (notified && last_send) {
             const TickType_t now = xTaskGetTickCount();
             const TickType_t elapsed = now - last_send;

--- a/software/io/network/data_streamer.cc
+++ b/software/io/network/data_streamer.cc
@@ -277,9 +277,6 @@ SubsysResultCode_e DataStreamer :: stopStream(SubsysCommand *cmd)
         taskENTER_CRITICAL();
         palette_stream_requested = false;
         taskEXIT_CRITICAL();
-        if (palette_task_handle) {
-            xTaskNotifyGive(palette_task_handle);
-        }
     }
     calculate_udp_headers(streamID);
     return SSRET_OK;
@@ -354,11 +351,6 @@ bool DataStreamer :: sendVicPalette()
     taskEXIT_CRITICAL();
 
     if (!requested || !source_ip || !dest_ip || !dest_port) {
-        if (palette_socket >= 0) {
-            lwip_close(palette_socket);
-            palette_socket = -1;
-            palette_socket_ip = 0;
-        }
         return false;
     }
 
@@ -432,10 +424,7 @@ void DataStreamer :: paletteTask()
     TickType_t last_send = 0;
 
     while (true) {
-        taskENTER_CRITICAL();
-        const bool requested = palette_stream_requested && streams[0].enable;
-        taskEXIT_CRITICAL();
-        const uint32_t notified = ulTaskNotifyTake(pdTRUE, requested ? repeat_ticks : portMAX_DELAY);
+        const uint32_t notified = ulTaskNotifyTake(pdTRUE, repeat_ticks);
         if (notified && last_send) {
             const TickType_t now = xTaskGetTickCount();
             const TickType_t elapsed = now - last_send;

--- a/software/io/network/data_streamer.h
+++ b/software/io/network/data_streamer.h
@@ -43,6 +43,7 @@ class DataStreamer : public ObjectWithMenu
 
     uint8_t  my_mac[6];
     uint32_t my_ip;
+    uint16_t palette_sequence;
 
     stream_config_t streams[4];
     TimerHandle_t timers[4];
@@ -52,13 +53,15 @@ class DataStreamer : public ObjectWithMenu
     SubsysResultCode_e stopStream(SubsysCommand *cmd);
 
     void calculate_udp_headers(int id);
-    void send_udp_packet(uint32_t ip, uint16_t port);
+    void send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *data, int length);
 public:
     DataStreamer();
     virtual ~DataStreamer();
 
     static SubsysResultCode_e S_startStream(SubsysCommand *cmd);
     static SubsysResultCode_e S_stopStream(SubsysCommand *cmd);
+
+    void sendVicPalette(const uint8_t rgb[16][3]);
 
     // from ObjectWithMenu
     void create_task_items(void);

--- a/software/io/network/data_streamer.h
+++ b/software/io/network/data_streamer.h
@@ -44,7 +44,6 @@ class DataStreamer : public ObjectWithMenu
     uint8_t  my_mac[6];
     uint32_t my_ip;
     volatile bool palette_stream_requested;
-    volatile uint16_t palette_generation;
     TaskHandle_t palette_task_handle;
     int palette_socket;
     uint32_t palette_socket_ip;
@@ -58,7 +57,7 @@ class DataStreamer : public ObjectWithMenu
     SubsysResultCode_e stopStream(SubsysCommand *cmd);
 
     void calculate_udp_headers(int id);
-    void send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *data, int length);
+    void send_udp_packet(uint32_t ip, uint16_t port);
     bool sendVicPalette();
     void paletteTask();
 public:

--- a/software/io/network/data_streamer.h
+++ b/software/io/network/data_streamer.h
@@ -43,7 +43,7 @@ class DataStreamer : public ObjectWithMenu
 
     uint8_t  my_mac[6];
     uint32_t my_ip;
-    uint16_t palette_sequence;
+    bool palette_stream_enabled;
 
     stream_config_t streams[4];
     TimerHandle_t timers[4];
@@ -61,7 +61,7 @@ public:
     static SubsysResultCode_e S_startStream(SubsysCommand *cmd);
     static SubsysResultCode_e S_stopStream(SubsysCommand *cmd);
 
-    void sendVicPalette(const uint8_t rgb[16][3]);
+    void sendVicPalette();
 
     // from ObjectWithMenu
     void create_task_items(void);

--- a/software/io/network/data_streamer.h
+++ b/software/io/network/data_streamer.h
@@ -43,17 +43,24 @@ class DataStreamer : public ObjectWithMenu
 
     uint8_t  my_mac[6];
     uint32_t my_ip;
-    bool palette_stream_enabled;
+    volatile bool palette_stream_requested;
+    volatile uint16_t palette_generation;
+    TaskHandle_t palette_task_handle;
+    int palette_socket;
+    uint32_t palette_socket_ip;
 
     stream_config_t streams[4];
     TimerHandle_t timers[4];
 
     static void S_timer(TimerHandle_t a);
+    static void S_palette_task(void *context);
     SubsysResultCode_e startStream(SubsysCommand *cmd);
     SubsysResultCode_e stopStream(SubsysCommand *cmd);
 
     void calculate_udp_headers(int id);
     void send_udp_packet(uint32_t ip, uint16_t port, const uint8_t *data, int length);
+    bool sendVicPalette();
+    void paletteTask();
 public:
     DataStreamer();
     virtual ~DataStreamer();
@@ -61,7 +68,7 @@ public:
     static SubsysResultCode_e S_startStream(SubsysCommand *cmd);
     static SubsysResultCode_e S_stopStream(SubsysCommand *cmd);
 
-    void sendVicPalette();
+    void vicPaletteChanged();
 
     // from ObjectWithMenu
     void create_task_items(void);

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -72,6 +72,7 @@ const uint8_t default_colors[16][3] = {
 
 static uint8_t active_palette[16][3];
 static bool active_palette_valid = false;
+static uint16_t active_palette_generation = 0;
 
 // static pointer
 U64Config *u64_configurator = NULL;
@@ -2761,6 +2762,7 @@ void U64Config :: set_palette_rgb(const uint8_t rgb[16][3])
     taskENTER_CRITICAL();
     memcpy(active_palette, rgb, sizeof(active_palette));
     active_palette_valid = true;
+    active_palette_generation++;
     taskEXIT_CRITICAL();
     program_palette_rgb(rgb);
     if (dataStreamer) {
@@ -2768,11 +2770,14 @@ void U64Config :: set_palette_rgb(const uint8_t rgb[16][3])
     }
 }
 
-void U64Config :: get_palette_rgb(uint8_t rgb[16][3])
+uint16_t U64Config :: get_palette_rgb(uint8_t rgb[16][3])
 {
+    // Pair the generation and RGB bytes from one complete palette snapshot.
     taskENTER_CRITICAL();
     memcpy(rgb, active_palette_valid ? active_palette : default_colors, sizeof(active_palette));
+    const uint16_t generation = active_palette_generation;
     taskEXIT_CRITICAL();
+    return generation;
 }
 
 void U64Config :: set_palette_color(uint8_t index, const uint8_t rgb[3])
@@ -2783,6 +2788,7 @@ void U64Config :: set_palette_color(uint8_t index, const uint8_t rgb[3])
         active_palette_valid = true;
     }
     memcpy(active_palette[index], rgb, 3);
+    active_palette_generation++;
     taskEXIT_CRITICAL();
     program_palette_color(index, rgb);
     if (dataStreamer) {

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -44,6 +44,7 @@ extern "C" {
 #include "usb_hid.h"
 #include "usb_hid_config.h"
 #include "monitor_init.h"
+#include "data_streamer.h"
 
 // TODO: This doesn't belong here.
 #ifndef CMD_IF_SLOT_BASE
@@ -2760,6 +2761,9 @@ void U64Config :: set_palette_rgb(const uint8_t rgb[16][3])
     memcpy(active_palette, rgb, sizeof(active_palette));
     active_palette_valid = true;
     program_palette_rgb(rgb);
+    if (dataStreamer) {
+        dataStreamer->sendVicPalette(active_palette);
+    }
 }
 
 void U64Config :: get_palette_rgb(uint8_t rgb[16][3])
@@ -2775,6 +2779,9 @@ void U64Config :: set_palette_color(uint8_t index, const uint8_t rgb[3])
     }
     memcpy(active_palette[index], rgb, 3);
     program_palette_color(index, rgb);
+    if (dataStreamer) {
+        dataStreamer->sendVicPalette(active_palette);
+    }
 }
 
 void U64Config :: reset_palette()

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -21,6 +21,7 @@ extern "C" {
 #include "product.h"
 #include "userinterface.h"
 #include "u64_config.h"
+#include "data_streamer.h"
 #include "audio_select.h"
 #include "fpll.h"
 #include "i2c_drv.h"
@@ -2757,24 +2758,36 @@ static void program_palette_color(uint8_t index, const uint8_t rgb[3])
 
 void U64Config :: set_palette_rgb(const uint8_t rgb[16][3])
 {
+    taskENTER_CRITICAL();
     memcpy(active_palette, rgb, sizeof(active_palette));
     active_palette_valid = true;
+    taskEXIT_CRITICAL();
     program_palette_rgb(rgb);
+    if (dataStreamer) {
+        dataStreamer->vicPaletteChanged();
+    }
 }
 
 void U64Config :: get_palette_rgb(uint8_t rgb[16][3])
 {
+    taskENTER_CRITICAL();
     memcpy(rgb, active_palette_valid ? active_palette : default_colors, sizeof(active_palette));
+    taskEXIT_CRITICAL();
 }
 
 void U64Config :: set_palette_color(uint8_t index, const uint8_t rgb[3])
 {
+    taskENTER_CRITICAL();
     if (!active_palette_valid) {
         memcpy(active_palette, default_colors, sizeof(active_palette));
         active_palette_valid = true;
     }
     memcpy(active_palette[index], rgb, 3);
+    taskEXIT_CRITICAL();
     program_palette_color(index, rgb);
+    if (dataStreamer) {
+        dataStreamer->vicPaletteChanged();
+    }
 }
 
 void U64Config :: reset_palette()

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -44,7 +44,6 @@ extern "C" {
 #include "usb_hid.h"
 #include "usb_hid_config.h"
 #include "monitor_init.h"
-#include "data_streamer.h"
 
 // TODO: This doesn't belong here.
 #ifndef CMD_IF_SLOT_BASE
@@ -2761,9 +2760,6 @@ void U64Config :: set_palette_rgb(const uint8_t rgb[16][3])
     memcpy(active_palette, rgb, sizeof(active_palette));
     active_palette_valid = true;
     program_palette_rgb(rgb);
-    if (dataStreamer) {
-        dataStreamer->sendVicPalette(active_palette);
-    }
 }
 
 void U64Config :: get_palette_rgb(uint8_t rgb[16][3])
@@ -2779,9 +2775,6 @@ void U64Config :: set_palette_color(uint8_t index, const uint8_t rgb[3])
     }
     memcpy(active_palette[index], rgb, 3);
     program_palette_color(index, rgb);
-    if (dataStreamer) {
-        dataStreamer->sendVicPalette(active_palette);
-    }
 }
 
 void U64Config :: reset_palette()

--- a/software/u64/u64_config.h
+++ b/software/u64/u64_config.h
@@ -161,7 +161,7 @@ public:
     static void get_sid_addresses(ConfigStore *cfg, uint8_t *base, uint8_t *mask, uint8_t *split);
     static void fix_splits(uint8_t *base, uint8_t *mask, uint8_t *split);
     static void list_palettes(ConfigItem *it, IndexedList<char *>& strings);
-    static void get_palette_rgb(uint8_t rgb[16][3]);
+    static uint16_t get_palette_rgb(uint8_t rgb[16][3]);
     static void set_palette_rgb(const uint8_t rgb[16][3]);
     static void set_palette_color(uint8_t index, const uint8_t rgb[3]);
     static void reset_palette();

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -45,6 +45,7 @@ import argparse
 import ftplib
 import json
 import sys
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -55,6 +56,7 @@ from pathlib import Path
 sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
                             if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
 import bootstrap  # noqa: E402,F401
+import assembler  # noqa: E402
 import cli  # noqa: E402
 import ftp as ftp_lib
 import rest as rest_lib
@@ -120,6 +122,11 @@ CTRL_CMD_SET_PALETTE_COLOR = 0x53
 CTRL_CMD_RESET_PALETTE = 0x54
 VIC_PALETTE_PACKET_SIZE = 60
 VIC_PALETTE_LINE = 239
+VIC_VIDEO_PACKET_SIZE = 780
+PALETTE_BURST_SOURCE = Path(__file__).with_name("vic_palette_burst.asm")
+PALETTE_BURST_STATUS = 0xC000
+PALETTE_BURST_RUNNING = 0xA5
+PALETTE_BURST_DONE = 0x5A
 SOFTIEC_CMD_IDENTIFY = 0x01
 SOFTIEC_CMD_LOAD_SU = 0x10
 SOFTIEC_CMD_GET_FATNAME = 0x22
@@ -234,12 +241,15 @@ class RestSession:
         self.timeout = timeout
 
     def request(self, method: str, path: str, params: dict[str, object] | None = None,
-                repeatable: bool = False, host: str | None = None) -> tuple[int, bytes]:
+                repeatable: bool = False, host: str | None = None,
+                data: bytes | None = None) -> tuple[int, bytes]:
         url = f"http://{host or self.target.host_for(path)}{path}"
         if params:
             url += "?" + urllib.parse.urlencode(params)
         headers = {"X-Password": self.password} if self.password else {}
-        request = urllib.request.Request(url, headers=headers, method=method)
+        if data is not None:
+            headers["Content-Type"] = "application/octet-stream"
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
         # Transport and retry policy come from tests/lib/rest.py; see
         # rest.may_retry. `repeatable` is this suite's word for idempotent: a
         # register read applies nothing, so it may go again after the request
@@ -258,14 +268,17 @@ class RestSession:
         except (OSError, TimeoutError, urllib.error.URLError) as exc:
             raise Failure(f"{method} {url} failed: {format_exception(exc)}") from exc
 
-    def peek(self, address: int, repeatable: bool = False) -> int:
+    def readmem(self, address: int, length: int, repeatable: bool = False) -> bytes:
         status, body = self.request(
-            "GET", READMEM_PATH, params={"address": f"{address:04x}", "length": 1},
+            "GET", READMEM_PATH, params={"address": f"{address:04x}", "length": length},
             repeatable=repeatable, host=self.register_host
         )
-        if status != 200 or len(body) != 1:
+        if status != 200 or len(body) != length:
             raise Failure(f"readmem(${address:04X}) failed with HTTP {status}: {body[:200]!r}")
-        return body[0]
+        return body
+
+    def peek(self, address: int, repeatable: bool = False) -> int:
+        return self.readmem(address, 1, repeatable)[0]
 
     def poke(self, address: int, value: int) -> None:
         status, body = self.request(
@@ -309,6 +322,11 @@ class RestSession:
         status, body = self.request("PUT", RESET_PATH)
         if status != 200:
             raise Failure(f"reset failed with HTTP {status}: {body[:200]!r}")
+
+    def run_prg(self, program: bytes) -> None:
+        status, body = self.request("POST", "/v1/runners:run_prg", data=program)
+        if status != 200:
+            raise Failure(f"runners:run_prg returned HTTP {status}: {body[:200]!r}")
 
 
 class FtpFixture:
@@ -629,6 +647,50 @@ def expect_no_palette_packet(sock, addresses: set[str], accept_any_source: bool 
             raise Failure("VIC stream sent palette data without an explicit palette request")
 
 
+def capture_palette_burst(session: RestSession, sock, addresses: set[str],
+                          accept_any_source: bool) -> tuple[list[tuple[float, int, bytes]], list[int], int, float]:
+    """Run the 6502 burst fixture while continuously draining the video socket."""
+    samples: list[tuple[float, int, bytes]] = []
+    video_sequences: list[int] = []
+    stop = threading.Event()
+
+    def receive() -> None:
+        while not stop.is_set():
+            for _, packet, mine in stream_lib.receive([sock], addresses, 0.05):
+                if not mine and not accept_any_source:
+                    continue
+                now = time.monotonic()
+                if (len(packet) == VIC_PALETTE_PACKET_SIZE and
+                        int.from_bytes(packet[4:6], "little") == VIC_PALETTE_LINE and
+                        packet[6:12] == bytes([0x80, 0x01, 1, 4, 1, 0])):
+                    samples.append((now, int.from_bytes(packet[:2], "little"), packet[12:]))
+                elif len(packet) == VIC_VIDEO_PACKET_SIZE:
+                    video_sequences.append(int.from_bytes(packet[:2], "little"))
+
+    program = assembler.assemble(PALETTE_BURST_SOURCE)
+    session.poke(PALETTE_BURST_STATUS, 0)
+    receiver = threading.Thread(target=receive, daemon=True)
+    receiver.start()
+    started = time.monotonic()
+    try:
+        session.run_prg(program)
+        deadline = started + 15.0
+        while True:
+            result = session.readmem(PALETTE_BURST_STATUS, 3, repeatable=True)
+            if result[0] == PALETTE_BURST_DONE:
+                break
+            if result[0] not in (0, PALETTE_BURST_RUNNING):
+                raise Failure(f"palette burst reported unexpected status ${result[0]:02X}")
+            if time.monotonic() >= deadline:
+                raise Failure("palette burst did not finish within 15 seconds")
+            time.sleep(0.05)
+        time.sleep(0.1)  # Include the rate-limited packet for the final change.
+    finally:
+        stop.set()
+        receiver.join(timeout=1.0)
+    return samples, video_sequences, int.from_bytes(result[1:3], "little"), time.monotonic() - started
+
+
 def run_palette(session: RestSession, uci: Uci) -> bool:
     """Exercise the U64 runtime palette protocol without changing saved config."""
     scenario = "palette"
@@ -666,9 +728,18 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
     sock = stream_lib.stream_socket(group, port)
     stream_started = False
     try:
-        with check(f"{scenario}: ordinary VIC stream sends no palette packets"):
+        with check(f"{scenario}: invalid palette stream options are rejected"):
+            for stream, value in (("video", 2), ("audio", 1), ("audio", 0)):
+                status, body = session.request(
+                    "PUT", f"/v1/streams/{stream}:start",
+                    params={"ip": f"{group}:{port}", "palette": value})
+                if status != 400:
+                    raise Failure(
+                        f"{stream} stream with palette={value} returned HTTP {status}: {body[:200]!r}")
+
+        with check(f"{scenario}: palette=0 sends no palette packets"):
             status, body = session.request(
-                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}"})
+                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}", "palette": 0})
             if status != 200:
                 raise Failure(f"video stream start returned HTTP {status}: {body[:200]!r}")
             stream_started = True
@@ -705,6 +776,63 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             if repeated_generation != generation:
                 raise Failure(
                     f"palette repeat generation {repeated_generation} differs from initial {generation}")
+
+        with check(f"{scenario}: rapid changes are coalesced without disturbing video"):
+            # Empty anything queued after the repeat above before measuring the burst.
+            tuple(stream_lib.receive([sock], addresses, 0.05))
+            samples, video_sequences, command_count, seconds = capture_palette_burst(
+                session, sock, addresses, accept_any_source)
+            if command_count < 2 or len(samples) < 2:
+                raise Failure(f"palette burst completed {command_count} changes but streamed {len(samples)} packets")
+            generation_delta = (samples[-1][1] - generation) & 0xFFFF
+            # runners:run_prg resets the C64 before loading; depending on the
+            # active machine settings that reset may also reapply the palette.
+            if generation_delta not in (command_count, command_count + 1):
+                raise Failure(
+                    f"{command_count} changes advanced the generation by {generation_delta}")
+            reset_changes = generation_delta - command_count
+            for _, sample_generation, sample_palette in samples:
+                change = ((sample_generation - generation) & 0xFFFF) - reset_changes
+                if 1 <= change <= command_count:
+                    index = change - 1
+                    expected = bytes(((13 * index) & 0xFF,
+                                      (85 + 29 * index) & 0xFF,
+                                      (170 + 47 * index) & 0xFF))
+                    if sample_palette[18:21] != expected:
+                        raise Failure(
+                            f"generation {sample_generation} carried color {sample_palette[18:21]!r}, "
+                            f"expected {expected!r}")
+            last = command_count - 1
+            expected_color = bytes(((13 * last) & 0xFF,
+                                    (85 + 29 * last) & 0xFF,
+                                    (170 + 47 * last) & 0xFF))
+            readback, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
+            if text != STATUS_OK or samples[-1][2] != readback:
+                raise Failure("final streamed palette did not match the device readback")
+            if readback[18:21] != expected_color:
+                raise Failure(f"rapid-change color was {readback[18:21]!r}, expected {expected_color!r}")
+            distinct = [sample for i, sample in enumerate(samples)
+                        if i == 0 or sample[1] != samples[i - 1][1]]
+            if len(distinct) >= command_count:
+                raise Failure(f"{command_count} changes produced {len(distinct)} distinct packets; no coalescing")
+            intervals = [current[0] - previous[0] for previous, current in zip(samples, samples[1:])]
+            sample_span = samples[-1][0] - samples[0][0]
+            packet_rate = (len(samples) - 1) / sample_span if sample_span > 0 else float("inf")
+            # Host scheduling can timestamp two already-queued UDP datagrams
+            # close together, so sustained rate is the stable wire-rate check.
+            if packet_rate > 55.0:
+                raise Failure(f"palette stream sustained {packet_rate:.1f} packets/s, expected at most 55")
+            discontinuities = sum(
+                1 for previous, current in zip(video_sequences, video_sequences[1:])
+                if ((current - previous) & 0xFFFF) != 1)
+            if len(video_sequences) < 100 or discontinuities:
+                raise Failure(
+                    f"video during burst had {len(video_sequences)} packets and "
+                    f"{discontinuities} sequence discontinuities")
+            detail(f"{command_count} palette changes in {seconds:.2f}s -> {len(distinct)} packets; "
+                   f"{packet_rate:.1f} packets/s, minimum observed spacing "
+                   f"{min(intervals) * 1000:.1f} ms; "
+                   f"{len(video_sequences)} consecutive video packets")
 
         expect(uci, f"{scenario}: color index 16 is rejected",
                bytes([TARGET_CONTROL, CTRL_CMD_SET_PALETTE_COLOR, 16, 0, 0, 0]),

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -119,7 +119,7 @@ CTRL_CMD_SET_PALETTE = 0x52
 CTRL_CMD_SET_PALETTE_COLOR = 0x53
 CTRL_CMD_RESET_PALETTE = 0x54
 VIC_PALETTE_PACKET_SIZE = 60
-VIC_PALETTE_LINE = 0x7FFF
+VIC_PALETTE_LINE = 239
 SOFTIEC_CMD_IDENTIFY = 0x01
 SOFTIEC_CMD_LOAD_SU = 0x10
 SOFTIEC_CMD_GET_FATNAME = 0x22
@@ -613,12 +613,21 @@ def expect_palette_packet(sock, addresses: set[str], expected: bytes) -> None:
             continue
         if int.from_bytes(packet[4:6], "little") != VIC_PALETTE_LINE:
             continue
-        if packet[6:12] != bytes([16, 0, 1, 24, 0, 0]):
+        if packet[:4] != bytes(4):
+            raise Failure(f"palette stream packet has nonzero sequence/frame {packet[:4]!r}")
+        if packet[6:12] != bytes([0x80, 0x01, 1, 4, 1, 0]):
             raise Failure(f"palette stream packet has invalid format bytes {packet[6:12]!r}")
         if packet[12:] != expected:
             raise Failure(f"palette stream packet was {packet[12:]!r}, expected {expected!r}")
         return
     raise Failure("no palette packet arrived on the VIC stream within 2 seconds")
+
+
+def expect_no_palette_packet(sock, addresses: set[str]) -> None:
+    for _, packet, mine in stream_lib.receive([sock], addresses, 0.25):
+        if (mine and len(packet) == VIC_PALETTE_PACKET_SIZE and
+                packet[10:12] == bytes([1, 0])):
+            raise Failure("VIC stream sent palette data before a runtime palette command")
 
 
 def run_palette(session: RestSession, uci: Uci) -> bool:
@@ -654,13 +663,13 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
     sock = stream_lib.stream_socket(group, port)
     stream_started = False
     try:
-        with check(f"{scenario}: VIC stream start sends the active RGB palette"):
+        with check(f"{scenario}: ordinary VIC stream sends no palette packets"):
             status, body = session.request(
                 "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}"})
             if status != 200:
                 raise Failure(f"video stream start returned HTTP {status}: {body[:200]!r}")
             stream_started = True
-            expect_palette_packet(sock, addresses, original)
+            expect_no_palette_packet(sock, addresses)
 
         with check(f"{scenario}: SET_PALETTE_COLOR changes only the requested color"):
             changed = bytearray(original)
@@ -674,6 +683,18 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
                 raise Failure(f"{scenario}: single-color readback was {actual!r}, expected {bytes(changed)!r}")
 
         with check(f"{scenario}: runtime color change sends the updated RGB palette"):
+            expect_palette_packet(sock, addresses, bytes(changed))
+
+        with check(f"{scenario}: restarted VIC stream repeats the runtime palette"):
+            status, body = session.request("PUT", "/v1/streams/video:stop")
+            if status != 200:
+                raise Failure(f"video stream stop returned HTTP {status}: {body[:200]!r}")
+            stream_started = False
+            status, body = session.request(
+                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}"})
+            if status != 200:
+                raise Failure(f"video stream restart returned HTTP {status}: {body[:200]!r}")
+            stream_started = True
             expect_palette_packet(sock, addresses, bytes(changed))
 
         expect(uci, f"{scenario}: color index 16 is rejected",

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -607,9 +607,10 @@ def run_control_target(uci: Uci) -> bool:
     return True
 
 
-def expect_palette_packet(sock, addresses: set[str], expected: bytes) -> int:
+def expect_palette_packet(sock, addresses: set[str], expected: bytes,
+                          accept_any_source: bool = False) -> int:
     for _, packet, mine in stream_lib.receive([sock], addresses, 2.0):
-        if not mine or len(packet) != VIC_PALETTE_PACKET_SIZE:
+        if (not mine and not accept_any_source) or len(packet) != VIC_PALETTE_PACKET_SIZE:
             continue
         if int.from_bytes(packet[4:6], "little") != VIC_PALETTE_LINE:
             continue
@@ -621,9 +622,9 @@ def expect_palette_packet(sock, addresses: set[str], expected: bytes) -> int:
     raise Failure("no palette packet arrived on the VIC stream within 2 seconds")
 
 
-def expect_no_palette_packet(sock, addresses: set[str]) -> None:
+def expect_no_palette_packet(sock, addresses: set[str], accept_any_source: bool = False) -> None:
     for _, packet, mine in stream_lib.receive([sock], addresses, 0.25):
-        if (mine and len(packet) == VIC_PALETTE_PACKET_SIZE and
+        if ((mine or accept_any_source) and len(packet) == VIC_PALETTE_PACKET_SIZE and
                 packet[10:12] == bytes([1, 0])):
             raise Failure("VIC stream sent palette data without an explicit palette request")
 
@@ -655,6 +656,10 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
 
     group = session.target.video_group
     port = session.target.video_port
+    # A dual-homed Ultimate can send the FPGA video from one interface and the
+    # software palette packet from another. A unicast destination belongs only
+    # to this socket; multicast still needs source filtering between devices.
+    accept_any_source = not stream_lib.is_multicast(group)
     addresses = stream_lib.source_addresses(session.target)
     if not addresses:
         raise Failure(f"{scenario}: could not resolve the VIC stream source address")
@@ -667,7 +672,7 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             if status != 200:
                 raise Failure(f"video stream start returned HTTP {status}: {body[:200]!r}")
             stream_started = True
-            expect_no_palette_packet(sock, addresses)
+            expect_no_palette_packet(sock, addresses, accept_any_source)
 
         with check(f"{scenario}: SET_PALETTE_COLOR changes only the requested color"):
             changed = bytearray(original)
@@ -681,7 +686,7 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
                 raise Failure(f"{scenario}: single-color readback was {actual!r}, expected {bytes(changed)!r}")
 
         with check(f"{scenario}: ordinary VIC stream remains unchanged after a runtime palette command"):
-            expect_no_palette_packet(sock, addresses)
+            expect_no_palette_packet(sock, addresses, accept_any_source)
 
         with check(f"{scenario}: opted-in VIC stream starts with the current runtime palette"):
             status, body = session.request("PUT", "/v1/streams/video:stop")
@@ -693,10 +698,10 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             if status != 200:
                 raise Failure(f"video stream restart returned HTTP {status}: {body[:200]!r}")
             stream_started = True
-            generation = expect_palette_packet(sock, addresses, bytes(changed))
+            generation = expect_palette_packet(sock, addresses, bytes(changed), accept_any_source)
 
         with check(f"{scenario}: opted-in VIC stream periodically repeats its palette"):
-            repeated_generation = expect_palette_packet(sock, addresses, bytes(changed))
+            repeated_generation = expect_palette_packet(sock, addresses, bytes(changed), accept_any_source)
             if repeated_generation != generation:
                 raise Failure(
                     f"palette repeat generation {repeated_generation} differs from initial {generation}")
@@ -716,7 +721,7 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
                 raise Failure(f"{scenario}: full-palette readback was {actual!r}, expected {replacement!r}")
 
         with check(f"{scenario}: palette changes advance the streamed generation"):
-            replacement_generation = expect_palette_packet(sock, addresses, replacement)
+            replacement_generation = expect_palette_packet(sock, addresses, replacement, accept_any_source)
             if ((replacement_generation - generation) & 0xFFFF) == 0:
                 raise Failure("palette generation did not advance after SET_PALETTE")
 
@@ -739,7 +744,7 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
                 raise Failure(f"{scenario}: reset palette readback was {actual!r}, expected {default_palette!r}")
 
         with check(f"{scenario}: RESET_PALETTE is streamed to an opted-in client"):
-            expect_palette_packet(sock, addresses, default_palette)
+            expect_palette_packet(sock, addresses, default_palette, accept_any_source)
 
         expect(uci, f"{scenario}: RESET_PALETTE rejects a payload",
                bytes([TARGET_CONTROL, CTRL_CMD_RESET_PALETTE, 0]),
@@ -755,7 +760,7 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             if status != 200:
                 raise Failure(f"video stream restart returned HTTP {status}: {body[:200]!r}")
             stream_started = True
-            expect_no_palette_packet(sock, addresses)
+            expect_no_palette_packet(sock, addresses, accept_any_source)
     finally:
         try:
             with check(f"{scenario}: restore the original runtime palette"):

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -44,8 +44,8 @@ them on exit.
 import argparse
 import ftplib
 import json
+import socket
 import sys
-import threading
 import time
 import urllib.error
 import urllib.parse
@@ -125,8 +125,10 @@ VIC_PALETTE_LINE = 239
 VIC_VIDEO_PACKET_SIZE = 780
 PALETTE_BURST_SOURCE = Path(__file__).with_name("vic_palette_burst.asm")
 PALETTE_BURST_STATUS = 0xC000
+PALETTE_BURST_READY = 0xA4
 PALETTE_BURST_RUNNING = 0xA5
 PALETTE_BURST_DONE = 0x5A
+PALETTE_BURST_GO = 0xC003
 SOFTIEC_CMD_IDENTIFY = 0x01
 SOFTIEC_CMD_LOAD_SU = 0x10
 SOFTIEC_CMD_GET_FATNAME = 0x22
@@ -626,8 +628,9 @@ def run_control_target(uci: Uci) -> bool:
 
 
 def expect_palette_packet(sock, addresses: set[str], expected: bytes,
-                          accept_any_source: bool = False) -> int:
-    for _, packet, mine in stream_lib.receive([sock], addresses, 2.0):
+                          accept_any_source: bool = False, timeout: float = 2.0) -> int:
+    last_unexpected = None
+    for _, packet, mine in stream_lib.receive([sock], addresses, timeout):
         if (not mine and not accept_any_source) or len(packet) != VIC_PALETTE_PACKET_SIZE:
             continue
         if int.from_bytes(packet[4:6], "little") != VIC_PALETTE_LINE:
@@ -635,9 +638,12 @@ def expect_palette_packet(sock, addresses: set[str], expected: bytes,
         if packet[6:12] != bytes([0x80, 0x01, 1, 4, 1, 0]):
             raise Failure(f"palette stream packet has invalid format bytes {packet[6:12]!r}")
         if packet[12:] != expected:
-            raise Failure(f"palette stream packet was {packet[12:]!r}, expected {expected!r}")
+            last_unexpected = packet[12:]
+            continue
         return int.from_bytes(packet[:2], "little")
-    raise Failure("no palette packet arrived on the VIC stream within 2 seconds")
+    if last_unexpected is not None:
+        raise Failure(f"last palette packet was {last_unexpected!r}, expected {expected!r}")
+    raise Failure(f"no palette packet arrived on the VIC stream within {timeout:g} seconds")
 
 
 def expect_no_palette_packet(sock, addresses: set[str], accept_any_source: bool = False) -> None:
@@ -652,42 +658,31 @@ def capture_palette_burst(session: RestSession, sock, addresses: set[str],
     """Run the 6502 burst fixture while continuously draining the video socket."""
     samples: list[tuple[float, int, bytes]] = []
     video_sequences: list[int] = []
-    stop = threading.Event()
 
-    def receive() -> None:
-        while not stop.is_set():
-            for _, packet, mine in stream_lib.receive([sock], addresses, 0.05):
-                if not mine and not accept_any_source:
-                    continue
-                now = time.monotonic()
-                if (len(packet) == VIC_PALETTE_PACKET_SIZE and
-                        int.from_bytes(packet[4:6], "little") == VIC_PALETTE_LINE and
-                        packet[6:12] == bytes([0x80, 0x01, 1, 4, 1, 0])):
-                    samples.append((now, int.from_bytes(packet[:2], "little"), packet[12:]))
-                elif len(packet) == VIC_VIDEO_PACKET_SIZE:
-                    video_sequences.append(int.from_bytes(packet[:2], "little"))
+    def receive(timeout: float) -> None:
+        for _, packet, mine in stream_lib.receive([sock], addresses, timeout):
+            if not mine and not accept_any_source:
+                continue
+            now = time.monotonic()
+            if (len(packet) == VIC_PALETTE_PACKET_SIZE and
+                    int.from_bytes(packet[4:6], "little") == VIC_PALETTE_LINE and
+                    packet[6:12] == bytes([0x80, 0x01, 1, 4, 1, 0])):
+                samples.append((now, int.from_bytes(packet[:2], "little"), packet[12:]))
+            elif len(packet) == VIC_VIDEO_PACKET_SIZE:
+                video_sequences.append(int.from_bytes(packet[:2], "little"))
 
-    program = assembler.assemble(PALETTE_BURST_SOURCE)
-    session.poke(PALETTE_BURST_STATUS, 0)
-    receiver = threading.Thread(target=receive, daemon=True)
-    receiver.start()
     started = time.monotonic()
-    try:
-        session.run_prg(program)
-        deadline = started + 15.0
-        while True:
-            result = session.readmem(PALETTE_BURST_STATUS, 3, repeatable=True)
-            if result[0] == PALETTE_BURST_DONE:
-                break
-            if result[0] not in (0, PALETTE_BURST_RUNNING):
-                raise Failure(f"palette burst reported unexpected status ${result[0]:02X}")
-            if time.monotonic() >= deadline:
-                raise Failure("palette burst did not finish within 15 seconds")
-            time.sleep(0.05)
-        time.sleep(0.1)  # Include the rate-limited packet for the final change.
-    finally:
-        stop.set()
-        receiver.join(timeout=1.0)
+    session.poke(PALETTE_BURST_GO, 1)
+    deadline = started + 15.0
+    while True:
+        receive(0.05)
+        result = session.readmem(PALETTE_BURST_STATUS, 3, repeatable=True)
+        if result[0] == PALETTE_BURST_DONE:
+            break
+        if result[0] != PALETTE_BURST_RUNNING:
+            raise Failure(f"palette burst reported unexpected status ${result[0]:02X}")
+        if time.monotonic() >= deadline:
+            raise Failure("palette burst did not finish within 15 seconds")
     return samples, video_sequences, int.from_bytes(result[1:3], "little"), time.monotonic() - started
 
 
@@ -726,6 +721,7 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
     if not addresses:
         raise Failure(f"{scenario}: could not resolve the VIC stream source address")
     sock = stream_lib.stream_socket(group, port)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4 * 1024 * 1024)
     stream_started = False
     try:
         with check(f"{scenario}: invalid palette stream options are rejected"):
@@ -772,27 +768,59 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             generation = expect_palette_packet(sock, addresses, bytes(changed), accept_any_source)
 
         with check(f"{scenario}: opted-in VIC stream periodically repeats its palette"):
-            repeated_generation = expect_palette_packet(sock, addresses, bytes(changed), accept_any_source)
-            if repeated_generation != generation:
-                raise Failure(
-                    f"palette repeat generation {repeated_generation} differs from initial {generation}")
+            for _ in range(2):
+                repeated_generation = expect_palette_packet(
+                    sock, addresses, bytes(changed), accept_any_source, timeout=3.0)
+                if repeated_generation != generation:
+                    raise Failure(
+                        f"palette repeat generation {repeated_generation} differs from initial {generation}")
 
         with check(f"{scenario}: rapid changes are coalesced without disturbing video"):
-            # Empty anything queued after the repeat above before measuring the burst.
+            session.poke(PALETTE_BURST_GO, 0)
+            session.poke(PALETTE_BURST_STATUS, 0)
+            session.run_prg(assembler.assemble(PALETTE_BURST_SOURCE))
+            deadline = time.monotonic() + 5.0
+            while session.peek(PALETTE_BURST_STATUS, repeatable=True) != PALETTE_BURST_READY:
+                if time.monotonic() >= deadline:
+                    raise Failure("palette burst fixture did not reach its ready state")
+                time.sleep(0.05)
+            burst_palette, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
+            if text != STATUS_OK:
+                raise Failure(f"GET_PALETTE before burst returned {text!r}")
+            status, body = session.request(
+                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}", "palette": 1})
+            if status != 200:
+                raise Failure(f"video stream restart returned HTTP {status}: {body[:200]!r}")
+            generation = expect_palette_packet(
+                sock, addresses, burst_palette, accept_any_source)
+            # Empty video queued around the stream restart before measuring.
             tuple(stream_lib.receive([sock], addresses, 0.05))
             samples, video_sequences, command_count, seconds = capture_palette_burst(
                 session, sock, addresses, accept_any_source)
             if command_count < 2 or len(samples) < 2:
-                raise Failure(f"palette burst completed {command_count} changes but streamed {len(samples)} packets")
-            generation_delta = (samples[-1][1] - generation) & 0xFFFF
-            # runners:run_prg resets the C64 before loading; depending on the
-            # active machine settings that reset may also reapply the palette.
-            if generation_delta not in (command_count, command_count + 1):
+                raise Failure(
+                    f"palette burst completed {command_count} changes but captured "
+                    f"{len(samples)} palette and {len(video_sequences)} video packets")
+            readback, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
+            if text != STATUS_OK:
+                raise Failure(f"GET_PALETTE after burst returned {text!r}")
+            tuple(stream_lib.receive([sock], addresses, 0.05))
+            status, body = session.request(
+                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}", "palette": 1})
+            if status != 200:
+                raise Failure(f"video stream restart returned HTTP {status}: {body[:200]!r}")
+            final_generation = expect_palette_packet(
+                sock, addresses, readback, accept_any_source)
+            session.poke(PALETTE_BURST_GO, 2)
+            generation_delta = (final_generation - generation) & 0xFFFF
+            detail(f"captured {len(samples)} palette and {len(video_sequences)} video packets; "
+                   f"last live generation delta {(samples[-1][1] - generation) & 0xFFFF}, "
+                   f"final delta {generation_delta}")
+            if generation_delta != command_count:
                 raise Failure(
                     f"{command_count} changes advanced the generation by {generation_delta}")
-            reset_changes = generation_delta - command_count
             for _, sample_generation, sample_palette in samples:
-                change = ((sample_generation - generation) & 0xFFFF) - reset_changes
+                change = (sample_generation - generation) & 0xFFFF
                 if 1 <= change <= command_count:
                     index = change - 1
                     expected = bytes(((13 * index) & 0xFF,
@@ -806,9 +834,6 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             expected_color = bytes(((13 * last) & 0xFF,
                                     (85 + 29 * last) & 0xFF,
                                     (170 + 47 * last) & 0xFF))
-            readback, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
-            if text != STATUS_OK or samples[-1][2] != readback:
-                raise Failure("final streamed palette did not match the device readback")
             if readback[18:21] != expected_color:
                 raise Failure(f"rapid-change color was {readback[18:21]!r}, expected {expected_color!r}")
             distinct = [sample for i, sample in enumerate(samples)
@@ -833,6 +858,17 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
                    f"{packet_rate:.1f} packets/s, minimum observed spacing "
                    f"{min(intervals) * 1000:.1f} ms; "
                    f"{len(video_sequences)} consecutive video packets")
+            session.reset()
+            uci.release()
+            resumed_palette, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
+            if text != STATUS_OK:
+                raise Failure(f"GET_PALETTE after fixture cleanup returned {text!r}")
+            status, body = session.request(
+                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}", "palette": 1})
+            if status != 200:
+                raise Failure(f"video stream resume returned HTTP {status}: {body[:200]!r}")
+            generation = expect_palette_packet(
+                sock, addresses, resumed_palette, accept_any_source)
 
         expect(uci, f"{scenario}: color index 16 is rejected",
                bytes([TARGET_CONTROL, CTRL_CMD_SET_PALETTE_COLOR, 16, 0, 0, 0]),
@@ -883,6 +919,7 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             if status != 200:
                 raise Failure(f"video stream stop returned HTTP {status}: {body[:200]!r}")
             stream_started = False
+            tuple(stream_lib.receive([sock], addresses, 0.05))
             status, body = session.request(
                 "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}"})
             if status != 200:
@@ -891,6 +928,10 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             expect_no_palette_packet(sock, addresses, accept_any_source)
     finally:
         try:
+            try:
+                session.poke(PALETTE_BURST_GO, 2)
+            except Failure:
+                pass
             with check(f"{scenario}: restore the original runtime palette"):
                 reply, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_SET_PALETTE]) + original)
                 if text != STATUS_OK or reply:

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -715,8 +715,10 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
 
     group = session.target.video_group
     port = session.target.video_port
-    # Palette metadata uses the same source address as the FPGA VIC stream.
-    accept_any_source = False
+    # A dual-homed Ultimate can send the FPGA video from one interface and the
+    # software palette packet from another. A unicast destination belongs only
+    # to this socket; multicast still needs source filtering between devices.
+    accept_any_source = not stream_lib.is_multicast(group)
     addresses = stream_lib.source_addresses(session.target)
     if not addresses:
         raise Failure(f"{scenario}: could not resolve the VIC stream source address")

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -58,6 +58,7 @@ import bootstrap  # noqa: E402,F401
 import cli  # noqa: E402
 import ftp as ftp_lib
 import rest as rest_lib
+import streams as stream_lib
 import targets
 from report import (
     FAIL, Failure, OK, SKIP, check, check_skip, check_start, detail,
@@ -117,6 +118,8 @@ CTRL_CMD_GET_PALETTE = 0x51
 CTRL_CMD_SET_PALETTE = 0x52
 CTRL_CMD_SET_PALETTE_COLOR = 0x53
 CTRL_CMD_RESET_PALETTE = 0x54
+VIC_PALETTE_PACKET_SIZE = 60
+VIC_PALETTE_LINE = 0x7FFF
 SOFTIEC_CMD_IDENTIFY = 0x01
 SOFTIEC_CMD_LOAD_SU = 0x10
 SOFTIEC_CMD_GET_FATNAME = 0x22
@@ -604,7 +607,21 @@ def run_control_target(uci: Uci) -> bool:
     return True
 
 
-def run_palette(uci: Uci) -> bool:
+def expect_palette_packet(sock, addresses: set[str], expected: bytes) -> None:
+    for _, packet, mine in stream_lib.receive([sock], addresses, 2.0):
+        if not mine or len(packet) != VIC_PALETTE_PACKET_SIZE:
+            continue
+        if int.from_bytes(packet[4:6], "little") != VIC_PALETTE_LINE:
+            continue
+        if packet[6:12] != bytes([16, 0, 1, 24, 0, 0]):
+            raise Failure(f"palette stream packet has invalid format bytes {packet[6:12]!r}")
+        if packet[12:] != expected:
+            raise Failure(f"palette stream packet was {packet[12:]!r}, expected {expected!r}")
+        return
+    raise Failure("no palette packet arrived on the VIC stream within 2 seconds")
+
+
+def run_palette(session: RestSession, uci: Uci) -> bool:
     """Exercise the U64 runtime palette protocol without changing saved config."""
     scenario = "palette"
     product, status = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_HWINFO, 0x00]))
@@ -629,7 +646,22 @@ def run_palette(uci: Uci) -> bool:
     if len(original) != 48:
         raise Failure(f"{scenario}: expected 48 palette bytes, got {len(original)}")
 
+    group = session.target.video_group
+    port = session.target.video_port
+    addresses = stream_lib.source_addresses(session.target)
+    if not addresses:
+        raise Failure(f"{scenario}: could not resolve the VIC stream source address")
+    sock = stream_lib.stream_socket(group, port)
+    stream_started = False
     try:
+        with check(f"{scenario}: VIC stream start sends the active RGB palette"):
+            status, body = session.request(
+                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}"})
+            if status != 200:
+                raise Failure(f"video stream start returned HTTP {status}: {body[:200]!r}")
+            stream_started = True
+            expect_palette_packet(sock, addresses, original)
+
         with check(f"{scenario}: SET_PALETTE_COLOR changes only the requested color"):
             changed = bytearray(original)
             changed[-3:] = bytes(component ^ 0x5A for component in changed[-3:])
@@ -640,6 +672,9 @@ def run_palette(uci: Uci) -> bool:
             actual, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
             if text != STATUS_OK or actual != bytes(changed):
                 raise Failure(f"{scenario}: single-color readback was {actual!r}, expected {bytes(changed)!r}")
+
+        with check(f"{scenario}: runtime color change sends the updated RGB palette"):
+            expect_palette_packet(sock, addresses, bytes(changed))
 
         expect(uci, f"{scenario}: color index 16 is rejected",
                bytes([TARGET_CONTROL, CTRL_CMD_SET_PALETTE_COLOR, 16, 0, 0, 0]),
@@ -677,13 +712,23 @@ def run_palette(uci: Uci) -> bool:
                bytes([TARGET_CONTROL, CTRL_CMD_RESET_PALETTE, 0]),
                STATUS_INVALID_PARAMS, reply=b"")
     finally:
-        with check(f"{scenario}: restore the original runtime palette"):
-            reply, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_SET_PALETTE]) + original)
-            if text != STATUS_OK or reply:
-                raise Failure(f"{scenario}: restore returned data {reply!r}, status {text!r}")
-            actual, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
-            if text != STATUS_OK or actual != original:
-                raise Failure(f"{scenario}: restored palette readback was {actual!r}")
+        try:
+            with check(f"{scenario}: restore the original runtime palette"):
+                reply, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_SET_PALETTE]) + original)
+                if text != STATUS_OK or reply:
+                    raise Failure(f"{scenario}: restore returned data {reply!r}, status {text!r}")
+                actual, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
+                if text != STATUS_OK or actual != original:
+                    raise Failure(f"{scenario}: restored palette readback was {actual!r}")
+        finally:
+            try:
+                if stream_started:
+                    with check(f"{scenario}: stop the VIC stream"):
+                        status, body = session.request("PUT", "/v1/streams/video:stop")
+                        if status != 200:
+                            raise Failure(f"video stream stop returned HTTP {status}: {body[:200]!r}")
+            finally:
+                sock.close()
     return True
 
 
@@ -982,7 +1027,7 @@ def main() -> int:
 
         run("transport", run_transport, uci)
         run("control-target", run_control_target, uci)
-        run("palette", run_palette, uci)
+        run("palette", run_palette, session, uci)
         run("issue-740-matrix", run_issue_740_matrix, session, ftp, uci)
         run("save-reu-offset-past-end", run_save_reu_offset_past_end, session, uci)
         run("load-reu-disabled", run_reu_disabled, session, uci, CTRL_CMD_LOAD_REU, "load-reu-disabled")

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -43,6 +43,7 @@ them on exit.
 
 import argparse
 import ftplib
+import itertools
 import json
 import socket
 import sys
@@ -840,7 +841,8 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
                         if i == 0 or sample[1] != samples[i - 1][1]]
             if len(distinct) >= command_count:
                 raise Failure(f"{command_count} changes produced {len(distinct)} distinct packets; no coalescing")
-            intervals = [current[0] - previous[0] for previous, current in zip(samples, samples[1:])]
+            intervals = [current[0] - previous[0]
+                         for previous, current in itertools.pairwise(samples)]
             sample_span = samples[-1][0] - samples[0][0]
             packet_rate = (len(samples) - 1) / sample_span if sample_span > 0 else float("inf")
             # Host scheduling can timestamp two already-queued UDP datagrams
@@ -848,7 +850,7 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             if packet_rate > 55.0:
                 raise Failure(f"palette stream sustained {packet_rate:.1f} packets/s, expected at most 55")
             discontinuities = sum(
-                1 for previous, current in zip(video_sequences, video_sequences[1:])
+                1 for previous, current in itertools.pairwise(video_sequences)
                 if ((current - previous) & 0xFFFF) != 1)
             if len(video_sequences) < 100 or discontinuities:
                 raise Failure(

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -650,7 +650,8 @@ def expect_palette_packet(sock, addresses: set[str], expected: bytes,
 def expect_no_palette_packet(sock, addresses: set[str], accept_any_source: bool = False) -> None:
     for _, packet, mine in stream_lib.receive([sock], addresses, 0.25):
         if ((mine or accept_any_source) and len(packet) == VIC_PALETTE_PACKET_SIZE and
-                packet[10:12] == bytes([1, 0])):
+                int.from_bytes(packet[4:6], "little") == VIC_PALETTE_LINE and
+                packet[6:12] == bytes([0x80, 0x01, 1, 4, 1, 0])):
             raise Failure("VIC stream sent palette data without an explicit palette request")
 
 
@@ -714,10 +715,8 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
 
     group = session.target.video_group
     port = session.target.video_port
-    # A dual-homed Ultimate can send the FPGA video from one interface and the
-    # software palette packet from another. A unicast destination belongs only
-    # to this socket; multicast still needs source filtering between devices.
-    accept_any_source = not stream_lib.is_multicast(group)
+    # Palette metadata uses the same source address as the FPGA VIC stream.
+    accept_any_source = False
     addresses = stream_lib.source_addresses(session.target)
     if not addresses:
         raise Failure(f"{scenario}: could not resolve the VIC stream source address")

--- a/tests/e2e/io/command_interface/uci_targets_test.py
+++ b/tests/e2e/io/command_interface/uci_targets_test.py
@@ -607,19 +607,17 @@ def run_control_target(uci: Uci) -> bool:
     return True
 
 
-def expect_palette_packet(sock, addresses: set[str], expected: bytes) -> None:
+def expect_palette_packet(sock, addresses: set[str], expected: bytes) -> int:
     for _, packet, mine in stream_lib.receive([sock], addresses, 2.0):
         if not mine or len(packet) != VIC_PALETTE_PACKET_SIZE:
             continue
         if int.from_bytes(packet[4:6], "little") != VIC_PALETTE_LINE:
             continue
-        if packet[:4] != bytes(4):
-            raise Failure(f"palette stream packet has nonzero sequence/frame {packet[:4]!r}")
         if packet[6:12] != bytes([0x80, 0x01, 1, 4, 1, 0]):
             raise Failure(f"palette stream packet has invalid format bytes {packet[6:12]!r}")
         if packet[12:] != expected:
             raise Failure(f"palette stream packet was {packet[12:]!r}, expected {expected!r}")
-        return
+        return int.from_bytes(packet[:2], "little")
     raise Failure("no palette packet arrived on the VIC stream within 2 seconds")
 
 
@@ -627,7 +625,7 @@ def expect_no_palette_packet(sock, addresses: set[str]) -> None:
     for _, packet, mine in stream_lib.receive([sock], addresses, 0.25):
         if (mine and len(packet) == VIC_PALETTE_PACKET_SIZE and
                 packet[10:12] == bytes([1, 0])):
-            raise Failure("VIC stream sent palette data before a runtime palette command")
+            raise Failure("VIC stream sent palette data without an explicit palette request")
 
 
 def run_palette(session: RestSession, uci: Uci) -> bool:
@@ -682,20 +680,26 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             if text != STATUS_OK or actual != bytes(changed):
                 raise Failure(f"{scenario}: single-color readback was {actual!r}, expected {bytes(changed)!r}")
 
-        with check(f"{scenario}: runtime color change sends the updated RGB palette"):
-            expect_palette_packet(sock, addresses, bytes(changed))
+        with check(f"{scenario}: ordinary VIC stream remains unchanged after a runtime palette command"):
+            expect_no_palette_packet(sock, addresses)
 
-        with check(f"{scenario}: restarted VIC stream repeats the runtime palette"):
+        with check(f"{scenario}: opted-in VIC stream starts with the current runtime palette"):
             status, body = session.request("PUT", "/v1/streams/video:stop")
             if status != 200:
                 raise Failure(f"video stream stop returned HTTP {status}: {body[:200]!r}")
             stream_started = False
             status, body = session.request(
-                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}"})
+                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}", "palette": 1})
             if status != 200:
                 raise Failure(f"video stream restart returned HTTP {status}: {body[:200]!r}")
             stream_started = True
-            expect_palette_packet(sock, addresses, bytes(changed))
+            generation = expect_palette_packet(sock, addresses, bytes(changed))
+
+        with check(f"{scenario}: opted-in VIC stream periodically repeats its palette"):
+            repeated_generation = expect_palette_packet(sock, addresses, bytes(changed))
+            if repeated_generation != generation:
+                raise Failure(
+                    f"palette repeat generation {repeated_generation} differs from initial {generation}")
 
         expect(uci, f"{scenario}: color index 16 is rejected",
                bytes([TARGET_CONTROL, CTRL_CMD_SET_PALETTE_COLOR, 16, 0, 0, 0]),
@@ -710,6 +714,11 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             actual, text = uci.transact(bytes([TARGET_CONTROL, CTRL_CMD_GET_PALETTE]))
             if text != STATUS_OK or actual != replacement:
                 raise Failure(f"{scenario}: full-palette readback was {actual!r}, expected {replacement!r}")
+
+        with check(f"{scenario}: palette changes advance the streamed generation"):
+            replacement_generation = expect_palette_packet(sock, addresses, replacement)
+            if ((replacement_generation - generation) & 0xFFFF) == 0:
+                raise Failure("palette generation did not advance after SET_PALETTE")
 
         expect(uci, f"{scenario}: short SET_PALETTE payload is rejected",
                bytes([TARGET_CONTROL, CTRL_CMD_SET_PALETTE]) + original[:-1],
@@ -729,9 +738,24 @@ def run_palette(session: RestSession, uci: Uci) -> bool:
             if text != STATUS_OK or actual != default_palette:
                 raise Failure(f"{scenario}: reset palette readback was {actual!r}, expected {default_palette!r}")
 
+        with check(f"{scenario}: RESET_PALETTE is streamed to an opted-in client"):
+            expect_palette_packet(sock, addresses, default_palette)
+
         expect(uci, f"{scenario}: RESET_PALETTE rejects a payload",
                bytes([TARGET_CONTROL, CTRL_CMD_RESET_PALETTE, 0]),
                STATUS_INVALID_PARAMS, reply=b"")
+
+        with check(f"{scenario}: a later ordinary stream is not opted in implicitly"):
+            status, body = session.request("PUT", "/v1/streams/video:stop")
+            if status != 200:
+                raise Failure(f"video stream stop returned HTTP {status}: {body[:200]!r}")
+            stream_started = False
+            status, body = session.request(
+                "PUT", "/v1/streams/video:start", params={"ip": f"{group}:{port}"})
+            if status != 200:
+                raise Failure(f"video stream restart returned HTTP {status}: {body[:200]!r}")
+            stream_started = True
+            expect_no_palette_packet(sock, addresses)
     finally:
         try:
             with check(f"{scenario}: restore the original runtime palette"):

--- a/tests/e2e/io/command_interface/vic_palette_burst.asm
+++ b/tests/e2e/io/command_interface/vic_palette_burst.asm
@@ -10,8 +10,9 @@ ST_STATE = $30
 ST_LAST  = $20
 ST_STAT  = $40
 
-STATUS   = $C000               ; $A5 while running, $5A when complete
+STATUS   = $C000               ; $A4 ready, $A5 running, $5A complete
 COUNT    = $C001               ; completed commands, little endian
+GO       = $C003               ; host writes nonzero to release the burst
 
 FRAMES            = 60
 CHANGES_PER_FRAME = 4
@@ -28,11 +29,17 @@ basic_end
 
 start
         sei
-        lda #$A5
-        sta STATUS
         lda #$00
         sta COUNT
         sta COUNT+1
+        sta GO
+        lda #$A4
+        sta STATUS
+wait_go
+        lda GO
+        beq wait_go
+        lda #$A5
+        sta STATUS
         lda #FRAMES
         sta frames_left
 
@@ -67,6 +74,10 @@ count_done
         lda #$5A
         sta STATUS
         cli
+wait_exit
+        lda GO
+        cmp #$02
+        bne wait_exit
         rts
 
 ; Wait for raster line zero in the low half. $D012 also reads zero at line 256,

--- a/tests/e2e/io/command_interface/vic_palette_burst.asm
+++ b/tests/e2e/io/command_interface/vic_palette_burst.asm
@@ -1,0 +1,126 @@
+; Change VIC color 6 four times per frame through the Ultimate Command
+; Interface. The host-side palette E2E test uses this to prove that firmware
+; coalesces a burst without disturbing the ordinary video packet sequence.
+
+CTRL    = $DF1C
+CMDREG  = $DF1D
+STATR   = $DF1F
+
+ST_STATE = $30
+ST_LAST  = $20
+ST_STAT  = $40
+
+STATUS   = $C000               ; $A5 while running, $5A when complete
+COUNT    = $C001               ; completed commands, little endian
+
+FRAMES            = 60
+CHANGES_PER_FRAME = 4
+
+        * = $0801
+
+; BASIC line "10 SYS 2061".
+        .word basic_end, 10
+        .byte $9e
+        .text "2061"
+        .byte 0
+basic_end
+        .word 0
+
+start
+        sei
+        lda #$A5
+        sta STATUS
+        lda #$00
+        sta COUNT
+        sta COUNT+1
+        lda #FRAMES
+        sta frames_left
+
+frame_loop
+        jsr wait_frame
+        lda #CHANGES_PER_FRAME
+        sta changes_left
+change_loop
+        jsr set_color
+        inc red
+        lda red
+        clc
+        adc #12                   ; net +13 including INC
+        sta red
+        lda green
+        clc
+        adc #29
+        sta green
+        lda blue
+        clc
+        adc #47
+        sta blue
+        inc COUNT
+        bne count_done
+        inc COUNT+1
+count_done
+        dec changes_left
+        bne change_loop
+        dec frames_left
+        bne frame_loop
+
+        lda #$5A
+        sta STATUS
+        cli
+        rts
+
+; Wait for raster line zero in the low half. $D012 also reads zero at line 256,
+; so $D011 bit 7 distinguishes the real frame boundary.
+wait_frame
+wait_away
+        bit $D011
+        bmi wait_away
+        lda $D012
+        beq wait_away
+wait_zero
+        bit $D011
+        bmi wait_zero
+        lda $D012
+        bne wait_zero
+        rts
+
+set_color
+wait_idle
+        lda CTRL
+        and #ST_STATE
+        bne wait_idle
+        lda #$04
+        sta CMDREG
+        lda #$53
+        sta CMDREG
+        lda #$06
+        sta CMDREG
+        lda red
+        sta CMDREG
+        lda green
+        sta CMDREG
+        lda blue
+        sta CMDREG
+        lda #$01
+        sta CTRL
+wait_reply
+        lda CTRL
+        and #ST_STATE
+        cmp #ST_LAST
+        bne wait_reply
+drain_status
+        lda CTRL
+        and #ST_STAT
+        beq accept_reply
+        lda STATR
+        jmp drain_status
+accept_reply
+        lda #$02
+        sta CTRL
+        rts
+
+frames_left  .byte 0
+changes_left .byte 0
+red          .byte 0
+green        .byte 85
+blue         .byte 170


### PR DESCRIPTION
VIC streams carry 4-bit color indices but no runtime palette, so clients cannot reproduce palette changes made by software such as Heartbeat. This adds an explicit `palette=1` option to `PUT /v1/streams/video:start` and sends compact palette metadata to the active video destination without an FPGA change.

Existing clients remain unchanged: palette packets are opt-in, use the agreed 60-byte video-compatible pseudo-header, and ordinary video packets retain their current format. Firmware sends an atomic RGB/generation snapshot, repeats it once per second for UDP recovery, and coalesces rapid writes to at most one packet per 20 ms.

Multicast metadata is bound to the VIC stream interface and source-filtered. Unicast lets LwIP select the usable software route because the FPGA video stream and software UDP stack can use different interfaces on a dual-homed Ultimate.

Validation:

- U2 RISC-V, U2+, U2+L, U64/Elite, and U64-II/Elite-II application targets compile on the CI-matched Beast toolchains
- all 23 firmware checks pass on an Ultimate 64 Elite in both multicast and unicast modes
- 240 rapid changes produced 49 multicast packets at 50.7 packets/s alongside 3,648 consecutive video packets
- 240 rapid changes produced 51 unicast packets at 50.6 packets/s alongside 3,732 consecutive video packets
- OBS hardware E2E passed with FPGA video from Ethernet and palette metadata from Wi-Fi, including a visible live palette transition

Companion OBS plugin PR: chrisgleissner/c64stream#131

Refs #850
