### PR TITLE
Stop REST fire2/fire3 leaking onto the other joystick port

### DIFF
--- a/software/api/route_input.cc
+++ b/software/api/route_input.cc
@@ -268,8 +268,11 @@ static void apply_joystick_event(const InputParsedEvent &event)
         active_low |= event.joystick_mask;
         if (event.port == 1) {
             JoystickOutput::instance().setRestPort1Persistent(active_low);
+            // Cancel any in-flight tap so it can't mask this release.
+            JoystickOutput::instance().cancelRestPort1Overlay(event.joystick_mask);
         } else {
             JoystickOutput::instance().setRestPort2Persistent(active_low);
+            JoystickOutput::instance().cancelRestPort2Overlay(event.joystick_mask);
         }
         break;
     case INPUT_PARSED_TAP:

--- a/software/api/tests/input_api_state_test.cpp
+++ b/software/api/tests/input_api_state_test.cpp
@@ -812,6 +812,43 @@ TEST(RestJoystickStateTest, Fire2AndFire3PersistAndReleaseIndependently)
     EXPECT_EQ(0x5F, port1);
 }
 
+TEST(RestJoystickStateTest, ReleaseCancelsInFlightTapOverlayImmediately)
+{
+    // Tap then release of the same input, as route_input.cc applies them.
+    reset_joystick_output();
+    uint8_t hold[7] = { 0, 0, 0, 0, 0, 1, 0 };  // fire2 (bit 5) tapped
+    uint8_t port1 = 0;
+    uint8_t port2 = 0;
+
+    // Tap shows fire2 pressed.
+    JoystickOutput::instance().armRestPort1Overlay(0x7F & ~0x20, hold);
+    JoystickOutput::instance().snapshot(port1, port2);
+    EXPECT_EQ(0x5F, port1);
+
+    // Release must take effect immediately, not wait for the tap to expire.
+    JoystickOutput::instance().setRestPort1Persistent(0x7F);
+    JoystickOutput::instance().cancelRestPort1Overlay(0x20);
+    JoystickOutput::instance().snapshot(port1, port2);
+    EXPECT_EQ(0x7F, port1);
+}
+
+TEST(RestJoystickStateTest, CancelOverlayLeavesOtherBitsAlone)
+{
+    reset_joystick_output();
+    uint8_t hold[7] = { 0, 0, 0, 0, 0, 1, 1 };  // fire2 and fire3 both tapped
+    uint8_t port1 = 0;
+    uint8_t port2 = 0;
+
+    JoystickOutput::instance().armRestPort1Overlay(0x7F & ~0x60, hold);
+    JoystickOutput::instance().cancelRestPort1Overlay(0x20);  // cancel fire2 only
+    JoystickOutput::instance().snapshot(port1, port2);
+    EXPECT_EQ(0x3F, port1);  // fire2 (bit 5) released, fire3 (bit 6) still mid-tap
+
+    JoystickOutput::instance().tickOverlays();
+    JoystickOutput::instance().snapshot(port1, port2);
+    EXPECT_EQ(0x7F, port1);  // fire3's own countdown still auto-releases normally
+}
+
 TEST(RestJoystickStateTest, Fire2MapsToPotXAndFire3MapsToPotY)
 {
     reset_joystick_output();

--- a/software/io/c64/joystick_output.cc
+++ b/software/io/c64/joystick_output.cc
@@ -134,10 +134,11 @@ void JoystickOutput :: restPersistentSnapshot(uint8_t &port1_active_low, uint8_t
     port2_active_low = rest_p2_persistent & JOYSTICK_INPUT_MASK;
 }
 
-static void arm_overlay_bits(uint8_t &overlay, uint8_t hold_state[7], uint8_t active_low_mask, const uint8_t hold[7])
+static void arm_overlay_bits(uint8_t &overlay, uint8_t hold_state[JOYSTICK_BUTTON_COUNT], uint8_t active_low_mask,
+    const uint8_t hold[JOYSTICK_BUTTON_COUNT])
 {
     active_low_mask &= JOYSTICK_INPUT_MASK;
-    for (int i = 0; i < 7; i++) {
+    for (int i = 0; i < JOYSTICK_BUTTON_COUNT; i++) {
         uint8_t bit = (1 << i);
         if (hold[i] != 0) {
             hold_state[i] = hold[i];
@@ -150,7 +151,7 @@ static void arm_overlay_bits(uint8_t &overlay, uint8_t hold_state[7], uint8_t ac
     }
 }
 
-void JoystickOutput :: armRestPort1Overlay(uint8_t active_low_mask, const uint8_t hold[7])
+void JoystickOutput :: armRestPort1Overlay(uint8_t active_low_mask, const uint8_t hold[JOYSTICK_BUTTON_COUNT])
 {
 #if U64
     portENTER_CRITICAL();
@@ -162,7 +163,7 @@ void JoystickOutput :: armRestPort1Overlay(uint8_t active_low_mask, const uint8_
 #endif
 }
 
-void JoystickOutput :: armRestPort2Overlay(uint8_t active_low_mask, const uint8_t hold[7])
+void JoystickOutput :: armRestPort2Overlay(uint8_t active_low_mask, const uint8_t hold[JOYSTICK_BUTTON_COUNT])
 {
 #if U64
     portENTER_CRITICAL();
@@ -174,10 +175,47 @@ void JoystickOutput :: armRestPort2Overlay(uint8_t active_low_mask, const uint8_
 #endif
 }
 
-static bool tick_overlay_bits(uint8_t &overlay, uint8_t hold_state[7])
+// Forces the masked bits' overlay back to released and cancels their hold
+// countdown; other bits' overlays and countdowns are untouched.
+static void cancel_overlay_bits(uint8_t &overlay, uint8_t hold_state[JOYSTICK_BUTTON_COUNT], uint8_t mask)
+{
+    mask &= JOYSTICK_INPUT_MASK;
+    for (int i = 0; i < JOYSTICK_BUTTON_COUNT; i++) {
+        if (mask & (1 << i)) {
+            hold_state[i] = 0;
+            overlay |= (1 << i);
+        }
+    }
+}
+
+void JoystickOutput :: cancelRestPort1Overlay(uint8_t mask)
+{
+#if U64
+    portENTER_CRITICAL();
+#endif
+    cancel_overlay_bits(rest_p1_overlay, rest_p1_hold, mask);
+    apply();
+#if U64
+    portEXIT_CRITICAL();
+#endif
+}
+
+void JoystickOutput :: cancelRestPort2Overlay(uint8_t mask)
+{
+#if U64
+    portENTER_CRITICAL();
+#endif
+    cancel_overlay_bits(rest_p2_overlay, rest_p2_hold, mask);
+    apply();
+#if U64
+    portEXIT_CRITICAL();
+#endif
+}
+
+static bool tick_overlay_bits(uint8_t &overlay, uint8_t hold_state[JOYSTICK_BUTTON_COUNT])
 {
     bool changed = false;
-    for (int i = 0; i < 7; i++) {
+    for (int i = 0; i < JOYSTICK_BUTTON_COUNT; i++) {
         if (hold_state[i] == 0) {
             continue;
         }

--- a/software/io/c64/joystick_output.cc
+++ b/software/io/c64/joystick_output.cc
@@ -80,15 +80,6 @@ void JoystickOutput :: apply(void)
     outputSnapshot(port1, port2, pot1x, pot1y, pot2x, pot2y);
     C64_JOY1_SWOUT = port1 | 0xE0;
     C64_JOY2_SWOUT = port2 | 0xE0;
-    // U64 exposes the C64-visible POT pair through the first paddle output registers.
-    // Keep the port 2 registers updated, but mirror asserted lows so Anykey-style
-    // button reads observe REST fire2/fire3 on either joystick port.
-    if (pot2x == JOYSTICK_POT_PRESSED) {
-        pot1x = JOYSTICK_POT_PRESSED;
-    }
-    if (pot2y == JOYSTICK_POT_PRESSED) {
-        pot1y = JOYSTICK_POT_PRESSED;
-    }
     C64_PADDLE_1_X = pot1x;
     C64_PADDLE_1_Y = pot1y;
     C64_PADDLE_2_X = pot2x;
@@ -96,10 +87,8 @@ void JoystickOutput :: apply(void)
     if (usb_hid_get_active_mouse_interfaces) {
         mouse_port1_enabled = usb_hid_get_active_mouse_interfaces() > 0;
     }
-    bool rest_port1_extra = joystick_has_extra_button_press(usb_p1 & rest_p1_persistent & rest_p1_overlay);
-    bool rest_port2_extra = joystick_has_extra_button_press(rest_p2_persistent & rest_p2_overlay);
-    C64_MOUSE_EN_1 = (mouse_port1_enabled || rest_port1_extra || rest_port2_extra) ? 1 : 0;
-    C64_MOUSE_EN_2 = rest_port2_extra ? 1 : 0;
+    C64_MOUSE_EN_1 = (mouse_port1_enabled || joystick_has_extra_button_press(usb_p1 & rest_p1_persistent & rest_p1_overlay)) ? 1 : 0;
+    C64_MOUSE_EN_2 = joystick_has_extra_button_press(rest_p2_persistent & rest_p2_overlay) ? 1 : 0;
 #endif
 }
 

--- a/software/io/c64/joystick_output.h
+++ b/software/io/c64/joystick_output.h
@@ -3,6 +3,9 @@
 
 #include "integer.h"
 
+// Must match INPUT_API_MAX_JOYSTICK_INPUTS in software/api/input_api.h.
+static const int JOYSTICK_BUTTON_COUNT = 7;
+
 class JoystickOutput
 {
     uint8_t usb_p1;
@@ -10,8 +13,8 @@ class JoystickOutput
     uint8_t rest_p2_persistent;
     uint8_t rest_p1_overlay;
     uint8_t rest_p2_overlay;
-    uint8_t rest_p1_hold[7];
-    uint8_t rest_p2_hold[7];
+    uint8_t rest_p1_hold[JOYSTICK_BUTTON_COUNT];
+    uint8_t rest_p2_hold[JOYSTICK_BUTTON_COUNT];
 
     JoystickOutput();
     void apply(void);
@@ -25,8 +28,12 @@ public:
     void setRestPort2Persistent(uint8_t active_low_mask);
     void restPersistentSnapshot(uint8_t &port1_active_low, uint8_t &port2_active_low) const;
 
-    void armRestPort1Overlay(uint8_t active_low_mask, const uint8_t hold[7]);
-    void armRestPort2Overlay(uint8_t active_low_mask, const uint8_t hold[7]);
+    void armRestPort1Overlay(uint8_t active_low_mask, const uint8_t hold[JOYSTICK_BUTTON_COUNT]);
+    void armRestPort2Overlay(uint8_t active_low_mask, const uint8_t hold[JOYSTICK_BUTTON_COUNT]);
+
+    // Cancels an in-flight tap for the given bits so a release isn't masked.
+    void cancelRestPort1Overlay(uint8_t mask);
+    void cancelRestPort2Overlay(uint8_t mask);
 
     void tickOverlays(void);
 

--- a/tests/e2e/api/input_test.py
+++ b/tests/e2e/api/input_test.py
@@ -641,8 +641,8 @@ def assert_input_state(
 
 
 def read_joystick_cia(session: RestInputSession) -> tuple[int, int]:
-    session.pause()
     try:
+        session.pause()
         session.write_memory(0xDC02, b"\x00")
         session.write_memory(0xDC03, b"\x00")
         regs = session.read_memory(0xDC00, 2)
@@ -654,8 +654,8 @@ def read_joystick_cia(session: RestInputSession) -> tuple[int, int]:
 
 
 def read_keyboard_row(session: RestInputSession, row: int) -> int:
-    session.pause()
     try:
+        session.pause()
         session.write_memory(0xDC02, b"\xFF")
         session.write_memory(0xDC03, b"\x00")
         session.write_memory(0xDC00, bytes([(~(1 << row)) & 0xFF]))
@@ -665,25 +665,32 @@ def read_keyboard_row(session: RestInputSession, row: int) -> int:
         session.resume()
 
 
+def _select_and_read_pot(session: RestInputSession, port: int) -> tuple[int, int]:
+    session.write_memory(0xDC00, b"\x40" if port == 1 else b"\x80")
+    time.sleep(0.10)
+    regs = session.read_memory(0xD419, 2)
+    return regs[0], regs[1]
+
+
 def read_joystick_pots(session: RestInputSession, port: int) -> tuple[int, int]:
     if port not in (1, 2):
         raise Failure(f"Invalid joystick port for POT read: {port}")
-    # Select the joystick port's paddle group on CIA1, then read SID
-    # POTX/POTY. This must pause the machine like read_joystick_cia and
-    # read_keyboard_row above: left running, the KERNAL's keyboard-scan IRQ
-    # rewrites $DC00 about every 20ms (it cycles the column-select mask,
-    # which shares bits 6/7 with the paddle-group select), racing whatever
-    # this function just wrote there before the 0.10s settle elapses. On real
-    # hardware that race made the port argument close to meaningless: reads
-    # reflected whichever group the KERNAL's scan last selected, not the one
-    # requested here.
-    session.pause()
+    # Select the paddle group on CIA1, then read SID POTX/POTY. Must pause
+    # like read_joystick_cia/read_keyboard_row: left running, the KERNAL's
+    # keyboard-scan IRQ overwrites $DC00 within ~20ms and races this write.
     try:
+        session.pause()
         session.write_memory(0xDC02, b"\xC0")
-        session.write_memory(0xDC00, b"\x40" if port == 1 else b"\x80")
-        time.sleep(0.10)
-        regs = session.read_memory(0xD419, 2)
-        return regs[0], regs[1]
+        return _select_and_read_pot(session, port)
+    finally:
+        session.resume()
+
+
+def read_joystick_pots_both(session: RestInputSession) -> dict[int, tuple[int, int]]:
+    try:
+        session.pause()
+        session.write_memory(0xDC02, b"\xC0")
+        return {1: _select_and_read_pot(session, 1), 2: _select_and_read_pot(session, 2)}
     finally:
         session.resume()
 
@@ -697,8 +704,7 @@ def assert_joystick_pots(session: RestInputSession, port: int, potx: int, poty: 
         )
 
 
-def assert_anykey_extra_buttons(session: RestInputSession, port: int, fire2: bool, fire3: bool) -> None:
-    potx, poty = read_joystick_pots(session, port)
+def _check_anykey_extra_buttons(port: int, potx: int, poty: int, fire2: bool, fire3: bool) -> None:
     actual_fire2 = (potx & 0x80) == 0
     actual_fire3 = (poty & 0x80) == 0
     if (actual_fire2, actual_fire3) != (fire2, fire3):
@@ -707,6 +713,18 @@ def assert_anykey_extra_buttons(session: RestInputSession, port: int, fire2: boo
             f"expected fire2/fire3={fire2}/{fire3}, got {actual_fire2}/{actual_fire3} "
             f"from POTX/POTY=${potx:02X}/${poty:02X}"
         )
+
+
+def assert_anykey_extra_buttons(session: RestInputSession, port: int, fire2: bool, fire3: bool) -> None:
+    potx, poty = read_joystick_pots(session, port)
+    _check_anykey_extra_buttons(port, potx, poty, fire2, fire3)
+
+
+def assert_anykey_extra_buttons_both(session: RestInputSession, expected: dict[int, tuple[bool, bool]]) -> None:
+    pots = read_joystick_pots_both(session)
+    for port, (fire2, fire3) in expected.items():
+        potx, poty = pots[port]
+        _check_anykey_extra_buttons(port, potx, poty, fire2, fire3)
 
 
 def assert_keyboard_matrix(session: RestInputSession, input_name: str, active: bool) -> None:
@@ -2337,41 +2355,48 @@ def run_joystick_tests(session: RestInputSession) -> None:
 def run_joystick_checks(session: RestInputSession) -> None:
     session.post_events([{"kind": "release_all"}])
 
-    with check("joystick port 2 fire keeps Anykey buttons 2 and 3 released"):
+    # Regression coverage for #879: fire2/fire3 on one port must not appear
+    # on the other port's POT reading. Covers both ports and both inputs.
+    ANYKEY_ISOLATION_CASES = (
+        # (input, fire2 expected on the pressed port, fire3 expected on the pressed port)
+        ("fire", False, False),
+        ("fire2", True, False),
+        ("fire3", False, True),
+    )
+    for own_port in (1, 2):
+        other_port = 2 if own_port == 1 else 1
+        for input_name, fire2_expected, fire3_expected in ANYKEY_ISOLATION_CASES:
+            if input_name == "fire":
+                label = f"joystick port {own_port} fire keeps Anykey buttons 2 and 3 released"
+            else:
+                button = "2" if input_name == "fire2" else "3"
+                label = (f"joystick port {own_port} {input_name} lights only Anykey button {button}, "
+                          f"only on port {own_port}")
+            with check(label):
+                session.post_events([{"kind": "release_all"}])
+                session.post_events(
+                    [{"kind": "joystick", "port": own_port, "inputs": [input_name], "transition": "press"}])
+                assert_anykey_extra_buttons_both(
+                    session, {own_port: (fire2_expected, fire3_expected), other_port: (False, False)})
+
+    with check("joystick fire2 on one port and fire3 on the other stay independent"):
+        # Both ports held at once with different extra-button state.
         session.post_events([{"kind": "release_all"}])
-        session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire"], "transition": "press"}])
-        assert_joystick_ports(session, 0x1F, 0x0F)
+        session.post_events(
+            [
+                {"kind": "joystick", "port": 1, "inputs": ["fire2"], "transition": "press"},
+                {"kind": "joystick", "port": 2, "inputs": ["fire3"], "transition": "press"},
+            ]
+        )
+        assert_anykey_extra_buttons_both(session, {1: (True, False), 2: (False, True)})
+
+    with check("joystick fire2/fire3 tap auto-releases the POT hardware state"):
+        session.post_events([{"kind": "release_all"}])
+        session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire2", "fire3"], "transition": "tap"}])
+        time.sleep(0.2)
         assert_anykey_extra_buttons(session, 2, fire2=False, fire3=False)
-
-    with check("joystick port 2 fire2 lights only Anykey button 2, only on port 2"):
-        session.post_events([{"kind": "release_all"}])
-        session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire2"], "transition": "press"}])
-        assert_anykey_extra_buttons(session, 2, fire2=True, fire3=False)
-        assert_anykey_extra_buttons(session, 1, fire2=False, fire3=False)
-
-    with check("joystick port 2 fire3 lights only Anykey button 3, only on port 2"):
-        session.post_events([{"kind": "release_all"}])
-        session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire3"], "transition": "press"}])
-        assert_anykey_extra_buttons(session, 2, fire2=False, fire3=True)
-        assert_anykey_extra_buttons(session, 1, fire2=False, fire3=False)
-
-    # Regression coverage for #879: fire2/fire3 pressed on one port must not
-    # appear on the other port's POT reading. The addendum spec requires a
-    # REST-held fire2/fire3 to assert only the selected port's POT line (see
-    # doc/research/keyboard-and-joystick-rest-api/spec-addendum1.md, section 4,
-    # constraint 3); the fix removed a cross-port POT mirror in
-    # JoystickOutput::apply() that violated this.
-    with check("joystick port 1 fire2 lights only Anykey button 2, only on port 1"):
-        session.post_events([{"kind": "release_all"}])
-        session.post_events([{"kind": "joystick", "port": 1, "inputs": ["fire2"], "transition": "press"}])
-        assert_anykey_extra_buttons(session, 1, fire2=True, fire3=False)
-        assert_anykey_extra_buttons(session, 2, fire2=False, fire3=False)
-
-    with check("joystick port 1 fire3 lights only Anykey button 3, only on port 1"):
-        session.post_events([{"kind": "release_all"}])
-        session.post_events([{"kind": "joystick", "port": 1, "inputs": ["fire3"], "transition": "press"}])
-        assert_anykey_extra_buttons(session, 1, fire2=False, fire3=True)
-        assert_anykey_extra_buttons(session, 2, fire2=False, fire3=False)
+        if session.get_state()["joysticks"][1]["inputs"] != []:
+            raise Failure(f"Expected port 2 state empty after tap auto-release, got {session.get_state()}")
 
     with check("joystick port 1 up press is visible on CIA reads"):
         session.post_events([{"kind": "release_all"}])
@@ -2407,14 +2432,27 @@ def run_joystick_checks(session: RestInputSession) -> None:
         session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire"], "transition": "release"}])
         assert_joystick_ports(session, 0x1F, 0x1E)
 
-    with check("joystick fire2/fire3 round-trip through REST state"):
+    with check("joystick fire2/fire3 round-trip through REST state and POT hardware"):
         session.post_events([{"kind": "release_all"}])
         session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire", "fire2", "fire3"], "transition": "press"}])
         assert_joystick_ports(session, 0x1F, 0x0F)
         assert_input_state(session, [], [], ["fire", "fire2", "fire3"])
+        assert_anykey_extra_buttons_both(session, {2: (True, True), 1: (False, False)})
         session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire2"], "transition": "release"}])
         assert_joystick_ports(session, 0x1F, 0x0F)
         assert_input_state(session, [], [], ["fire", "fire3"])
+        assert_anykey_extra_buttons_both(session, {2: (False, True), 1: (False, False)})
+
+    with check("joystick release in the same batch as a tap on the same input wins"):
+        session.post_events([{"kind": "release_all"}])
+        response = session.post_events(
+            [
+                {"kind": "joystick", "port": 2, "inputs": ["fire2"], "transition": "tap"},
+                {"kind": "joystick", "port": 2, "inputs": ["fire2"], "transition": "release"},
+            ]
+        )
+        if response["joysticks"][1]["inputs"] != []:
+            raise Failure(f"Expected port 2 empty right after the batch, got {response}")
 
     with check("joystick release_all then press in same batch is visible on CIA reads"):
         session.post_events(
@@ -2477,16 +2515,17 @@ def run_joystick_checks(session: RestInputSession) -> None:
         assert_joystick_ports(session, 0x1F, 0x0F)
         session.post_events([{"kind": "release_all"}])
 
-    with check("joystick release_all clears both ports"):
+    with check("joystick release_all clears both ports, including POT hardware"):
         session.post_events(
             [
-                {"kind": "joystick", "port": 1, "inputs": ["up"], "transition": "press"},
-                {"kind": "joystick", "port": 2, "inputs": ["fire"], "transition": "press"},
+                {"kind": "joystick", "port": 1, "inputs": ["up", "fire2"], "transition": "press"},
+                {"kind": "joystick", "port": 2, "inputs": ["fire", "fire3"], "transition": "press"},
                 {"kind": "release_all"},
             ]
         )
         assert_joystick_ports(session, 0x1F, 0x1F)
         assert_state_empty(session)
+        assert_anykey_extra_buttons_both(session, {1: (False, False), 2: (False, False)})
 
     with check("machine reset clears keyboard and joystick REST state"):
         session.post_events(

--- a/tests/e2e/api/input_test.py
+++ b/tests/e2e/api/input_test.py
@@ -668,13 +668,24 @@ def read_keyboard_row(session: RestInputSession, row: int) -> int:
 def read_joystick_pots(session: RestInputSession, port: int) -> tuple[int, int]:
     if port not in (1, 2):
         raise Failure(f"Invalid joystick port for POT read: {port}")
-    # Mirror Anykey's VIC-II probe: select the joystick port on CIA1 first,
-    # leave the machine running briefly, then read SID POTX/POTY.
-    session.write_memory(0xDC02, b"\xC0")
-    session.write_memory(0xDC00, b"\x40" if port == 1 else b"\x80")
-    time.sleep(0.10)
-    regs = session.read_memory(0xD419, 2)
-    return regs[0], regs[1]
+    # Select the joystick port's paddle group on CIA1, then read SID
+    # POTX/POTY. This must pause the machine like read_joystick_cia and
+    # read_keyboard_row above: left running, the KERNAL's keyboard-scan IRQ
+    # rewrites $DC00 about every 20ms (it cycles the column-select mask,
+    # which shares bits 6/7 with the paddle-group select), racing whatever
+    # this function just wrote there before the 0.10s settle elapses. On real
+    # hardware that race made the port argument close to meaningless: reads
+    # reflected whichever group the KERNAL's scan last selected, not the one
+    # requested here.
+    session.pause()
+    try:
+        session.write_memory(0xDC02, b"\xC0")
+        session.write_memory(0xDC00, b"\x40" if port == 1 else b"\x80")
+        time.sleep(0.10)
+        regs = session.read_memory(0xD419, 2)
+        return regs[0], regs[1]
+    finally:
+        session.resume()
 
 
 def assert_joystick_pots(session: RestInputSession, port: int, potx: int, poty: int) -> None:
@@ -2332,15 +2343,35 @@ def run_joystick_checks(session: RestInputSession) -> None:
         assert_joystick_ports(session, 0x1F, 0x0F)
         assert_anykey_extra_buttons(session, 2, fire2=False, fire3=False)
 
-    with check("joystick port 2 fire2 lights only Anykey button 2"):
+    with check("joystick port 2 fire2 lights only Anykey button 2, only on port 2"):
         session.post_events([{"kind": "release_all"}])
         session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire2"], "transition": "press"}])
         assert_anykey_extra_buttons(session, 2, fire2=True, fire3=False)
+        assert_anykey_extra_buttons(session, 1, fire2=False, fire3=False)
 
-    with check("joystick port 2 fire3 lights only Anykey button 3"):
+    with check("joystick port 2 fire3 lights only Anykey button 3, only on port 2"):
         session.post_events([{"kind": "release_all"}])
         session.post_events([{"kind": "joystick", "port": 2, "inputs": ["fire3"], "transition": "press"}])
         assert_anykey_extra_buttons(session, 2, fire2=False, fire3=True)
+        assert_anykey_extra_buttons(session, 1, fire2=False, fire3=False)
+
+    # Regression coverage for #879: fire2/fire3 pressed on one port must not
+    # appear on the other port's POT reading. The addendum spec requires a
+    # REST-held fire2/fire3 to assert only the selected port's POT line (see
+    # doc/research/keyboard-and-joystick-rest-api/spec-addendum1.md, section 4,
+    # constraint 3); the fix removed a cross-port POT mirror in
+    # JoystickOutput::apply() that violated this.
+    with check("joystick port 1 fire2 lights only Anykey button 2, only on port 1"):
+        session.post_events([{"kind": "release_all"}])
+        session.post_events([{"kind": "joystick", "port": 1, "inputs": ["fire2"], "transition": "press"}])
+        assert_anykey_extra_buttons(session, 1, fire2=True, fire3=False)
+        assert_anykey_extra_buttons(session, 2, fire2=False, fire3=False)
+
+    with check("joystick port 1 fire3 lights only Anykey button 3, only on port 1"):
+        session.post_events([{"kind": "release_all"}])
+        session.post_events([{"kind": "joystick", "port": 1, "inputs": ["fire3"], "transition": "press"}])
+        assert_anykey_extra_buttons(session, 1, fire2=False, fire3=True)
+        assert_anykey_extra_buttons(session, 2, fire2=False, fire3=False)
 
     with check("joystick port 1 up press is visible on CIA reads"):
         session.post_events([{"kind": "release_all"}])


### PR DESCRIPTION
## Summary

Fixes #879.

`JoystickOutput::apply()` mirrors an asserted-low POTX/POTY value into port 1's paddle registers whenever port 2's `fire2`/`fire3` is pressed, and OR's port 2's extra-button state into port 1's mouse-enable line. Holding `fire2` or `fire3` on one REST joystick port also reads as pressed on the other port's Anykey-style POT read, matching #879. The fix removes the mirror and the OR term; each port's paddle registers now reflect only that port's own `fire2`/`fire3` state.

A second defect: `apply_joystick_event()` releases an input by updating persistent state only. A `tap` on the same input that's still mid-hold keeps its overlay bit pressed, which outranks the new persistent state in `JoystickOutput::outputSnapshot()`'s `persistent & overlay` combination, so the release has no visible effect for up to one 20ms timer tick. `JoystickOutput::cancelRestPort1Overlay`/`cancelRestPort2Overlay`, called from the release branch, clear the released bit's overlay and hold countdown immediately.

## Changes

- `joystick_output.cc`/`.h`: removes the cross-port mirror and mouse-enable OR term; adds `cancelRestPortXOverlay` + `cancel_overlay_bits`; replaces a literal `7` with a named `JOYSTICK_BUTTON_COUNT` constant matching `input_api.h`'s `INPUT_API_MAX_JOYSTICK_INPUTS`.
- `route_input.cc`: calls the new cancel methods on release.
- `input_api_state_test.cpp`: two host unit tests for the release/tap fix.
- `input_test.py`: Anykey-isolation checks collapsed into one parametrized loop; added a check holding `fire2` on port 1 and `fire3` on port 2 at once (a mirror can't satisfy this by chance the way it can a one-port-at-a-time check); added hardware checks for tap auto-release and for release-in-the-same-batch-as-tap; extended the round-trip and `release_all` checks to assert POT hardware, not just REST JSON and CIA state; `read_joystick_pots` now pauses the C64 like its siblings (unpaused, the KERNAL's keyboard-scan IRQ races the CIA1 write within ~20ms); all three pause-then-read helpers now attempt `resume()` even if `pause()` itself raises; paired-port checks now pause once via `read_joystick_pots_both` instead of twice.

## Test plan

Both defects verified red/green on an Ultimate 64 Elite (firmware 3.15, real hardware):

- Cross-port mirror: reverting only `joystick_output.cc` reproduces #879's exact symptom (`expected fire2/fire3=False/False, got True/False`); fixed, `joystick` 21/21, `contract` 7/7, `keyboard` 19/19 pass.
- Release/tap race: disabling only the two `cancelRestPortXOverlay` calls fails the new same-batch check (response still shows `fire2` pressed); restored, it passes. Also covered by 2 host unit tests (`cd software/api/tests && make input-api-state`, 30/30 pass).

`u64` and `u64ii` both build cleanly with the full change set.

## Related, not fixed here

`usb_hid.cc`'s mouse-move handler unconditionally writes `C64_PADDLE_1_X`/`C64_PADDLE_1_Y` from raw USB mouse position right after `JoystickOutput::apply()` writes the same registers from REST state, so an attached USB mouse clobbers a REST-held port-1 `fire2`/`fire3`. Same register family, a different, uncoordinated writer. No USB mouse was available to verify a fix red/green.
