### PR TITLE
fix(tests): reboot the cartridge host so External preference reaches the bus

### DIFF
--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -1035,6 +1035,10 @@ def _in_range(name: str, value: int, bounds: tuple[int, int]) -> None:
 CARTRIDGE_STORE = "C64 and Cartridge Settings"
 CARTRIDGE_PREFERENCE_ITEM = "Cartridge Preference"
 CARTRIDGE_PREFERENCE_EXTERNAL = "External"
+# How long the computer gets to reach the BASIC prompt after the reboot that
+# makes the preference reach the running bus. A reboot restarts the whole
+# machine, so this is longer than READY_TIMEOUT_SECONDS, which covers a reset.
+CARTRIDGE_REBOOT_TIMEOUT_SECONDS = 30.0
 
 
 class CartridgePreferenceUnavailable(Failure):
@@ -1055,16 +1059,20 @@ def ensure_cartridge_preference(target, password: str | None = None,
 
     Answers what it did, for a caller that reports it:
 
-      None            nothing to do - the target is its own computer, or the
-                      computer already prefers the external cartridge
-      a description   the value it changed, and from what
+      None            nothing to do - the target is its own computer
+      a description   the config state and that the computer was rebooted
 
     Raises `CartridgePreferenceUnavailable` when the computer cannot be asked,
     and `Failure` when it serves the setting and will not take it.
 
-    The change is not saved to flash. It takes effect through the item's own
-    change hook, and leaving flash alone keeps a test run from deciding what a
-    machine boots with.
+    The config write is not saved to flash, which keeps a test run from
+    deciding what a machine boots with. The value alone does not reach the
+    running bus: the computer routes the cartridge port only when it boots and
+    initialises its cartridge, so the item's change hook updates the stored
+    value without re-routing the bus that is already running. For a split
+    target this therefore reboots the computer and waits for it to come back,
+    unconditionally - including when the value already read External, because
+    the stored value does not prove the running bus is routed to the cartridge.
     """
     handle = targets.resolve(target)
     if not handle.split:
@@ -1081,18 +1089,31 @@ def ensure_cartridge_preference(target, password: str | None = None,
         raise CartridgePreferenceUnavailable(
             f"{handle.computer} did not answer for "
             f"'{CARTRIDGE_PREFERENCE_ITEM}': {reason}") from exc
-    if current == CARTRIDGE_PREFERENCE_EXTERNAL:
-        return None
-    computer.configs.set(CARTRIDGE_STORE, CARTRIDGE_PREFERENCE_ITEM,
-                         CARTRIDGE_PREFERENCE_EXTERNAL)
-    now = computer.configs.current(CARTRIDGE_STORE, CARTRIDGE_PREFERENCE_ITEM)
-    if now != CARTRIDGE_PREFERENCE_EXTERNAL:
-        raise Failure(
-            f"{handle.computer} kept '{CARTRIDGE_PREFERENCE_ITEM}' at {now!r} "
-            f"after it was set to {CARTRIDGE_PREFERENCE_EXTERNAL!r}; the "
-            f"cartridge in its port will not own the bus")
-    return (f"{handle.computer}: {CARTRIDGE_PREFERENCE_ITEM} "
-            f"{current!r} -> {CARTRIDGE_PREFERENCE_EXTERNAL!r}")
+    if current != CARTRIDGE_PREFERENCE_EXTERNAL:
+        computer.configs.set(CARTRIDGE_STORE, CARTRIDGE_PREFERENCE_ITEM,
+                             CARTRIDGE_PREFERENCE_EXTERNAL)
+        now = computer.configs.current(CARTRIDGE_STORE, CARTRIDGE_PREFERENCE_ITEM)
+        if now != CARTRIDGE_PREFERENCE_EXTERNAL:
+            raise Failure(
+                f"{handle.computer} kept '{CARTRIDGE_PREFERENCE_ITEM}' at {now!r} "
+                f"after it was set to {CARTRIDGE_PREFERENCE_EXTERNAL!r}; the "
+                f"cartridge in its port will not own the bus")
+    # The reboot is what makes the value reach the running bus. Blank the top
+    # of screen RAM first, the same way reset() does: without it,
+    # wait_until_ready() can match the READY prompt the computer was already
+    # showing before the reboot took the machine down, and return before the
+    # machine has actually restarted.
+    computer.machine.writemem(SCREEN_RAM, bytes([0x20]) * len(READY_SCREEN_CODES))
+    computer.machine.reboot()
+    ready = computer.machine.wait_until_ready(CARTRIDGE_REBOOT_TIMEOUT_SECONDS)
+    reached = "reached the BASIC prompt" if ready else (
+        f"did not reach the BASIC prompt within "
+        f"{CARTRIDGE_REBOOT_TIMEOUT_SECONDS:.0f}s")
+    from_state = (f"{current!r} -> {CARTRIDGE_PREFERENCE_EXTERNAL!r}"
+                  if current != CARTRIDGE_PREFERENCE_EXTERNAL
+                  else f"already {CARTRIDGE_PREFERENCE_EXTERNAL!r}")
+    return (f"{handle.computer}: {CARTRIDGE_PREFERENCE_ITEM} {from_state}, "
+            f"rebooted so the cartridge owns the bus ({reached})")
 
 
 # "External" sets internal=0 in C64::ConfigureU64SystemBus, bit 0x08 of which


### PR DESCRIPTION
## Previous behaviour

`ensure_cartridge_preference` in `tests/lib/api.py` prepares a cartridge (split) target's host computer to hand the bus to the cartridge in its port by setting the config item `Cartridge Preference = External`. On upstream master the function returned `None` without doing anything when the value already read `External`, and when it did change the value it wrote the config item and returned, without rebooting the computer.

## The defect

The routing this controls is applied by `C64::ConfigureU64SystemBus`, which runs only when the computer boots and initialises its cartridge port. The config item's change hook updates the stored value but does not re-route the bus that is already running. Two consequences followed:

1. A stored value of `External` does not prove the running bus is actually routed to the cartridge. The value can have been set at an earlier boot or by a prior run, with no reboot since, while the internal cartridge still owns the bus. The early `return None` on an already-`External` read therefore left this state in place.
2. Even when the function changed the value, writing the config item alone did not move the running bus, so the cartridge still did not own it until the next boot.

With the cartridge not owning the bus, its launches and its NMI never reach the 6510, and tests fail in ways that look like firmware faults rather than a bus-routing setup problem.

This was observed on real hardware this session: a cartridge debug launch failed with a "held context at $FFFE did not advance" / missing-NMI symptom while the config read `External`. Setting `External` and rebooting the C64 Ultimate restored cartridge bus ownership and the launches worked.

## The change

For a split target, after ensuring the config value is `External`, the function now reboots the host computer and waits for the BASIC prompt to come back, so the value reaches the running bus. It does this unconditionally for a split target, including when the value already read `External`, because the stored value alone does not prove the bus is routed.

Before waiting, it blanks the top of screen RAM (`SCREEN_RAM`, over the length of `READY_SCREEN_CODES`), the same way `MachineApi.reset()` does. Without this, `wait_until_ready` polls screen RAM and can match the `READY.` prompt the computer was already showing before the reboot took the machine down, returning before the machine has actually restarted.

The reboot timeout is a new module-level constant `CARTRIDGE_REBOOT_TIMEOUT_SECONDS = 30.0`, placed next to the other cartridge constants. A reboot restarts the whole machine, so this is longer than `READY_TIMEOUT_SECONDS`, which covers a reset.

Behaviour that is unchanged: a non-split target still returns `None`; the config write is still not saved to flash; and the function still raises `Failure` when the write does not take.

This backports only the reboot-and-wait from the machine-code-monitor feature branch. It adds no debugger, NMI probe, or monitor-specific logic.

## Why the alternative was rejected

Relying on the config item's change hook without a reboot was rejected because the hook updates only the stored value. It does not call `C64::ConfigureU64SystemBus`, so the already-running bus keeps whatever routing it had at the last boot. There is no cheap way to query the running computer for the routing it is actually using, so a reboot is the only way to make `External` take effect on the bus.

## Verification

Static and observational, not a device run of this branch:

- `python3 -c "import ast; ast.parse(open('tests/lib/api.py').read())"` passes.
- The repo lint gate `tests/lib/lint_test.py` (ruff with `tests/ruff.toml` over `tests` and `run-tests`) passes, and `ruff check --config tests/ruff.toml tests/lib/api.py` and `pyflakes` report no findings on the changed file.
- The on-hardware observation described above (cartridge launch fails while the config reads `External`; setting `External` and rebooting restores it) was seen on the feature firmware this session, not on a device run of master. No device was available for this change.
