### PR TITLE
Let the E2E suites run on a pruned checkout, and stop blanking the menu

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -44,7 +44,12 @@ $(document).ready(async function () {
             // Power off reaches hardware on the Ultimate 64 family only; a
             // cartridge answers 501. These are the names /v1/info reports for
             // that family, from product_name[] in software/system/product.cc.
-            const ProductsWithPwrCtrl = ["Ultimate 64", "Ultimate 64 Elite", "Ultimate 64-II"];
+            // That array is conditional on COMMODORE, which renames the last
+            // two entries, so both namings of the same hardware are listed
+            // here: leaving either out hides the item on machines that can
+            // power off.
+            const ProductsWithPwrCtrl = ["Ultimate 64", "Ultimate 64 Elite", "Ultimate 64-II",
+                                         "C64 Ultimate (MK1)", "C64 Ultimate"];
             if (ProductsWithPwrCtrl.includes(product))
                 $("#menu-power").show();
 

--- a/tests/e2e/api/input_test.py
+++ b/tests/e2e/api/input_test.py
@@ -2113,7 +2113,9 @@ def run_menu_open_tests(session: RestInputSession) -> None:
     Which machines have a keyboard route, and the request sequence that
     produces the stimulus, are both in tests/e2e/lib/menu.py so that there is
     one place to change when the firmware lets the sequence become a single
-    request.
+    request. Having the route is not the same as the firmware answering it,
+    so the check is also tagged with machine.KEYBOARD_COMBINATION_OPENS_MENU
+    and reports a skip on a firmware line that ignores the combination.
     """
     machine = session.machine
     opener = menu_lib.keyboard_menu_opener(machine.kind, session.post_events)
@@ -2123,7 +2125,11 @@ def run_menu_open_tests(session: RestInputSession) -> None:
                    f"machine:menu_button is the only signal that opens it")
         return
 
-    with check(f"{opener.name} opens the menu"):
+    label = f"{opener.name} opens the menu"
+    if machine.skip_without_fix(machine_lib.KEYBOARD_COMBINATION_OPENS_MENU, label):
+        return
+
+    with check(label):
         session.close_menu_from_anywhere()
         if session.menu_screen_open():
             raise Failure("the menu was already open, so this check would "

--- a/tests/e2e/io/c64/deferred_actions_test.py
+++ b/tests/e2e/io/c64/deferred_actions_test.py
@@ -144,6 +144,14 @@ def blank_screen(api: UltimateApi) -> None:
     the prompt returns at once, proving nothing. The menu's own characters
     would still be there too, which is exactly what the leftover check is
     looking for.
+
+    This must only be called while the menu is closed. The freeze interface
+    draws the menu into the same screen RAM, so blanking it there erases a
+    menu the firmware still reports as open and does not redraw. The browser
+    then reads a blank screen and cannot find its selected row. Blanking
+    before the menu opens still gives each check what it needs, because the
+    menu is drawn into the blanked screen afterwards and any characters it
+    leaves behind are still there to be found.
     """
     api.machine.writemem(SCREEN_RAM, bytes([SPACE_CODE]) * SCREEN_BYTES)
 
@@ -376,12 +384,12 @@ def run_menu_action(browser, api: UltimateApi, action: str,
     # it instead. Nothing here should leave a menu behind, and this is the
     # cheap guarantee that it did not.
     close_menu(api)
+    blank_screen(api)
     route = open_menu(api)
     if not api.machine.menu_open():
         raise Failure(f"the menu did not open after {MENU_OPEN_PRESSES} x "
                       f"{route}")
     browser.go_to_root()
-    blank_screen(api)
     take_menu_action(browser, browser.backend.machine.machine_task_category,
                      action)
     return wait_for_prompt(api, timeout), route
@@ -429,12 +437,12 @@ def scenario_browser_reset_shortcut(browser, api: UltimateApi) -> None:
         # request_hide_then_action sets to MENU_HIDE, so the browser leaves
         # before the reset runs.
         close_menu(api)
+        blank_screen(api)
         route = open_menu(api)
         if not api.machine.menu_open():
             raise Failure(f"the menu did not open after {MENU_OPEN_PRESSES} x "
                           f"{route}")
         browser.go_to_root()
-        blank_screen(api)
         # C= + R resets the machine, which closes the menu, so the settle read
         # after the keystroke answers 404; see take_menu_action.
         try:

--- a/tests/e2e/web/index_test.py
+++ b/tests/e2e/web/index_test.py
@@ -209,7 +209,20 @@ class Page:
         return self.driver.find_element(By.ID, element_id)
 
     def visible(self, element_id):
-        return self.element(element_id).is_displayed()
+        """Whether the page is showing that element, with absent counting as no.
+
+        A page that never wrote the element at all is the strongest form of not
+        showing it, and a check that asks whether something is offered wants a
+        verdict rather than an exception. A firmware line whose index.html has
+        no such element would otherwise end the run on a traceback instead of
+        reporting the product gap it found. element() still raises, because the
+        callers that click or type need the element to be there.
+        """
+        from selenium.common.exceptions import NoSuchElementException
+        try:
+            return self.element(element_id).is_displayed()
+        except NoSuchElementException:
+            return False
 
     def click(self, element_id):
         self.element(element_id).click()

--- a/tests/e2e/web/index_test.py
+++ b/tests/e2e/web/index_test.py
@@ -83,7 +83,12 @@ READY_TIMEOUT = 20.0
 
 # Every name product_name[] in software/system/product.cc can report, split by
 # whether MENU_C64_POWEROFF does anything on that product.
-POWER_PRODUCTS = ("Ultimate 64", "Ultimate 64 Elite", "Ultimate 64-II")
+# Both namings of the same hardware. product_name[] in
+# software/system/product.cc renames the last two under COMMODORE, so a
+# check that lists only one naming passes while the other build hides the
+# item on machines that can power off.
+POWER_PRODUCTS = ("Ultimate 64", "Ultimate 64 Elite", "Ultimate 64-II",
+                  "C64 Ultimate (MK1)", "C64 Ultimate")
 CARTRIDGE_PRODUCTS = ("Ultimate", "Ultimate II", "Ultimate II+", "Ultimate II+L")
 
 # The disk images the page mounts rather than runs, and the drive it uses.

--- a/tests/lib/esp_depends_test.py
+++ b/tests/lib/esp_depends_test.py
@@ -40,6 +40,14 @@ WORKFLOW = os.path.join(ROOT, ".github", "workflows", "build.yml")
 # "/build/", minus the leading "software/" that esp_depends.py runs inside of.
 CACHED_ARTIFACT = re.compile(r"^\s*software/(\S+?)/build/\S+\s*$", re.MULTILINE)
 
+# esp_depends.py names the directories it hashes in one list near the top, of
+# the form `dirs = [ 'u64ctrl', 'u64ctrl/main' ]`. The two firmware lines that
+# run this test tree do not list the same projects, so the directory the
+# missing-directory check breaks is read out of the script rather than written
+# in here.
+DIRS_LIST = re.compile(r"^\s*dirs\s*=\s*\[(.*?)\]", re.MULTILINE | re.DOTALL)
+QUOTED_PATH = re.compile(r"'([^']*)'|\"([^\"]*)\"")
+
 
 def cached_projects():
     """The ESP32 projects whose build output CI stores in the ESP32 cache."""
@@ -94,13 +102,46 @@ def run_coverage_check():
         detail("watched: " + ", ".join(f"{p} ({hashed[p]} files)" for p in cached))
 
 
+def listed_directories(script):
+    """The quoted paths in esp_depends.py's own `dirs` list, in source order."""
+    match = DIRS_LIST.search(script)
+    if not match:
+        return []
+    return [single or double
+            for single, double in QUOTED_PATH.findall(match.group(1))
+            if single or double]
+
+
+def directory_to_break(dirs):
+    """The entry to misspell: a nested path when the list holds one.
+
+    A nested path is the interesting case. Its parent directory still exists,
+    so a misspelling of the child is the one that hashes nothing while looking
+    plausible. The choice is by source order, so the same list always picks the
+    same directory.
+    """
+    for entry in dirs:
+        if "/" in entry:
+            return entry
+    return dirs[0]
+
+
 def run_missing_directory_check():
     """A directory that is not there has to be an error, not a quiet no-op."""
     with check("a misspelt directory fails instead of silently hashing nothing"):
         with open(DEPENDS_SCRIPT, encoding="utf-8") as handle:
             original = handle.read()
-        if "wifi/raw_u64/main" not in original:
-            raise Failure("esp_depends.py no longer lists wifi/raw_u64/main; "
+        dirs = listed_directories(original)
+        if not dirs:
+            raise Failure("esp_depends.py has no directory list this check can "
+                          "use: no `dirs = [ ... ]` of quoted paths was found")
+        target = directory_to_break(dirs)
+        broken = target + "_does_not_exist"
+        mutated = re.sub(r"(['\"])" + re.escape(target) + r"\1",
+                         lambda match: match.group(1) + broken + match.group(1),
+                         original, count=1)
+        if mutated == original:
+            raise Failure(f"could not misspell {target!r} in esp_depends.py; "
                           "this check needs updating")
         # The copy runs from software/ because the globs are relative to it, but
         # it is a copy: a run interrupted here must not leave the real script
@@ -108,16 +149,17 @@ def run_missing_directory_check():
         broken_path = os.path.join(SOFTWARE_DIR, ".esp_depends_missing_dir_check.py")
         try:
             with open(broken_path, "w", encoding="utf-8") as handle:
-                handle.write(original.replace("wifi/raw_u64/main",
-                                              "wifi/raw_does_not_exist/main"))
+                handle.write(mutated)
             result = subprocess.run([sys.executable, broken_path], cwd=SOFTWARE_DIR,
                                     capture_output=True, text=True, check=False)
         finally:
             if os.path.exists(broken_path):
                 os.remove(broken_path)
         if result.returncode == 0:
-            raise Failure("a missing directory was accepted; the cache key would "
-                          "silently stop depending on that project")
+            raise Failure(f"a missing directory ({broken}) was accepted; the "
+                          "cache key would silently stop depending on that project")
+        detail(f"{target} misspelt as {broken}: esp_depends.py exited "
+               f"{result.returncode}")
 
 
 def main():

--- a/tests/lib/esp_depends_test.py
+++ b/tests/lib/esp_depends_test.py
@@ -47,9 +47,15 @@ def cached_projects():
         workflow = handle.read()
 
     # Only the ESP32 cache step; the FPGA caches list .bit files elsewhere.
-    start = workflow.find("name: Cache ESP32 Targets")
+    # Found by the step's `id`, not by its display name. The workflow refers to
+    # that id itself, in `steps.cache-esp32.outputs.cache-hit`, so renaming it
+    # breaks the build and cannot pass unnoticed. The display name is free text:
+    # it reads "Cache ESP32 Targets" here and "Cache ESP32 Target" on the C64
+    # Ultimate firmware line, which runs this same test tree, and matching it
+    # exactly made the check raise before it compared anything.
+    start = workflow.find("id: cache-esp32")
     if start < 0:
-        raise Failure("build.yml has no 'Cache ESP32 Targets' step any more; "
+        raise Failure("build.yml has no step with `id: cache-esp32` any more; "
                       "this check needs updating to wherever the ESP32 cache moved")
     end = workflow.find("restore-keys:", start)
     projects = sorted(set(CACHED_ARTIFACT.findall(workflow[start:end])))

--- a/tests/lib/machine.py
+++ b/tests/lib/machine.py
@@ -218,6 +218,24 @@ QUERY_FORM_SURVIVES_DROPDOWN_CONFIRM = _fix(
     "the other fields, rather than emptying the whole form",
     (C64U,))
 
+# What the "opens the menu" check in tests/e2e/api/input_test.py asserts, on
+# the one machine tests/e2e/lib/menu.py gives a keyboard route into the menu.
+# A C64 Ultimate's core reads the keyboard matrix at a RESTORE NMI edge and
+# treats CBM held down plus that edge the way it treats the menu button, so
+# the combination has to open the menu.
+#
+# Measured on a C64 Ultimate, 2026-09-07: an injected C= plus RESTORE did not
+# open the menu on any of 6 attempts, while machine:menu_button opened it every
+# time. The firmware that lacks this fix does not resync the button edge
+# detector after the menu closes, so the edge the combination raises is not
+# read as a fresh press. tests/e2e/io/c64/deferred_actions_test.py records the
+# same limitation for its own menu-reopening checks.
+KEYBOARD_COMBINATION_OPENS_MENU = _fix(
+    "keyboard-combination-opens-menu",
+    "an injected C= plus RESTORE opens the menu, the same way the menu button "
+    "does, rather than being ignored",
+    (C64U,))
+
 # Every fix at once, for a sweep that asks whether the lagging line has caught
 # up rather than about one behaviour.
 ASSUME_ALL = "all"

--- a/tests/lib/observability/pure_test.py
+++ b/tests/lib/observability/pure_test.py
@@ -2073,7 +2073,15 @@ def every_record_kind_is_in_the_table() -> str:
 @case(1, "OBS-4.9", "OBS-4.10")
 def the_gate_workflow_is_the_one_described() -> str:
     """The workflow file, read as the facts the specification states about it."""
+    # This same suite runs from a checkout that carries the tests but not the
+    # gate workflow, and there the file is absent by design rather than lost.
+    # Opening it regardless ends the case in a FileNotFoundError, which reads
+    # as a broken check rather than as a check with nothing to read, so the
+    # absence is reported as a skip and every assertion below still runs
+    # wherever the workflow is present.
     path = os.path.join(ROOT, ".github", "workflows", "e2e.yml")
+    if not os.path.exists(path):
+        raise Skipped(".github/workflows/e2e.yml is not in this checkout")
     with open(path, encoding="utf-8") as handle:
         text = handle.read()
     for wanted, why in (


### PR DESCRIPTION
Found by running the deep E2E profile against a C64 Ultimate. This test tree is
also run from a second, pruned checkout of a different firmware line, and three
suites did not survive there. Each failed in a way that told the reader nothing:
a stack trace, or a message claiming the check needed updating when the check
was fine and only its lookup was too narrow. A fourth defect is real on both
lines and was only ever hidden by a timing difference.

No assertion is weakened. Where a file or an element is present, every check
that ran before still runs and still asserts the same thing.

## The ESP32 cache step was found by its display name

`esp_depends_test` located the cache step with the literal string
`"name: Cache ESP32 Targets"`. The other line names that step
`Cache ESP32 Target`, so the search missed and the suite raised
"build.yml has no 'Cache ESP32 Targets' step any more; this check needs
updating to wherever the ESP32 cache moved". The cache had not moved and
nothing needed updating.

The step is now found by `id: cache-esp32`. The workflow reads that id itself,
in `steps.cache-esp32.outputs.cache-hit`, so renaming it breaks the build and
cannot pass unnoticed, which is not true of a display name. Three projects are
discovered here, one on the other line.

## The gate workflow check opened a file that is absent by design

`the_gate_workflow_is_the_one_described` opened `.github/workflows/e2e.yml`
unconditionally. The other checkout carries the tests but not that workflow, so
the case ended in a `FileNotFoundError`, which reads as a broken check rather
than a check with nothing to read.

It now raises `Skipped` naming the file, the idiom this module already uses for
a missing specification. An audit of every repo-relative path built under
`tests/` found no second instance.

## An absent element ended the web suite on a traceback

`Page.visible()` is used as a predicate, and `check_power_menu` asserts False
for products that should not offer Power Off. It was implemented on `element()`,
which raises `NoSuchElementException`, so a page that does not carry the element
at all ended the suite on a stack trace rather than answering the question.

A page that never wrote the element is the strongest form of not showing it, so
`visible()` now answers False. `element()` is unchanged, because callers that
click or type do need it to raise.

## The screen was blanked while the menu was open

This one is a real defect in the test, not a portability problem, and it is the
reason the other line could not run `deferred-machine-actions` in freeze mode at
all.

`run_menu_action` and `scenario_browser_reset_shortcut` called `blank_screen()`
after `browser.go_to_root()`, so the blanking happened while the menu was open.
In freeze mode the menu is drawn into C64 screen RAM, so this erased it. The
firmware still reported the menu as open and did not redraw it, and the browser
then failed to find its selected row on a blank screen.

Measured on a C64 Ultimate, freeze mode, before the fix:

```
after go_to_root, BEFORE blank_screen: 307 non-space cells of 1000
immediately AFTER blank_screen:          0 non-space cells
1s later:                                0 non-space cells, menu_open still True
browser.rows() -> 25 rows, 0 non-blank
selected_row() -> Failure: could not locate selected menu row from colour codes
```

In isolation this failed for both 'Reset C64' and 'Reboot C64' every time. On an
Ultimate 64 the same order is harmless, which is why it went unnoticed.

Both scenarios now blank immediately after `close_menu` and before `open_menu`,
matching `scenario_rest_routes`, which already had that order. The checks keep
their meaning: the screen read back is still this boot's, so the wait for READY
cannot pass on a stale prompt, and menu characters left behind are still
detectable because the menu is drawn into the blanked screen afterwards.

## The misspelt-directory check named a project only this line has

Fixing the step lookup above unmasked a second hardcoded path in the same
suite. `run_missing_directory_check` proves that a directory which is not there
becomes an error rather than a silent no-op, and it did that by replacing the
literal `"wifi/raw_u64/main"` in a copy of `software/esp_depends.py`. It first
asserted that string was present, so on a line whose `esp_depends.py` reads
`dirs = [ 'u64ctrl', 'u64ctrl/main' ]` the case died with "this check needs
updating" without testing anything.

The directory to break is now taken from the script's own `dirs` list,
preferring an entry with a `/` because a nested path is the interesting case.
The mutation still goes to a copy, never to the real script, and the copy is
still removed in the `finally`. The chosen directory is named in the detail
line, so a reader can see which one was exercised.

## One suite failed hard where another skipped for the same missing firmware

`tests/e2e/lib/menu.py` registers a C64 Ultimate as the one machine with a
keyboard route to the menu, and `input_test` check 42 asserts that C= plus
RESTORE opens it. On firmware that does not resync the button edge detector
after the menu closes, it does not: measured deterministically, six attempts out
of six, while `machine:menu_button` opened the menu every time.

`deferred_actions_test` already skips three of its own checks for exactly that
firmware limitation, with a reason string naming it. So the tree was
inconsistent, and the same absent behaviour produced a clean SKIP in one suite
and a hard failure in another.

Check 42 now goes through the `FIXES` table, the mechanism this tree already has
for a firmware line that has not caught up. Nothing it asserts when it does run
has changed, and `menu.py` is untouched. When the firmware lands, deleting the
table entry is the one-line edit `Machine.has_fix` documents, and
`stale_gates_test` is what notices if that is forgotten.

## Power Off was offered on only one naming of the same hardware

`ProductsWithPwrCtrl` in `html/index.html` decides whether the Power Off item is
shown, from the names `/v1/info` reports. Its own comment says those come from
`product_name[]` in `software/system/product.cc`, and that array is conditional:

```c
    "Ultimate 64",
#if COMMODORE
    "C64 Ultimate (MK1)",
    "C64 Ultimate",
#else
    "Ultimate 64 Elite",
    "Ultimate 64-II",
#endif
```

The same two hardware slots, renamed. A list carrying one naming therefore hides
the item on a build that reports the other, even though the firmware serves
`PUT /v1/machine:poweroff` either way. Both namings are now listed.

`POWER_PRODUCTS` in the web suite had the same gap, so the check passed while the
item was missing on the build it did not name. It now covers both, which is what
turns this from a change you have to take on trust into one the suite can hold.

## Testing

`deferred-machine-actions`, on real hardware, both machines and both transports:

| Target | Result |
|---|---|
| C64 Ultimate, freeze | OK (10 checks, 5.196s), was the failing case |
| C64 Ultimate, overlay | OK (10 checks, 13.9s) |
| Ultimate 64, freeze | OK (10 checks, 4.848s) |
| Ultimate 64, overlay | OK (10 checks, 4.996s) |

The Ultimate 64 was measured before the fix as well, to confirm this change does
not paper over a regression there: it already passed, `OK (10 checks, 4.908s)`.

Device-free suites on this branch: `esp_depends_test: OK (2 checks)` and
`observability: OK (178 cases, 2 skipped)`, the two skips being the pre-existing
"fixture was recorded without a recording" ones.

`web_index: OK (70 checks, 23.6s)` where `menu-power` is present, the four extra checks being the renamed products, so the
`visible()` change regresses nothing. Run against a page that lacks the element,
the suite now reports
`[01] a Ultimate 64 offers Power Off Machine ... FAIL (the menu item is False, expected True)`
instead of a traceback, which names the real gap in that page rather than hiding
it.

Each fix was also exercised in both states, present and absent: the gate workflow
case reports OK with the workflow in place and SKIP with it moved aside, and
`visible()` was driven against fake drivers to confirm an absent element returns
False, a present one returns True, and `element()` still raises. The directory
parsing was checked against both shapes of `esp_depends.py`, choosing
`wifi/raw_c3/main` here and `u64ctrl/main` on a trimmed copy, without touching
the real script.

`stale_gates_test: OK (7 checks)`, `registry_test: OK (64 suites, 6 checks)`,
`runner_policy_test: OK (99 checks)` and `lint_test` all pass, which is what
polices the `FIXES` table, the suite registry and ruff over the whole tree.

Applied to the other line and run there, these six take its gate from four
failing suites to one: `esp_depends_test: OK (2 checks)`,
`observability: OK (178 cases, 3 skipped)`, `deferred_actions_test: OK` in both
transports, and `input_test: OK (45 checks)` with check 42 reporting
`SKIP (needs the keyboard-combination-opens-menu fix...)`. The one that still
fails there is `web-index`, correctly, because that line's `index.html` genuinely
has no `menu-power` element. That is a gap in the page, not in the test, and it
is being fixed where the page lives.
