### PR TITLE
Reject malformed hexadecimal in machine:readmem, machine:writemem and machine:debugreg

### DIFF
--- a/doc/api/rest_api_openapi_u64.yaml
+++ b/doc/api/rest_api_openapi_u64.yaml
@@ -1892,7 +1892,7 @@ paths:
         - name: value
           in: query
           required: true
-          description: Byte to write, in hexadecimal.
+          description: Byte to write, in hexadecimal, 00 to FF.
           schema:
             type: string
           example: '1F'
@@ -1903,6 +1903,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DebugRegisterResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                Invalid value:
+                  value:
+                    errors:
+                      - Invalid value
         '403':
           $ref: '#/components/responses/Forbidden'
   '/v1/machine:heap':

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -26,25 +26,25 @@ static uint8_t chartohex(const char a)
     return 0xff;
 }
 
-// The grammar the three memory endpoints document for their address: hex
-// digits, 0000 to FFFF, and nothing else. strtol is not that grammar. It skips
+// The grammar this file's hexadecimal parameters document: hex digits, no
+// larger than `limit`, and nothing else. strtol is not that grammar. It skips
 // leading whitespace, accepts an optional sign, and stops at the first
 // character it cannot use, so " 1234", "+1234", "-0" and "12ZZ" all parsed and
-// were acted on.
-static bool parse_address(const char *text, int &address)
+// were acted on, and a value over the limit was truncated rather than refused.
+static bool parse_hex(const char *text, int limit, int &value)
 {
     if ((text == NULL) || (*text == '\0')) {
         return false;
     }
-    int value = 0;
+    int parsed = 0;
     for (const char *p = text; *p; p++) {
         uint8_t digit = chartohex(*p);
-        if ((digit == 0xff) || (value > 0x0FFF)) {
+        if ((digit == 0xff) || (parsed > (limit >> 4))) {
             return false;
         }
-        value = (value << 4) | digit;
+        parsed = (parsed << 4) | digit;
     }
-    address = value;
+    value = parsed;
     return true;
 }
 
@@ -234,7 +234,7 @@ API_DOC(PUT, machine, writemem,
 API_CALL(PUT, machine, writemem, NULL, ARRAY( { {"address", P_REQUIRED}, {"data", P_REQUIRED} }))
 {
     int address;
-    if (!parse_address(args["address"], address)) {
+    if (!parse_hex(args["address"], 0xFFFF, address)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;
@@ -305,7 +305,7 @@ API_DOC(POST, machine, writemem,
 API_CALL(POST, machine, writemem, &attachment_writer, ARRAY( { {"address", P_REQUIRED} }))
 {
     int address;
-    if (!parse_address(args["address"], address)) {
+    if (!parse_hex(args["address"], 0xFFFF, address)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;
@@ -370,7 +370,7 @@ API_DOC(GET, machine, readmem,
 API_CALL(GET, machine, readmem, NULL, ARRAY( { {"address", P_REQUIRED}, {"length", P_OPTIONAL} }))
 {
     int address;
-    if (!parse_address(args["address"], address)) {
+    if (!parse_hex(args["address"], 0xFFFF, address)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;
@@ -472,12 +472,18 @@ API_DOC(PUT, machine, debugreg,
                 "reads back afterwards, which is not necessarily what was written: some bits are "
                 "driven by the hardware.")
     PATH("/v1/machine:debugreg", "writeDebugRegister", "")
-    PARAM("value", "string", "Byte to write, in hexadecimal.", "", "1F")
+    PARAM("value", "string", "Byte to write, in hexadecimal, 00 to FF.", "", "1F")
     RESPONSE("200", "application/json", "DebugRegisterResponse", "The register after the write.", "")
+    RESPONSE_ERROR("400", "Invalid value", "")
 )
 API_CALL(PUT, machine, debugreg, NULL, ARRAY( { { "value", P_REQUIRED } }))
 {
-    int value = strtol(args["value"], NULL, 16);
+    int value;
+    if (!parse_hex(args["value"], 0xFF, value)) {
+        resp->error("Invalid value");
+        resp->json_response(HTTP_BAD_REQUEST);
+        return;
+    }
     U64_DEBUG_REGISTER = (uint8_t)value;
 
     char buf[4];

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -26,6 +26,28 @@ static uint8_t chartohex(const char a)
     return 0xff;
 }
 
+// The grammar the three memory endpoints document for their address: hex
+// digits, 0000 to FFFF, and nothing else. strtol is not that grammar. It skips
+// leading whitespace, accepts an optional sign, and stops at the first
+// character it cannot use, so " 1234", "+1234", "-0" and "12ZZ" all parsed and
+// were acted on.
+static bool parse_address(const char *text, int &address)
+{
+    if ((text == NULL) || (*text == '\0')) {
+        return false;
+    }
+    int value = 0;
+    for (const char *p = text; *p; p++) {
+        uint8_t digit = chartohex(*p);
+        if ((digit == 0xff) || (value > 0x0FFF)) {
+            return false;
+        }
+        value = (value << 4) | digit;
+    }
+    address = value;
+    return true;
+}
+
 API_DOC(PUT, machine, menu_button,
     TAG("Machine")
     SUMMARY("Press the menu button")
@@ -211,13 +233,8 @@ API_DOC(PUT, machine, writemem,
 )
 API_CALL(PUT, machine, writemem, NULL, ARRAY( { {"address", P_REQUIRED}, {"data", P_REQUIRED} }))
 {
-    const char *addr_str = args["address"];
-    char *addr_end;
-    int address = strtol(addr_str, &addr_end, 16);
-
-    // Reject an unparseable or trailing-garbage address: strtol() yields 0 for such
-    // input, which would otherwise pass the range check and be treated as $0000.
-    if ((addr_end == addr_str) || (*addr_end != '\0') || (address < 0) || (address > 65535)) {
+    int address;
+    if (!parse_address(args["address"], address)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;
@@ -287,13 +304,8 @@ API_DOC(POST, machine, writemem,
 )
 API_CALL(POST, machine, writemem, &attachment_writer, ARRAY( { {"address", P_REQUIRED} }))
 {
-    const char *addr_str = args["address"];
-    char *addr_end;
-    int address = strtol(addr_str, &addr_end, 16);
-
-    // Reject an unparseable or trailing-garbage address: strtol() yields 0 for such
-    // input, which would otherwise pass the range check and be treated as $0000.
-    if ((addr_end == addr_str) || (*addr_end != '\0') || (address < 0) || (address > 65535)) {
+    int address;
+    if (!parse_address(args["address"], address)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;
@@ -357,13 +369,8 @@ API_DOC(GET, machine, readmem,
 )
 API_CALL(GET, machine, readmem, NULL, ARRAY( { {"address", P_REQUIRED}, {"length", P_OPTIONAL} }))
 {
-    const char *addr_str = args["address"];
-    char *addr_end;
-    int address = strtol(addr_str, &addr_end, 16);
-
-    // Reject an unparseable or trailing-garbage address: strtol() yields 0 for such
-    // input, which would otherwise pass the range check and be treated as $0000.
-    if ((addr_end == addr_str) || (*addr_end != '\0') || (address < 0) || (address > 65535)) {
+    int address;
+    if (!parse_address(args["address"], address)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;

--- a/software/api/route_machine.cc
+++ b/software/api/route_machine.cc
@@ -211,9 +211,13 @@ API_DOC(PUT, machine, writemem,
 )
 API_CALL(PUT, machine, writemem, NULL, ARRAY( { {"address", P_REQUIRED}, {"data", P_REQUIRED} }))
 {
-    int address = strtol(args["address"], NULL, 16);
+    const char *addr_str = args["address"];
+    char *addr_end;
+    int address = strtol(addr_str, &addr_end, 16);
 
-    if ((address < 0) || (address > 65535)) {
+    // Reject an unparseable or trailing-garbage address: strtol() yields 0 for such
+    // input, which would otherwise pass the range check and be treated as $0000.
+    if ((addr_end == addr_str) || (*addr_end != '\0') || (address < 0) || (address > 65535)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;
@@ -283,9 +287,13 @@ API_DOC(POST, machine, writemem,
 )
 API_CALL(POST, machine, writemem, &attachment_writer, ARRAY( { {"address", P_REQUIRED} }))
 {
-    int address = strtol(args["address"], NULL, 16);
+    const char *addr_str = args["address"];
+    char *addr_end;
+    int address = strtol(addr_str, &addr_end, 16);
 
-    if ((address < 0) || (address > 65535)) {
+    // Reject an unparseable or trailing-garbage address: strtol() yields 0 for such
+    // input, which would otherwise pass the range check and be treated as $0000.
+    if ((addr_end == addr_str) || (*addr_end != '\0') || (address < 0) || (address > 65535)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;
@@ -349,9 +357,13 @@ API_DOC(GET, machine, readmem,
 )
 API_CALL(GET, machine, readmem, NULL, ARRAY( { {"address", P_REQUIRED}, {"length", P_OPTIONAL} }))
 {
-    int address = strtol(args["address"], NULL, 16);
+    const char *addr_str = args["address"];
+    char *addr_end;
+    int address = strtol(addr_str, &addr_end, 16);
 
-    if ((address < 0) || (address > 65535)) {
+    // Reject an unparseable or trailing-garbage address: strtol() yields 0 for such
+    // input, which would otherwise pass the range check and be treated as $0000.
+    if ((addr_end == addr_str) || (*addr_end != '\0') || (address < 0) || (address > 65535)) {
         resp->error("Invalid address");
         resp->json_response(HTTP_BAD_REQUEST);
         return;

--- a/tests/e2e/api/readmem_writemem_test.py
+++ b/tests/e2e/api/readmem_writemem_test.py
@@ -656,10 +656,12 @@ def run_bounds(session: RestSession) -> bool:
     return True
 
 
-# Addresses that are not valid hexadecimal. strtol() yields 0 for each of them,
-# so an unguarded parse passes the range check and the endpoint acts on $0000 --
-# for writemem, a destructive write answered with HTTP 200.
-BAD_ADDRESSES = ["ZZZZ", "0xZZZZ", "gggg"]
+# Addresses outside the documented grammar, which is hex digits and nothing
+# else. strtol() accepts every one of them: it yields 0 for the first three,
+# takes the sign on "-0" and "+1", and stops at the first unusable character on
+# "12GG", so an unguarded parse passes the range check and the endpoint acts on
+# an address. For writemem that is a destructive write answered with HTTP 200.
+BAD_ADDRESSES = ["ZZZZ", "0xZZZZ", "gggg", "-0", "+1", "12GG"]
 
 
 def run_bad_address(session: RestSession) -> bool:

--- a/tests/e2e/api/readmem_writemem_test.py
+++ b/tests/e2e/api/readmem_writemem_test.py
@@ -16,11 +16,12 @@ sys.path.insert(0, str(next(p for p in Path(__file__).resolve().parents
                             if (p / "tests" / "lib").is_dir()) / "tests" / "lib"))
 import bootstrap  # noqa: E402,F401
 import cli  # noqa: E402
+import machine as machine_lib  # noqa: E402  (needs tests/lib on sys.path first)
 import pacing  # noqa: E402  (needs tests/lib on sys.path first)
 import profiles  # noqa: E402  (needs tests/lib on sys.path first)
 import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
 import targets  # noqa: E402  (needs tests/lib on sys.path first)
-from api import UltimateApi  # noqa: E402  (needs tests/lib on sys.path first)
+from api import UltimateApi, identify_machine  # noqa: E402  (needs tests/lib on sys.path first)
 from report import (
     FAIL, OK, SKIP, Failure, check, detail, format_exception, section, suite_fail,
     suite_ok, warn)
@@ -655,6 +656,59 @@ def run_bounds(session: RestSession) -> bool:
     return True
 
 
+# Addresses that are not valid hexadecimal. strtol() yields 0 for each of them,
+# so an unguarded parse passes the range check and the endpoint acts on $0000 --
+# for writemem, a destructive write answered with HTTP 200.
+BAD_ADDRESSES = ["ZZZZ", "0xZZZZ", "gggg"]
+
+
+def run_bad_address(session: RestSession) -> bool:
+    """Reject an address that is not valid hex, on every endpoint that parses one.
+
+    The status code is the whole assertion. $0000 is the 6510 processor port
+    rather than plain RAM, so reading it back is not a reliable witness to the
+    clobber this rejects, and a memory compare there could pass either way.
+    """
+    label = "readmem and writemem reject a malformed address"
+    if identify_machine(session.host).skip_without_fix(
+            machine_lib.MEMORY_API_REJECTS_INVALID_ADDRESS, label):
+        return True
+
+    section("bad-address: readmem and writemem reject an address that is not valid hex")
+
+    for bad in BAD_ADDRESSES:
+        with check(f"readmem rejects address={bad!r}"):
+            status, _, body = session.request(
+                "GET", READMEM_PATH, params={"address": bad, "length": 1})
+            if status != 400:
+                raise Failure(f"readmem(address={bad!r}) returned HTTP {status}, "
+                              f"expected 400: {body[:200]!r}")
+
+        # data= is sent so the request reaches the address parse at all: a
+        # missing required parameter is refused before it, which would pass this
+        # check for a reason that has nothing to do with the address.
+        with check(f"writemem PUT rejects address={bad!r}"):
+            status, _, body = session.request(
+                "PUT", WRITEMEM_PATH, params={"address": bad, "data": "00"})
+            if status != 400:
+                raise Failure(f"writemem PUT(address={bad!r}) returned HTTP {status}, "
+                              f"expected 400: {body[:200]!r}")
+
+        # A body is sent for the same reason: an empty one is refused with 412
+        # before the address is parsed. session.request rather than
+        # session.writemem, which raises on any non-200.
+        with check(f"writemem POST rejects address={bad!r}"):
+            raw_body, content_type = build_multipart("file", "data.bin", b"\x00")
+            status, _, body = session.request(
+                "POST", WRITEMEM_PATH, params={"address": bad},
+                raw_body=raw_body, content_type=content_type)
+            if status != 400:
+                raise Failure(f"writemem POST(address={bad!r}) returned HTTP {status}, "
+                              f"expected 400: {body[:200]!r}")
+
+    return True
+
+
 FREEZE_ONLY_TESTS = ["selfcheck-freeze"]
 OVERLAY_DEPENDENT_TESTS = ["selfcheck-overlay", "screen-round-trip",
                            "overlay-to-freeze", "freeze-to-overlay"]
@@ -677,8 +731,8 @@ NOISE_DEPENDENT_TESTS = ["selfcheck-overlay", "screen-round-trip",
 
 
 def expand_tests(selected: list[str] | None) -> list[str]:
-    all_tests = ["bounds", "selfcheck-freeze", "selfcheck-overlay", "screen-round-trip",
-                 "overlay-to-freeze", "freeze-to-overlay"]
+    all_tests = ["bounds", "bad-address", "selfcheck-freeze", "selfcheck-overlay",
+                 "screen-round-trip", "overlay-to-freeze", "freeze-to-overlay"]
     if not selected:
         if not profiles.includes(profiles.QUICK):
             return list(SMOKE_TESTS)
@@ -702,8 +756,8 @@ def main() -> int:
     parser.add_argument(
         "--test",
         action="append",
-        choices=("all", "bounds", "selfcheck-freeze", "selfcheck-overlay", "screen-round-trip",
-                 "overlay-to-freeze", "freeze-to-overlay"),
+        choices=("all", "bounds", "bad-address", "selfcheck-freeze", "selfcheck-overlay",
+                 "screen-round-trip", "overlay-to-freeze", "freeze-to-overlay"),
     )
     parser.add_argument(
         "--keep-config",
@@ -769,6 +823,12 @@ def main() -> int:
         # if readmem mishandles its own parameters, everything after it is noise.
         if "bounds" in tests:
             results["bounds"] = run_bounds(session)
+
+        # Same reasoning as bounds, and equally cheap: an address the firmware
+        # mis-parses is acted on at $0000, so prove it is refused before any
+        # stage writes memory in earnest.
+        if "bad-address" in tests:
+            results["bad-address"] = run_bad_address(session)
 
         noise_addrs: set[int] = set()
         # Eight full 64KB reads, so it is only worth paying where a stage

--- a/tests/e2e/api/readmem_writemem_test.py
+++ b/tests/e2e/api/readmem_writemem_test.py
@@ -23,12 +23,13 @@ import rest as rest_lib  # noqa: E402  (needs tests/lib on sys.path first)
 import targets  # noqa: E402  (needs tests/lib on sys.path first)
 from api import UltimateApi, identify_machine  # noqa: E402  (needs tests/lib on sys.path first)
 from report import (
-    FAIL, OK, SKIP, Failure, check, detail, format_exception, section, suite_fail,
-    suite_ok, warn)
+    FAIL, OK, SKIP, Failure, check, check_skip, check_start, detail,
+    format_exception, section, suite_fail, suite_ok, warn)
 
 MENU_SCREEN_PATH = "/v1/machine:menu_screen"
 MENU_BUTTON_PATH = "/v1/machine:menu_button"
 READMEM_PATH = "/v1/machine:readmem"
+DEBUGREG_PATH = "/v1/machine:debugreg"
 WRITEMEM_PATH = "/v1/machine:writemem"
 MEASURE_PATH = "/v1/machine:measure"
 RESET_PATH = "/v1/machine:reset"
@@ -711,6 +712,54 @@ def run_bad_address(session: RestSession) -> bool:
     return True
 
 
+# Values outside the documented grammar for machine:debugreg, which is two hex
+# digits. strtol() yields 0 for the first two, takes the sign on "-0", stops at
+# the first unusable character on "1G", and truncates "1FF" to FF, so an
+# unguarded parse writes a byte the caller never asked for.
+BAD_DEBUGREG_VALUES = ["ZZ", "0xZZ", "-0", "1G", "1FF"]
+
+
+def run_bad_debugreg(session: RestSession) -> bool:
+    """Reject a debug register value that is not two hex digits, and write nothing.
+
+    The register is readable, so "wrote nothing" is asserted directly: the GET
+    before and after each refused write has to answer the same byte.
+    """
+    label = "machine:debugreg rejects a malformed value"
+    if identify_machine(session.host).skip_without_fix(
+            machine_lib.DEBUGREG_REJECTS_INVALID_VALUE, label):
+        return True
+
+    api = session.api
+    before = api.machine.debugreg()
+    if before is None:
+        # Both debugreg routes sit inside `#if U64`; elsewhere they are not in
+        # the route table at all.
+        check_start(label)
+        check_skip("this machine does not serve machine:debugreg")
+        return True
+
+    section("bad-debugreg: machine:debugreg rejects a value that is not two hex digits")
+
+    for bad in BAD_DEBUGREG_VALUES:
+        with check(f"debugreg rejects value={bad!r}"):
+            status, _, body = session.request(
+                "PUT", DEBUGREG_PATH, params={"value": bad})
+            if status != 400:
+                raise Failure(f"debugreg(value={bad!r}) returned HTTP {status}, "
+                              f"expected 400: {body[:200]!r}")
+            after = api.machine.debugreg()
+            if after != before:
+                raise Failure(f"debugreg(value={bad!r}) changed the register "
+                              f"from {before!r} to {after!r}")
+
+    with check("debugreg still takes a valid value"):
+        if api.machine.set_debugreg("1F") is None:
+            raise Failure("machine:debugreg stopped answering")
+
+    return True
+
+
 FREEZE_ONLY_TESTS = ["selfcheck-freeze"]
 OVERLAY_DEPENDENT_TESTS = ["selfcheck-overlay", "screen-round-trip",
                            "overlay-to-freeze", "freeze-to-overlay"]
@@ -733,8 +782,9 @@ NOISE_DEPENDENT_TESTS = ["selfcheck-overlay", "screen-round-trip",
 
 
 def expand_tests(selected: list[str] | None) -> list[str]:
-    all_tests = ["bounds", "bad-address", "selfcheck-freeze", "selfcheck-overlay",
-                 "screen-round-trip", "overlay-to-freeze", "freeze-to-overlay"]
+    all_tests = ["bounds", "bad-address", "bad-debugreg", "selfcheck-freeze",
+                 "selfcheck-overlay", "screen-round-trip", "overlay-to-freeze",
+                 "freeze-to-overlay"]
     if not selected:
         if not profiles.includes(profiles.QUICK):
             return list(SMOKE_TESTS)
@@ -758,8 +808,9 @@ def main() -> int:
     parser.add_argument(
         "--test",
         action="append",
-        choices=("all", "bounds", "bad-address", "selfcheck-freeze", "selfcheck-overlay",
-                 "screen-round-trip", "overlay-to-freeze", "freeze-to-overlay"),
+        choices=("all", "bounds", "bad-address", "bad-debugreg", "selfcheck-freeze",
+                 "selfcheck-overlay", "screen-round-trip", "overlay-to-freeze",
+                 "freeze-to-overlay"),
     )
     parser.add_argument(
         "--keep-config",
@@ -831,6 +882,11 @@ def main() -> int:
         # stage writes memory in earnest.
         if "bad-address" in tests:
             results["bad-address"] = run_bad_address(session)
+
+        # Same defect in the one other hexadecimal parameter this file's
+        # endpoints take; see GideonZ/1541ultimate#885.
+        if "bad-debugreg" in tests:
+            results["bad-debugreg"] = run_bad_debugreg(session)
 
         noise_addrs: set[int] = set()
         # Eight full 64KB reads, so it is only worth paying where a stage

--- a/tests/lib/machine.py
+++ b/tests/lib/machine.py
@@ -236,6 +236,12 @@ KEYBOARD_COMBINATION_OPENS_MENU = _fix(
     "does, rather than being ignored",
     (C64U,))
 
+MEMORY_API_REJECTS_INVALID_ADDRESS = _fix(
+    "memory-api-rejects-invalid-address",
+    "readmem and writemem answer HTTP 400 to an address that is not valid "
+    "hexadecimal, rather than parsing it as $0000 and acting there",
+    (C64U, U2))
+
 # Every fix at once, for a sweep that asks whether the lagging line has caught
 # up rather than about one behaviour.
 ASSUME_ALL = "all"

--- a/tests/lib/machine.py
+++ b/tests/lib/machine.py
@@ -236,6 +236,12 @@ KEYBOARD_COMBINATION_OPENS_MENU = _fix(
     "does, rather than being ignored",
     (C64U,))
 
+DEBUGREG_REJECTS_INVALID_VALUE = _fix(
+    "debugreg-rejects-invalid-value",
+    "machine:debugreg answers HTTP 400 to a value that is not two hexadecimal "
+    "digits, rather than writing a truncated or zero byte to the register",
+    (C64U,))
+
 MEMORY_API_REJECTS_INVALID_ADDRESS = _fix(
     "memory-api-rejects-invalid-address",
     "readmem and writemem answer HTTP 400 to an address that is not valid "


### PR DESCRIPTION
### What's wrong

`/v1/machine:writemem` and `/v1/machine:readmem` parse the `address` query parameter with

```c
int address = strtol(args["address"], NULL, 16);
```

The end pointer is passed as `NULL` and never checked, so `strtol()` silently yields `0` for input
that is not a number at all. `0` then passes the `(address < 0) || (address > 65535)` range check,
and the request proceeds against `$0000`.

For `writemem` that means a **destructive write to zero page, answered with HTTP 200**. Measured on
an Ultimate 64 Elite (fw 3.15):

```
readmem  GET   address=ZZZZ           -> HTTP 200 b'\xa1'                     (the byte at $0000)
writemem PUT   address=ZZZZ  data=00  -> HTTP 200 { "address" : "0000-0..." }
writemem POST  address=ZZZZ  +body    -> HTTP 200 { "address" : "0000-0..." }
```

The firmware names `$0000` in its own success payload — it reports success for a write the caller
never asked for.

### Also #885

`PUT /v1/machine:debugreg` had the same defect in its `value` parameter, found
while reviewing this PR and filed as #885. It is fixed here because it is the
same parser: `ZZ`, `0xZZ` and `-0` wrote `00`, `1G` wrote `01`, and `1FF` was
truncated to `FF`, each answered HTTP 200 with the register changed.

### Scope

Reaching this requires sending an address that is not hexadecimal, which a careful client will not do
deliberately — but a typo, an unvalidated string, or a programmatically built query does it easily, and
the failure is silent: the caller is told 200 while zero page is overwritten. The argument for the
change is the API contract rather than a report of damage in the field: an unparseable address should
be refused, not resolved to `$0000` and acted on.

### The change

One parser, used by the three handlers that take an address — PUT `writemem`,
POST `writemem`, GET `readmem`. It implements the grammar the API documents,
"Start address in hexadecimal, 0000 to FFFF", and nothing else, built on the
`chartohex` helper already at the top of the file:

```c
static bool parse_address(const char *text, int &address)
{
    if ((text == NULL) || (*text == '\0')) {
        return false;
    }
    int value = 0;
    for (const char *p = text; *p; p++) {
        uint8_t digit = chartohex(*p);
        if ((digit == 0xff) || (value > 0x0FFF)) {
            return false;
        }
        value = (value << 4) | digit;
    }
    address = value;
    return true;
}
```

`machine:debugreg` uses the same parser with a limit of `0xFF`, so an
out-of-range byte is refused rather than truncated. Its API doc gains the
`400 Invalid value` response it now returns, and `doc/api/rest_api_openapi_u64.yaml`
is regenerated to match — `make openapi_check` is a build gate, so the
committed document cannot drift from the source.

Each handler is then:

```c
int address;
if (!parse_address(args["address"], address)) {
    resp->error("Invalid address");
    resp->json_response(HTTP_BAD_REQUEST);
    return;
}
```

Notes on the shape:
- `400 Invalid address` is already the documented response at all three
  handlers, so the API docs and the generated OpenAPI are unchanged.
- The range check is inside the loop, so an over-long address is refused as it
  is read and no `errno` or overflow reasoning is needed.
- This is stricter than `strtol` in four ways, all of them the documented
  grammar: leading whitespace, a leading sign, a `0x` prefix and trailing
  characters are all refused. `" D020"`, `"+D020"`, `"-0"`, `"0xD020"` and
  `"D020 "` are 400s.
- The `0x` prefix is the one form that used to be accepted and now is not. No
  client in this repository sends it: the harness formats `%04X`, and the
  firmware's own web UI uses `toString(16).padStart(4, "0")` and literal
  four-digit strings, with its typed-address path validating as a 16-bit hex
  number first.

### Test

New `bad-address` stage in `tests/e2e/api/readmem_writemem_test.py`, gated through the existing
`FIXES` table (`memory-api-rejects-invalid-address`, `lacking=(C64U, U2)`) so machines whose
released firmware predates the fix skip with a named reason instead of going red.

`BAD_ADDRESSES` covers `ZZZZ`, `0xZZZZ` and `gggg` (nothing parses), `-0` and
`+1` (a sign, which `strtol` takes), and `12GG` (a valid prefix with trailing
garbage).

A second stage, `bad-debugreg`, covers #885 with `ZZ`, `0xZZ`, `-0`, `1G` and
`1FF`. `machine:debugreg` has a GET as well as a PUT, so "the refused request
wrote nothing" is asserted directly: the register is read before and after each
rejected write and has to be unchanged. It is gated on its own fix entry,
`debugreg-rejects-invalid-value`, and skips where the route does not exist,
since both debugreg routes sit inside `#if U64`.

The stage sends a valid `data=` on the PUT case and a real body on the POST case **deliberately**:
without them the request is refused earlier — 400 for a missing required parameter, 412 for a
missing body — and the check would pass for a reason unrelated to the address. The HTTP status is
the assertion; `$0000` is the 6510 processor port rather than plain RAM, so reading it back is not a
reliable witness.

### Rig proof

Both halves on the same Ultimate 64 Elite, by JTAG-deploying a build of the
parent commit and then a build of this branch.

Before, every malformed address is accepted on both endpoints:

```
'ZZZZ'    readmem HTTP 200  writemem HTTP 200
'0xZZZZ'  readmem HTTP 200  writemem HTTP 200
'gggg'    readmem HTTP 200  writemem HTTP 200
'-0'      readmem HTTP 200  writemem HTTP 200
'+1'      readmem HTTP 200  writemem HTTP 200
'12GG'    readmem HTTP 200  writemem HTTP 200
```

and the stage fails on the first check:

```
[03] readmem rejects address='ZZZZ' ... FAIL (returned HTTP 200, expected 400: b'\x00')
```

`machine:debugreg` before, with the register set to `1F` first:

```
'ZZ'     HTTP 200  wrote -> register now '00'
'0xZZ'   HTTP 200  wrote -> register now '00'
'-0'     HTTP 200  wrote -> register now '00'
'1G'     HTTP 200  wrote -> register now '01'
'1FF'    HTTP 200  wrote -> register now 'FF'
```

After, the stages are green and so is the rest of the suite:

```
readmem_writemem_test: OK (20 checks, 6.7s)     --test bad-address, 18/18
readmem_writemem_test: OK (8 checks, 6.4s)      --test bad-debugreg, 6/6
readmem_writemem_test: OK (78 checks, 23.3s)    --test all, all eight stages
```

`bounds` still passes, so the numeric out-of-range cases (`10000`, `-1`) are
unaffected: both were 400 before and are 400 now, refused at the parse rather
than by the range check.

Wider run, `./run-tests --profile quick u64`: 25 of 26 suite runs pass. The one
failure is `rest-api-coverage` check 10, `git_commit_hash is not a commit hash:
''`, with 78 of its 79 checks passing. That is an artefact of building in a git
worktree — `target/common/rules.mk` runs `git rev-parse --short HEAD` inside the
build container, where a worktree's `.git` pointer file resolves to a path that
is not mounted, so `APP_VERSION_HASH` comes out empty. It is independent of this
change and does not occur for a CI build.

On `u2@c64u`, with the Ultimate II+L flashed from this branch's CI artifact
(`git_commit_hash 38033b87`) and the fix table assumption lifted so the stage
runs rather than skipping:

```
readmem_writemem_test: OK (20 checks, 8.1s)     --test bad-address, 18/18
readmem_writemem_test: OK (38 checks, 17.0s)    --test all
```

The RISC-V build rejects the same six addresses on all three endpoints, so the
parser behaves identically on both CPUs. `bad-debugreg` skips there, because
both debugreg routes are inside `#if U64` and a cartridge does not serve them.

`tests/lib/openapi_contract_test.py` and `tests/e2e/api/openapi_contract_test.py`
both pass against the rebuilt document and the running device.

Compiles for u64 and u64ii; `route_machine.o` also builds and links for u2pl's
RISC-V target.

### Not covered

The same unchecked `strtol(..., NULL, ...)` pattern exists elsewhere — `route_machine.cc`'s debugreg
`value`, `routes.h`'s `get_int` (benign for `length`, whose range check catches `0`), and
`route_configs.cc` / `json.cc`. Left alone here to keep this change to the address parse; happy to
follow up separately if wanted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

