### PR TITLE
Remove stale 3 MB comment from the RAM disk size computation

### DIFF
--- a/software/filesystem/ramdisk.cc
+++ b/software/filesystem/ramdisk.cc
@@ -22,7 +22,7 @@ void init_ram_disk(void *obj, void *param)
     uint8_t *ramdisk_mem = new uint8_t[size]; // 1 MB only
     ramdisk_blk = new BlockDevice_Ram(ramdisk_mem, sz, sectors);
 #else
-    const int size = (int)&__ram_disk_limit - (int)&__ram_disk_start; // 3 * 1024 * 1024;
+    const int size = (int)&__ram_disk_limit - (int)&__ram_disk_start;
     const int sectors = size / sz;
     ramdisk_blk = new BlockDevice_Ram(&__ram_disk_start, sz, sectors);
 #endif


### PR DESCRIPTION
The size comes from the linker symbols, and both `ultimate` linker scripts
give `0x02000000` to `0x03000000` — 16 MiB, not the 3 MB in the trailing
comment.

The comment is a leftover rather than a figure that went stale:

* `54123496` (2020-11-24, "Added fixed 3MB ramdisk.") introduced
  `const int size = 3 * 1024 * 1024;`
* `6c4ee01a` (2020-12-05, "Memory map formalized in linker script. Ram disk
  now uses that instead of malloc.") replaced it with the current expression
  and kept the old literal as the trailing comment.

At `6c4ee01a` the linker script defining the symbols already gave
`0x2000000` to `0x3000000`, so the comment did not match the expression it
was attached to even then.
