### PR TITLE
Mute U64II speaker SIDs during freeze

### DIFF
--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -828,7 +828,7 @@ void C64::dma_transfer_frozen(uint16_t offset, uint8_t *buffer, int length, int 
     C64_DMA_MEMONLY = saved_memonly;
 }
 
-#if U64 == 1
+#if U64
 // Defined in u64_config.cc, which owns the FPGA audio mixer and the settings
 // it is programmed from. Weak because the updater application links this file
 // without that one; there the SID writes below stand on their own.
@@ -836,13 +836,12 @@ extern void u64_mute_sids(void) __attribute__((weak));
 extern void u64_unmute_sids(void) __attribute__((weak));
 #endif
 
-// Silence the SIDs while the freezer owns the machine. The SID master volume
-// is what does it, on every target. Where an FPGA mixer is available it is
-// closed around those writes, so the click they make is not heard; see
-// u64_mute_sids().
+// Silence the SIDs while the freezer owns the machine. Where an FPGA mixer is
+// available, use it instead of stepping the SID master-volume DC offset. Other
+// targets retain the portable SID-register fallback.
 static void freezer_mute_sids(void)
 {
-#if U64 == 1
+#if U64
     if (u64_mute_sids) {
         u64_mute_sids();
         return;
@@ -855,7 +854,7 @@ static void freezer_mute_sids(void)
 
 static void freezer_unmute_sids(void)
 {
-#if U64 == 1
+#if U64
     if (u64_unmute_sids) {
         u64_unmute_sids();
         return;

--- a/software/u64/u64_config.cc
+++ b/software/u64/u64_config.cc
@@ -1312,9 +1312,9 @@ int U64Config :: setFilter(ConfigItem *it)
 // rather than instead of them: the $D418 mute stays, and stays portable, and
 // on this hardware it happens where it cannot be heard.
 //
-// The first eight bytes are the SID channels: UltiSID 1 and 2, socket 1 and 2,
-// right and left. SetMixerAutoSid zeroes the same eight to mute the SIDs while
-// it remaps them.
+// The first eight bytes of either mixer are the SID channels: UltiSID 1 and 2,
+// socket 1 and 2, right and left. SetMixerAutoSid zeroes the same eight in the
+// main mixer while it remaps them.
 void u64_mute_sids(void)
 {
     volatile uint8_t *mixer = (volatile uint8_t *)U64_AUDIO_MIXER;
@@ -1322,6 +1322,12 @@ void u64_mute_sids(void)
     for (int i = 0; i < 8; i++) {
         mixer[i] = 0;
     }
+#if U64 == 2
+    mixer = (volatile uint8_t *)U64_SPEAKER_MIXER;
+    for (int i = 0; i < 8; i++) {
+        mixer[i] = 0;
+    }
+#endif
 }
 
 // From the stored settings, not from what was there before the mute: the mixer


### PR DESCRIPTION
U64E2 and C64U builds skipped the FPGA mixer mute path when entering the freezer, leaving SID master-volume writes audible as clicks. Enable the existing mixer helper for all U64 targets and, on U64II, mute the eight SID inputs in both the main and internal-speaker mixers. The existing restore path reapplies both mixers from configuration, including a disabled speaker.

Fixes #868.

Validation:

- `make u64ii` on Beast, including ESP-IDF control firmware and both U64E2 size checks
- `make u64_no_esp` on Beast as an original-U64 regression build
- OpenAPI validation and 36 repository tests pass in both builds
- Linked U64II code writes all eight SID inputs in both mixer banks; linked U64 code retains its existing single mixer-bank writes

The audible result still needs confirmation on a U64E2 or C64U. @GideonZ @chrisgleissner, could one of you verify entry and exit from the freezer with the internal speaker enabled?
